### PR TITLE
Add VENDOR_CONFIRMED PO status (#54)

### DIFF
--- a/backend/alembic/versions/016_add_vendor_confirmed_status.py
+++ b/backend/alembic/versions/016_add_vendor_confirmed_status.py
@@ -1,0 +1,26 @@
+"""Add VENDOR_CONFIRMED to po_status enum
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-03-26
+"""
+
+from alembic import op
+
+revision = "016"
+down_revision = "015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE po_status ADD VALUE 'VENDOR_CONFIRMED' AFTER 'ORDERED'")
+
+
+def downgrade() -> None:
+    # PostgreSQL cannot remove enum values directly.
+    # Recreate the type without VENDOR_CONFIRMED and update the column.
+    op.execute("ALTER TYPE po_status RENAME TO po_status_old")
+    op.execute("CREATE TYPE po_status AS ENUM ('DRAFT', 'ORDERED', 'PARTIALLY_RECEIVED', 'CLOSED', 'CANCELLED')")
+    op.execute("ALTER TABLE purchase_orders ALTER COLUMN status TYPE po_status USING status::text::po_status")
+    op.execute("DROP TYPE po_status_old")

--- a/backend/app/graphql/po.graphql
+++ b/backend/app/graphql/po.graphql
@@ -19,6 +19,7 @@ type PurchaseOrder {
 enum POStatus {
   DRAFT
   ORDERED
+  VENDOR_CONFIRMED
   PARTIALLY_RECEIVED
   CLOSED
   CANCELLED
@@ -42,6 +43,7 @@ type POStatistics {
   total: Int!
   draft: Int!
   ordered: Int!
+  vendor_confirmed: Int!
   partially_received: Int!
   closed: Int!
   cancelled: Int!

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -13,6 +13,7 @@ class HardwareItemState(str, enum.Enum):
 class POStatus(str, enum.Enum):
     DRAFT = "DRAFT"
     ORDERED = "ORDERED"
+    VENDOR_CONFIRMED = "VENDOR_CONFIRMED"
     PARTIALLY_RECEIVED = "PARTIALLY_RECEIVED"
     CLOSED = "CLOSED"
     CANCELLED = "CANCELLED"

--- a/backend/app/repositories/admin_repository.py
+++ b/backend/app/repositories/admin_repository.py
@@ -42,7 +42,7 @@ def get_hardware_summary(session: Session, project_id: uuid.UUID | None = None) 
             func.sum(
                 case(
                     (
-                        POModel.status.in_([POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED]),
+                        POModel.status.in_([POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED]),
                         POLineItemModel.ordered_quantity - POLineItemModel.received_quantity,
                     ),
                     else_=0,
@@ -52,7 +52,9 @@ def get_hardware_summary(session: Session, project_id: uuid.UUID | None = None) 
         .join(POModel, POLineItemModel.po_id == POModel.id)
         .where(
             POModel.deleted_at.is_(None),
-            POModel.status.in_([POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED]),
+            POModel.status.in_(
+                [POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED]
+            ),
         )
         .group_by(POLineItemModel.hardware_category, POLineItemModel.product_code)
     )
@@ -143,7 +145,7 @@ def get_opening_hardware_status(session: Session, project_id: uuid.UUID | None =
 
         if po_status == POStatus.DRAFT:
             status = "PO_DRAFTED"
-        elif po_status in (POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED):
+        elif po_status in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED):
             status = "ORDERED"
         elif po_status == POStatus.CLOSED:
             status = "RECEIVED"

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -85,7 +85,7 @@ def reconcile_schedule(
 
             if po_status == POStatus.DRAFT:
                 buckets["PO_DRAFTED"] += hi_qty
-            elif po_status == POStatus.ORDERED:
+            elif po_status in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED):
                 buckets["ORDERED"] += hi_qty
             elif po_status == POStatus.PARTIALLY_RECEIVED:
                 if row.ordered_quantity > 0:

--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -71,6 +71,7 @@ def get_po_statistics(session: Session, project_id: uuid.UUID | None = None) -> 
         "total": 0,
         "draft": 0,
         "ordered": 0,
+        "vendor_confirmed": 0,
         "partially_received": 0,
         "closed": 0,
         "cancelled": 0,
@@ -78,6 +79,7 @@ def get_po_statistics(session: Session, project_id: uuid.UUID | None = None) -> 
     status_key_map = {
         POStatus.DRAFT: "draft",
         POStatus.ORDERED: "ordered",
+        POStatus.VENDOR_CONFIRMED: "vendor_confirmed",
         POStatus.PARTIALLY_RECEIVED: "partially_received",
         POStatus.CLOSED: "closed",
         POStatus.CANCELLED: "cancelled",
@@ -112,7 +114,7 @@ def update_po(
     if po is None:
         raise NotFoundError(f"Purchase order {po_id} not found")
 
-    if po.status not in (POStatus.DRAFT, POStatus.ORDERED):
+    if po.status not in (POStatus.DRAFT, POStatus.ORDERED, POStatus.VENDOR_CONFIRMED):
         raise InvalidStateTransitionError(f"Cannot edit PO in {po.status.value} status")
 
     # Check for existing receive records
@@ -147,6 +149,17 @@ def update_po(
     if vendor_quote_number is not None:
         po.vendor_quote_number = vendor_quote_number if vendor_quote_number.strip() else None
 
+    # Auto-transition: ORDERED → VENDOR_CONFIRMED when both vendor_quote_number and vendor_ack doc exist
+    if po.status == POStatus.ORDERED:
+        has_vendor_ack = any(doc.document_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT for doc in (po.documents or []))
+        if po.vendor_quote_number is not None and has_vendor_ack:
+            po.status = POStatus.VENDOR_CONFIRMED
+    # Auto-revert: VENDOR_CONFIRMED → ORDERED when conditions no longer met
+    elif po.status == POStatus.VENDOR_CONFIRMED:
+        has_vendor_ack = any(doc.document_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT for doc in (po.documents or []))
+        if po.vendor_quote_number is None or not has_vendor_ack:
+            po.status = POStatus.ORDERED
+
     return po
 
 
@@ -156,8 +169,6 @@ def mark_po_as_ordered(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     - Validate status == Draft (InvalidStateTransitionError)
     - Validate po_number is not None (ValidationError)
     - Validate vendor_name is not None (ValidationError)
-    - Validate vendor_quote_number is not None (ValidationError)
-    - Validate at least one VENDOR_ACKNOWLEDGEMENT document exists (ValidationError)
     - Set status=Ordered, ordered_at=datetime.utcnow()
     - Return updated PO
     """
@@ -177,15 +188,6 @@ def mark_po_as_ordered(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
             field="vendor_name",
         )
 
-    if po.vendor_quote_number is None:
-        raise ValidationError("Vendor quote number is required before marking as ordered", field="vendor_quote_number")
-
-    has_vendor_ack = any(doc.document_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT for doc in (po.documents or []))
-    if not has_vendor_ack:
-        raise ValidationError(
-            "Vendor acknowledgement document is required before marking as ordered", field="vendor_acknowledgement"
-        )
-
     po.status = POStatus.ORDERED
     po.ordered_at = datetime.utcnow()
 
@@ -203,7 +205,7 @@ def cancel_po(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     if po is None:
         raise NotFoundError(f"Purchase order {po_id} not found")
 
-    if po.status not in (POStatus.DRAFT, POStatus.ORDERED):
+    if po.status not in (POStatus.DRAFT, POStatus.ORDERED, POStatus.VENDOR_CONFIRMED):
         raise InvalidStateTransitionError(f"Cannot cancel PO in {po.status.value} status")
 
     po.status = POStatus.CANCELLED
@@ -295,6 +297,15 @@ def upload_po_document(
         s3_key=s3_key,
     )
     session.add(doc)
+
+    # Auto-transition: ORDERED → VENDOR_CONFIRMED when uploading vendor ack and quote number exists
+    if (
+        document_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT
+        and po.status == POStatus.ORDERED
+        and po.vendor_quote_number is not None
+    ):
+        po.status = POStatus.VENDOR_CONFIRMED
+
     return doc
 
 
@@ -314,8 +325,24 @@ def delete_po_document(session: Session, document_id: uuid.UUID) -> None:
     if po.status in (POStatus.CANCELLED, POStatus.CLOSED):
         raise InvalidStateTransitionError(f"Cannot delete documents from PO in {po.status.value} status")
 
+    deleted_doc_id = doc.id
+    deleted_doc_po_id = doc.po_id
+    deleted_doc_type = doc.document_type
+
     storage.delete_file(doc.s3_key)
     session.delete(doc)
+
+    # Auto-revert: VENDOR_CONFIRMED → ORDERED when last vendor ack doc is deleted
+    if deleted_doc_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT and po.status == POStatus.VENDOR_CONFIRMED:
+        remaining_ack = session.scalars(
+            select(PODocument).where(
+                PODocument.po_id == deleted_doc_po_id,
+                PODocument.document_type == PODocumentType.VENDOR_ACKNOWLEDGEMENT,
+                PODocument.id != deleted_doc_id,
+            )
+        ).first()
+        if remaining_ack is None:
+            po.status = POStatus.ORDERED
 
 
 def get_po_document(session: Session, document_id: uuid.UUID) -> PODocument:

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -332,9 +332,9 @@ def create_receive(
         raise NotFoundError(f"Purchase order {po_id} not found")
 
     # Validate PO status
-    if po.status not in (POStatus.ORDERED, POStatus.PARTIALLY_RECEIVED):
+    if po.status not in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED):
         raise InvalidStateTransitionError(
-            f"PO status must be Ordered or Partially_Received to receive, got {po.status.value}"
+            f"PO status must be Ordered, Vendor_Confirmed, or Partially_Received to receive, got {po.status.value}"
         )
 
     # 2. Validate received_by

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -432,6 +432,7 @@ class Query:
                 total=stats["total"],
                 draft=stats["draft"],
                 ordered=stats["ordered"],
+                vendor_confirmed=stats["vendor_confirmed"],
                 partially_received=stats["partially_received"],
                 closed=stats["closed"],
                 cancelled=stats["cancelled"],
@@ -452,6 +453,7 @@ class Query:
                     POModel.status.in_(
                         [
                             DBPOStatus.ORDERED,
+                            DBPOStatus.VENDOR_CONFIRMED,
                             DBPOStatus.PARTIALLY_RECEIVED,
                         ]
                     ),

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -334,6 +334,7 @@ class POStatistics:
     total: int
     draft: int
     ordered: int
+    vendor_confirmed: int
     partially_received: int
     closed: int
     cancelled: int

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -17,6 +17,7 @@ export const GET_PO_STATISTICS = gql`
       total
       draft
       ordered
+      vendorConfirmed
       partiallyReceived
       closed
       cancelled

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -46,9 +46,10 @@ import type { PurchaseOrder } from './index';
 
 // --- Status chip colors ---
 
-const STATUS_CHIP_COLOR: Record<string, 'default' | 'primary' | 'warning' | 'success' | 'error'> = {
+const STATUS_CHIP_COLOR: Record<string, 'default' | 'primary' | 'info' | 'warning' | 'success' | 'error'> = {
   DRAFT: 'default',
   ORDERED: 'primary',
+  VENDOR_CONFIRMED: 'info',
   PARTIALLY_RECEIVED: 'warning',
   CLOSED: 'success',
   CANCELLED: 'error',
@@ -420,11 +421,10 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
 
   const canEdit =
     po.status === 'DRAFT' ||
-    (po.status === 'ORDERED' && po.receiveRecords.length === 0);
+    (po.status === 'ORDERED' && po.receiveRecords.length === 0) ||
+    (po.status === 'VENDOR_CONFIRMED' && po.receiveRecords.length === 0);
 
   const canUploadDocs = po.status !== 'CANCELLED' && po.status !== 'CLOSED';
-
-  const hasVendorAck = po.documents.some((d) => d.documentType === 'VENDOR_ACKNOWLEDGEMENT');
 
   const canMarkAsOrdered = po.status === 'DRAFT';
 
@@ -433,14 +433,12 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
     const missing: string[] = [];
     if (!po.poNumber) missing.push('PO Number');
     if (!po.vendorName) missing.push('Vendor Name');
-    if (!po.vendorQuoteNumber) missing.push('Vendor Quote Number');
-    if (!hasVendorAck) missing.push('Vendor Acknowledgement document');
     return missing;
-  }, [po.poNumber, po.vendorName, po.vendorQuoteNumber, hasVendorAck]);
+  }, [po.poNumber, po.vendorName]);
 
   const markAsOrderedEnabled = canMarkAsOrdered && missingRequirements.length === 0;
 
-  const canCancel = po.status === 'DRAFT' || po.status === 'ORDERED';
+  const canCancel = po.status === 'DRAFT' || po.status === 'ORDERED' || po.status === 'VENDOR_CONFIRMED';
 
   const displayTitle = po.poNumber ? `PO: ${po.poNumber}` : `Request: ${po.requestNumber}`;
 

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -88,6 +88,7 @@ interface POStatistics {
   total: number;
   draft: number;
   ordered: number;
+  vendorConfirmed: number;
   partiallyReceived: number;
   closed: number;
   cancelled: number;
@@ -95,11 +96,12 @@ interface POStatistics {
 
 // --- Status config ---
 
-type StatusFilter = '' | 'DRAFT' | 'ORDERED' | 'PARTIALLY_RECEIVED' | 'CLOSED' | 'CANCELLED';
+type StatusFilter = '' | 'DRAFT' | 'ORDERED' | 'VENDOR_CONFIRMED' | 'PARTIALLY_RECEIVED' | 'CLOSED' | 'CANCELLED';
 
-const STATUS_CHIP_COLOR: Record<string, 'default' | 'primary' | 'warning' | 'success' | 'error'> = {
+const STATUS_CHIP_COLOR: Record<string, 'default' | 'primary' | 'info' | 'warning' | 'success' | 'error'> = {
   DRAFT: 'default',
   ORDERED: 'primary',
+  VENDOR_CONFIRMED: 'info',
   PARTIALLY_RECEIVED: 'warning',
   CLOSED: 'success',
   CANCELLED: 'error',
@@ -109,6 +111,7 @@ const TAB_FILTERS: { label: string; value: StatusFilter }[] = [
   { label: 'All', value: '' },
   { label: 'Draft', value: 'DRAFT' },
   { label: 'Ordered', value: 'ORDERED' },
+  { label: 'Vendor Confirmed', value: 'VENDOR_CONFIRMED' },
   { label: 'Partially Received', value: 'PARTIALLY_RECEIVED' },
   { label: 'Closed', value: 'CLOSED' },
   { label: 'Cancelled', value: 'CANCELLED' },
@@ -126,6 +129,7 @@ const STAT_CARDS: StatCard[] = [
   { label: 'Total', filter: '', key: 'total' },
   { label: 'Draft', filter: 'DRAFT', key: 'draft' },
   { label: 'Ordered', filter: 'ORDERED', key: 'ordered' },
+  { label: 'Vendor Confirmed', filter: 'VENDOR_CONFIRMED', key: 'vendorConfirmed' },
   { label: 'Partially Received', filter: 'PARTIALLY_RECEIVED', key: 'partiallyReceived' },
   { label: 'Closed', filter: 'CLOSED', key: 'closed' },
   { label: 'Cancelled', filter: 'CANCELLED', key: 'cancelled' },


### PR DESCRIPTION
## Summary
- Adds a new **Vendor Confirmed** status between Ordered and Partially Received in the PO lifecycle
- Relaxes "Mark as Ordered" requirements — no longer requires vendor quote number or vendor acknowledgement document (only PO number + vendor name)
- Auto-transitions PO to Vendor Confirmed when an Ordered PO gains both a vendor quote number and a vendor acknowledgement document; auto-reverts if those conditions are removed
- Vendor Confirmed is non-blocking — warehouse can receive items directly from Ordered, bypassing Vendor Confirmed

Closes #54