### PR TITLE
Skip classification step for PO imports (GH #3)

### DIFF
--- a/backend/alembic/versions/011_make_po_line_item_classification_nullable.py
+++ b/backend/alembic/versions/011_make_po_line_item_classification_nullable.py
@@ -1,0 +1,36 @@
+"""make po_line_item classification nullable
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-02-27
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "po_line_items",
+        "classification",
+        existing_type=sa.Enum("SITE_HARDWARE", "SHOP_HARDWARE", name="classification", create_constraint=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Backfill NULLs before re-applying NOT NULL
+    op.execute("UPDATE po_line_items SET classification = 'SITE_HARDWARE' WHERE classification IS NULL")
+    op.alter_column(
+        "po_line_items",
+        "classification",
+        existing_type=sa.Enum("SITE_HARDWARE", "SHOP_HARDWARE", name="classification", create_constraint=True),
+        nullable=False,
+    )

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -43,9 +43,9 @@ class POLineItem(Base):
     po_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("purchase_orders.id"), nullable=False)
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
-    classification: Mapped[Classification] = mapped_column(
+    classification: Mapped[Classification | None] = mapped_column(
         Enum(Classification, name="classification", create_constraint=True),
-        nullable=False,
+        nullable=True,
     )
     ordered_quantity: Mapped[int] = mapped_column(Integer, nullable=False)
     received_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -350,7 +350,7 @@ def finalize_import_session(
 
                 unit_cost = hi_data.get("unit_cost") or 0.0
                 class_key = (hi_data["hardware_category"], hi_data["product_code"], unit_cost)
-                classification = classification_map.get(class_key, Classification.SITE_HARDWARE)
+                classification = classification_map.get(class_key)
 
                 # Create HardwareItem
                 hw_item = HardwareItemModel(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -77,7 +77,7 @@ class POLineItem:
     po_id: strawberry.ID
     hardware_category: str
     product_code: str
-    classification: Classification
+    classification: Classification | None
     ordered_quantity: int
     received_quantity: int
     unit_cost: float
@@ -354,7 +354,7 @@ class ShipReadyItems:
 class InventoryItemDetail:
     inventory_location: InventoryLocation
     po_number: str
-    classification: Classification
+    classification: Classification | None
 
 
 @strawberry.type

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -132,8 +132,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       { id: 'purpose', label: 'Purpose' },
       { id: 'openings', label: 'Select Openings' },
       { id: 'reconciliation', label: 'Reconciliation' },
-      { id: 'classification', label: 'Classification' },
     ];
+    if (purpose !== 'po') {
+      base.push({ id: 'classification', label: 'Classification' });
+    }
     if (purpose === 'po') base.push({ id: 'purchase-orders', label: 'Purchase Orders' });
     if (purpose === 'assembly') base.push({ id: 'shop-assembly', label: 'Shop Assembly' });
     if (purpose === 'shipping') base.push({ id: 'shipping-prs', label: 'Shipping PRs' });
@@ -146,7 +148,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   const effectiveStepId = useMemo<StepId>(
     () =>
       activeStepId !== 'upload' && !steps.find((s) => s.id === activeStepId)
-        ? 'classification'
+        ? 'reconciliation'
         : activeStepId,
     [steps, activeStepId],
   );
@@ -442,7 +444,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             };
           })
         : null,
-      classifications: purpose === 'po'
+      classifications: purpose === 'assembly'
         ? Array.from(classifications.entries()).map(([key, cls]) => {
             const [hardwareCategory, productCode, unitCost] = key.split('|');
             return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -53,7 +53,13 @@ function formatDateTime(dateStr: string | null | undefined): string {
 const lineItemColumns: GridColDef[] = [
   { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 130 },
   { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, minWidth: 150 },
-  { field: 'classification', headerName: 'Classification', flex: 1, minWidth: 130 },
+  {
+    field: 'classification',
+    headerName: 'Classification',
+    flex: 1,
+    minWidth: 130,
+    renderCell: (params) => params.value || '\u2014',
+  },
   {
     field: 'orderedQuantity',
     headerName: 'Ordered Qty',

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -25,7 +25,7 @@ interface POLineItem {
   poId: string;
   hardwareCategory: string;
   productCode: string;
-  classification: string;
+  classification: string | null;
   orderedQuantity: number;
   receivedQuantity: number;
   unitCost: number;

--- a/frontend/src/modules/warehouse/ReceiveWizard.tsx
+++ b/frontend/src/modules/warehouse/ReceiveWizard.tsx
@@ -54,7 +54,7 @@ interface PODetailLineItem {
   poId: string;
   hardwareCategory: string;
   productCode: string;
-  classification: string;
+  classification: string | null;
   orderedQuantity: number;
   receivedQuantity: number;
   unitCost: number;


### PR DESCRIPTION
## Summary

- Removes the Classification step from the import wizard when purpose is `po` — classification only matters at shop assembly and shipping time
- Makes `POLineItem.classification` nullable in the DB model and adds migration `011`
- Updates GraphQL types (`POLineItem`, `InventoryItemDetail`) to return `Classification | None`
- Defaults classification to `None` (instead of `SITE_HARDWARE`) when no classification map entry exists
- PO detail modal displays an em-dash for null classification values
- Frontend type interfaces updated to accept `string | null` for classification