### PR TITLE
Add data-testid attributes for E2E testing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,7 +58,7 @@ function ModuleSelector() {
         {MODULE_LINKS.map((mod) => (
           <Grid key={mod.path} size={{ xs: 12, sm: 6, md: 4 }}>
             <Card sx={{ height: '100%', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 6 } }}>
-              <CardActionArea onClick={() => navigate(mod.path)} sx={{ height: '100%', p: 2 }}>
+              <CardActionArea data-testid={`module-card-${mod.label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}`} onClick={() => navigate(mod.path)} sx={{ height: '100%', p: 2 }}>
                 <CardContent sx={{ textAlign: 'center' }}>
                   <Box sx={{ color: 'primary.main', mb: 1 }}>{mod.icon}</Box>
                   <Typography variant="h6" gutterBottom>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -104,6 +104,7 @@ export default function AppLayout() {
           <FormControl size="small" sx={{ minWidth: 200, mr: 2 }}>
             <InputLabel sx={{ color: 'inherit' }}>Project</InputLabel>
             <Select
+              data-testid="project-selector"
               value={project?.id ?? ''}
               onChange={handleProjectChange}
               label="Project"
@@ -115,7 +116,7 @@ export default function AppLayout() {
               }}
             >
               {projects.map((p) => (
-                <MenuItem key={p.id} value={p.id}>
+                <MenuItem key={p.id} value={p.id} data-testid={`project-option-${p.id}`}>
                   {p.description || p.projectId}
                 </MenuItem>
               ))}
@@ -123,6 +124,7 @@ export default function AppLayout() {
           </FormControl>
 
           <Button
+            data-testid="reset-data-button"
             variant="outlined"
             color="inherit"
             size="small"
@@ -156,6 +158,7 @@ export default function AppLayout() {
           </IconButton>
 
           <Button
+            data-testid="switch-role-button"
             color="inherit"
             startIcon={<SwapHorizIcon />}
             onClick={handleSwitchRole}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -33,8 +33,8 @@ export default function ConfirmDialog({
         <DialogContentText>{message}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>{cancelLabel}</Button>
-        <Button onClick={onConfirm} variant="contained" autoFocus>
+        <Button data-testid="confirm-dialog-cancel" onClick={onCancel}>{cancelLabel}</Button>
+        <Button data-testid="confirm-dialog-confirm" onClick={onConfirm} variant="contained" autoFocus>
           {confirmLabel}
         </Button>
       </DialogActions>

--- a/frontend/src/pages/RoleSelectionPage.tsx
+++ b/frontend/src/pages/RoleSelectionPage.tsx
@@ -90,7 +90,11 @@ export default function RoleSelectionPage() {
                   </Typography>
                 </CardContent>
                 <CardActions sx={{ justifyContent: 'center', pb: 2 }}>
-                  <Button variant="contained" onClick={() => handleSelect(role)}>
+                  <Button
+                    data-testid={`role-card-${role.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}`}
+                    variant="contained"
+                    onClick={() => handleSelect(role)}
+                  >
                     Enter
                   </Button>
                 </CardActions>


### PR DESCRIPTION
## Summary

- Add `data-testid` attributes to UI elements that are ambiguous or hard to target by text (duplicate "Enter" buttons on role cards, portal-mounted dropdowns, toolbar actions)
- 4 files changed, ~20 test IDs total — purely additive HTML attributes with no behavior changes
- Enables Chrome DevTools MCP-based ad-hoc testing against the Railway deployment