### PR TITLE
Add Select Hardware Items step to import wizard (#40)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -43,6 +43,7 @@ import type { AggregatedHardwareItem, ImportPurpose, OpeningProcurementStatus, R
 import { aggregationKey, classificationKey } from './types';
 import SelectOpeningsStep from './SelectOpeningsStep';
 import ReconciliationStep from './ReconciliationStep';
+import SelectHardwareItemsStep from './SelectHardwareItemsStep';
 import ClassificationStep from './ClassificationStep';
 import PurchaseOrdersStep from './PurchaseOrdersStep';
 import ShopAssemblyStep from './ShopAssemblyStep';
@@ -50,7 +51,7 @@ import ShippingPRsStep from './ShippingPRsStep';
 
 // ---- Local Types ----
 
-type StepId = 'upload' | 'purpose' | 'openings' | 'reconciliation'
+type StepId = 'upload' | 'purpose' | 'openings' | 'reconciliation' | 'select-items'
   | 'classification' | 'purchase-orders' | 'shop-assembly'
   | 'shipping-prs' | 'finalize';
 
@@ -110,6 +111,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
   const [selectedReconItems, setSelectedReconItems] = useState<Set<string>>(new Set());
+  const [selectedItemKeys, setSelectedItemKeys] = useState<Set<string>>(new Set());
 
   // Finalize state
   const [finalizeLoading, setFinalizeLoading] = useState(false);
@@ -126,6 +128,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       { id: 'purpose', label: 'Purpose' },
       { id: 'openings', label: 'Select Openings' },
       { id: 'reconciliation', label: 'Reconciliation' },
+      { id: 'select-items', label: 'Select Items' },
     ];
     if (purpose === 'assembly') {
       base.push({ id: 'classification', label: 'Classification' });
@@ -211,7 +214,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     return selectedHardwareItems.filter((hi) => selectedReconItems.has(aggregationKey(hi)));
   }, [selectedHardwareItems, selectedReconItems, purpose, isReimport]);
 
-  const aggregatedHardwareItems = useMemo<AggregatedHardwareItem[]>(() => {
+  const allAggregatedItems = useMemo<AggregatedHardwareItem[]>(() => {
     const map = new Map<string, AggregatedHardwareItem>();
     for (const hi of reconFilteredHardwareItems) {
       const key = aggregationKey(hi);
@@ -226,6 +229,11 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     }
     return Array.from(map.values());
   }, [reconFilteredHardwareItems]);
+
+  const aggregatedHardwareItems = useMemo(
+    () => allAggregatedItems.filter((hi) => selectedItemKeys.has(aggregationKey(hi))),
+    [allAggregatedItems, selectedItemKeys],
+  );
 
   // Reconciliation rows for DataGrid
   const reconciliationRows = useMemo<ReconciliationRow[]>(() => {
@@ -368,6 +376,11 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
     if (effectiveStepId === 'openings') {
       setSelectedReconItems(new Set());
+      setSelectedItemKeys(new Set());
+    }
+
+    if (effectiveStepId === 'reconciliation') {
+      setSelectedItemKeys(new Set());
     }
 
     if (effectiveStepId === 'openings' && isReimport && existingProjectId) {
@@ -524,8 +537,13 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
   const buildFinalizeInput = useCallback(() => {
     if (!parsed) return null;
-    const selectedOpeningsList = parsed.openings.filter((o) => selectedOpenings.has(o.opening_number));
-    const filteredHardwareItems = parsed.hardwareItems.filter((hi) => selectedOpenings.has(hi.opening_number));
+    const openingNumbersFromItems = new Set(aggregatedHardwareItems.map((hi) => hi.opening_number));
+    const selectedOpeningsList = parsed.openings.filter(
+      (o) => selectedOpenings.has(o.opening_number) && openingNumbersFromItems.has(o.opening_number),
+    );
+    const filteredHardwareItems = parsed.hardwareItems.filter(
+      (hi) => selectedOpenings.has(hi.opening_number) && selectedItemKeys.has(aggregationKey(hi)),
+    );
 
     return {
       project: snakeToCamel(parsed.project as unknown as Record<string, unknown>),
@@ -632,7 +650,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             .filter(Boolean)
         : null,
     };
-  }, [parsed, selectedOpenings, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, vendorAliases, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, selectedOpenings, selectedItemKeys, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, vendorAliases, classifications, shippingPRDrafts, sarRequestNumber]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -699,6 +717,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     setSarRequestNumber('');
     setShippingPRDrafts([]);
     setSelectedReconItems(new Set());
+    setSelectedItemKeys(new Set());
     setFinalizeLoading(false);
     setFinalizeResult(null);
     setConfirmOpen(false);
@@ -717,6 +736,8 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     if (purpose === 'po' && isReimport) return selectedReconItems.size > 0;
     return true;
   }, [purpose, isReimport, selectedReconItems]);
+
+  const canProceedSelectItems = selectedItemKeys.size > 0;
 
   // ---- Render ----
 
@@ -899,6 +920,18 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
               selectedReconItems={selectedReconItems}
               onSelectionChange={setSelectedReconItems}
               canProceed={canProceedStep3}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
+          )}
+
+          {/* ============ Step: Select Items ============ */}
+          {effectiveStepId === 'select-items' && (
+            <SelectHardwareItemsStep
+              allAggregatedItems={allAggregatedItems}
+              selectedItemKeys={selectedItemKeys}
+              onSelectionChange={setSelectedItemKeys}
+              canProceed={canProceedSelectItems}
               onNext={handleNext}
               onBack={handleBack}
             />

--- a/frontend/src/modules/import/SelectHardwareItemsStep.tsx
+++ b/frontend/src/modules/import/SelectHardwareItemsStep.tsx
@@ -1,0 +1,172 @@
+import {
+  Box,
+  Typography,
+  Button,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Checkbox,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import type { AggregatedHardwareItem } from './types';
+import { aggregationKey, itemGroupKey } from './types';
+
+interface SelectHardwareItemsStepProps {
+  allAggregatedItems: AggregatedHardwareItem[];
+  selectedItemKeys: Set<string>;
+  onSelectionChange: (selected: Set<string>) => void;
+  canProceed: boolean;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function SelectHardwareItemsStep({
+  allAggregatedItems,
+  selectedItemKeys,
+  onSelectionChange,
+  canProceed,
+  onNext,
+  onBack,
+}: SelectHardwareItemsStepProps) {
+  // Group items by (hardware_category, product_code)
+  const groups = new Map<string, AggregatedHardwareItem[]>();
+  for (const item of allAggregatedItems) {
+    const key = itemGroupKey(item);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(item);
+  }
+  const sortedGroups = Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+  const totalCount = allAggregatedItems.length;
+  const selectedCount = selectedItemKeys.size;
+
+  const handleSelectAll = () => {
+    onSelectionChange(new Set(allAggregatedItems.map((hi) => aggregationKey(hi))));
+  };
+
+  const handleDeselectAll = () => {
+    onSelectionChange(new Set());
+  };
+
+  const toggleItem = (key: string) => {
+    const next = new Set(selectedItemKeys);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    onSelectionChange(next);
+  };
+
+  const toggleGroup = (groupItems: AggregatedHardwareItem[]) => {
+    const groupKeys = groupItems.map((hi) => aggregationKey(hi));
+    const allSelected = groupKeys.every((k) => selectedItemKeys.has(k));
+    const next = new Set(selectedItemKeys);
+    if (allSelected) {
+      for (const k of groupKeys) next.delete(k);
+    } else {
+      for (const k of groupKeys) next.add(k);
+    }
+    onSelectionChange(next);
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6">
+          Select Hardware Items
+          <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+            ({selectedCount} of {totalCount} selected)
+          </Typography>
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button size="small" variant="outlined" onClick={handleSelectAll}>
+            Select All
+          </Button>
+          <Button size="small" variant="outlined" onClick={handleDeselectAll}>
+            Deselect All
+          </Button>
+        </Box>
+      </Box>
+
+      {sortedGroups.map(([groupKey, items]) => {
+        const [category, productCode] = groupKey.split('|');
+        const groupKeys = items.map((hi) => aggregationKey(hi));
+        const selectedInGroup = groupKeys.filter((k) => selectedItemKeys.has(k)).length;
+        const allSelected = selectedInGroup === items.length;
+        const someSelected = selectedInGroup > 0 && !allSelected;
+
+        return (
+          <Accordion key={groupKey} defaultExpanded={false}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                <Checkbox
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={() => toggleGroup(items)}
+                  size="small"
+                />
+                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                  {productCode}
+                </Typography>
+                <Chip label={category} size="small" variant="outlined" />
+                <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto', mr: 2 }}>
+                  {selectedInGroup}/{items.length} items
+                </Typography>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails sx={{ p: 0 }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell padding="checkbox" />
+                    <TableCell>Opening</TableCell>
+                    <TableCell align="right">Qty</TableCell>
+                    <TableCell>Vendor</TableCell>
+                    <TableCell align="right">Unit Cost</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {items.map((hi) => {
+                    const key = aggregationKey(hi);
+                    return (
+                      <TableRow key={key} hover>
+                        <TableCell padding="checkbox">
+                          <Checkbox
+                            checked={selectedItemKeys.has(key)}
+                            onChange={() => toggleItem(key)}
+                            size="small"
+                          />
+                        </TableCell>
+                        <TableCell>{hi.opening_number}</TableCell>
+                        <TableCell align="right">{hi.item_quantity}</TableCell>
+                        <TableCell>{hi.vendor_no ?? '(No Vendor)'}</TableCell>
+                        <TableCell align="right">
+                          {hi.unit_cost != null ? `$${hi.unit_cost.toFixed(2)}` : '\u2014'}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
+        <Button onClick={onBack}>Back</Button>
+        <Button variant="contained" disabled={!canProceed} onClick={onNext}>
+          Next
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -46,3 +46,7 @@ export interface ReconciliationRow {
 export function classificationKey(hi: { hardware_category: string; product_code: string; unit_cost: number | null }) {
   return `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
 }
+
+export function itemGroupKey(hi: { hardware_category: string; product_code: string }) {
+  return `${hi.hardware_category}|${hi.product_code}`;
+}


### PR DESCRIPTION
## Summary

- Adds a new **Select Items** step between Reconciliation and purpose-specific steps in the import wizard, for all three import purposes (PO, Assembly, Shipping)
- Users now cherry-pick individual hardware items (grouped by product code + category in accordions) instead of automatically including all items from selected openings
- Nothing is selected by default — users must explicitly choose items before proceeding
- `buildFinalizeInput` narrowed to only send openings/items that match the user's item selection

Closes #40