### PR TITLE
Rebrand UC Covet → UC Nexus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,16 @@ jobs:
         env:
           POSTGRES_USER: ci_user
           POSTGRES_PASSWORD: ci_password
-          POSTGRES_DB: uc_covet
+          POSTGRES_DB: uc_nexus
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U ci_user -d uc_covet"
+          --health-cmd="pg_isready -U ci_user -d uc_nexus"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
     env:
-      DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/uc_covet
+      DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/uc_nexus
     steps:
       - uses: actions/checkout@v4
 
@@ -83,16 +83,16 @@ jobs:
         env:
           POSTGRES_USER: ci_user
           POSTGRES_PASSWORD: ci_password
-          POSTGRES_DB: uc_covet_migrations
+          POSTGRES_DB: uc_nexus_migrations
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U ci_user -d uc_covet_migrations"
+          --health-cmd="pg_isready -U ci_user -d uc_nexus_migrations"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
     env:
-      DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/uc_covet_migrations
+      DATABASE_URL: postgresql://ci_user:ci_password@localhost:5432/uc_nexus_migrations
     steps:
       - uses: actions/checkout@v4
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=postgresql://user:password@localhost:5432/uc_covet
+DATABASE_URL=postgresql://user:password@localhost:5432/uc_nexus

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,4 +4,4 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/uc_covet")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/uc_nexus")

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,7 @@ schema = strawberry.Schema(
 
 graphql_app = GraphQLRouter(schema)
 
-app = FastAPI(title="UC Covet - Hardware Management System")
+app = FastAPI(title="UC Nexus - Hardware Management System")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "uc-covet-backend"
+name = "uc-nexus-backend"
 version = "0.1.0"
-description = "UC Covet Hardware Management System - Backend"
+description = "UC Nexus Hardware Management System - Backend"
 authors = []
 package-mode = false
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend-temp</title>
+    <title>UC Nexus</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "uc-covet-frontend",
+  "name": "uc-nexus-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uc-covet-frontend",
+      "name": "uc-nexus-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@apollo/client": "^4.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uc-covet-frontend",
+  "name": "uc-nexus-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -98,7 +98,7 @@ export default function AppLayout() {
       <AppBar position="static">
         <Toolbar>
           <Typography variant="h6" sx={{ mr: 3 }}>
-            UC Covet
+            UC Nexus
           </Typography>
 
           <FormControl size="small" sx={{ minWidth: 200, mr: 2 }}>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,7 +18,7 @@ import './index.css';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ApolloProvider client={client}>
-      <ThemeProvider theme={theme} defaultMode="light" modeStorageKey="uc-covet-mode">
+      <ThemeProvider theme={theme} defaultMode="light" modeStorageKey="uc-nexus-mode">
         <CssBaseline />
         <BrowserRouter>
           <RoleProvider>


### PR DESCRIPTION
## Summary
- Rename all instances of "UC Covet" / "uc-covet" / "uc_covet" to "UC Nexus" / "uc-nexus" / "uc_nexus" across 10 files
- Covers frontend branding (AppLayout, page title), package identity (package.json, pyproject.toml), backend app title, default DB name, and CI database names
- Pure find-and-replace rebrand — no logic, schema, or architecture changes