### PR TITLE
Add user-initiated project creation (closes #94)

### DIFF
--- a/backend/alembic/versions/024_add_project_client_and_unique_number.py
+++ b/backend/alembic/versions/024_add_project_client_and_unique_number.py
@@ -1,0 +1,49 @@
+"""Add client column to projects, enforce unique project_id
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-05-01
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "024"
+down_revision = "023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Dev DB only — wipe project-tied data so the unique constraint applies cleanly.
+    # Order respects FK dependencies (children before parents).
+    op.execute("DELETE FROM inventory_audit_log")
+    op.execute("DELETE FROM project_excluded_items")
+    op.execute("DELETE FROM notifications")
+    op.execute("DELETE FROM opening_item_hardware")
+    op.execute("DELETE FROM shop_assembly_opening_items")
+    op.execute("DELETE FROM po_documents")
+    op.execute("DELETE FROM packing_slip_items")
+    op.execute("DELETE FROM pull_request_items")
+    op.execute("DELETE FROM inventory_locations")
+    op.execute("DELETE FROM shop_assembly_openings")
+    op.execute("DELETE FROM shop_assembly_requests")
+    op.execute("DELETE FROM packing_slips")
+    op.execute("DELETE FROM pull_requests")
+    op.execute("DELETE FROM opening_items")
+    op.execute("DELETE FROM hardware_items")
+    op.execute("DELETE FROM receive_line_items")
+    op.execute("DELETE FROM receive_records")
+    op.execute("DELETE FROM po_line_items")
+    op.execute("DELETE FROM purchase_orders")
+    op.execute("DELETE FROM openings")
+    op.execute("DELETE FROM projects")
+
+    op.add_column("projects", sa.Column("client", sa.String(), nullable=True))
+    op.create_unique_constraint("uq_projects_project_id", "projects", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_projects_project_id", "projects", type_="unique")
+    op.drop_column("projects", "client")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -11,8 +11,9 @@ class Project(Base):
     __tablename__ = "projects"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    project_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    project_id: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
     description: Mapped[str | None] = mapped_column(String, nullable=True)
+    client: Mapped[str | None] = mapped_column(String, nullable=True)
     job_site_name: Mapped[str | None] = mapped_column(String, nullable=True)
     address: Mapped[str | None] = mapped_column(String, nullable=True)
     city: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, Index, Integer, String
+from sqlalchemy import ForeignKey, Index, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -9,9 +9,10 @@ from . import Base
 
 class Project(Base):
     __tablename__ = "projects"
+    __table_args__ = (UniqueConstraint("project_id", name="uq_projects_project_id"),)
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    project_id: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    project_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     description: Mapped[str | None] = mapped_column(String, nullable=True)
     client: Mapped[str | None] = mapped_column(String, nullable=True)
     job_site_name: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -259,8 +259,8 @@ def finalize_import_session(
     session: Session,
     input_data: dict,
 ) -> dict:
-    """Finalize an import session: create project, POs, PRs, and SAR atomically."""
-    project_input = input_data["project"]
+    """Finalize an import session: attach openings/POs/PRs/SAR to an existing project atomically."""
+    project_id = uuid.UUID(input_data["project_id"])
     openings_input = input_data.get("openings", [])
     hardware_items_input = input_data.get("hardware_items") or []
     po_drafts = input_data.get("po_drafts") or []
@@ -271,37 +271,19 @@ def finalize_import_session(
     sar_request_number = input_data.get("shop_assembly_request_number")
     sar_openings_input = input_data.get("shop_assembly_openings") or []
 
-    # 1. Project lookup/create
+    # 1. Project lookup (must already exist)
     project_stmt = (
-        select(ProjectModel)
-        .options(selectinload(ProjectModel.openings))
-        .where(ProjectModel.project_id == project_input["project_id"])
+        select(ProjectModel).options(selectinload(ProjectModel.openings)).where(ProjectModel.id == project_id)
     )
     project = session.scalars(project_stmt).unique().first()
 
     if project is None:
-        # First import — create project + openings
-        project = ProjectModel(
-            id=uuid.uuid4(),
-            project_id=project_input["project_id"],
-            description=project_input.get("description"),
-            job_site_name=project_input.get("job_site_name"),
-            address=project_input.get("address"),
-            city=project_input.get("city"),
-            state=project_input.get("state"),
-            zip=project_input.get("zip"),
-            contractor=project_input.get("contractor"),
-            project_manager=project_input.get("project_manager"),
-            application=project_input.get("application"),
-            submittal_job_no=project_input.get("submittal_job_no"),
-            submittal_assignment_count=project_input.get("submittal_assignment_count"),
-            estimator_code=project_input.get("estimator_code"),
-            titan_user_id=project_input.get("titan_user_id"),
-        )
-        session.add(project)
-        session.flush()
+        raise NotFoundError(f"Project {project_id} not found")
 
-        for opening_input in openings_input:
+    # Create any NEW openings from this import (idempotent across re-imports)
+    existing_opening_numbers = {o.opening_number for o in project.openings}
+    for opening_input in openings_input:
+        if opening_input["opening_number"] not in existing_opening_numbers:
             opening = OpeningModel(
                 id=uuid.uuid4(),
                 project_id=project.id,
@@ -325,46 +307,8 @@ def finalize_import_session(
                 assignment_multiplier=opening_input.get("assignment_multiplier"),
             )
             session.add(opening)
-        session.flush()
-
-        # Re-load project with openings
-        project = (
-            session.scalars(
-                select(ProjectModel).options(selectinload(ProjectModel.openings)).where(ProjectModel.id == project.id)
-            )
-            .unique()
-            .first()
-        )
-    else:
-        # Re-import — create any NEW openings that don't exist yet
-        existing_opening_numbers = {o.opening_number for o in project.openings}
-        for opening_input in openings_input:
-            if opening_input["opening_number"] not in existing_opening_numbers:
-                opening = OpeningModel(
-                    id=uuid.uuid4(),
-                    project_id=project.id,
-                    opening_number=opening_input["opening_number"],
-                    building=opening_input.get("building"),
-                    floor=opening_input.get("floor"),
-                    location=opening_input.get("location"),
-                    location_to=opening_input.get("location_to"),
-                    location_from=opening_input.get("location_from"),
-                    hand=opening_input.get("hand"),
-                    width=opening_input.get("width"),
-                    length=opening_input.get("length"),
-                    door_thickness=opening_input.get("door_thickness"),
-                    jamb_thickness=opening_input.get("jamb_thickness"),
-                    door_type=opening_input.get("door_type"),
-                    frame_type=opening_input.get("frame_type"),
-                    interior_exterior=opening_input.get("interior_exterior"),
-                    keying=opening_input.get("keying"),
-                    heading_no=opening_input.get("heading_no"),
-                    single_pair=opening_input.get("single_pair"),
-                    assignment_multiplier=opening_input.get("assignment_multiplier"),
-                )
-                session.add(opening)
-                project.openings.append(opening)
-        session.flush()
+            project.openings.append(opening)
+    session.flush()
 
     # Build opening_map: opening_number -> Opening.id
     opening_map: dict[str, uuid.UUID] = {o.opening_number: o.id for o in project.openings}

--- a/backend/app/repositories/project_repository.py
+++ b/backend/app/repositories/project_repository.py
@@ -1,0 +1,29 @@
+"""Repository for project CRUD operations."""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import ConflictError
+from app.models.project import Project as ProjectModel
+
+
+def create_project(session: Session, project_id: str, description: str, client: str) -> ProjectModel:
+    """Create a new project. Raises ConflictError if project_id already exists."""
+    existing = session.scalars(select(ProjectModel).where(ProjectModel.project_id == project_id)).first()
+    if existing is not None:
+        raise ConflictError(
+            f"Project number {project_id} already exists",
+            field="project_id",
+        )
+
+    project = ProjectModel(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        description=description,
+        client=client,
+    )
+    session.add(project)
+    session.flush()
+    return project

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -4,21 +4,10 @@ from .enums import Classification, PullRequestItemType
 
 
 @strawberry.input
-class ProjectInput:
+class CreateProjectInput:
     project_id: str
-    description: str | None = None
-    job_site_name: str | None = None
-    address: str | None = None
-    city: str | None = None
-    state: str | None = None
-    zip: str | None = None
-    contractor: str | None = None
-    project_manager: str | None = None
-    application: str | None = None
-    submittal_job_no: str | None = None
-    submittal_assignment_count: int | None = None
-    estimator_code: str | None = None
-    titan_user_id: str | None = None
+    description: str
+    client: str
 
 
 @strawberry.input
@@ -131,7 +120,7 @@ class ExcludedItemInput:
 
 @strawberry.input
 class FinalizeImportSessionInput:
-    project: ProjectInput
+    project_id: strawberry.ID
     openings: list[OpeningInput] = strawberry.field(default_factory=list)
     hardware_items: list[HardwareItemInput] | None = None
     po_drafts: list[PODraftInput] | None = None

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -8,6 +8,7 @@ from app.database import SessionLocal
 from app.repositories import (
     notification_repository,
     po_repository,
+    project_repository,
     shipping_repository,
     shop_assembly_repository,
     user_repository,
@@ -21,6 +22,7 @@ from .inputs import (
     CompleteOpeningInput,
     ConfirmShipmentInput,
     CreatePOInput,
+    CreateProjectInput,
     CreateReceiveInput,
     FinalizeImportSessionInput,
 )
@@ -52,6 +54,7 @@ from .types import (
     OpeningItem,
     PODocumentInfo,
     POLineItem,
+    Project,
     PullRequest,
     PurchaseOrder,
     ReceiveRecord,
@@ -69,6 +72,20 @@ from .types import (
 
 @strawberry.type
 class Mutation:
+    # Project
+    @strawberry.mutation
+    def create_project(self, input: CreateProjectInput) -> Project:
+        with SessionLocal() as session:
+            project = project_repository.create_project(
+                session,
+                project_id=input.project_id,
+                description=input.description,
+                client=input.client,
+            )
+            session.commit()
+            session.refresh(project)
+            return _project_to_type(project)
+
     # Import
     @strawberry.mutation
     def finalize_import_session(self, input: FinalizeImportSessionInput) -> FinalizeImportResult:
@@ -87,22 +104,7 @@ class Mutation:
 
         # Convert Strawberry input to dict
         input_data = {
-            "project": {
-                "project_id": input.project.project_id,
-                "description": input.project.description,
-                "job_site_name": input.project.job_site_name,
-                "address": input.project.address,
-                "city": input.project.city,
-                "state": input.project.state,
-                "zip": input.project.zip,
-                "contractor": input.project.contractor,
-                "project_manager": input.project.project_manager,
-                "application": input.project.application,
-                "submittal_job_no": input.project.submittal_job_no,
-                "submittal_assignment_count": input.project.submittal_assignment_count,
-                "estimator_code": input.project.estimator_code,
-                "titan_user_id": input.project.titan_user_id,
-            },
+            "project_id": str(input.project_id),
             "openings": [
                 {
                     "opening_number": o.opening_number,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -161,6 +161,7 @@ def _project_to_type(p: ProjectModel) -> Project:
         id=strawberry.ID(str(p.id)),
         project_id=p.project_id,
         description=p.description,
+        client=p.client,
         job_site_name=p.job_site_name,
         address=p.address,
         city=p.city,

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -160,6 +160,7 @@ class Project:
     id: strawberry.ID
     project_id: str
     description: str | None
+    client: str | None
     job_site_name: str | None
     address: str | None
     city: str | None

--- a/frontend/src/components/ProjectLandingPage.tsx
+++ b/frontend/src/components/ProjectLandingPage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import {
   Box,
   Typography,
@@ -17,9 +18,18 @@ import type { Project } from '../types/project';
 interface ProjectLandingPageProps {
   title: string;
   onSelect: (project: Project | null) => void;
+  showAllProjects?: boolean;
+  createButton?: ReactNode;
+  emptyStateText?: string;
 }
 
-export default function ProjectLandingPage({ title, onSelect }: ProjectLandingPageProps) {
+export default function ProjectLandingPage({
+  title,
+  onSelect,
+  showAllProjects = true,
+  createButton,
+  emptyStateText,
+}: ProjectLandingPageProps) {
   const { data, loading, error } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
   const projects = data?.projects ?? [];
 
@@ -35,54 +45,73 @@ export default function ProjectLandingPage({ title, onSelect }: ProjectLandingPa
     return <Alert severity="error">Error loading projects: {error.message}</Alert>;
   }
 
+  const subtitle = showAllProjects
+    ? 'Select a project to continue, or view data across all projects.'
+    : 'Select a project to continue.';
+
   return (
     <Box>
       <Typography variant="h5" gutterBottom>
         {title}
       </Typography>
       <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-        Select a project to continue, or view data across all projects.
+        {subtitle}
       </Typography>
 
-      <Button
-        variant="outlined"
-        size="large"
-        startIcon={<AllInboxIcon />}
-        onClick={() => onSelect(null)}
-        sx={{ mb: 3 }}
-      >
-        All Projects
-      </Button>
+      <Box sx={{ display: 'flex', gap: 1.5, mb: 3, flexWrap: 'wrap' }}>
+        {showAllProjects && (
+          <Button
+            variant="outlined"
+            size="large"
+            startIcon={<AllInboxIcon />}
+            onClick={() => onSelect(null)}
+          >
+            All Projects
+          </Button>
+        )}
+        {createButton}
+      </Box>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-        {projects.map((p) => (
-          <Card
-            key={p.id}
-            variant="outlined"
-            sx={{ transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 4 } }}
-          >
-            <CardActionArea onClick={() => onSelect(p)}>
-              <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1.5 }}>
-                <FolderIcon color="primary" />
-                <Box>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {p.description || p.projectId}
-                  </Typography>
-                  {p.jobSiteName && (
-                    <Typography variant="body2" color="text.secondary">
-                      {p.jobSiteName}
+        {projects.map((p) => {
+          const subtitleParts: string[] = [];
+          if (p.projectId) subtitleParts.push(`#${p.projectId}`);
+          if (p.client) subtitleParts.push(p.client);
+          const cardSubtitle = subtitleParts.join(' • ');
+          return (
+            <Card
+              key={p.id}
+              variant="outlined"
+              sx={{ transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 4 } }}
+            >
+              <CardActionArea onClick={() => onSelect(p)}>
+                <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1.5 }}>
+                  <FolderIcon color="primary" />
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                      {p.description || p.projectId}
                     </Typography>
-                  )}
-                </Box>
-              </CardContent>
-            </CardActionArea>
-          </Card>
-        ))}
+                    {cardSubtitle && (
+                      <Typography variant="body2" color="text.secondary">
+                        {cardSubtitle}
+                      </Typography>
+                    )}
+                    {p.jobSiteName && (
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        {p.jobSiteName}
+                      </Typography>
+                    )}
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          );
+        })}
       </Box>
 
       {projects.length === 0 && (
         <Alert severity="info" sx={{ mt: 2 }}>
-          No projects found. Import a hardware schedule to create your first project.
+          {emptyStateText ?? 'No projects found.'}
         </Alert>
       )}
     </Box>

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -425,6 +425,7 @@ export const FINALIZE_IMPORT_SESSION = gql`
         id
         projectId
         description
+        client
         jobSiteName
       }
       purchaseOrders {
@@ -444,6 +445,18 @@ export const FINALIZE_IMPORT_SESSION = gql`
         requestNumber
         status
       }
+    }
+  }
+`;
+
+export const CREATE_PROJECT = gql`
+  mutation CreateProject($input: CreateProjectInput!) {
+    createProject(input: $input) {
+      id
+      projectId
+      description
+      client
+      jobSiteName
     }
   }
 `;

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -6,7 +6,11 @@ export const GET_PROJECTS = gql`
       id
       projectId
       description
+      client
       jobSiteName
+      openings {
+        id
+      }
     }
   }
 `;

--- a/frontend/src/modules/import/CreateProjectDialog.tsx
+++ b/frontend/src/modules/import/CreateProjectDialog.tsx
@@ -1,0 +1,136 @@
+import { useState, useCallback } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Stack,
+  Alert,
+} from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+import { CREATE_PROJECT } from '../../graphql/mutations';
+import { GET_PROJECTS } from '../../graphql/queries';
+import { useToast } from '../../components/Toast';
+import type { Project } from '../../types/project';
+
+interface CreateProjectDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function CreateProjectDialog({ open, onClose }: CreateProjectDialogProps) {
+  const { showToast } = useToast();
+  const [projectId, setProjectId] = useState('');
+  const [description, setDescription] = useState('');
+  const [client, setClient] = useState('');
+  const [numberError, setNumberError] = useState<string | null>(null);
+  const [generalError, setGeneralError] = useState<string | null>(null);
+
+  const [createProject, { loading }] = useMutation<{ createProject: Project }>(CREATE_PROJECT, {
+    refetchQueries: [{ query: GET_PROJECTS }],
+  });
+
+  const reset = useCallback(() => {
+    setProjectId('');
+    setDescription('');
+    setClient('');
+    setNumberError(null);
+    setGeneralError(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [reset, onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    setNumberError(null);
+    setGeneralError(null);
+
+    const trimmedNumber = projectId.trim();
+    const trimmedName = description.trim();
+    const trimmedClient = client.trim();
+    if (!trimmedNumber || !trimmedName || !trimmedClient) {
+      setGeneralError('All fields are required.');
+      return;
+    }
+
+    try {
+      await createProject({
+        variables: {
+          input: {
+            projectId: trimmedNumber,
+            description: trimmedName,
+            client: trimmedClient,
+          },
+        },
+      });
+      showToast('Project created.', 'success');
+      handleClose();
+    } catch (err) {
+      if (CombinedGraphQLErrors.is(err)) {
+        const conflict = err.errors.find(
+          (e) => (e.extensions as { code?: string } | undefined)?.code === 'CONFLICT',
+        );
+        if (conflict) {
+          setNumberError(conflict.message);
+          return;
+        }
+      }
+      const message = err instanceof Error ? err.message : 'Failed to create project.';
+      setGeneralError(message);
+    }
+  }, [projectId, description, client, createProject, showToast, handleClose]);
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Create New Project</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Project Name"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+            required
+            autoFocus
+            disabled={loading}
+          />
+          <TextField
+            label="Project Number"
+            value={projectId}
+            onChange={(e) => {
+              setProjectId(e.target.value);
+              if (numberError) setNumberError(null);
+            }}
+            fullWidth
+            required
+            disabled={loading}
+            error={Boolean(numberError)}
+            helperText={numberError ?? 'Must be unique across all projects.'}
+          />
+          <TextField
+            label="Client"
+            value={client}
+            onChange={(e) => setClient(e.target.value)}
+            fullWidth
+            required
+            disabled={loading}
+          />
+          {generalError && <Alert severity="error">{generalError}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+          {loading ? 'Creating…' : 'Create Project'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -34,7 +34,6 @@ import { useHardwareScheduleParser } from '../../hooks/useHardwareScheduleParser
 import { useNavigate } from 'react-router-dom';
 import {
   GET_PROJECTS,
-  GET_PROJECT_BY_SCHEDULE_ID,
   GET_PROJECT_EXCLUDED_ITEMS,
   RECONCILE_SCHEDULE,
 } from '../../graphql/queries';
@@ -42,6 +41,7 @@ import { FINALIZE_IMPORT_SESSION } from '../../graphql/mutations';
 import type { ClassificationRow } from './ClassificationGrid';
 import type { AggregatedHardwareItem, ImportPurpose, ReconciliationRow, ShippingPRDraft } from './types';
 import { aggregationKey, classificationKey } from './types';
+import type { Project } from '../../types/project';
 import SelectOpeningsHardwareStep from './SelectOpeningsHardwareStep';
 import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
@@ -76,10 +76,11 @@ function snakeToCamel<T extends Record<string, unknown>>(obj: T): Record<string,
 
 interface ImportWizardProps {
   open: boolean;
+  project: Project;
   onClose: () => void;
 }
 
-export default function ImportWizard({ open, onClose }: ImportWizardProps) {
+export default function ImportWizard({ open, project, onClose }: ImportWizardProps) {
   const { showToast } = useToast();
   const { setTotalSteps, reset: resetWizardContext } = useWizard();
   const navigate = useNavigate();
@@ -88,10 +89,10 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   // Step tracking
   const [activeStepId, setActiveStepId] = useState<StepId>('upload');
 
-  // Step 1 state
-  const [isReimport, setIsReimport] = useState(false);
-  const [existingProjectId, setExistingProjectId] = useState<string | null>(null);
-  const [existingProjectName, setExistingProjectName] = useState<string | null>(null);
+  // Selected project context (from prop)
+  const existingProjectId = project.id;
+  const existingProjectName = project.description || project.projectId;
+  const isReimport = (project.openings?.length ?? 0) > 0;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Step 2 state
@@ -163,10 +164,6 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
   // ---- Apollo ----
 
-  const [checkProject] = useLazyQuery<{
-    projectByScheduleId: { id: string; projectId: string; description: string | null; jobSiteName: string | null } | null;
-  }>(GET_PROJECT_BY_SCHEDULE_ID);
-
   const [reconcileSchedule, { data: reconcileData, loading: reconcileLoading }] = useLazyQuery<{
     reconcileSchedule: ReconciliationRow[];
   }>(RECONCILE_SCHEDULE);
@@ -185,6 +182,29 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
   }>(FINALIZE_IMPORT_SESSION, {
     refetchQueries: [{ query: GET_PROJECTS }],
   });
+
+  // Pre-populate BY_OTHERS classifications from this project's exclusion table once XML is parsed
+  const parsedHardwareItems = parser.parseResult?.hardwareItems;
+  useEffect(() => {
+    if (!isReimport || !parsedHardwareItems || parsedHardwareItems.length === 0) return;
+    fetchExcludedItems({ variables: { projectId: existingProjectId } }).then((res) => {
+      const excluded = res.data?.projectExcludedItems;
+      if (excluded && excluded.length > 0) {
+        setClassifications((prev) => {
+          const next = new Map(prev);
+          for (const ei of excluded) {
+            for (const hi of parsedHardwareItems) {
+              if (hi.hardware_category === ei.hardwareCategory && hi.product_code === ei.productCode) {
+                const ck = `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
+                next.set(ck, 'BY_OTHERS');
+              }
+            }
+          }
+          return next;
+        });
+      }
+    });
+  }, [isReimport, parsedHardwareItems, existingProjectId, fetchExcludedItems]);
 
   // ---- Derived Data ----
 
@@ -351,53 +371,11 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     const nextStep = steps[currentIndex + 1];
     if (!nextStep) return;
 
-    // Side effects per step
-    if (effectiveStepId === 'upload' && parsed) {
-      try {
-        const result = await checkProject({
-          variables: { projectId: parsed.project.project_id },
-        });
-        const existing = result.data?.projectByScheduleId;
-        if (existing) {
-          setIsReimport(true);
-          setExistingProjectId(existing.id);
-          setExistingProjectName(existing.description || existing.projectId);
-          // Pre-populate BY_OTHERS classifications from exclusion table
-          fetchExcludedItems({ variables: { projectId: existing.id } }).then((res) => {
-            const excluded = res.data?.projectExcludedItems;
-            if (excluded && excluded.length > 0) {
-              setClassifications((prev) => {
-                const next = new Map(prev);
-                for (const ei of excluded) {
-                  // Match against all classificationKeys that share this (hardwareCategory, productCode)
-                  for (const hi of hardwareItems) {
-                    if (hi.hardware_category === ei.hardwareCategory && hi.product_code === ei.productCode) {
-                      const ck = `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
-                      next.set(ck, 'BY_OTHERS');
-                    }
-                  }
-                }
-                return next;
-              });
-            }
-          });
-        } else {
-          setIsReimport(false);
-          setExistingProjectId(null);
-          setExistingProjectName(null);
-        }
-      } catch {
-        setIsReimport(false);
-        setExistingProjectId(null);
-        setExistingProjectName(null);
-      }
-    }
-
     if (effectiveStepId === 'openings') {
       setSelectedReconItems(new Set());
     }
 
-    if (effectiveStepId === 'openings' && isReimport && existingProjectId) {
+    if (effectiveStepId === 'openings' && isReimport) {
       // Aggregate by (opening, category, product) to avoid duplicate entries
       const itemMap = new Map<string, { openingNumber: string; hardwareCategory: string; productCode: string; quantityNeeded: number }>();
       for (const hi of selectedHardwareItems) {
@@ -420,7 +398,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
     }
 
     setActiveStepId(nextStep.id);
-  }, [effectiveStepId, steps, parsed, checkProject, isReimport, existingProjectId, selectedHardwareItems, reconcileSchedule, purpose, hardwareItems, fetchExcludedItems]);
+  }, [effectiveStepId, steps, isReimport, existingProjectId, selectedHardwareItems, reconcileSchedule]);
 
   const handleBack = useCallback(() => {
     const currentIndex = steps.findIndex((s) => s.id === effectiveStepId);
@@ -598,7 +576,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
       : null;
 
     return {
-      project: snakeToCamel(parsed.project as unknown as Record<string, unknown>),
+      projectId: project.id,
       openings: selectedOpeningsList.map((o) => snakeToCamel(o as unknown as Record<string, unknown>)),
       hardwareItems: purpose === 'po'
         ? aggregatedHardwareItems
@@ -708,7 +686,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
             .filter(Boolean)
         : null,
     };
-  }, [parsed, selectedOpenings, selectedItemKeys, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, project.id, selectedOpenings, selectedItemKeys, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -752,9 +730,6 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
   const handleClose = useCallback(() => {
     setActiveStepId('upload');
-    setIsReimport(false);
-    setExistingProjectId(null);
-    setExistingProjectName(null);
     setPurpose(null);
     setSelectedOpenings(new Set());
     setSelectedVendors(new Set());
@@ -881,25 +856,20 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
 
                   <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
                     <Typography variant="subtitle1">
-                      Project: {parsed.project.description || parsed.project.project_id}
+                      Project: {existingProjectName}
                     </Typography>
-                    {isReimport ? (
-                      <Chip label={`Re-import for: ${existingProjectName}`} color="info" size="small" />
-                    ) : existingProjectId === null && parser.state === 'done' ? (
-                      <Chip label="New Project" color="success" size="small" />
-                    ) : null}
+                    <Chip
+                      label={isReimport ? 'Existing schedule data' : 'First import'}
+                      color={isReimport ? 'info' : 'success'}
+                      size="small"
+                    />
                   </Box>
 
                   <ValidationSummaryDisplay summary={parsed.validationSummary} />
 
                   <Button
                     size="small"
-                    onClick={() => {
-                      parser.reset();
-                      setIsReimport(false);
-                      setExistingProjectId(null);
-                      setExistingProjectName(null);
-                    }}
+                    onClick={() => parser.reset()}
                     sx={{ mt: 2 }}
                   >
                     Upload Different File
@@ -1094,7 +1064,7 @@ export default function ImportWizard({ open, onClose }: ImportWizardProps) {
                 </Typography>
 
                 <Typography variant="body1" sx={{ mb: 1 }}>
-                  Project: {parsed?.project.description || parsed?.project.project_id}
+                  Project: {existingProjectName}
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                   {selectedOpenings.size} openings | {selectedHardwareItems.length} hardware items

--- a/frontend/src/modules/import/index.tsx
+++ b/frontend/src/modules/import/index.tsx
@@ -1,30 +1,53 @@
 import { useState } from 'react';
-import { Box, Typography, Button, Paper } from '@mui/material';
-import UploadFileIcon from '@mui/icons-material/UploadFile';
+import { Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import ProjectLandingPage from '../../components/ProjectLandingPage';
+import CreateProjectDialog from './CreateProjectDialog';
 import ImportWizard from './ImportWizard';
+import type { Project } from '../../types/project';
 
 export default function ImportModule() {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [wizardOpen, setWizardOpen] = useState(false);
 
+  const handleSelect = (project: Project | null) => {
+    if (!project) return;
+    setSelectedProject(project);
+    setWizardOpen(true);
+  };
+
+  const handleWizardClose = () => {
+    setWizardOpen(false);
+    setSelectedProject(null);
+  };
+
   return (
-    <Box>
-      <Typography variant="h5" sx={{ mb: 3 }}>Hardware Schedule Import</Typography>
-      <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
-        <UploadFileIcon sx={{ fontSize: 64, color: 'action.disabled', mb: 2 }} />
-        <Typography variant="h6" sx={{ mb: 1 }}>Import Hardware Schedule</Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Upload a TITAN XML file to create purchase orders, assembly requests, and shipping pull requests.
-        </Typography>
-        <Button
-          variant="contained"
-          size="large"
-          startIcon={<UploadFileIcon />}
-          onClick={() => setWizardOpen(true)}
-        >
-          Start Import
-        </Button>
-      </Paper>
-      <ImportWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
-    </Box>
+    <>
+      <ProjectLandingPage
+        title="Hardware Schedule Import"
+        showAllProjects={false}
+        emptyStateText="No projects yet. Click 'Create New Project' to get started."
+        createButton={
+          <Button
+            variant="contained"
+            size="large"
+            startIcon={<AddIcon />}
+            onClick={() => setCreateOpen(true)}
+          >
+            Create New Project
+          </Button>
+        }
+        onSelect={handleSelect}
+      />
+      <CreateProjectDialog open={createOpen} onClose={() => setCreateOpen(false)} />
+      {selectedProject && (
+        <ImportWizard
+          open={wizardOpen}
+          project={selectedProject}
+          onClose={handleWizardClose}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -2,5 +2,7 @@ export interface Project {
   id: string;
   projectId: string;
   description: string | null;
+  client: string | null;
   jobSiteName: string | null;
+  openings?: Array<{ id: string }>;
 }


### PR DESCRIPTION
## Summary

Closes #94. Inverts the project creation flow: projects are now user-created up front via a dedicated `createProject` mutation with three required fields — project name (`description`), project number (`project_id`), and **client** (NEW). Hardware-schedule import is no longer how projects come into existence — instead the user picks an existing project before uploading the XML, and the XML's embedded project metadata is ignored.

This is the foundation for #96 (load persisted HS) and #97 (Start a task rename).

## Changes

**Backend**
- `Project` model gains a nullable `client` column and a unique constraint on `project_id`
- New migration `024` (wipes dev project-tied data in FK-safe order, then adds column + uq)
- New `CreateProjectInput`; `FinalizeImportSessionInput.project` replaced by `project_id: ID`
- New `project_repository.create_project` with conflict check (`ConflictError(field=\"project_id\")`)
- New `createProject` mutation; `finalize_import_session` now looks up project by UUID and raises `NotFoundError` if missing — the auto-create branch is gone
- `_project_to_type` returns `client`

**Frontend**
- `ProjectLandingPage` extended with optional `showAllProjects` / `createButton` / `emptyStateText` props (PO and Shipping modules unaffected); each card displays `#projectId • client`
- New `CreateProjectDialog` (modal: name, number, client) — surfaces backend `CONFLICT` errors inline on the number field
- Import module landing page rewritten as a project list with a Create New Project button; clicking an existing project opens the import wizard with that project preselected
- `ImportWizard` accepts a required `project` prop. `isReimport` is now derived from `project.openings.length > 0`. The XML-driven `projectByScheduleId` lookup is gone — the wizard sends `projectId` to finalize and ignores XML project metadata mismatch (per intent)
- `GET_PROJECTS` returns `client` and `openings { id }`; `CREATE_PROJECT` mutation added; `FINALIZE_IMPORT_SESSION` no longer nests a project block

## Notes

- Dev DB will be wiped of project-tied rows by the migration (warehouse layout data is preserved).
- XML metadata other than openings/items is no longer persisted on import — project metadata is purely user-entered.