### PR TITLE
Make unit cost editable in PO step (GH #7)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -114,6 +114,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   // Action step state
   const [selectedVendors, setSelectedVendors] = useState<Set<string>>(new Set());
   const [vendorPOInfo, setVendorPOInfo] = useState<Map<string, { poNumber: string; vendorContact: string }>>(new Map());
+  const [unitCostOverrides, setUnitCostOverrides] = useState<Map<string, number>>(new Map());
   const [classifications, setClassifications] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
@@ -355,6 +356,17 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     });
   }, []);
 
+  // Unit cost overrides
+  const handleUpdateUnitCost = useCallback(
+    (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => {
+      setUnitCostOverrides(prev => {
+        const next = new Map(prev);
+        next.set(`${vendor}|${productCode}|${hardwareCategory}`, newCost);
+        return next;
+      });
+    }, []
+  );
+
   // Vendor PO info
   const updateVendorPO = useCallback((vendorNo: string, field: 'poNumber' | 'vendorContact', value: string) => {
     setVendorPOInfo((prev) => {
@@ -445,7 +457,15 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       hardwareItems: purpose === 'po'
         ? filteredHardwareItems
             .filter((hi) => selectedVendors.has(hi.vendor_no ?? '(No Vendor)'))
-            .map((hi) => snakeToCamel(hi as unknown as Record<string, unknown>))
+            .map((hi) => {
+              const vendor = hi.vendor_no ?? '(No Vendor)';
+              const overrideKey = `${vendor}|${hi.product_code}|${hi.hardware_category}`;
+              const overriddenCost = unitCostOverrides.get(overrideKey);
+              const item = overriddenCost !== undefined
+                ? { ...hi, unit_cost: overriddenCost }
+                : hi;
+              return snakeToCamel(item as unknown as Record<string, unknown>);
+            })
         : null,
       poDrafts: purpose === 'po'
         ? Array.from(vendorGroups.entries())
@@ -507,7 +527,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             .filter(Boolean)
         : null,
     };
-  }, [parsed, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, classifications, shippingPRDrafts, sarRequestNumber]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -568,6 +588,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     setSelectedOpenings(new Set());
     setSelectedVendors(new Set());
     setVendorPOInfo(new Map());
+    setUnitCostOverrides(new Map());
     setClassifications(new Map());
     setSarRequestNumber('');
     setShippingPRDrafts([]);
@@ -863,8 +884,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
               vendorGroups={vendorGroups}
               vendorPOInfo={vendorPOInfo}
               selectedVendors={selectedVendors}
+              unitCostOverrides={unitCostOverrides}
               onToggleVendor={toggleVendor}
               onUpdateVendorPO={updateVendorPO}
+              onUpdateUnitCost={handleUpdateUnitCost}
               onNext={handleNext}
               onBack={handleBack}
             />

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, Checkbox, FormControlLabel, Paper, TextField, Typography } from '@mui/material';
+import { Box, Button, Checkbox, FormControlLabel, InputAdornment, Paper, TextField, Typography } from '@mui/material';
 import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
 
 // ---- Aggregation Types ----
@@ -18,30 +18,38 @@ interface PurchaseOrdersStepProps {
   vendorGroups: Map<string, ParsedHardwareItem[]>;
   vendorPOInfo: Map<string, { poNumber: string; vendorContact: string }>;
   selectedVendors: Set<string>;
+  unitCostOverrides: Map<string, number>;
   onToggleVendor: (vendor: string) => void;
   onUpdateVendorPO: (vendorNo: string, field: 'poNumber' | 'vendorContact', value: string) => void;
+  onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
   onNext: () => void;
   onBack: () => void;
 }
 
 // ---- Helpers ----
 
-function aggregateLineItems(items: ParsedHardwareItem[]): AggregatedLineItem[] {
+function aggregateLineItems(
+  items: ParsedHardwareItem[],
+  vendor: string,
+  overrides: Map<string, number>,
+): AggregatedLineItem[] {
   const groups = new Map<string, AggregatedLineItem>();
 
   for (const item of items) {
     const key = `${item.product_code}|${item.hardware_category}`;
+    const overrideKey = `${vendor}|${item.product_code}|${item.hardware_category}`;
+    const cost = overrides.get(overrideKey) ?? item.unit_cost ?? 0;
     const existing = groups.get(key);
     if (existing) {
       existing.totalQuantity += item.item_quantity;
-      existing.totalCost += (item.unit_cost ?? 0) * item.item_quantity;
+      existing.totalCost = existing.unitCost * (existing.totalQuantity);
     } else {
       groups.set(key, {
         productCode: item.product_code,
         hardwareCategory: item.hardware_category,
         totalQuantity: item.item_quantity,
-        unitCost: item.unit_cost ?? 0,
-        totalCost: (item.unit_cost ?? 0) * item.item_quantity,
+        unitCost: cost,
+        totalCost: cost * item.item_quantity,
       });
     }
   }
@@ -59,8 +67,10 @@ export default function PurchaseOrdersStep({
   vendorGroups,
   vendorPOInfo,
   selectedVendors,
+  unitCostOverrides,
   onToggleVendor,
   onUpdateVendorPO,
+  onUpdateUnitCost,
   onNext,
   onBack,
 }: PurchaseOrdersStepProps) {
@@ -89,11 +99,8 @@ export default function PurchaseOrdersStep({
 
       {sortedVendors.map(([vendor, items]) => {
         const info = vendorPOInfo.get(vendor) ?? { poNumber: '', vendorContact: '' };
-        const aggregated = aggregateLineItems(items);
-        const poTotal = items.reduce(
-          (sum, hi) => sum + (hi.unit_cost ?? 0) * hi.item_quantity,
-          0,
-        );
+        const aggregated = aggregateLineItems(items, vendor, unitCostOverrides);
+        const poTotal = aggregated.reduce((sum, line) => sum + line.totalCost, 0);
         const isSelected = selectedVendors.has(vendor);
 
         return (
@@ -188,7 +195,24 @@ export default function PurchaseOrdersStep({
                       <Typography variant="body2">{line.totalQuantity}</Typography>
                     </Box>
                     <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
-                      <Typography variant="body2">${line.unitCost.toFixed(2)}</Typography>
+                      <TextField
+                        size="small"
+                        type="number"
+                        value={line.unitCost}
+                        onChange={(e) => {
+                          const val = parseFloat(e.target.value);
+                          if (!isNaN(val) && val >= 0) {
+                            onUpdateUnitCost(vendor, line.productCode, line.hardwareCategory, val);
+                          }
+                        }}
+                        slotProps={{
+                          input: {
+                            startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                          },
+                          htmlInput: { min: 0, step: 0.01 },
+                        }}
+                        sx={{ width: 120 }}
+                      />
                     </Box>
                     <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
                       <Typography variant="body2">${line.totalCost.toFixed(2)}</Typography>


### PR DESCRIPTION
## Summary

- Replace static unit cost text with editable `TextField` inputs in the Purchase Orders step of the import wizard
- Unit cost overrides are stored in wizard state and applied when building the finalize input, so edited values flow through to both `HardwareItem` and `POLineItem` records
- Total Cost and PO Total recalculate reactively when a unit cost is changed
- Frontend-only change — no backend modifications needed