### PR TITLE
Add procurement status to Select Openings step (SAR)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -40,7 +40,7 @@ import {
 } from '../../graphql/queries';
 import { FINALIZE_IMPORT_SESSION } from '../../graphql/mutations';
 import type { ClassificationRow } from './ClassificationGrid';
-import type { AggregatedHardwareItem, ImportPurpose, ShippingPRDraft } from './types';
+import type { AggregatedHardwareItem, ImportPurpose, OpeningProcurementStatus, ShippingPRDraft } from './types';
 import { aggregationKey, classificationKey } from './types';
 import SelectOpeningsStep from './SelectOpeningsStep';
 import ClassificationStep from './ClassificationStep';
@@ -179,6 +179,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     reconcileSchedule: ReconciliationRow[];
   }>(RECONCILE_SCHEDULE);
 
+  const [previewReconcile, { data: previewReconcileData, loading: previewReconcileLoading }] = useLazyQuery<{
+    reconcileSchedule: ReconciliationRow[];
+  }>(RECONCILE_SCHEDULE);
+
   const [finalizeImport] = useMutation<{
     finalizeImportSession: {
       project: { id: string; projectId: string; description: string | null; jobSiteName: string | null };
@@ -230,6 +234,30 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     const raw = reconcileData?.reconcileSchedule ?? [];
     return raw.map((r, i) => ({ ...r, id: `recon-${i}` }));
   }, [reconcileData]);
+
+  // Aggregate preview reconcile data into per-opening procurement status
+  const openingStatusMap = useMemo<Map<string, OpeningProcurementStatus> | undefined>(() => {
+    const rows = previewReconcileData?.reconcileSchedule;
+    if (!rows || rows.length === 0) return undefined;
+
+    const receivedStatuses = new Set(['RECEIVED', 'ASSEMBLING', 'SHIPPING_OUT', 'SHIPPED_OUT']);
+    const orderedStatuses = new Set(['ORDERED', 'PO_DRAFTED']);
+
+    const map = new Map<string, OpeningProcurementStatus>();
+    for (const row of rows) {
+      const existing = map.get(row.openingNumber) ?? { totalItems: 0, received: 0, ordered: 0, notCovered: 0 };
+      existing.totalItems += row.quantity;
+      if (receivedStatuses.has(row.status)) {
+        existing.received += row.quantity;
+      } else if (orderedStatuses.has(row.status)) {
+        existing.ordered += row.quantity;
+      } else if (row.status === 'NOT_COVERED') {
+        existing.notCovered += row.quantity;
+      }
+      map.set(row.openingNumber, existing);
+    }
+    return map;
+  }, [previewReconcileData]);
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
@@ -318,6 +346,28 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       }
     }
 
+    // Fire preview reconcile when leaving purpose step heading to openings (SAR re-import only)
+    if (effectiveStepId === 'purpose' && purpose === 'assembly' && isReimport && existingProjectId) {
+      const itemMap = new Map<string, { openingNumber: string; hardwareCategory: string; productCode: string; quantityNeeded: number }>();
+      for (const hi of hardwareItems) {
+        const key = `${hi.opening_number}|${hi.hardware_category}|${hi.product_code}`;
+        const existing = itemMap.get(key);
+        if (existing) {
+          existing.quantityNeeded += hi.item_quantity;
+        } else {
+          itemMap.set(key, {
+            openingNumber: hi.opening_number,
+            hardwareCategory: hi.hardware_category,
+            productCode: hi.product_code,
+            quantityNeeded: hi.item_quantity,
+          });
+        }
+      }
+      previewReconcile({
+        variables: { projectId: existingProjectId, items: Array.from(itemMap.values()) },
+      });
+    }
+
     if (effectiveStepId === 'openings' && isReimport && existingProjectId) {
       // Aggregate by (opening, category, product) to avoid duplicate entries
       const itemMap = new Map<string, { openingNumber: string; hardwareCategory: string; productCode: string; quantityNeeded: number }>();
@@ -341,7 +391,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     }
 
     setActiveStepId(nextStep.id);
-  }, [effectiveStepId, steps, parsed, checkProject, isReimport, existingProjectId, selectedHardwareItems, reconcileSchedule]);
+  }, [effectiveStepId, steps, parsed, checkProject, isReimport, existingProjectId, selectedHardwareItems, reconcileSchedule, purpose, hardwareItems, previewReconcile]);
 
   const handleBack = useCallback(() => {
     const currentIndex = steps.findIndex((s) => s.id === effectiveStepId);
@@ -866,6 +916,8 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
               canProceed={canProceedStep2}
               onNext={handleNext}
               onBack={handleBack}
+              openingStatusMap={openingStatusMap}
+              statusLoading={previewReconcileLoading}
             />
           )}
 

--- a/frontend/src/modules/import/SelectOpeningsStep.tsx
+++ b/frontend/src/modules/import/SelectOpeningsStep.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useCallback } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, Typography } from '@mui/material';
 import { DataGrid, type GridColDef, type GridRowSelectionModel } from '@mui/x-data-grid';
 import type { ParsedOpening } from '../../types/hardwareSchedule';
+import type { OpeningProcurementStatus } from './types';
 
 // ---- Props ----
 
@@ -13,6 +14,8 @@ interface SelectOpeningsStepProps {
   canProceed: boolean;
   onNext: () => void;
   onBack: () => void;
+  openingStatusMap?: Map<string, OpeningProcurementStatus>;
+  statusLoading?: boolean;
 }
 
 // ---- Row type ----
@@ -20,31 +23,33 @@ interface SelectOpeningsStepProps {
 interface OpeningRow extends ParsedOpening {
   id: string;
   hardwareCount: number;
+  procurementReceived?: number;
+  procurementOrdered?: number;
+  procurementNotCovered?: number;
+  procurementSummary?: string;
 }
 
-// ---- Columns ----
+// ---- Helpers ----
 
-const columns: GridColDef<OpeningRow>[] = [
-  { field: 'opening_number', headerName: 'Opening #', width: 110 },
-  { field: 'building', headerName: 'Building', width: 120 },
-  { field: 'floor', headerName: 'Floor', width: 90 },
-  { field: 'location', headerName: 'Location', width: 120 },
-  { field: 'location_to', headerName: 'Location To', width: 120 },
-  { field: 'location_from', headerName: 'Location From', width: 120 },
-  { field: 'hand', headerName: 'Hand', width: 80 },
-  { field: 'single_pair', headerName: 'Single/Pair', width: 100 },
-  { field: 'width', headerName: 'Width', width: 80 },
-  { field: 'length', headerName: 'Length', width: 80 },
-  { field: 'door_thickness', headerName: 'Door Thickness', width: 120 },
-  { field: 'jamb_thickness', headerName: 'Jamb Thickness', width: 120 },
-  { field: 'door_type', headerName: 'Door Type', width: 110 },
-  { field: 'frame_type', headerName: 'Frame Type', width: 110 },
-  { field: 'interior_exterior', headerName: 'Int/Ext', width: 80 },
-  { field: 'keying', headerName: 'Keying', width: 100 },
-  { field: 'heading_no', headerName: 'Heading #', width: 100 },
-  { field: 'assignment_multiplier', headerName: 'Multiplier', width: 90 },
-  { field: 'hardwareCount', headerName: 'Hardware Items', width: 120, type: 'number' },
-];
+function getProcurementSummary(status: OpeningProcurementStatus): string {
+  if (status.totalItems === 0) return '';
+  if (status.received === status.totalItems) return 'All Received';
+  if (status.notCovered === status.totalItems) return 'Not Ordered';
+  if (status.notCovered === 0) return 'In Progress';
+  return 'Partial';
+}
+
+type ChipColor = 'success' | 'info' | 'warning' | 'error' | 'default';
+
+function getSummaryChipColor(summary: string): ChipColor {
+  switch (summary) {
+    case 'All Received': return 'success';
+    case 'In Progress': return 'info';
+    case 'Partial': return 'warning';
+    case 'Not Ordered': return 'error';
+    default: return 'default';
+  }
+}
 
 // ---- Main Component ----
 
@@ -56,16 +61,83 @@ export default function SelectOpeningsStep({
   canProceed,
   onNext,
   onBack,
+  openingStatusMap,
+  statusLoading,
 }: SelectOpeningsStepProps) {
-  const rows = useMemo<OpeningRow[]>(
-    () =>
-      openings.map((o) => ({
+  const rows = useMemo<OpeningRow[]>(() => {
+    return openings.map((o) => {
+      const row: OpeningRow = {
         ...o,
         id: o.opening_number,
         hardwareCount: hardwareCountByOpening.get(o.opening_number) ?? 0,
-      })),
-    [openings, hardwareCountByOpening],
-  );
+      };
+      if (openingStatusMap) {
+        const status = openingStatusMap.get(o.opening_number);
+        if (status) {
+          row.procurementReceived = status.received;
+          row.procurementOrdered = status.ordered;
+          row.procurementNotCovered = status.notCovered;
+          row.procurementSummary = getProcurementSummary(status);
+        }
+      }
+      return row;
+    });
+  }, [openings, hardwareCountByOpening, openingStatusMap]);
+
+  const columns = useMemo<GridColDef<OpeningRow>[]>(() => {
+    const base: GridColDef<OpeningRow>[] = [
+      { field: 'opening_number', headerName: 'Opening #', width: 110 },
+      { field: 'building', headerName: 'Building', width: 120 },
+      { field: 'floor', headerName: 'Floor', width: 90 },
+      { field: 'location', headerName: 'Location', width: 120 },
+      { field: 'location_to', headerName: 'Location To', width: 120 },
+      { field: 'location_from', headerName: 'Location From', width: 120 },
+      { field: 'hand', headerName: 'Hand', width: 80 },
+      { field: 'single_pair', headerName: 'Single/Pair', width: 100 },
+      { field: 'width', headerName: 'Width', width: 80 },
+      { field: 'length', headerName: 'Length', width: 80 },
+      { field: 'door_thickness', headerName: 'Door Thickness', width: 120 },
+      { field: 'jamb_thickness', headerName: 'Jamb Thickness', width: 120 },
+      { field: 'door_type', headerName: 'Door Type', width: 110 },
+      { field: 'frame_type', headerName: 'Frame Type', width: 110 },
+      { field: 'interior_exterior', headerName: 'Int/Ext', width: 80 },
+      { field: 'keying', headerName: 'Keying', width: 100 },
+      { field: 'heading_no', headerName: 'Heading #', width: 100 },
+      { field: 'assignment_multiplier', headerName: 'Multiplier', width: 90 },
+      { field: 'hardwareCount', headerName: 'Hardware Items', width: 120, type: 'number' },
+    ];
+
+    if (openingStatusMap) {
+      base.push(
+        {
+          field: 'procurementSummary',
+          headerName: 'Procurement',
+          width: 140,
+          renderCell: (params) => {
+            const label = params.value as string | undefined;
+            if (!label) return null;
+            return <Chip size="small" label={label} color={getSummaryChipColor(label)} />;
+          },
+        },
+        { field: 'procurementReceived', headerName: 'Received', width: 90, type: 'number' },
+        { field: 'procurementOrdered', headerName: 'Ordered', width: 90, type: 'number' },
+        {
+          field: 'procurementNotCovered',
+          headerName: 'Not Covered',
+          width: 100,
+          type: 'number',
+          renderCell: (params) => {
+            const val = params.value as number | undefined;
+            if (val == null) return null;
+            if (val > 0) return <Chip size="small" label={val} color="error" />;
+            return val;
+          },
+        },
+      );
+    }
+
+    return base;
+  }, [openingStatusMap]);
 
   const rowSelectionModel = useMemo<GridRowSelectionModel>(
     () => ({ type: 'include' as const, ids: new Set<string>(selectedOpenings) }),
@@ -92,6 +164,12 @@ export default function SelectOpeningsStep({
       <Typography variant="h6" sx={{ mb: 1 }}>
         Select Openings
       </Typography>
+
+      {statusLoading && (
+        <Alert severity="info" sx={{ mb: 1 }}>
+          Loading procurement status...
+        </Alert>
+      )}
 
       {/* Top Controls */}
       <Box sx={{ display: 'flex', gap: 2, mb: 2, alignItems: 'center' }}>

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -8,6 +8,13 @@ export function aggregationKey(hi: { opening_number: string; product_code: strin
 
 export type ImportPurpose = 'po' | 'assembly' | 'shipping';
 
+export interface OpeningProcurementStatus {
+  totalItems: number;
+  received: number;   // RECEIVED + ASSEMBLING + SHIPPING_OUT + SHIPPED_OUT
+  ordered: number;    // ORDERED + PO_DRAFTED
+  notCovered: number; // NOT_COVERED
+}
+
 export interface ShippingPRItem {
   itemType: 'OPENING_ITEM' | 'LOOSE';
   openingNumber: string;


### PR DESCRIPTION
## Summary

- Adds procurement status columns (Procurement, Received, Ordered, Not Covered) to the Select Openings grid when creating a Shop Assembly Request via re-import
- Fires a preview `reconcileSchedule` query when leaving the Purpose step, aggregating ALL hardware items to show status before opening selection
- Non-SAR imports and new projects are unaffected — no extra columns appear

Closes #25