### PR TITLE
Add reconciliation step checkboxes for PO re-imports

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -22,7 +22,6 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useLazyQuery, useMutation } from '@apollo/client/react';
 import { useProject } from '../../contexts/ProjectContext';
 import { useRole } from '../../contexts/RoleContext';
@@ -40,24 +39,16 @@ import {
 } from '../../graphql/queries';
 import { FINALIZE_IMPORT_SESSION } from '../../graphql/mutations';
 import type { ClassificationRow } from './ClassificationGrid';
-import type { AggregatedHardwareItem, ImportPurpose, OpeningProcurementStatus, ShippingPRDraft } from './types';
+import type { AggregatedHardwareItem, ImportPurpose, OpeningProcurementStatus, ReconciliationRow, ShippingPRDraft } from './types';
 import { aggregationKey, classificationKey } from './types';
 import SelectOpeningsStep from './SelectOpeningsStep';
+import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
 import PurchaseOrdersStep from './PurchaseOrdersStep';
 import ShopAssemblyStep from './ShopAssemblyStep';
 import ShippingPRsStep from './ShippingPRsStep';
 
 // ---- Local Types ----
-
-interface ReconciliationRow {
-  id: string;
-  openingNumber: string;
-  hardwareCategory: string;
-  productCode: string;
-  quantity: number;
-  status: string;
-}
 
 type StepId = 'upload' | 'purpose' | 'openings' | 'reconciliation'
   | 'classification' | 'purchase-orders' | 'shop-assembly'
@@ -118,6 +109,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   const [vendorAliases, setVendorAliases] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
+  const [selectedReconItems, setSelectedReconItems] = useState<Set<string>>(new Set());
 
   // Finalize state
   const [finalizeLoading, setFinalizeLoading] = useState(false);
@@ -213,9 +205,15 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     [hardwareItems, selectedOpenings],
   );
 
+  // For PO re-imports, only pass through items the user checked in reconciliation
+  const reconFilteredHardwareItems = useMemo(() => {
+    if (purpose !== 'po' || !isReimport) return selectedHardwareItems;
+    return selectedHardwareItems.filter((hi) => selectedReconItems.has(aggregationKey(hi)));
+  }, [selectedHardwareItems, selectedReconItems, purpose, isReimport]);
+
   const aggregatedHardwareItems = useMemo<AggregatedHardwareItem[]>(() => {
     const map = new Map<string, AggregatedHardwareItem>();
-    for (const hi of selectedHardwareItems) {
+    for (const hi of reconFilteredHardwareItems) {
       const key = aggregationKey(hi);
       const existing = map.get(key);
       if (existing) {
@@ -227,7 +225,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       }
     }
     return Array.from(map.values());
-  }, [selectedHardwareItems]);
+  }, [reconFilteredHardwareItems]);
 
   // Reconciliation rows for DataGrid
   const reconciliationRows = useMemo<ReconciliationRow[]>(() => {
@@ -366,6 +364,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       previewReconcile({
         variables: { projectId: existingProjectId, items: Array.from(itemMap.values()) },
       });
+    }
+
+    if (effectiveStepId === 'openings') {
+      setSelectedReconItems(new Set());
     }
 
     if (effectiveStepId === 'openings' && isReimport && existingProjectId) {
@@ -696,6 +698,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     setClassifications(new Map());
     setSarRequestNumber('');
     setShippingPRDrafts([]);
+    setSelectedReconItems(new Set());
     setFinalizeLoading(false);
     setFinalizeResult(null);
     setConfirmOpen(false);
@@ -710,46 +713,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   const canProceedStep0 = parser.state === 'done';
   const canProceedStep1 = purpose !== null;
   const canProceedStep2 = selectedOpenings.size > 0;
-  const canProceedStep3 = true; // Reconciliation is informational
-
-  // ---- Reconciliation DataGrid columns ----
-
-  const reconColumns: GridColDef[] = useMemo(
-    () => [
-      { field: 'openingNumber', headerName: 'Opening #', flex: 1 },
-      { field: 'productCode', headerName: 'Product Code', flex: 1 },
-      { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
-      { field: 'quantity', headerName: 'Quantity', flex: 0.7, type: 'number' },
-      {
-        field: 'status',
-        headerName: 'Status',
-        flex: 1,
-        renderCell: (params) => {
-          const s = params.value as string;
-          const colorMap: Record<string, 'success' | 'warning' | 'error' | 'info' | 'default'> = {
-            PO_DRAFTED: 'info',
-            ORDERED: 'info',
-            RECEIVED: 'success',
-            ASSEMBLING: 'warning',
-            SHIPPING_OUT: 'warning',
-            SHIPPED_OUT: 'success',
-            NOT_COVERED: 'error',
-          };
-          const labelMap: Record<string, string> = {
-            PO_DRAFTED: 'PO Drafted',
-            ORDERED: 'Ordered',
-            RECEIVED: 'Received',
-            ASSEMBLING: 'Assembling',
-            SHIPPING_OUT: 'Shipping Out',
-            SHIPPED_OUT: 'Shipped Out',
-            NOT_COVERED: 'Not Covered',
-          };
-          return <Chip size="small" label={labelMap[s] ?? s} color={colorMap[s] ?? 'default'} />;
-        },
-      },
-    ],
-    [],
-  );
+  const canProceedStep3 = useMemo(() => {
+    if (purpose === 'po' && isReimport) return selectedReconItems.size > 0;
+    return true;
+  }, [purpose, isReimport, selectedReconItems]);
 
   // ---- Render ----
 
@@ -923,51 +890,18 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
           {/* ============ Step: Reconciliation ============ */}
           {effectiveStepId === 'reconciliation' && (
-            <Box>
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                Reconciliation
-              </Typography>
-
-              {!isReimport && (
-                <Alert severity="info" sx={{ mb: 2 }}>
-                  New project -- all items will be ordered fresh. No existing records to reconcile
-                  against.
-                </Alert>
-              )}
-
-              {isReimport && reconcileLoading && (
-                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress />
-                </Box>
-              )}
-
-              {isReimport && !reconcileLoading && reconciliationRows.length > 0 && (
-                <Box sx={{ height: 500, width: '100%' }}>
-                  <DataGrid
-                    rows={reconciliationRows}
-                    columns={reconColumns}
-                    pageSizeOptions={[10, 25, 50]}
-                    initialState={{
-                      pagination: { paginationModel: { pageSize: 25 } },
-                      sorting: { sortModel: [{ field: 'status', sort: 'asc' }] },
-                    }}
-                    disableRowSelectionOnClick
-                    density="compact"
-                  />
-                </Box>
-              )}
-
-              {isReimport && !reconcileLoading && reconciliationRows.length === 0 && (
-                <Alert severity="info">No existing records found for selected items.</Alert>
-              )}
-
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
-                <Button onClick={handleBack}>Back</Button>
-                <Button variant="contained" disabled={!canProceedStep3} onClick={handleNext}>
-                  Next
-                </Button>
-              </Box>
-            </Box>
+            <ReconciliationStep
+              isReimport={isReimport}
+              isPoPurpose={purpose === 'po'}
+              reconcileLoading={reconcileLoading}
+              reconciliationRows={reconciliationRows}
+              selectedHardwareItems={selectedHardwareItems}
+              selectedReconItems={selectedReconItems}
+              onSelectionChange={setSelectedReconItems}
+              canProceed={canProceedStep3}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
           )}
 
           {/* ============ Step: Classification ============ */}

--- a/frontend/src/modules/import/ReconciliationStep.tsx
+++ b/frontend/src/modules/import/ReconciliationStep.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useCallback } from 'react';
+import { Alert, Box, Button, Chip, CircularProgress, Typography } from '@mui/material';
+import { DataGrid, type GridColDef, type GridRowSelectionModel } from '@mui/x-data-grid';
+import type { ReconciliationRow } from './types';
+import { aggregationKey } from './types';
+import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
+
+// ---- Props ----
+
+interface ReconciliationStepProps {
+  isReimport: boolean;
+  isPoPurpose: boolean;
+  reconcileLoading: boolean;
+  reconciliationRows: ReconciliationRow[];
+  selectedHardwareItems: ParsedHardwareItem[];
+  selectedReconItems: Set<string>;
+  onSelectionChange: (selected: Set<string>) => void;
+  canProceed: boolean;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+// ---- Aggregated row type ----
+
+interface AggregatedReconRow {
+  id: string;
+  openingNumber: string;
+  productCode: string;
+  hardwareCategory: string;
+  quantityNeeded: number;
+  statusBreakdown: Map<string, number>;
+}
+
+// ---- Helpers ----
+
+const STATUS_COLOR_MAP: Record<string, 'success' | 'warning' | 'error' | 'info' | 'default'> = {
+  PO_DRAFTED: 'info',
+  ORDERED: 'info',
+  RECEIVED: 'success',
+  ASSEMBLING: 'warning',
+  SHIPPING_OUT: 'warning',
+  SHIPPED_OUT: 'success',
+  NOT_COVERED: 'error',
+};
+
+const STATUS_LABEL_MAP: Record<string, string> = {
+  PO_DRAFTED: 'PO Drafted',
+  ORDERED: 'Ordered',
+  RECEIVED: 'Received',
+  ASSEMBLING: 'Assembling',
+  SHIPPING_OUT: 'Shipping Out',
+  SHIPPED_OUT: 'Shipped Out',
+  NOT_COVERED: 'Not Covered',
+};
+
+// ---- Component ----
+
+export default function ReconciliationStep({
+  isReimport,
+  isPoPurpose,
+  reconcileLoading,
+  reconciliationRows,
+  selectedHardwareItems,
+  selectedReconItems,
+  onSelectionChange,
+  canProceed,
+  onNext,
+  onBack,
+}: ReconciliationStepProps) {
+  // Compute quantity needed from selected hardware items, keyed by aggregation key
+  const qtyNeededMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const hi of selectedHardwareItems) {
+      const key = aggregationKey(hi);
+      map.set(key, (map.get(key) ?? 0) + hi.item_quantity);
+    }
+    return map;
+  }, [selectedHardwareItems]);
+
+  // Aggregate per-status-bucket reconciliation rows into one row per (opening, product, category)
+  const aggregatedRows = useMemo<AggregatedReconRow[]>(() => {
+    const map = new Map<string, AggregatedReconRow>();
+    for (const row of reconciliationRows) {
+      const key = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
+      const existing = map.get(key);
+      if (existing) {
+        existing.statusBreakdown.set(
+          row.status,
+          (existing.statusBreakdown.get(row.status) ?? 0) + row.quantity,
+        );
+      } else {
+        const breakdown = new Map<string, number>();
+        breakdown.set(row.status, row.quantity);
+        map.set(key, {
+          id: key,
+          openingNumber: row.openingNumber,
+          productCode: row.productCode,
+          hardwareCategory: row.hardwareCategory,
+          quantityNeeded: qtyNeededMap.get(key) ?? 0,
+          statusBreakdown: breakdown,
+        });
+      }
+    }
+    return Array.from(map.values());
+  }, [reconciliationRows, qtyNeededMap]);
+
+  // Columns for aggregated view (PO re-imports with checkboxes, or non-PO read-only)
+  const columns = useMemo<GridColDef[]>(
+    () => [
+      { field: 'openingNumber', headerName: 'Opening #', flex: 1 },
+      { field: 'productCode', headerName: 'Product Code', flex: 1 },
+      { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
+      { field: 'quantityNeeded', headerName: 'Qty Needed', flex: 0.7, type: 'number' },
+      {
+        field: 'statusBreakdown',
+        headerName: 'Status',
+        flex: 1.5,
+        sortable: false,
+        renderCell: (params) => {
+          const breakdown = params.value as Map<string, number>;
+          return (
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center', py: 0.5 }}>
+              {Array.from(breakdown.entries()).map(([status, qty]) => (
+                <Chip
+                  key={status}
+                  size="small"
+                  label={`${STATUS_LABEL_MAP[status] ?? status}: ${qty}`}
+                  color={STATUS_COLOR_MAP[status] ?? 'default'}
+                />
+              ))}
+            </Box>
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  const showCheckboxes = isReimport && isPoPurpose;
+
+  const rowSelectionModel = useMemo<GridRowSelectionModel>(
+    () => ({ type: 'include' as const, ids: new Set<string>(selectedReconItems) }),
+    [selectedReconItems],
+  );
+
+  const handleRowSelectionChange = useCallback(
+    (model: GridRowSelectionModel) => {
+      onSelectionChange(new Set(model.ids as Set<string>));
+    },
+    [onSelectionChange],
+  );
+
+  const handleSelectAll = useCallback(() => {
+    onSelectionChange(new Set(aggregatedRows.map((r) => r.id)));
+  }, [aggregatedRows, onSelectionChange]);
+
+  const handleDeselectAll = useCallback(() => {
+    onSelectionChange(new Set());
+  }, [onSelectionChange]);
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Reconciliation
+      </Typography>
+
+      {!isReimport && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          New project -- all items will be ordered fresh. No existing records to reconcile against.
+        </Alert>
+      )}
+
+      {isReimport && reconcileLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {isReimport && !reconcileLoading && aggregatedRows.length > 0 && (
+        <>
+          {showCheckboxes && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+              <Button size="small" variant="outlined" onClick={handleSelectAll}>
+                Select All
+              </Button>
+              <Button size="small" variant="outlined" onClick={handleDeselectAll}>
+                Deselect All
+              </Button>
+              <Typography variant="body2" color="text.secondary">
+                {selectedReconItems.size} of {aggregatedRows.length} item(s) selected
+              </Typography>
+            </Box>
+          )}
+
+          {showCheckboxes && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              Select the items you want to carry forward to Purchase Order creation.
+              Only checked items will be included.
+            </Alert>
+          )}
+
+          <Box sx={{ height: 500, width: '100%' }}>
+            <DataGrid
+              rows={aggregatedRows}
+              columns={columns}
+              pageSizeOptions={[10, 25, 50]}
+              initialState={{
+                pagination: { paginationModel: { pageSize: 25 } },
+              }}
+              checkboxSelection={showCheckboxes}
+              rowSelectionModel={showCheckboxes ? rowSelectionModel : undefined}
+              onRowSelectionModelChange={showCheckboxes ? handleRowSelectionChange : undefined}
+              disableRowSelectionOnClick
+              density="compact"
+              getRowHeight={() => 'auto'}
+              sx={{
+                '& .MuiDataGrid-cell': { py: 0.5 },
+              }}
+            />
+          </Box>
+        </>
+      )}
+
+      {isReimport && !reconcileLoading && reconciliationRows.length === 0 && (
+        <Alert severity="info">No existing records found for selected items.</Alert>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
+        <Button onClick={onBack}>Back</Button>
+        <Button variant="contained" disabled={!canProceed} onClick={onNext}>
+          Next
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -34,6 +34,15 @@ export function hardwareItemKey(hi: ParsedHardwareItem) {
   return `${hi.opening_number}|${hi.product_code}|${hi.material_id}`;
 }
 
+export interface ReconciliationRow {
+  id: string;
+  openingNumber: string;
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+  status: string;
+}
+
 export function classificationKey(hi: { hardware_category: string; product_code: string; unit_cost: number | null }) {
   return `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
 }


### PR DESCRIPTION
## Summary

- Extract reconciliation step into dedicated `ReconciliationStep.tsx` component
- For PO re-imports: add checkbox selection to reconciliation DataGrid so users explicitly choose which items carry forward to PO creation (default unchecked, Next disabled until at least one selected)
- Aggregate per-status-bucket rows into one row per (opening, product, category) with status chips and a Qty Needed column
- New-import and non-PO re-import flows remain unchanged (informational only, no checkboxes)

Closes #26