### PR TITLE
Add nested multi-level group-by in Classification step (GH #5)

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Button,
   Chip,
+  IconButton,
   MenuItem,
   TextField,
   Typography,
@@ -13,6 +14,8 @@ import {
   ToggleButtonGroup,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
 import {
   DataGrid,
   type GridColDef,
@@ -54,12 +57,10 @@ interface ClassificationGridProps {
   readOnly?: boolean;
 }
 
-interface CategoryGridProps {
-  groupLabel: string;
+interface GroupNode {
+  label: string;
   rows: ClassificationRow[];
-  columns: GridColDef[];
-  onClassify: ClassificationGridProps['onClassify'];
-  readOnly?: boolean;
+  children: Map<string, GroupNode> | null;
 }
 
 function formatGroupKey(field: GroupByField, value: unknown): string {
@@ -73,110 +74,29 @@ function uniqueClassificationKeys(rows: ClassificationRow[]): string[] {
   return Array.from(new Set(rows.map((r) => r.classificationKey)));
 }
 
-function CategoryGrid({ groupLabel, rows, columns, onClassify, readOnly }: CategoryGridProps) {
-  const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>({
-    type: 'include',
-    ids: new Set(),
-  });
-
-  const selectedCount = selectionModel.ids.size;
-  const classifiedCount = rows.filter((r) => r.classification !== '').length;
-  const uniqueClassifications = new Set(rows.filter((r) => r.classification !== '').map((r) => r.classification));
-  const allSameClassification = classifiedCount === rows.length && uniqueClassifications.size === 1;
-
-  const handleBulkClassify = useCallback(
-    (value: 'SITE_HARDWARE' | 'SHOP_HARDWARE') => {
-      const selectedRows = rows.filter((r) => selectionModel.ids.has(r.id));
-      onClassify(uniqueClassificationKeys(selectedRows), value);
-      setSelectionModel({ type: 'include', ids: new Set() });
-    },
-    [selectionModel, rows, onClassify],
-  );
-
-  const handleGroupAll = useCallback(
-    (value: 'SITE_HARDWARE' | 'SHOP_HARDWARE', e: React.MouseEvent) => {
-      e.stopPropagation();
-      onClassify(uniqueClassificationKeys(rows), value);
-    },
-    [rows, onClassify],
-  );
-
-  return (
-    <Accordion
-      defaultExpanded={false}
-      TransitionProps={{ unmountOnExit: true }}
-    >
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', mr: 1 }}>
-          <Typography sx={{ fontWeight: 700 }}>{groupLabel}</Typography>
-          <Chip
-            size="small"
-            label={
-              allSameClassification
-                ? `All ${[...uniqueClassifications][0] === 'SITE_HARDWARE' ? 'Site' : 'Shop'}`
-                : `${classifiedCount}/${rows.length} classified`
-            }
-            color={
-              allSameClassification
-                ? ([...uniqueClassifications][0] === 'SITE_HARDWARE' ? 'success' : 'info')
-                : classifiedCount === rows.length ? 'success' : 'default'
-            }
-          />
-          <Typography variant="body2" color="text.secondary">
-            ({rows.length} items)
-          </Typography>
-          {!readOnly && (
-            <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5 }}>
-              <Button
-                size="small"
-                variant="outlined"
-                color="success"
-                onClick={(e) => handleGroupAll('SITE_HARDWARE', e)}
-              >
-                Site All
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                color="info"
-                onClick={(e) => handleGroupAll('SHOP_HARDWARE', e)}
-              >
-                Shop All
-              </Button>
-            </Box>
-          )}
-        </Box>
-      </AccordionSummary>
-      <AccordionDetails>
-        <DataGrid
-          rows={rows}
-          columns={columns}
-          checkboxSelection={!readOnly}
-          density="compact"
-          rowHeight={42}
-          hideFooter
-          disableRowSelectionOnClick
-          rowSelectionModel={selectionModel}
-          onRowSelectionModelChange={setSelectionModel}
-          slots={{
-            toolbar: !readOnly && selectedCount > 0
-              ? () => (
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5 }}>
-                    <Typography variant="body2">{selectedCount} selected</Typography>
-                    <Button size="small" color="success" onClick={() => handleBulkClassify('SITE_HARDWARE')}>
-                      Classify as Site
-                    </Button>
-                    <Button size="small" color="info" onClick={() => handleBulkClassify('SHOP_HARDWARE')}>
-                      Classify as Shop
-                    </Button>
-                  </Box>
-                )
-              : undefined,
-          }}
-        />
-      </AccordionDetails>
-    </Accordion>
-  );
+function buildGroupTree(rows: ClassificationRow[], fields: GroupByField[]): Map<string, GroupNode> | null {
+  if (fields.length === 0) return null;
+  const [field, ...rest] = fields;
+  const map = new Map<string, ClassificationRow[]>();
+  for (const row of rows) {
+    const key = formatGroupKey(field, row[field]);
+    const existing = map.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      map.set(key, [row]);
+    }
+  }
+  const sorted = Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  const result = new Map<string, GroupNode>();
+  for (const [key, groupRows] of sorted) {
+    result.set(key, {
+      label: key,
+      rows: groupRows,
+      children: buildGroupTree(groupRows, rest),
+    });
+  }
+  return result;
 }
 
 const ALL_COLUMNS: GridColDef[] = [
@@ -208,42 +128,176 @@ const ALL_COLUMNS: GridColDef[] = [
   { field: 'itemQuantity', headerName: 'Qty', flex: 0.4, type: 'number' },
 ];
 
-// Map GroupByField to the DataGrid field name to hide when grouping
-const GROUP_FIELD_MAP: Record<GroupByField, string> = {
-  hardwareCategory: 'hardwareCategory',
-  vendorNo: 'vendorNo',
-  productCode: 'productCode',
-  openingNumber: 'openingNumber',
-  unitCost: 'unitCost',
-  listPrice: 'listPrice',
-  vendorDiscount: 'vendorDiscount',
-  itemQuantity: 'itemQuantity',
-};
+interface LeafGridProps {
+  rows: ClassificationRow[];
+  columns: GridColDef[];
+  onClassify: ClassificationGridProps['onClassify'];
+  readOnly?: boolean;
+}
+
+function LeafGrid({ rows, columns, onClassify, readOnly }: LeafGridProps) {
+  const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>({
+    type: 'include',
+    ids: new Set(),
+  });
+
+  const selectedCount = selectionModel.ids.size;
+
+  const handleBulkClassify = useCallback(
+    (value: 'SITE_HARDWARE' | 'SHOP_HARDWARE') => {
+      const selectedRows = rows.filter((r) => selectionModel.ids.has(r.id));
+      onClassify(uniqueClassificationKeys(selectedRows), value);
+      setSelectionModel({ type: 'include', ids: new Set() });
+    },
+    [selectionModel, rows, onClassify],
+  );
+
+  return (
+    <DataGrid
+      rows={rows}
+      columns={columns}
+      checkboxSelection={!readOnly}
+      density="compact"
+      rowHeight={42}
+      hideFooter
+      disableRowSelectionOnClick
+      rowSelectionModel={selectionModel}
+      onRowSelectionModelChange={setSelectionModel}
+      slots={{
+        toolbar: !readOnly && selectedCount > 0
+          ? () => (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5 }}>
+                <Typography variant="body2">{selectedCount} selected</Typography>
+                <Button size="small" color="success" onClick={() => handleBulkClassify('SITE_HARDWARE')}>
+                  Classify as Site
+                </Button>
+                <Button size="small" color="info" onClick={() => handleBulkClassify('SHOP_HARDWARE')}>
+                  Classify as Shop
+                </Button>
+              </Box>
+            )
+          : undefined,
+      }}
+    />
+  );
+}
+
+interface GroupAccordionProps {
+  node: GroupNode;
+  columns: GridColDef[];
+  onClassify: ClassificationGridProps['onClassify'];
+  readOnly?: boolean;
+  depth: number;
+}
+
+function GroupAccordion({ node, columns, onClassify, readOnly, depth }: GroupAccordionProps) {
+  const classifiedCount = node.rows.filter((r) => r.classification !== '').length;
+  const uniqueClassifications = new Set(node.rows.filter((r) => r.classification !== '').map((r) => r.classification));
+  const allSameClassification = classifiedCount === node.rows.length && uniqueClassifications.size === 1;
+
+  const handleGroupAll = useCallback(
+    (value: 'SITE_HARDWARE' | 'SHOP_HARDWARE', e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClassify(uniqueClassificationKeys(node.rows), value);
+    },
+    [node.rows, onClassify],
+  );
+
+  return (
+    <Accordion
+      defaultExpanded={false}
+      TransitionProps={{ unmountOnExit: true }}
+      sx={{ pl: depth * 2 }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', mr: 1 }}>
+          <Typography sx={{ fontWeight: 700 }}>{node.label}</Typography>
+          <Chip
+            size="small"
+            label={
+              allSameClassification
+                ? `All ${[...uniqueClassifications][0] === 'SITE_HARDWARE' ? 'Site' : 'Shop'}`
+                : `${classifiedCount}/${node.rows.length} classified`
+            }
+            color={
+              allSameClassification
+                ? ([...uniqueClassifications][0] === 'SITE_HARDWARE' ? 'success' : 'info')
+                : classifiedCount === node.rows.length ? 'success' : 'default'
+            }
+          />
+          <Typography variant="body2" color="text.secondary">
+            ({node.rows.length} items)
+          </Typography>
+          {!readOnly && (
+            <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5 }}>
+              <Button
+                size="small"
+                variant="outlined"
+                color="success"
+                onClick={(e) => handleGroupAll('SITE_HARDWARE', e)}
+              >
+                Site All
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                color="info"
+                onClick={(e) => handleGroupAll('SHOP_HARDWARE', e)}
+              >
+                Shop All
+              </Button>
+            </Box>
+          )}
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        {node.children ? (
+          Array.from(node.children.values()).map((child) => (
+            <GroupAccordion
+              key={child.label}
+              node={child}
+              columns={columns}
+              onClassify={onClassify}
+              readOnly={readOnly}
+              depth={depth + 1}
+            />
+          ))
+        ) : (
+          <LeafGrid rows={node.rows} columns={columns} onClassify={onClassify} readOnly={readOnly} />
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}
 
 export default function ClassificationGrid({ rows, onClassify, readOnly }: ClassificationGridProps) {
-  const [groupByField, setGroupByField] = useState<GroupByField>('hardwareCategory');
+  const [groupByFields, setGroupByFields] = useState<GroupByField[]>([]);
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, ClassificationRow[]>();
-    for (const row of rows) {
-      const rawValue = row[groupByField];
-      const key = formatGroupKey(groupByField, rawValue);
-      const existing = map.get(key);
-      if (existing) {
-        existing.push(row);
-      } else {
-        map.set(key, [row]);
-      }
+  const usedFields = useMemo(() => new Set(groupByFields), [groupByFields]);
+
+  const handleAddLevel = useCallback(() => {
+    const firstUnused = GROUP_BY_OPTIONS.find((opt) => !usedFields.has(opt.value));
+    if (firstUnused) {
+      setGroupByFields((prev) => [...prev, firstUnused.value]);
     }
-    return new Map(
-      Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b)),
-    );
-  }, [rows, groupByField]);
+  }, [usedFields]);
 
-  // Build columns: hide the grouped-by field, append classification column
+  const handleRemoveLevel = useCallback((index: number) => {
+    setGroupByFields((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleChangeLevel = useCallback((index: number, value: GroupByField) => {
+    setGroupByFields((prev) => prev.map((f, i) => (i === index ? value : f)));
+  }, []);
+
+  const groupTree = useMemo(
+    () => buildGroupTree(rows, groupByFields),
+    [rows, groupByFields],
+  );
+
   const columns: GridColDef[] = useMemo(() => {
-    const hiddenField = GROUP_FIELD_MAP[groupByField];
-    const visible = ALL_COLUMNS.filter((col) => col.field !== hiddenField);
+    const hiddenFields = new Set(groupByFields);
+    const visible = ALL_COLUMNS.filter((col) => !hiddenFields.has(col.field as GroupByField));
     return [
       ...visible,
       {
@@ -307,34 +361,60 @@ export default function ClassificationGrid({ rows, onClassify, readOnly }: Class
         },
       },
     ];
-  }, [groupByField, onClassify, readOnly]);
+  }, [groupByFields, onClassify, readOnly]);
 
   return (
     <Box>
-      <Box sx={{ mb: 2 }}>
-        <TextField
-          select
-          size="small"
-          label="Group by"
-          value={groupByField}
-          onChange={(e) => setGroupByField(e.target.value as GroupByField)}
-          sx={{ minWidth: 200 }}
-        >
-          {GROUP_BY_OPTIONS.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>{opt.label}</MenuItem>
-          ))}
-        </TextField>
+      <Box sx={{ mb: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {groupByFields.map((field, index) => (
+          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ minWidth: 56 }}>
+              Level {index + 1}:
+            </Typography>
+            <TextField
+              select
+              size="small"
+              value={field}
+              onChange={(e) => handleChangeLevel(index, e.target.value as GroupByField)}
+              sx={{ minWidth: 200 }}
+            >
+              {GROUP_BY_OPTIONS
+                .filter((opt) => opt.value === field || !usedFields.has(opt.value))
+                .map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>{opt.label}</MenuItem>
+                ))}
+            </TextField>
+            <IconButton size="small" onClick={() => handleRemoveLevel(index)}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        ))}
+        {groupByFields.length < GROUP_BY_OPTIONS.length && (
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={handleAddLevel}
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            Add group level
+          </Button>
+        )}
       </Box>
-      {Array.from(grouped.entries()).map(([groupKey, groupRows]) => (
-        <CategoryGrid
-          key={groupKey}
-          groupLabel={groupKey}
-          rows={groupRows}
-          columns={columns}
-          onClassify={onClassify}
-          readOnly={readOnly}
-        />
-      ))}
+
+      {groupTree ? (
+        Array.from(groupTree.values()).map((node) => (
+          <GroupAccordion
+            key={node.label}
+            node={node}
+            columns={columns}
+            onClassify={onClassify}
+            readOnly={readOnly}
+            depth={0}
+          />
+        ))
+      ) : (
+        <LeafGrid rows={rows} columns={columns} onClassify={onClassify} readOnly={readOnly} />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- Replace the single group-by dropdown with an ordered stack of group levels that users can add, remove, and change
- Default view is now a flat DataGrid (no grouping) instead of always grouping by Hardware Category
- Adding group levels creates nested accordions via recursive tree builder — supports up to 8 nesting levels
- Columns used for grouping are automatically hidden from the DataGrid
- Extracted `LeafGrid` and `GroupAccordion` components, removed old `CategoryGrid` and redundant `GROUP_FIELD_MAP`

Single file change: `frontend/src/modules/import/ClassificationGrid.tsx`