### PR TITLE
Add selective vendor checkbox to PO import step

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -112,6 +112,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   const [selectedOpenings, setSelectedOpenings] = useState<Set<string>>(new Set());
 
   // Action step state
+  const [selectedVendors, setSelectedVendors] = useState<Set<string>>(new Set());
   const [vendorPOInfo, setVendorPOInfo] = useState<Map<string, { poNumber: string; vendorContact: string }>>(new Map());
   const [classifications, setClassifications] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
@@ -341,6 +342,19 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     setSelectedOpenings(selected);
   }, []);
 
+  // Vendor selection
+  const toggleVendor = useCallback((vendor: string) => {
+    setSelectedVendors((prev) => {
+      const next = new Set(prev);
+      if (next.has(vendor)) {
+        next.delete(vendor);
+      } else {
+        next.add(vendor);
+      }
+      return next;
+    });
+  }, []);
+
   // Vendor PO info
   const updateVendorPO = useCallback((vendorNo: string, field: 'poNumber' | 'vendorContact', value: string) => {
     setVendorPOInfo((prev) => {
@@ -428,21 +442,27 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     return {
       project: snakeToCamel(parsed.project as unknown as Record<string, unknown>),
       openings: selectedOpeningsList.map((o) => snakeToCamel(o as unknown as Record<string, unknown>)),
-      hardwareItems: purpose === 'po' ? filteredHardwareItems.map((hi) => snakeToCamel(hi as unknown as Record<string, unknown>)) : null,
+      hardwareItems: purpose === 'po'
+        ? filteredHardwareItems
+            .filter((hi) => selectedVendors.has(hi.vendor_no ?? '(No Vendor)'))
+            .map((hi) => snakeToCamel(hi as unknown as Record<string, unknown>))
+        : null,
       poDrafts: purpose === 'po'
-        ? Array.from(vendorGroups.entries()).map(([vendor, items]) => {
-            const info = vendorPOInfo.get(vendor) ?? { poNumber: '', vendorContact: '' };
-            return {
-              poNumber: info.poNumber,
-              vendorName: vendor !== '(No Vendor)' ? vendor : null,
-              vendorContact: info.vendorContact || null,
-              hardwareItemRefs: items.map((hi) => ({
-                openingNumber: hi.opening_number,
-                productCode: hi.product_code,
-                materialId: hi.material_id,
-              })),
-            };
-          })
+        ? Array.from(vendorGroups.entries())
+            .filter(([vendor]) => selectedVendors.has(vendor))
+            .map(([vendor, items]) => {
+              const info = vendorPOInfo.get(vendor) ?? { poNumber: '', vendorContact: '' };
+              return {
+                poNumber: info.poNumber,
+                vendorName: vendor !== '(No Vendor)' ? vendor : null,
+                vendorContact: info.vendorContact || null,
+                hardwareItemRefs: items.map((hi) => ({
+                  openingNumber: hi.opening_number,
+                  productCode: hi.product_code,
+                  materialId: hi.material_id,
+                })),
+              };
+            })
         : null,
       classifications: purpose === 'assembly'
         ? Array.from(classifications.entries()).map(([key, cls]) => {
@@ -487,7 +507,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             .filter(Boolean)
         : null,
     };
-  }, [parsed, selectedOpenings, purpose, vendorGroups, vendorPOInfo, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, classifications, shippingPRDrafts, sarRequestNumber]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -546,6 +566,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     setExistingProjectName(null);
     setPurpose(null);
     setSelectedOpenings(new Set());
+    setSelectedVendors(new Set());
     setVendorPOInfo(new Map());
     setClassifications(new Map());
     setSarRequestNumber('');
@@ -841,6 +862,8 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             <PurchaseOrdersStep
               vendorGroups={vendorGroups}
               vendorPOInfo={vendorPOInfo}
+              selectedVendors={selectedVendors}
+              onToggleVendor={toggleVendor}
               onUpdateVendorPO={updateVendorPO}
               onNext={handleNext}
               onBack={handleBack}
@@ -899,7 +922,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
                 {purpose === 'po' && (
                   <Box sx={{ mb: 1 }}>
                     <Typography variant="body1">
-                      {vendorGroups.size} Purchase Order(s) across {vendorGroups.size} vendor(s)
+                      {selectedVendors.size} Purchase Order(s) across {selectedVendors.size} vendor(s)
                     </Typography>
                   </Box>
                 )}

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, Paper, TextField, Typography } from '@mui/material';
+import { Box, Button, Checkbox, FormControlLabel, Paper, TextField, Typography } from '@mui/material';
 import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
 
 // ---- Aggregation Types ----
@@ -17,6 +17,8 @@ interface AggregatedLineItem {
 interface PurchaseOrdersStepProps {
   vendorGroups: Map<string, ParsedHardwareItem[]>;
   vendorPOInfo: Map<string, { poNumber: string; vendorContact: string }>;
+  selectedVendors: Set<string>;
+  onToggleVendor: (vendor: string) => void;
   onUpdateVendorPO: (vendorNo: string, field: 'poNumber' | 'vendorContact', value: string) => void;
   onNext: () => void;
   onBack: () => void;
@@ -56,17 +58,20 @@ function aggregateLineItems(items: ParsedHardwareItem[]): AggregatedLineItem[] {
 export default function PurchaseOrdersStep({
   vendorGroups,
   vendorPOInfo,
+  selectedVendors,
+  onToggleVendor,
   onUpdateVendorPO,
   onNext,
   onBack,
 }: PurchaseOrdersStepProps) {
   const canProceed = useMemo(() => {
-    for (const vendor of vendorGroups.keys()) {
+    if (selectedVendors.size === 0) return false;
+    for (const vendor of selectedVendors) {
       const info = vendorPOInfo.get(vendor);
       if (!info || info.poNumber.trim() === '') return false;
     }
     return true;
-  }, [vendorGroups, vendorPOInfo]);
+  }, [selectedVendors, vendorPOInfo]);
 
   const sortedVendors = useMemo(
     () => Array.from(vendorGroups.entries()).sort(([a], [b]) => a.localeCompare(b)),
@@ -79,7 +84,7 @@ export default function PurchaseOrdersStep({
         Purchase Orders
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        {vendorGroups.size} vendor(s). Enter a PO number for each.
+        {vendorGroups.size} vendor(s). Select which vendors to create POs for, then enter a PO number for each.
       </Typography>
 
       {sortedVendors.map(([vendor, items]) => {
@@ -89,14 +94,25 @@ export default function PurchaseOrdersStep({
           (sum, hi) => sum + (hi.unit_cost ?? 0) * hi.item_quantity,
           0,
         );
+        const isSelected = selectedVendors.has(vendor);
 
         return (
-          <Paper key={vendor} variant="outlined" sx={{ p: 2, mb: 2 }}>
-            {/* Header: vendor name + PO total */}
+          <Paper key={vendor} variant="outlined" sx={{ p: 2, mb: 2, opacity: isSelected ? 1 : 0.5 }}>
+            {/* Header: checkbox + vendor name + PO total */}
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                {vendor}
-              </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isSelected}
+                    onChange={() => onToggleVendor(vendor)}
+                  />
+                }
+                label={
+                  <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                    {vendor}
+                  </Typography>
+                }
+              />
               <Typography variant="subtitle1" color="primary">
                 PO Total: ${poTotal.toFixed(2)}
               </Typography>
@@ -108,6 +124,7 @@ export default function PurchaseOrdersStep({
                 label="PO Number"
                 size="small"
                 required
+                disabled={!isSelected}
                 value={info.poNumber}
                 onChange={(e) => onUpdateVendorPO(vendor, 'poNumber', e.target.value)}
                 sx={{ flex: 1 }}
@@ -115,6 +132,7 @@ export default function PurchaseOrdersStep({
               <TextField
                 label="Vendor Contact"
                 size="small"
+                disabled={!isSelected}
                 value={info.vendorContact}
                 onChange={(e) => onUpdateVendorPO(vendor, 'vendorContact', e.target.value)}
                 sx={{ flex: 1 }}


### PR DESCRIPTION
## Summary
- Adds a checkbox (default unchecked) per vendor card in the Purchase Orders step of the import wizard, letting users opt-in to which POs get created
- Unchecked vendor cards are visually de-emphasized (50% opacity) with disabled PO Number and Vendor Contact fields
- `buildFinalizeInput` filters both `poDrafts` and `hardwareItems` to only include selected vendors — unselected vendors are never sent to the backend
- "Next" button requires at least one vendor selected with a non-empty PO number

Closes #6