### PR TITLE
Add admin hardware dashboard (GH #10)

### DIFF
--- a/backend/app/repositories/admin_repository.py
+++ b/backend/app/repositories/admin_repository.py
@@ -1,0 +1,167 @@
+import uuid
+from collections import defaultdict
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from app.models.enums import POStatus
+from app.models.hardware import HardwareItem as HardwareItemModel
+from app.models.project import Opening as OpeningModel
+from app.models.purchase_order import POLineItem as POLineItemModel
+from app.models.purchase_order import PurchaseOrder as POModel
+from app.models.shipping import PackingSlip as PackingSlipModel
+from app.models.shipping import PackingSlipItem as PackingSlipItemModel
+
+
+def get_hardware_summary(session: Session, project_id: uuid.UUID) -> list[dict]:
+    # Query 1: DRAFT POs — po_drafted quantities
+    draft_stmt = (
+        select(
+            POLineItemModel.hardware_category,
+            POLineItemModel.product_code,
+            func.sum(POLineItemModel.ordered_quantity).label("po_drafted"),
+        )
+        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .where(
+            POModel.project_id == project_id,
+            POModel.deleted_at.is_(None),
+            POModel.status == POStatus.DRAFT,
+        )
+        .group_by(POLineItemModel.hardware_category, POLineItemModel.product_code)
+    )
+    draft_rows = session.execute(draft_stmt).all()
+
+    # Query 2: Placed POs (ORDERED, PARTIALLY_RECEIVED, CLOSED) — ordered + received
+    placed_stmt = (
+        select(
+            POLineItemModel.hardware_category,
+            POLineItemModel.product_code,
+            func.sum(POLineItemModel.ordered_quantity).label("ordered"),
+            func.sum(POLineItemModel.received_quantity).label("received"),
+            func.sum(
+                case(
+                    (
+                        POModel.status.in_([POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED]),
+                        POLineItemModel.ordered_quantity - POLineItemModel.received_quantity,
+                    ),
+                    else_=0,
+                )
+            ).label("back_ordered"),
+        )
+        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .where(
+            POModel.project_id == project_id,
+            POModel.deleted_at.is_(None),
+            POModel.status.in_([POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED]),
+        )
+        .group_by(POLineItemModel.hardware_category, POLineItemModel.product_code)
+    )
+    placed_rows = session.execute(placed_stmt).all()
+
+    # Query 3: Shipped — packing slip quantities
+    shipped_stmt = (
+        select(
+            PackingSlipItemModel.hardware_category,
+            PackingSlipItemModel.product_code,
+            func.sum(PackingSlipItemModel.quantity).label("shipped_out"),
+        )
+        .join(PackingSlipModel, PackingSlipItemModel.packing_slip_id == PackingSlipModel.id)
+        .where(PackingSlipModel.project_id == project_id)
+        .group_by(PackingSlipItemModel.hardware_category, PackingSlipItemModel.product_code)
+    )
+    shipped_rows = session.execute(shipped_stmt).all()
+
+    # Merge all by (hardware_category, product_code)
+    merged: dict[tuple[str, str], dict] = defaultdict(
+        lambda: {
+            "hardware_category": "",
+            "product_code": "",
+            "po_drafted": 0,
+            "ordered": 0,
+            "received": 0,
+            "back_ordered": 0,
+            "shipped_out": 0,
+        }
+    )
+
+    for row in draft_rows:
+        key = (row.hardware_category, row.product_code)
+        merged[key]["hardware_category"] = row.hardware_category
+        merged[key]["product_code"] = row.product_code
+        merged[key]["po_drafted"] = row.po_drafted or 0
+
+    for row in placed_rows:
+        key = (row.hardware_category, row.product_code)
+        merged[key]["hardware_category"] = row.hardware_category
+        merged[key]["product_code"] = row.product_code
+        merged[key]["ordered"] = row.ordered or 0
+        merged[key]["received"] = row.received or 0
+        merged[key]["back_ordered"] = row.back_ordered or 0
+
+    for row in shipped_rows:
+        key = (row.hardware_category, row.product_code)
+        merged[key]["hardware_category"] = row.hardware_category
+        merged[key]["product_code"] = row.product_code
+        merged[key]["shipped_out"] = row.shipped_out or 0
+
+    return sorted(merged.values(), key=lambda r: (r["hardware_category"], r["product_code"]))
+
+
+def get_opening_hardware_status(session: Session, project_id: uuid.UUID) -> list[dict]:
+    stmt = (
+        select(
+            HardwareItemModel,
+            OpeningModel.opening_number,
+            OpeningModel.building,
+            OpeningModel.floor,
+            OpeningModel.location,
+            POModel.status.label("po_status"),
+        )
+        .join(OpeningModel, HardwareItemModel.opening_id == OpeningModel.id)
+        .outerjoin(POLineItemModel, HardwareItemModel.po_line_item_id == POLineItemModel.id)
+        .outerjoin(
+            POModel,
+            (POLineItemModel.po_id == POModel.id) & (POModel.deleted_at.is_(None)),
+        )
+        .where(HardwareItemModel.project_id == project_id)
+        .order_by(OpeningModel.opening_number)
+    )
+    rows = session.execute(stmt).all()
+
+    openings: dict[str, dict] = {}
+    for row in rows:
+        hi = row[0]
+        opening_number = row.opening_number
+        building = row.building
+        floor = row.floor
+        location = row.location
+        po_status = row.po_status
+
+        if po_status == POStatus.DRAFT:
+            status = "PO_DRAFTED"
+        elif po_status in (POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED):
+            status = "ORDERED"
+        elif po_status == POStatus.CLOSED:
+            status = "RECEIVED"
+        else:
+            status = "PO_DRAFTED"
+
+        if opening_number not in openings:
+            openings[opening_number] = {
+                "opening_number": opening_number,
+                "building": building,
+                "floor": floor,
+                "location": location,
+                "items": [],
+            }
+
+        openings[opening_number]["items"].append(
+            {
+                "hardware_category": hi.hardware_category,
+                "product_code": hi.product_code,
+                "item_quantity": hi.item_quantity,
+                "status": status,
+            }
+        )
+
+    return sorted(openings.values(), key=lambda o: o["opening_number"])

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -7,6 +7,7 @@ from app.database import SessionLocal
 from app.models.enums import POStatus as DBPOStatus
 from app.models.project import Project as ProjectModel
 from app.repositories import (
+    admin_repository,
     notification_repository,
     po_repository,
     shipping_repository,
@@ -22,10 +23,13 @@ from .enums import (
 )
 from .inputs import ReconciliationItemInput
 from .types import (
+    HardwareSummaryRow,
     InventoryHierarchyNode,
     InventoryItemDetail,
     Notification,
     Opening,
+    OpeningHardwareStatus,
+    OpeningHardwareStatusItem,
     OpeningItem,
     OpeningItemDetail,
     POLineItem,
@@ -554,3 +558,43 @@ class Query:
         with SessionLocal() as session:
             rows = shop_assembly_repository.get_my_work(session, assigned_to)
             return [_shop_assembly_opening_to_type(sao, opening_model=opening) for sao, opening in rows]
+
+    @strawberry.field
+    def hardware_summary(self, project_id: strawberry.ID) -> list[HardwareSummaryRow]:
+        with SessionLocal() as session:
+            rows = admin_repository.get_hardware_summary(session, uuid.UUID(str(project_id)))
+            return [
+                HardwareSummaryRow(
+                    hardware_category=r["hardware_category"],
+                    product_code=r["product_code"],
+                    po_drafted=r["po_drafted"],
+                    ordered=r["ordered"],
+                    received=r["received"],
+                    back_ordered=r["back_ordered"],
+                    shipped_out=r["shipped_out"],
+                )
+                for r in rows
+            ]
+
+    @strawberry.field
+    def opening_hardware_status(self, project_id: strawberry.ID) -> list[OpeningHardwareStatus]:
+        with SessionLocal() as session:
+            rows = admin_repository.get_opening_hardware_status(session, uuid.UUID(str(project_id)))
+            return [
+                OpeningHardwareStatus(
+                    opening_number=r["opening_number"],
+                    building=r["building"],
+                    floor=r["floor"],
+                    location=r["location"],
+                    items=[
+                        OpeningHardwareStatusItem(
+                            hardware_category=item["hardware_category"],
+                            product_code=item["product_code"],
+                            item_quantity=item["item_quantity"],
+                            status=item["status"],
+                        )
+                        for item in r["items"]
+                    ],
+                )
+                for r in rows
+            ]

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -377,3 +377,31 @@ class ReconciliationResult:
     product_code: str
     quantity: int
     status: ReconciliationStatus
+
+
+@strawberry.type
+class HardwareSummaryRow:
+    hardware_category: str
+    product_code: str
+    po_drafted: int
+    ordered: int
+    received: int
+    back_ordered: int
+    shipped_out: int
+
+
+@strawberry.type
+class OpeningHardwareStatusItem:
+    hardware_category: str
+    product_code: str
+    item_quantity: int
+    status: str
+
+
+@strawberry.type
+class OpeningHardwareStatus:
+    opening_number: str
+    building: str | None
+    floor: str | None
+    location: str | None
+    items: list[OpeningHardwareStatusItem]

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -346,6 +346,37 @@ export const RECONCILE_SCHEDULE = gql`
   }
 `;
 
+export const GET_HARDWARE_SUMMARY = gql`
+  query GetHardwareSummary($projectId: ID!) {
+    hardwareSummary(projectId: $projectId) {
+      hardwareCategory
+      productCode
+      poDrafted
+      ordered
+      received
+      backOrdered
+      shippedOut
+    }
+  }
+`;
+
+export const GET_OPENING_HARDWARE_STATUS = gql`
+  query GetOpeningHardwareStatus($projectId: ID!) {
+    openingHardwareStatus(projectId: $projectId) {
+      openingNumber
+      building
+      floor
+      location
+      items {
+        hardwareCategory
+        productCode
+        itemQuantity
+        status
+      }
+    }
+  }
+`;
+
 export const GET_NOTIFICATIONS = gql`
   query GetNotifications($projectId: ID!, $recipientRole: String!, $unreadOnly: Boolean, $limit: Int) {
     notifications(projectId: $projectId, recipientRole: $recipientRole, unreadOnly: $unreadOnly, limit: $limit) {

--- a/frontend/src/modules/admin/HardwareSummaryTab.tsx
+++ b/frontend/src/modules/admin/HardwareSummaryTab.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { Box, CircularProgress, Alert } from '@mui/material';
+import { useQuery } from '@apollo/client/react';
+import type { GridColDef } from '@mui/x-data-grid';
+import { GET_HARDWARE_SUMMARY } from '../../graphql/queries';
+import { useProject } from '../../contexts/ProjectContext';
+import DataTable from '../../components/DataTable';
+
+interface HardwareSummaryRow {
+  hardwareCategory: string;
+  productCode: string;
+  poDrafted: number;
+  ordered: number;
+  received: number;
+  backOrdered: number;
+  shippedOut: number;
+}
+
+const columns: GridColDef[] = [
+  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, minWidth: 160 },
+  { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 140 },
+  { field: 'poDrafted', headerName: 'PO Drafted', type: 'number', width: 110 },
+  { field: 'ordered', headerName: 'Ordered', type: 'number', width: 100 },
+  { field: 'received', headerName: 'Received', type: 'number', width: 100 },
+  { field: 'backOrdered', headerName: 'Back-Ordered', type: 'number', width: 120 },
+  { field: 'shippedOut', headerName: 'Shipped Out', type: 'number', width: 110 },
+];
+
+export default function HardwareSummaryTab() {
+  const { project } = useProject();
+
+  const { data, loading, error } = useQuery<{ hardwareSummary: HardwareSummaryRow[] }>(
+    GET_HARDWARE_SUMMARY,
+    {
+      variables: { projectId: project?.id },
+      skip: !project,
+    },
+  );
+
+  const rows = useMemo(
+    () =>
+      (data?.hardwareSummary ?? []).map((row, idx) => ({
+        id: idx,
+        ...row,
+      })),
+    [data],
+  );
+
+  if (!project) {
+    return <Alert severity="info">Select a project first</Alert>;
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">Error loading hardware summary: {error.message}</Alert>;
+  }
+
+  if (rows.length === 0) {
+    return <Alert severity="info">No hardware data for this project</Alert>;
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      height={600}
+      getRowId={(row) => row.id}
+    />
+  );
+}

--- a/frontend/src/modules/admin/OpeningStatusTab.tsx
+++ b/frontend/src/modules/admin/OpeningStatusTab.tsx
@@ -1,0 +1,132 @@
+import {
+  Box,
+  CircularProgress,
+  Alert,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useQuery } from '@apollo/client/react';
+import { GET_OPENING_HARDWARE_STATUS } from '../../graphql/queries';
+import { useProject } from '../../contexts/ProjectContext';
+
+interface OpeningHardwareStatusItem {
+  hardwareCategory: string;
+  productCode: string;
+  itemQuantity: number;
+  status: string;
+}
+
+interface OpeningHardwareStatus {
+  openingNumber: string;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  items: OpeningHardwareStatusItem[];
+}
+
+const STATUS_CHIP: Record<string, { label: string; color: 'default' | 'info' | 'success' }> = {
+  PO_DRAFTED: { label: 'PO Drafted', color: 'default' },
+  ORDERED: { label: 'Ordered', color: 'info' },
+  RECEIVED: { label: 'Received', color: 'success' },
+};
+
+export default function OpeningStatusTab() {
+  const { project } = useProject();
+
+  const { data, loading, error } = useQuery<{ openingHardwareStatus: OpeningHardwareStatus[] }>(
+    GET_OPENING_HARDWARE_STATUS,
+    {
+      variables: { projectId: project?.id },
+      skip: !project,
+    },
+  );
+
+  if (!project) {
+    return <Alert severity="info">Select a project first</Alert>;
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">Error loading opening status: {error.message}</Alert>;
+  }
+
+  const openings = data?.openingHardwareStatus ?? [];
+
+  if (openings.length === 0) {
+    return <Alert severity="info">No opening hardware data for this project</Alert>;
+  }
+
+  return (
+    <Box>
+      {openings.map((opening) => {
+        const subtitle = [opening.building, opening.floor, opening.location]
+          .filter(Boolean)
+          .join(' / ');
+
+        return (
+          <Accordion key={opening.openingNumber}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box>
+                <Typography variant="subtitle1" fontWeight="bold">
+                  {opening.openingNumber}
+                </Typography>
+                {subtitle && (
+                  <Typography variant="body2" color="text.secondary">
+                    {subtitle}
+                  </Typography>
+                )}
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              <TableContainer component={Paper} variant="outlined">
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Hardware Category</TableCell>
+                      <TableCell>Product Code</TableCell>
+                      <TableCell align="right">Quantity</TableCell>
+                      <TableCell>Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {opening.items.map((item, idx) => {
+                      const chip = STATUS_CHIP[item.status] ?? STATUS_CHIP.PO_DRAFTED;
+                      return (
+                        <TableRow key={idx}>
+                          <TableCell>{item.hardwareCategory}</TableCell>
+                          <TableCell>{item.productCode}</TableCell>
+                          <TableCell align="right">{item.itemQuantity}</TableCell>
+                          <TableCell>
+                            <Chip label={chip.label} color={chip.color} size="small" />
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -1,5 +1,31 @@
-import { Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import { Box, Tabs, Tab, Typography } from '@mui/material';
+import HardwareSummaryTab from './HardwareSummaryTab';
+import OpeningStatusTab from './OpeningStatusTab';
+
+const SUB_ROUTES = [
+  { label: 'Hardware Summary', path: 'hardware-summary' },
+  { label: 'Opening Status', path: 'opening-status' },
+];
 
 export default function AdminModule() {
-  return <Navigate to="/app/warehouse/inventory" replace />;
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const currentSub = location.pathname.split('/').pop();
+  const tabIndex = Math.max(SUB_ROUTES.findIndex((r) => r.path === currentSub), 0);
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>Admin</Typography>
+      <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/admin/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
+        {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
+      </Tabs>
+      <Routes>
+        <Route path="hardware-summary" element={<HardwareSummaryTab />} />
+        <Route path="opening-status" element={<OpeningStatusTab />} />
+        <Route index element={<Navigate to="hardware-summary" replace />} />
+      </Routes>
+    </Box>
+  );
 }


### PR DESCRIPTION
## Summary

- Replace admin module redirect with two-tab dashboard: **Hardware Summary** and **Opening Status**
- **Hardware Summary** tab: DataGrid showing aggregated PO Drafted, Ordered, Received, Back-Ordered, and Shipped Out quantities per (hardware category, product code)
- **Opening Status** tab: Accordion per opening with hardware items table and color-coded status chips (PO Drafted / Ordered / Received)
- Backend: new `admin_repository.py` with two query functions, 3 new GraphQL types, 2 new resolvers

Closes #10