### PR TITLE
Multi-select POs and search in Receiving Wizard

### DIFF
--- a/frontend/src/modules/warehouse/ReceiveWizard.tsx
+++ b/frontend/src/modules/warehouse/ReceiveWizard.tsx
@@ -15,12 +15,15 @@ import {
   CircularProgress,
   Divider,
   Paper,
+  InputAdornment,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import SearchIcon from '@mui/icons-material/Search';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
-import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { useApolloClient } from '@apollo/client/react';
 import { useProject } from '../../contexts/ProjectContext';
 import { useRole } from '../../contexts/RoleContext';
 import { useToast } from '../../components/Toast';
@@ -103,21 +106,26 @@ interface ReceiveWizardProps {
   onClose: () => void;
 }
 
-const STEPS = ['Select PO', 'Enter Quantities', 'Assign Locations'];
+const STEPS = ['Select POs', 'Enter Quantities', 'Assign Locations'];
 
 export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
   const { project } = useProject();
   const { role } = useRole();
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const client = useApolloClient();
 
   const [activeStep, setActiveStep] = useState(0);
-  const [selectedPOId, setSelectedPOId] = useState<string | null>(null);
+  const [selectedPOIds, setSelectedPOIds] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
   const [receiveQuantities, setReceiveQuantities] = useState<Record<string, number>>({});
   const [locationAssignments, setLocationAssignments] = useState<LocationAssignment[]>([]);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [postSuccessOpen, setPostSuccessOpen] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [poDetailsMap, setPoDetailsMap] = useState<Record<string, PODetails>>({});
+  const [poDetailsLoading, setPoDetailsLoading] = useState(false);
+  const [poDetailsError, setPoDetailsError] = useState<string | null>(null);
 
   // Step 1: Open POs
   const {
@@ -130,31 +138,29 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
     skip: !project || !open,
   });
 
-  // Step 2: PO Details (lazy)
-  const [
-    fetchPODetails,
-    { data: poDetailsData, loading: poDetailsLoading, error: poDetailsError },
-  ] = useLazyQuery<{ poReceivingDetails: PODetails }>(GET_PO_RECEIVING_DETAILS, {
-    fetchPolicy: 'network-only',
-  });
-
   // Mutation
   const [createReceive, { loading: submitLoading }] = useMutation(CREATE_RECEIVE);
 
   // ---- Derived Data ----
 
   const openPOs = openPOsData?.openPOs ?? [];
-  const poDetails = poDetailsData?.poReceivingDetails ?? null;
 
-  // Line items with pending > 0 and receive now > 0
+  // All line items across all selected POs that have pending > 0 and receive now > 0
   const lineItemsToReceive = useMemo(() => {
-    if (!poDetails) return [];
-    return poDetails.lineItems.filter((li) => {
-      const pending = li.orderedQuantity - li.receivedQuantity;
-      const receiveNow = receiveQuantities[li.id] ?? 0;
-      return pending > 0 && receiveNow > 0;
-    });
-  }, [poDetails, receiveQuantities]);
+    const items: PODetailLineItem[] = [];
+    for (const poId of selectedPOIds) {
+      const details = poDetailsMap[poId];
+      if (!details) continue;
+      for (const li of details.lineItems) {
+        const pending = li.orderedQuantity - li.receivedQuantity;
+        const receiveNow = receiveQuantities[li.id] ?? 0;
+        if (pending > 0 && receiveNow > 0) {
+          items.push(li);
+        }
+      }
+    }
+    return items;
+  }, [selectedPOIds, poDetailsMap, receiveQuantities]);
 
   const totalItemsToReceive = useMemo(
     () => lineItemsToReceive.reduce((sum, li) => sum + (receiveQuantities[li.id] ?? 0), 0),
@@ -198,6 +204,15 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
       })),
     [openPOs],
   );
+
+  const filteredPoRows = useMemo(() => {
+    if (!searchQuery.trim()) return poRows;
+    const q = searchQuery.toLowerCase();
+    return poRows.filter(
+      (row) =>
+        row.poNumber.toLowerCase().includes(q) || row.vendorName.toLowerCase().includes(q),
+    );
+  }, [poRows, searchQuery]);
 
   // ---- Step 2: Quantity Entry Columns ----
 
@@ -255,29 +270,20 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
     [receiveQuantities],
   );
 
-  const quantityRows = useMemo(() => {
-    if (!poDetails) return [];
-    return poDetails.lineItems.map((li) => ({
-      id: li.id,
-      productCode: li.productCode,
-      vendorAlias: li.vendorAlias,
-      hardwareCategory: li.hardwareCategory,
-      orderedQuantity: li.orderedQuantity,
-      receivedQuantity: li.receivedQuantity,
-      pending: li.orderedQuantity - li.receivedQuantity,
-    }));
-  }, [poDetails]);
-
   // ---- Step 2 Validation ----
 
   const hasQuantityErrors = useMemo(() => {
-    if (!poDetails) return false;
-    return poDetails.lineItems.some((li) => {
-      const pending = li.orderedQuantity - li.receivedQuantity;
-      const receiveNow = receiveQuantities[li.id] ?? 0;
-      return receiveNow > pending;
-    });
-  }, [poDetails, receiveQuantities]);
+    for (const poId of selectedPOIds) {
+      const details = poDetailsMap[poId];
+      if (!details) continue;
+      for (const li of details.lineItems) {
+        const pending = li.orderedQuantity - li.receivedQuantity;
+        const receiveNow = receiveQuantities[li.id] ?? 0;
+        if (receiveNow > pending) return true;
+      }
+    }
+    return false;
+  }, [selectedPOIds, poDetailsMap, receiveQuantities]);
 
   const hasAnyReceiveQuantity = useMemo(
     () => Object.values(receiveQuantities).some((v) => v > 0),
@@ -306,9 +312,39 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
 
   // ---- Handlers ----
 
+  const fetchAllPODetails = useCallback(
+    async (poIds: string[]) => {
+      setPoDetailsLoading(true);
+      setPoDetailsError(null);
+      try {
+        const results = await Promise.all(
+          poIds.map((poId) =>
+            client.query<{ poReceivingDetails: PODetails }>({
+              query: GET_PO_RECEIVING_DETAILS,
+              variables: { poId },
+              fetchPolicy: 'network-only',
+            }),
+          ),
+        );
+        const map: Record<string, PODetails> = {};
+        for (const result of results) {
+          const details = result.data?.poReceivingDetails;
+          if (details) map[details.id] = details;
+        }
+        setPoDetailsMap(map);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to load PO details';
+        setPoDetailsError(message);
+      } finally {
+        setPoDetailsLoading(false);
+      }
+    },
+    [client],
+  );
+
   const handleNext = useCallback(() => {
-    if (activeStep === 0 && selectedPOId) {
-      fetchPODetails({ variables: { poId: selectedPOId } });
+    if (activeStep === 0 && selectedPOIds.length > 0) {
+      fetchAllPODetails(selectedPOIds);
       setReceiveQuantities({});
       setActiveStep(1);
     } else if (activeStep === 1) {
@@ -320,7 +356,7 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
       setLocationAssignments(newAssignments);
       setActiveStep(2);
     }
-  }, [activeStep, selectedPOId, fetchPODetails, lineItemsToReceive, receiveQuantities]);
+  }, [activeStep, selectedPOIds, fetchAllPODetails, lineItemsToReceive, receiveQuantities]);
 
   const handleBack = useCallback(() => {
     if (activeStep === 1) {
@@ -371,37 +407,47 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
     setConfirmOpen(false);
     setMutationError(null);
 
-    const input = {
-      poId: selectedPOId,
-      receivedBy: role ?? 'Unknown',
-      lineItems: lineItemsToReceive.map((li) => {
-        const assignment = locationAssignments.find((a) => a.lineItemId === li.id);
-        return {
-          poLineItemId: li.id,
-          quantityReceived: receiveQuantities[li.id] ?? 0,
-          locations: (assignment?.locations ?? []).map((loc) => ({
-            aisle: loc.aisle,
-            bay: loc.bay,
-            bin: loc.bin,
-            quantity: loc.quantity,
-          })),
-        };
-      }),
-    };
+    // Submit one createReceive per PO, sequentially
+    for (const poId of selectedPOIds) {
+      const poLineItems = lineItemsToReceive.filter((li) => li.poId === poId);
+      if (poLineItems.length === 0) continue;
 
-    try {
-      await createReceive({ variables: { input } });
-      showToast(
-        `Receive completed successfully. ${totalItemsToReceive} items added to inventory.`,
-        'success',
-      );
-      setPostSuccessOpen(true);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An unknown error occurred';
-      setMutationError(message);
+      const input = {
+        poId,
+        receivedBy: role ?? 'Unknown',
+        lineItems: poLineItems.map((li) => {
+          const assignment = locationAssignments.find((a) => a.lineItemId === li.id);
+          return {
+            poLineItemId: li.id,
+            quantityReceived: receiveQuantities[li.id] ?? 0,
+            locations: (assignment?.locations ?? []).map((loc) => ({
+              aisle: loc.aisle,
+              bay: loc.bay,
+              bin: loc.bin,
+              quantity: loc.quantity,
+            })),
+          };
+        }),
+      };
+
+      try {
+        await createReceive({ variables: { input } });
+      } catch (err: unknown) {
+        const poDetails = poDetailsMap[poId];
+        const poLabel = poDetails ? poDetails.poNumber : poId;
+        const message = err instanceof Error ? err.message : 'An unknown error occurred';
+        setMutationError(`Error receiving ${poLabel}: ${message}`);
+        return; // Stop on first error
+      }
     }
+
+    showToast(
+      `Receive completed successfully. ${totalItemsToReceive} items added to inventory.`,
+      'success',
+    );
+    setPostSuccessOpen(true);
   }, [
-    selectedPOId,
+    selectedPOIds,
     role,
     lineItemsToReceive,
     locationAssignments,
@@ -409,26 +455,20 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
     createReceive,
     showToast,
     totalItemsToReceive,
+    poDetailsMap,
   ]);
 
   const handlePostAction = useCallback(
-    (action: 'same-po' | 'another-po' | 'inventory' | 'home') => {
+    (action: 'another-po' | 'inventory' | 'home') => {
       setPostSuccessOpen(false);
       setMutationError(null);
 
-      if (action === 'same-po') {
-        // Refetch this PO's details and go to step 2
+      if (action === 'another-po') {
+        setSelectedPOIds([]);
+        setSearchQuery('');
         setReceiveQuantities({});
         setLocationAssignments([]);
-        if (selectedPOId) {
-          fetchPODetails({ variables: { poId: selectedPOId } });
-        }
-        setActiveStep(1);
-      } else if (action === 'another-po') {
-        // Reset and go to step 1
-        setSelectedPOId(null);
-        setReceiveQuantities({});
-        setLocationAssignments([]);
+        setPoDetailsMap({});
         refetchOpenPOs();
         setActiveStep(0);
       } else if (action === 'inventory') {
@@ -438,19 +478,176 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
         onClose();
       }
     },
-    [selectedPOId, fetchPODetails, refetchOpenPOs, onClose, navigate],
+    [refetchOpenPOs, onClose, navigate],
   );
 
   const handleClose = useCallback(() => {
     setActiveStep(0);
-    setSelectedPOId(null);
+    setSelectedPOIds([]);
+    setSearchQuery('');
     setReceiveQuantities({});
     setLocationAssignments([]);
+    setPoDetailsMap({});
+    setPoDetailsError(null);
     setMutationError(null);
     setPostSuccessOpen(false);
     setConfirmOpen(false);
     onClose();
   }, [onClose]);
+
+  // ---- Render Helpers ----
+
+  const renderQuantitySection = (poId: string) => {
+    const details = poDetailsMap[poId];
+    if (!details) return null;
+    const rows = details.lineItems.map((li) => ({
+      id: li.id,
+      productCode: li.productCode,
+      vendorAlias: li.vendorAlias,
+      hardwareCategory: li.hardwareCategory,
+      orderedQuantity: li.orderedQuantity,
+      receivedQuantity: li.receivedQuantity,
+      pending: li.orderedQuantity - li.receivedQuantity,
+    }));
+    return (
+      <Paper key={poId} variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+          {details.poNumber}
+          {details.vendorName ? ` — ${details.vendorName}` : ''}
+        </Typography>
+        <Box sx={{ height: 300, width: '100%' }}>
+          <DataGrid
+            rows={rows}
+            columns={quantityColumns}
+            pageSizeOptions={[5, 10, 25]}
+            initialState={{
+              pagination: { paginationModel: { pageSize: 10 } },
+            }}
+            disableRowSelectionOnClick
+            density="compact"
+            getRowClassName={(params) =>
+              (params.row.pending as number) === 0 ? 'row-fully-received' : ''
+            }
+            sx={{
+              '& .row-fully-received': {
+                bgcolor: 'action.disabledBackground',
+                color: 'text.disabled',
+              },
+            }}
+          />
+        </Box>
+      </Paper>
+    );
+  };
+
+  const renderLocationSection = (poId: string) => {
+    const details = poDetailsMap[poId];
+    if (!details) return null;
+    const poLineItems = lineItemsToReceive.filter((li) => li.poId === poId);
+    if (poLineItems.length === 0) return null;
+
+    return (
+      <Paper key={poId} variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2 }}>
+          {details.poNumber}
+          {details.vendorName ? ` — ${details.vendorName}` : ''}
+        </Typography>
+
+        {poLineItems.map((li) => {
+          const assignment = locationAssignments.find((a) => a.lineItemId === li.id);
+          const locations = assignment?.locations ?? [];
+          const receiveNow = receiveQuantities[li.id] ?? 0;
+          const totalAssigned = locations.reduce((sum, loc) => sum + (loc.quantity || 0), 0);
+          const isComplete = totalAssigned === receiveNow;
+
+          return (
+            <Box key={li.id} sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                {li.productCode} - {li.hardwareCategory} (Receive Now: {receiveNow})
+              </Typography>
+              <Typography
+                variant="body2"
+                color={isComplete ? 'success.main' : 'error.main'}
+                sx={{ mb: 1 }}
+              >
+                {totalAssigned} of {receiveNow} assigned
+              </Typography>
+
+              {locations.map((loc, locIndex) => (
+                <Box
+                  key={locIndex}
+                  sx={{ display: 'flex', gap: 1, mb: 1, alignItems: 'center' }}
+                >
+                  <TextField
+                    label="Aisle"
+                    size="small"
+                    value={loc.aisle}
+                    onChange={(e) =>
+                      handleLocationChange(li.id, locIndex, 'aisle', e.target.value)
+                    }
+                    sx={{ flex: 1 }}
+                  />
+                  <TextField
+                    label="Bay"
+                    size="small"
+                    value={loc.bay}
+                    onChange={(e) =>
+                      handleLocationChange(li.id, locIndex, 'bay', e.target.value)
+                    }
+                    sx={{ flex: 1 }}
+                  />
+                  <TextField
+                    label="Bin"
+                    size="small"
+                    value={loc.bin}
+                    onChange={(e) =>
+                      handleLocationChange(li.id, locIndex, 'bin', e.target.value)
+                    }
+                    sx={{ flex: 1 }}
+                  />
+                  <TextField
+                    label="Quantity"
+                    size="small"
+                    type="number"
+                    value={loc.quantity}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value, 10);
+                      handleLocationChange(
+                        li.id,
+                        locIndex,
+                        'quantity',
+                        isNaN(val) ? 0 : val,
+                      );
+                    }}
+                    slotProps={{ htmlInput: { min: 1 } }}
+                    sx={{ flex: 0.7 }}
+                  />
+                  {locations.length > 1 && (
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => handleRemoveLocation(li.id, locIndex)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </Box>
+              ))}
+
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => handleAddLocation(li.id)}
+              >
+                Add Location
+              </Button>
+              <Divider sx={{ mt: 1 }} />
+            </Box>
+          );
+        })}
+      </Paper>
+    );
+  };
 
   // ---- Render ----
 
@@ -477,12 +674,29 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
             ))}
           </Stepper>
 
-          {/* Step 1: Select PO */}
+          {/* Step 1: Select POs */}
           {activeStep === 0 && (
             <Box>
               <Typography variant="h6" sx={{ mb: 2 }}>
-                Select a Purchase Order
+                Select Purchase Orders
               </Typography>
+              <TextField
+                fullWidth
+                size="small"
+                placeholder="Search by PO number or vendor..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                sx={{ mb: 2 }}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
               {openPOsLoading && (
                 <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
                   <CircularProgress />
@@ -499,14 +713,17 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
               {!openPOsLoading && !openPOsError && poRows.length > 0 && (
                 <Box sx={{ height: 400, width: '100%' }}>
                   <DataGrid
-                    rows={poRows}
+                    rows={filteredPoRows}
                     columns={poColumns}
                     pageSizeOptions={[5, 10, 25]}
                     initialState={{
                       pagination: { paginationModel: { pageSize: 10 } },
                     }}
-                    rowSelectionModel={{ type: 'include' as const, ids: new Set(selectedPOId ? [selectedPOId] : []) }}
-                    onRowClick={(params) => setSelectedPOId(params.id as string)}
+                    checkboxSelection
+                    rowSelectionModel={{ type: 'include' as const, ids: new Set(selectedPOIds) }}
+                    onRowSelectionModelChange={(newModel) =>
+                      setSelectedPOIds(Array.from(newModel.ids) as string[])
+                    }
                     density="compact"
                   />
                 </Box>
@@ -514,7 +731,7 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
               <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                 <Button
                   variant="contained"
-                  disabled={!selectedPOId}
+                  disabled={selectedPOIds.length === 0}
                   onClick={handleNext}
                 >
                   Next
@@ -526,48 +743,20 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
           {/* Step 2: Enter Quantities */}
           {activeStep === 1 && (
             <Box>
-              <Typography variant="h6" sx={{ mb: 1 }}>
+              <Typography variant="h6" sx={{ mb: 2 }}>
                 Enter Receive Quantities
               </Typography>
-              {poDetails && (
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                  PO: {poDetails.poNumber}
-                  {poDetails.vendorName ? ` | Vendor: ${poDetails.vendorName}` : ''}
-                </Typography>
-              )}
               {poDetailsLoading && (
                 <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
                   <CircularProgress />
                 </Box>
               )}
               {poDetailsError && (
-                <Alert severity="error">
-                  Error loading PO details: {poDetailsError.message}
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  Error loading PO details: {poDetailsError}
                 </Alert>
               )}
-              {!poDetailsLoading && !poDetailsError && quantityRows.length > 0 && (
-                <Box sx={{ height: 400, width: '100%' }}>
-                  <DataGrid
-                    rows={quantityRows}
-                    columns={quantityColumns}
-                    pageSizeOptions={[5, 10, 25]}
-                    initialState={{
-                      pagination: { paginationModel: { pageSize: 10 } },
-                    }}
-                    disableRowSelectionOnClick
-                    density="compact"
-                    getRowClassName={(params) =>
-                      (params.row.pending as number) === 0 ? 'row-fully-received' : ''
-                    }
-                    sx={{
-                      '& .row-fully-received': {
-                        bgcolor: 'action.disabledBackground',
-                        color: 'text.disabled',
-                      },
-                    }}
-                  />
-                </Box>
-              )}
+              {!poDetailsLoading && !poDetailsError && selectedPOIds.map(renderQuantitySection)}
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
                 <Button onClick={handleBack}>Back</Button>
                 <Button
@@ -588,98 +777,7 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
                 Assign Warehouse Locations
               </Typography>
 
-              {lineItemsToReceive.map((li) => {
-                const assignment = locationAssignments.find((a) => a.lineItemId === li.id);
-                const locations = assignment?.locations ?? [];
-                const receiveNow = receiveQuantities[li.id] ?? 0;
-                const totalAssigned = locations.reduce((sum, loc) => sum + (loc.quantity || 0), 0);
-                const isComplete = totalAssigned === receiveNow;
-
-                return (
-                  <Paper key={li.id} variant="outlined" sx={{ p: 2, mb: 2 }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-                      {li.productCode} - {li.hardwareCategory} (Receive Now: {receiveNow})
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      color={isComplete ? 'success.main' : 'error.main'}
-                      sx={{ mb: 1 }}
-                    >
-                      {totalAssigned} of {receiveNow} assigned
-                    </Typography>
-
-                    {locations.map((loc, locIndex) => (
-                      <Box
-                        key={locIndex}
-                        sx={{ display: 'flex', gap: 1, mb: 1, alignItems: 'center' }}
-                      >
-                        <TextField
-                          label="Aisle"
-                          size="small"
-                          value={loc.aisle}
-                          onChange={(e) =>
-                            handleLocationChange(li.id, locIndex, 'aisle', e.target.value)
-                          }
-                          sx={{ flex: 1 }}
-                        />
-                        <TextField
-                          label="Bay"
-                          size="small"
-                          value={loc.bay}
-                          onChange={(e) =>
-                            handleLocationChange(li.id, locIndex, 'bay', e.target.value)
-                          }
-                          sx={{ flex: 1 }}
-                        />
-                        <TextField
-                          label="Bin"
-                          size="small"
-                          value={loc.bin}
-                          onChange={(e) =>
-                            handleLocationChange(li.id, locIndex, 'bin', e.target.value)
-                          }
-                          sx={{ flex: 1 }}
-                        />
-                        <TextField
-                          label="Quantity"
-                          size="small"
-                          type="number"
-                          value={loc.quantity}
-                          onChange={(e) => {
-                            const val = parseInt(e.target.value, 10);
-                            handleLocationChange(
-                              li.id,
-                              locIndex,
-                              'quantity',
-                              isNaN(val) ? 0 : val,
-                            );
-                          }}
-                          slotProps={{ htmlInput: { min: 1 } }}
-                          sx={{ flex: 0.7 }}
-                        />
-                        {locations.length > 1 && (
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => handleRemoveLocation(li.id, locIndex)}
-                          >
-                            <DeleteIcon fontSize="small" />
-                          </IconButton>
-                        )}
-                      </Box>
-                    ))}
-
-                    <Button
-                      size="small"
-                      startIcon={<AddIcon />}
-                      onClick={() => handleAddLocation(li.id)}
-                    >
-                      Add Location
-                    </Button>
-                    <Divider sx={{ mt: 1 }} />
-                  </Paper>
-                );
-              })}
+              {selectedPOIds.map(renderLocationSection)}
 
               {mutationError && (
                 <Alert severity="error" sx={{ mb: 2 }}>
@@ -706,7 +804,7 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
       <ConfirmDialog
         open={confirmOpen}
         title="Confirm Receive"
-        message={`Receive ${totalItemsToReceive} items into inventory?`}
+        message={`Receive ${totalItemsToReceive} items across ${selectedPOIds.length} PO${selectedPOIds.length > 1 ? 's' : ''} into inventory?`}
         confirmLabel="Receive"
         onConfirm={handleSubmit}
         onCancel={() => setConfirmOpen(false)}
@@ -722,9 +820,6 @@ export default function ReceiveWizard({ open, onClose }: ReceiveWizardProps) {
             What would you like to do next?
           </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <Button variant="outlined" onClick={() => handlePostAction('same-po')}>
-              Receive More from This PO
-            </Button>
             <Button variant="outlined" onClick={() => handlePostAction('another-po')}>
               Receive from Another PO
             </Button>


### PR DESCRIPTION
## Summary
- Replaces single PO selection with checkbox multi-select in the Receiving Wizard
- Adds a search bar to filter POs by number or vendor name (case-insensitive)
- Steps 2 (quantity entry) and 3 (location assignment) now render per-PO sections with headers
- Submits one `createReceive` mutation per selected PO sequentially, stopping on first error
- Removes the "Receive More from This PO" post-success option (not applicable for multi-PO flow)

Closes #23