### PR TITLE
Close PO detail modal after marking as ordered

### DIFF
--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -159,6 +159,7 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
       showToast('PO marked as ordered', 'success');
       setConfirmOrderOpen(false);
       onRefetch();
+      onClose();
     },
     onError: (error) => {
       setConfirmOrderOpen(false);


### PR DESCRIPTION
## Summary

- **Fix**: After clicking "Mark as Ordered", the PO detail modal stayed open because `selectedPO` held stale state with `status: DRAFT`, keeping the button visible
- **Change**: Call `onClose()` after `onRefetch()` in the `markPoAsOrdered` success callback, matching the existing `cancelPo` pattern

Fixes #22