### PR TITLE
Fix PO counts and lists not updating after status changes

### DIFF
--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -186,6 +186,7 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
     onCompleted: () => {
       showToast('PO cancelled', 'success');
       setConfirmCancelOpen(false);
+      onRefetch();
       onClose();
     },
     onError: (error) => {

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -186,6 +186,7 @@ export default function POModule() {
   const {
     data: statsData,
     loading: statsLoading,
+    refetch: refetchStats,
   } = useQuery<{ poStatistics: POStatistics }>(GET_PO_STATISTICS, {
     variables: { projectId: project?.id },
     skip: !project?.id,
@@ -201,6 +202,7 @@ export default function POModule() {
       status: activeFilter || undefined,
     },
     skip: !project?.id,
+    fetchPolicy: 'cache-and-network',
   });
 
   const stats = statsData?.poStatistics;
@@ -228,6 +230,7 @@ export default function POModule() {
 
   const handleRefetch = () => {
     refetchPOs();
+    refetchStats();
   };
 
   // --- No project selected ---


### PR DESCRIPTION
## Summary

- Refetch `GET_PO_STATISTICS` alongside `GET_PURCHASE_ORDERS` in `handleRefetch` so stat cards update after mark-as-ordered or cancel actions
- Add `fetchPolicy: 'cache-and-network'` to the PO list query so switching tabs always fires a network request, preventing stale cached lists
- Call `onRefetch()` in `CANCEL_PO`'s `onCompleted` callback so the list and counts refresh after cancellation

Closes #22