### PR TITLE
Add Vendor entity and replace PO free-text vendor with FK (closes #95)

### DIFF
--- a/backend/alembic/versions/025_create_vendors.py
+++ b/backend/alembic/versions/025_create_vendors.py
@@ -1,0 +1,85 @@
+"""Create vendors table; replace PO vendor_name/vendor_contact with vendor_id FK
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-05-01
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "025"
+down_revision = "024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vendors",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("contact_name", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column("phone", sa.String(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("name", name="uq_vendors_name"),
+    )
+
+    op.add_column("purchase_orders", sa.Column("vendor_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_purchase_orders_vendor_id",
+        "purchase_orders",
+        "vendors",
+        ["vendor_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index("ix_purchase_orders_vendor_id", "purchase_orders", ["vendor_id"])
+
+    # Backfill: create a Vendor row per distinct non-null vendor_name, then map POs
+    op.execute(
+        """
+        INSERT INTO vendors (id, name, created_at, updated_at)
+        SELECT gen_random_uuid(), name, now(), now()
+        FROM (
+            SELECT DISTINCT vendor_name AS name
+            FROM purchase_orders
+            WHERE vendor_name IS NOT NULL
+        ) AS src
+        """
+    )
+    op.execute(
+        """
+        UPDATE purchase_orders
+        SET vendor_id = v.id
+        FROM vendors v
+        WHERE v.name = purchase_orders.vendor_name
+        """
+    )
+
+    op.drop_column("purchase_orders", "vendor_name")
+    op.drop_column("purchase_orders", "vendor_contact")
+
+
+def downgrade() -> None:
+    op.add_column("purchase_orders", sa.Column("vendor_name", sa.String(), nullable=True))
+    op.add_column("purchase_orders", sa.Column("vendor_contact", sa.String(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE purchase_orders
+        SET vendor_name = v.name
+        FROM vendors v
+        WHERE v.id = purchase_orders.vendor_id
+        """
+    )
+
+    op.drop_index("ix_purchase_orders_vendor_id", table_name="purchase_orders")
+    op.drop_constraint("fk_purchase_orders_vendor_id", "purchase_orders", type_="foreignkey")
+    op.drop_column("purchase_orders", "vendor_id")
+
+    op.drop_table("vendors")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,4 +22,5 @@ from .shop_assembly import (  # noqa: E402, F401
     ShopAssemblyOpeningItem,
     ShopAssemblyRequest,
 )
+from .vendor import Vendor  # noqa: E402, F401
 from .warehouse_layout import WarehouseAisle, WarehouseBay, WarehouseBin, WarehouseRow  # noqa: E402, F401

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
 from .enums import Classification, PODocumentType, POStatus
+from .vendor import Vendor
 
 
 class PurchaseOrder(Base):
@@ -33,9 +34,10 @@ class PurchaseOrder(Base):
     po_number: Mapped[str | None] = mapped_column(String(50), nullable=True)
     request_number: Mapped[str] = mapped_column(String(50), nullable=False)
     project_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("projects.id"), nullable=True)
+    vendor_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("vendors.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
     status: Mapped[POStatus] = mapped_column(Enum(POStatus, name="po_status", create_constraint=True), nullable=False)
-    vendor_name: Mapped[str | None] = mapped_column(String, nullable=True)
-    vendor_contact: Mapped[str | None] = mapped_column(String, nullable=True)
     vendor_quote_number: Mapped[str | None] = mapped_column(String, nullable=True)
     expected_delivery_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     ordered_at: Mapped[datetime | None] = mapped_column(nullable=True)
@@ -44,6 +46,7 @@ class PurchaseOrder(Base):
     deleted_at: Mapped[datetime | None] = mapped_column(nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    vendor: Mapped[Vendor | None] = relationship()
     line_items: Mapped[list["POLineItem"]] = relationship(back_populates="purchase_order")
     documents: Mapped[list["PODocument"]] = relationship(back_populates="purchase_order")
 

--- a/backend/app/models/vendor.py
+++ b/backend/app/models/vendor.py
@@ -1,0 +1,21 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class Vendor(Base):
+    __tablename__ = "vendors"
+    __table_args__ = (UniqueConstraint("name", name="uq_vendors_name"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    contact_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    email: Mapped[str | None] = mapped_column(String, nullable=True)
+    phone: Mapped[str | None] = mapped_column(String, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -386,6 +386,15 @@ def finalize_import_session(
             request_number = f"PO-REQ-{next_seq:03d}"
             next_seq += 1
 
+            # Resolve vendor_id (validate FK target exists if provided)
+            vendor_id_str = po_draft.get("vendor_id")
+            vendor_id = uuid.UUID(vendor_id_str) if vendor_id_str else None
+            if vendor_id is not None:
+                from app.models.vendor import Vendor as VendorModel
+
+                if session.get(VendorModel, vendor_id) is None:
+                    raise NotFoundError(f"Vendor {vendor_id} not found")
+
             # Create PO
             po = POModel(
                 id=uuid.uuid4(),
@@ -393,8 +402,7 @@ def finalize_import_session(
                 request_number=request_number,
                 project_id=project.id,
                 status=POStatus.DRAFT,
-                vendor_name=po_draft.get("vendor_name"),
-                vendor_contact=po_draft.get("vendor_contact"),
+                vendor_id=vendor_id,
                 notes=po_draft.get("notes"),
             )
             session.add(po)

--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -33,8 +33,7 @@ def create_po(
     session: Session,
     line_items: list[dict],
     project_id: uuid.UUID | None = None,
-    vendor_name: str | None = None,
-    vendor_contact: str | None = None,
+    vendor_id: uuid.UUID | None = None,
     notes: str | None = None,
 ) -> PurchaseOrder:
     """Create a manual PO with line items. No hardware items are created."""
@@ -49,15 +48,21 @@ def create_po(
         if project is None:
             raise NotFoundError(f"Project {project_id} not found")
 
+    if vendor_id is not None:
+        from app.models.vendor import Vendor as VendorModel
+
+        vendor = session.get(VendorModel, vendor_id)
+        if vendor is None:
+            raise NotFoundError(f"Vendor {vendor_id} not found")
+
     request_number = generate_next_request_number(session)
 
     po = PurchaseOrder(
         id=uuid.uuid4(),
         request_number=request_number,
         project_id=project_id,
+        vendor_id=vendor_id,
         status=POStatus.DRAFT,
-        vendor_name=vendor_name,
-        vendor_contact=vendor_contact,
         notes=notes,
     )
     session.add(po)
@@ -88,10 +93,14 @@ def create_po(
 def get_purchase_orders(
     session: Session, project_id: uuid.UUID | None = None, status: POStatus | None = None
 ) -> list[PurchaseOrder]:
-    """Filter by optional project_id + optional status + deleted_at IS NULL, eagerly load line_items and documents."""
+    """Filter by optional project_id + status + deleted_at IS NULL; eagerly load line_items, documents, vendor."""
     stmt = (
         select(PurchaseOrder)
-        .options(selectinload(PurchaseOrder.line_items), selectinload(PurchaseOrder.documents))
+        .options(
+            selectinload(PurchaseOrder.line_items),
+            selectinload(PurchaseOrder.documents),
+            selectinload(PurchaseOrder.vendor),
+        )
         .where(PurchaseOrder.deleted_at.is_(None))
         .order_by(PurchaseOrder.created_at.desc())
     )
@@ -103,10 +112,14 @@ def get_purchase_orders(
 
 
 def get_purchase_order(session: Session, po_id: uuid.UUID) -> PurchaseOrder | None:
-    """Single PO by id + deleted_at IS NULL, eagerly load line_items and documents."""
+    """Single PO by id + deleted_at IS NULL, eagerly load line_items, documents, vendor."""
     stmt = (
         select(PurchaseOrder)
-        .options(selectinload(PurchaseOrder.line_items), selectinload(PurchaseOrder.documents))
+        .options(
+            selectinload(PurchaseOrder.line_items),
+            selectinload(PurchaseOrder.documents),
+            selectinload(PurchaseOrder.vendor),
+        )
         .where(
             PurchaseOrder.id == po_id,
             PurchaseOrder.deleted_at.is_(None),
@@ -168,9 +181,8 @@ def get_po_statistics(session: Session, project_id: uuid.UUID | None = None) -> 
 def update_po(
     session: Session,
     po_id: uuid.UUID,
-    vendor_name: str | None,
-    vendor_contact: str | None,
-    expected_delivery_date,
+    vendor_id=_UNSET,
+    expected_delivery_date=None,
     po_number: str | None = None,
     vendor_quote_number: str | None = None,
     project_id=_UNSET,
@@ -181,7 +193,7 @@ def update_po(
     - Validate status in (Draft, Ordered) (InvalidStateTransitionError)
     - Validate no ReceiveRecords exist (InvalidStateTransitionError)
     - Validate po_number uniqueness within project if provided
-    - Update only provided (non-None) fields
+    - Update only provided fields (vendor_id/project_id use _UNSET sentinel)
     - Return updated PO
     """
     po = get_purchase_order(session, po_id)
@@ -206,6 +218,18 @@ def update_po(
             raise NotFoundError(f"Project {project_id} not found")
         po.project_id = project_id
 
+    # Update vendor_id if provided (sentinel _UNSET means "not provided")
+    if vendor_id is not _UNSET:
+        if vendor_id is None:
+            po.vendor_id = None
+        else:
+            from app.models.vendor import Vendor as VendorModel
+
+            vendor = session.get(VendorModel, vendor_id)
+            if vendor is None:
+                raise NotFoundError(f"Vendor {vendor_id} not found")
+            po.vendor_id = vendor_id
+
     if po_number is not None:
         # Validate uniqueness scoped to project (or globally for project-less POs)
         if po_number.strip():
@@ -225,10 +249,6 @@ def update_po(
         else:
             po.po_number = None
 
-    if vendor_name is not None:
-        po.vendor_name = vendor_name
-    if vendor_contact is not None:
-        po.vendor_contact = vendor_contact
     if expected_delivery_date is not None:
         po.expected_delivery_date = expected_delivery_date
     if vendor_quote_number is not None:
@@ -255,7 +275,7 @@ def mark_po_as_ordered(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     - Validate exists + not soft-deleted (NotFoundError)
     - Validate status == Draft (InvalidStateTransitionError)
     - Validate po_number is not None (ValidationError)
-    - Validate vendor_name is not None (ValidationError)
+    - Validate vendor_id is not None (ValidationError)
     - Set status=Ordered, ordered_at=datetime.utcnow()
     - Return updated PO
     """
@@ -269,10 +289,10 @@ def mark_po_as_ordered(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     if po.po_number is None:
         raise ValidationError("PO number is required before marking as ordered", field="po_number")
 
-    if po.vendor_name is None:
+    if po.vendor_id is None:
         raise ValidationError(
-            "Vendor name is required before marking as ordered",
-            field="vendor_name",
+            "Vendor is required before marking as ordered",
+            field="vendor_id",
         )
 
     po.status = POStatus.ORDERED

--- a/backend/app/repositories/vendor_repository.py
+++ b/backend/app/repositories/vendor_repository.py
@@ -1,0 +1,100 @@
+"""Repository for Vendor CRUD operations."""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.errors import ConflictError, NotFoundError, ValidationError
+from app.models.purchase_order import PurchaseOrder as POModel
+from app.models.vendor import Vendor
+
+
+def list_vendors(session: Session) -> list[Vendor]:
+    return list(session.scalars(select(Vendor).order_by(Vendor.name)).all())
+
+
+def get_vendor(session: Session, vendor_id: uuid.UUID) -> Vendor:
+    vendor = session.get(Vendor, vendor_id)
+    if vendor is None:
+        raise NotFoundError(f"Vendor {vendor_id} not found")
+    return vendor
+
+
+def _check_name_unique(session: Session, name: str, exclude_id: uuid.UUID | None = None) -> None:
+    stmt = select(Vendor).where(Vendor.name == name)
+    if exclude_id is not None:
+        stmt = stmt.where(Vendor.id != exclude_id)
+    existing = session.scalars(stmt).first()
+    if existing is not None:
+        raise ConflictError(f"Vendor name '{name}' already exists", field="name")
+
+
+def create_vendor(
+    session: Session,
+    name: str,
+    contact_name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    notes: str | None = None,
+) -> Vendor:
+    name = name.strip()
+    if not name:
+        raise ValidationError("Vendor name is required", field="name")
+
+    _check_name_unique(session, name)
+
+    vendor = Vendor(
+        id=uuid.uuid4(),
+        name=name,
+        contact_name=contact_name,
+        email=email,
+        phone=phone,
+        notes=notes,
+    )
+    session.add(vendor)
+    session.flush()
+    return vendor
+
+
+def update_vendor(
+    session: Session,
+    vendor_id: uuid.UUID,
+    name: str | None = None,
+    contact_name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    notes: str | None = None,
+) -> Vendor:
+    vendor = get_vendor(session, vendor_id)
+
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValidationError("Vendor name is required", field="name")
+        _check_name_unique(session, name, exclude_id=vendor_id)
+        vendor.name = name
+    if contact_name is not None:
+        vendor.contact_name = contact_name
+    if email is not None:
+        vendor.email = email
+    if phone is not None:
+        vendor.phone = phone
+    if notes is not None:
+        vendor.notes = notes
+
+    session.flush()
+    return vendor
+
+
+def delete_vendor(session: Session, vendor_id: uuid.UUID) -> None:
+    vendor = get_vendor(session, vendor_id)
+
+    referenced = session.scalar(select(func.count()).select_from(POModel).where(POModel.vendor_id == vendor_id))
+    if referenced and referenced > 0:
+        raise ConflictError(
+            f"Cannot delete vendor: referenced by {referenced} purchase order(s)",
+        )
+
+    session.delete(vendor)
+    session.flush()

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -28,6 +28,7 @@ from app.models.purchase_order import PurchaseOrder as POModel
 from app.models.receiving import ReceiveLineItem as ReceiveLineItemModel
 from app.models.receiving import ReceiveRecord as ReceiveRecordModel
 from app.models.shop_assembly import ShopAssemblyRequest as SARModel
+from app.models.vendor import Vendor as VendorModel
 from app.services import notification_service
 from app.services.locking import lock_rows
 
@@ -167,7 +168,7 @@ def get_expected_deliveries(session: Session, project_id: uuid.UUID | None = Non
     """Active POs with outstanding line items, ordered by expected_delivery_date."""
     stmt = (
         select(POModel)
-        .options(selectinload(POModel.line_items))
+        .options(selectinload(POModel.line_items), selectinload(POModel.vendor))
         .where(
             POModel.status.in_([POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED]),
             POModel.deleted_at.is_(None),
@@ -182,8 +183,9 @@ def get_expected_deliveries(session: Session, project_id: uuid.UUID | None = Non
 def get_back_ordered_items(session: Session, project_id: uuid.UUID | None = None) -> list[dict]:
     """PO line items where received < ordered on active POs."""
     stmt = (
-        select(POLineItemModel, POModel.po_number, POModel.vendor_name, POModel.expected_delivery_date)
+        select(POLineItemModel, POModel.po_number, VendorModel.name, POModel.expected_delivery_date)
         .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(VendorModel, POModel.vendor_id == VendorModel.id)
         .where(
             POModel.status.in_([POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED]),
             POModel.deleted_at.is_(None),
@@ -207,15 +209,16 @@ def get_back_ordered_items(session: Session, project_id: uuid.UUID | None = None
 
 
 def get_inventory_by_vendor(session: Session, project_id: uuid.UUID | None = None) -> list[dict]:
-    """Group inventory by vendor_name, then product_code."""
+    """Group inventory by vendor name (via PO.vendor_id → Vendor), then product_code."""
     stmt = (
-        select(InventoryLocationModel, POLineItemModel.unit_cost, POModel.vendor_name)
+        select(InventoryLocationModel, POLineItemModel.unit_cost, VendorModel.name)
         .join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
         .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(VendorModel, POModel.vendor_id == VendorModel.id)
     )
     if project_id is not None:
         stmt = stmt.where(InventoryLocationModel.project_id == project_id)
-    stmt = stmt.order_by(POModel.vendor_name, InventoryLocationModel.product_code)
+    stmt = stmt.order_by(VendorModel.name, InventoryLocationModel.product_code)
     rows = list(session.execute(stmt).all())
 
     vendor_map: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
@@ -850,10 +853,14 @@ def get_po_receiving_details(session: Session, po_id: uuid.UUID) -> tuple[POMode
     Returns:
         Tuple of (po, receive_records)
     """
-    # Look up PO with line_items and documents
+    # Look up PO with line_items, documents, and vendor
     stmt = (
         select(POModel)
-        .options(selectinload(POModel.line_items), selectinload(POModel.documents))
+        .options(
+            selectinload(POModel.line_items),
+            selectinload(POModel.documents),
+            selectinload(POModel.vendor),
+        )
         .where(POModel.id == po_id)
     )
     po = session.scalars(stmt).unique().first()

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -67,8 +67,7 @@ class POLineItemOrderAsInput:
 @strawberry.input
 class PODraftInput:
     po_number: str | None = None
-    vendor_name: str | None = None
-    vendor_contact: str | None = None
+    vendor_id: strawberry.ID | None = None
     notes: str | None = None
     hardware_item_refs: list[HardwareItemRef] = strawberry.field(default_factory=list)
     line_item_aliases: list[POLineItemOrderAsInput] = strawberry.field(default_factory=list)
@@ -146,8 +145,25 @@ class CreatePOLineItemInput:
 class CreatePOInput:
     line_items: list[CreatePOLineItemInput]
     project_id: strawberry.ID | None = None
-    vendor_name: str | None = None
-    vendor_contact: str | None = None
+    vendor_id: strawberry.ID | None = None
+    notes: str | None = None
+
+
+@strawberry.input
+class CreateVendorInput:
+    name: str
+    contact_name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    notes: str | None = None
+
+
+@strawberry.input
+class UpdateVendorInput:
+    name: str | None = None
+    contact_name: str | None = None
+    email: str | None = None
+    phone: str | None = None
     notes: str | None = None
 
 

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -12,6 +12,7 @@ from app.repositories import (
     shipping_repository,
     shop_assembly_repository,
     user_repository,
+    vendor_repository,
     warehouse_layout_repository,
     warehouse_repository,
 )
@@ -24,7 +25,9 @@ from .inputs import (
     CreatePOInput,
     CreateProjectInput,
     CreateReceiveInput,
+    CreateVendorInput,
     FinalizeImportSessionInput,
+    UpdateVendorInput,
 )
 from .queries import (
     _aisle_to_type,
@@ -43,6 +46,7 @@ from .queries import (
     _row_to_type,
     _shop_assembly_opening_to_type,
     _shop_assembly_request_to_type,
+    _vendor_to_type,
 )
 from .types import (
     ApproveResult,
@@ -60,6 +64,7 @@ from .types import (
     ReceiveRecord,
     ShopAssemblyOpening,
     ShopAssemblyRequest,
+    Vendor,
     WarehouseAisleType,
     WarehouseBayType,
     WarehouseBinType,
@@ -152,8 +157,7 @@ class Mutation:
             "po_drafts": [
                 {
                     "po_number": po.po_number,
-                    "vendor_name": po.vendor_name,
-                    "vendor_contact": po.vendor_contact,
+                    "vendor_id": str(po.vendor_id) if po.vendor_id else None,
                     "notes": po.notes,
                     "hardware_item_refs": [
                         {
@@ -251,13 +255,17 @@ class Mutation:
                 .first()
             )
 
-            # Re-load POs with line_items and documents
+            # Re-load POs with line_items, documents, and vendor
             pos = []
             for po_obj in result["purchase_orders"]:
                 refreshed_po = (
                     session.scalars(
                         select(POModel)
-                        .options(selectinload(POModel.line_items), selectinload(POModel.documents))
+                        .options(
+                            selectinload(POModel.line_items),
+                            selectinload(POModel.documents),
+                            selectinload(POModel.vendor),
+                        )
                         .where(POModel.id == po_obj.id)
                     )
                     .unique()
@@ -304,6 +312,7 @@ class Mutation:
         from app.models.purchase_order import PurchaseOrder as POModel
 
         project_id = uuid.UUID(str(input.project_id)) if input.project_id else None
+        vendor_id = uuid.UUID(str(input.vendor_id)) if input.vendor_id else None
         line_items_data = [
             {
                 "hardware_category": li.hardware_category,
@@ -321,17 +330,20 @@ class Mutation:
                 session,
                 line_items=line_items_data,
                 project_id=project_id,
-                vendor_name=input.vendor_name,
-                vendor_contact=input.vendor_contact,
+                vendor_id=vendor_id,
                 notes=input.notes,
             )
             session.commit()
 
-            # Re-load with line_items and documents
+            # Re-load with line_items, documents, and vendor
             refreshed_po = (
                 session.scalars(
                     select(POModel)
-                    .options(selectinload(POModel.line_items), selectinload(POModel.documents))
+                    .options(
+                        selectinload(POModel.line_items),
+                        selectinload(POModel.documents),
+                        selectinload(POModel.vendor),
+                    )
                     .where(POModel.id == po.id)
                 )
                 .unique()
@@ -343,32 +355,46 @@ class Mutation:
     def update_po(
         self,
         id: strawberry.ID,
-        vendor_name: str | None = None,
-        vendor_contact: str | None = None,
+        vendor_id: strawberry.ID | None = None,
         expected_delivery_date: date | None = None,
         po_number: str | None = None,
         vendor_quote_number: str | None = None,
         project_id: strawberry.ID | None = None,
         notes: str | None = None,
     ) -> PurchaseOrder:
+        from sqlalchemy.orm import selectinload
+
+        from app.models.purchase_order import PurchaseOrder as POModel
         from app.repositories.po_repository import _UNSET
 
         pid = uuid.UUID(str(project_id)) if project_id else _UNSET
+        vid = uuid.UUID(str(vendor_id)) if vendor_id else _UNSET
         with SessionLocal() as session:
             po = po_repository.update_po(
                 session,
                 uuid.UUID(str(id)),
-                vendor_name,
-                vendor_contact,
-                expected_delivery_date,
+                vendor_id=vid,
+                expected_delivery_date=expected_delivery_date,
                 po_number=po_number,
                 vendor_quote_number=vendor_quote_number,
                 project_id=pid,
                 notes=notes,
             )
             session.commit()
-            session.refresh(po)
-            return _po_to_type(po)
+            refreshed_po = (
+                session.scalars(
+                    select(POModel)
+                    .options(
+                        selectinload(POModel.line_items),
+                        selectinload(POModel.documents),
+                        selectinload(POModel.vendor),
+                    )
+                    .where(POModel.id == po.id)
+                )
+                .unique()
+                .first()
+            )
+            return _po_to_type(refreshed_po)
 
     @strawberry.mutation
     def mark_po_as_ordered(self, id: strawberry.ID) -> PurchaseOrder:
@@ -761,6 +787,45 @@ class Mutation:
             stmt = select(OIModel).options(selectinload(OIModel.installed_hardware)).where(OIModel.id == result.id)
             refreshed = session.scalars(stmt).unique().first()
             return _opening_item_to_type(refreshed)
+
+    # Vendors
+    @strawberry.mutation
+    def create_vendor(self, input: CreateVendorInput) -> Vendor:
+        with SessionLocal() as session:
+            vendor = vendor_repository.create_vendor(
+                session,
+                name=input.name,
+                contact_name=input.contact_name,
+                email=input.email,
+                phone=input.phone,
+                notes=input.notes,
+            )
+            session.commit()
+            session.refresh(vendor)
+            return _vendor_to_type(vendor)
+
+    @strawberry.mutation
+    def update_vendor(self, id: strawberry.ID, input: UpdateVendorInput) -> Vendor:
+        with SessionLocal() as session:
+            vendor = vendor_repository.update_vendor(
+                session,
+                uuid.UUID(str(id)),
+                name=input.name,
+                contact_name=input.contact_name,
+                email=input.email,
+                phone=input.phone,
+                notes=input.notes,
+            )
+            session.commit()
+            session.refresh(vendor)
+            return _vendor_to_type(vendor)
+
+    @strawberry.mutation
+    def delete_vendor(self, id: strawberry.ID) -> bool:
+        with SessionLocal() as session:
+            vendor_repository.delete_vendor(session, uuid.UUID(str(id)))
+            session.commit()
+            return True
 
     @strawberry.mutation
     def update_user_roles(self, user_id: str, roles: list[str]) -> ClerkUser:

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -13,6 +13,7 @@ from app.repositories import (
     shipping_repository,
     shop_assembly_repository,
     user_repository,
+    vendor_repository,
     warehouse_layout_repository,
     warehouse_repository,
 )
@@ -59,6 +60,7 @@ from .types import (
     ShopAssemblyOpening,
     ShopAssemblyOpeningItem,
     ShopAssemblyRequest,
+    Vendor,
     VendorInventoryNode,
     WarehouseAisleType,
     WarehouseBayType,
@@ -134,16 +136,29 @@ def _po_document_to_type(doc) -> PODocumentInfo:
     )
 
 
+def _vendor_to_type(v) -> Vendor:
+    return Vendor(
+        id=strawberry.ID(str(v.id)),
+        name=v.name,
+        contact_name=v.contact_name,
+        email=v.email,
+        phone=v.phone,
+        notes=v.notes,
+        created_at=v.created_at,
+        updated_at=v.updated_at,
+    )
+
+
 def _po_to_type(po, receive_records=None) -> PurchaseOrder:
     documents = getattr(po, "documents", None) or []
+    vendor = getattr(po, "vendor", None)
     return PurchaseOrder(
         id=strawberry.ID(str(po.id)),
         po_number=po.po_number,
         request_number=po.request_number,
         project_id=strawberry.ID(str(po.project_id)) if po.project_id else None,
         status=po.status,
-        vendor_name=po.vendor_name,
-        vendor_contact=po.vendor_contact,
+        vendor=_vendor_to_type(vendor) if vendor is not None else None,
         vendor_quote_number=po.vendor_quote_number,
         notes=po.notes,
         expected_delivery_date=po.expected_delivery_date,
@@ -532,7 +547,11 @@ class Query:
         with SessionLocal() as session:
             stmt = (
                 select(POModel)
-                .options(selectinload(POModel.line_items), selectinload(POModel.documents))
+                .options(
+                    selectinload(POModel.line_items),
+                    selectinload(POModel.documents),
+                    selectinload(POModel.vendor),
+                )
                 .where(
                     POModel.deleted_at.is_(None),
                     POModel.status.in_(
@@ -779,6 +798,19 @@ class Query:
             )
             for u in results
         ]
+
+    @strawberry.field
+    def vendors(self) -> list[Vendor]:
+        with SessionLocal() as session:
+            return [_vendor_to_type(v) for v in vendor_repository.list_vendors(session)]
+
+    @strawberry.field
+    def vendor(self, id: strawberry.ID) -> Vendor | None:
+        from app.models.vendor import Vendor as VendorModel
+
+        with SessionLocal() as session:
+            v = session.get(VendorModel, uuid.UUID(str(id)))
+            return _vendor_to_type(v) if v is not None else None
 
     @strawberry.field
     def expected_deliveries(self, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -81,6 +81,18 @@ class HardwareItem:
 
 
 @strawberry.type
+class Vendor:
+    id: strawberry.ID
+    name: str
+    contact_name: str | None
+    email: str | None
+    phone: str | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@strawberry.type
 class POLineItem:
     id: strawberry.ID
     po_id: strawberry.ID
@@ -142,8 +154,7 @@ class PurchaseOrder:
     request_number: str
     project_id: strawberry.ID | None
     status: POStatus
-    vendor_name: str | None
-    vendor_contact: str | None
+    vendor: Vendor | None
     vendor_quote_number: str | None
     notes: str | None
     expected_delivery_date: date | None

--- a/frontend/src/components/VendorSelect.tsx
+++ b/frontend/src/components/VendorSelect.tsx
@@ -1,0 +1,93 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Autocomplete, TextField } from '@mui/material';
+import { useQuery } from '@apollo/client/react';
+import { GET_VENDORS } from '../graphql/queries';
+import VendorEditDialog from '../modules/admin/VendorEditDialog';
+
+export interface VendorOption {
+  id: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface VendorSelectProps {
+  value: string | null;
+  onChange: (vendorId: string | null) => void;
+  label?: string;
+  size?: 'small' | 'medium';
+  error?: boolean;
+  helperText?: string;
+  disabled?: boolean;
+  fullWidth?: boolean;
+}
+
+const CREATE_NEW_ID = '__create_new__';
+
+export default function VendorSelect({
+  value,
+  onChange,
+  label = 'Vendor',
+  size = 'small',
+  error,
+  helperText,
+  disabled,
+  fullWidth = true,
+}: VendorSelectProps) {
+  const { data } = useQuery<{ vendors: VendorOption[] }>(GET_VENDORS);
+  const vendors = useMemo(() => data?.vendors ?? [], [data]);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const options: (VendorOption | { id: typeof CREATE_NEW_ID; name: string })[] = useMemo(() => {
+    return [...vendors, { id: CREATE_NEW_ID, name: '+ Create new vendor…' }];
+  }, [vendors]);
+
+  const selected = useMemo(
+    () => vendors.find((v) => v.id === value) ?? null,
+    [vendors, value],
+  );
+
+  const handleChange = useCallback(
+    (_: unknown, option: (typeof options)[number] | null) => {
+      if (option && option.id === CREATE_NEW_ID) {
+        setCreateOpen(true);
+        return;
+      }
+      onChange(option ? option.id : null);
+    },
+    [onChange],
+  );
+
+  return (
+    <>
+      <Autocomplete
+        size={size}
+        fullWidth={fullWidth}
+        value={selected}
+        options={options}
+        getOptionLabel={(o) => o.name}
+        isOptionEqualToValue={(o, v) => o.id === v.id}
+        onChange={handleChange}
+        disabled={disabled}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            error={error}
+            helperText={helperText}
+          />
+        )}
+      />
+      <VendorEditDialog
+        open={createOpen}
+        vendor={null}
+        onClose={() => setCreateOpen(false)}
+        onSaved={(vendor) => {
+          onChange(vendor.id);
+          setCreateOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -1,14 +1,19 @@
 import { gql } from '@apollo/client/core';
 
 export const UPDATE_PO = gql`
-  mutation UpdatePO($id: ID!, $vendorName: String, $vendorContact: String, $expectedDeliveryDate: Date, $poNumber: String, $vendorQuoteNumber: String, $notes: String) {
-    updatePo(id: $id, vendorName: $vendorName, vendorContact: $vendorContact, expectedDeliveryDate: $expectedDeliveryDate, poNumber: $poNumber, vendorQuoteNumber: $vendorQuoteNumber, notes: $notes) {
+  mutation UpdatePO($id: ID!, $vendorId: ID, $expectedDeliveryDate: Date, $poNumber: String, $vendorQuoteNumber: String, $notes: String) {
+    updatePo(id: $id, vendorId: $vendorId, expectedDeliveryDate: $expectedDeliveryDate, poNumber: $poNumber, vendorQuoteNumber: $vendorQuoteNumber, notes: $notes) {
       id
       poNumber
       requestNumber
       status
-      vendorName
-      vendorContact
+      vendor {
+        id
+        name
+        contactName
+        email
+        phone
+      }
       vendorQuoteNumber
       notes
       expectedDeliveryDate
@@ -56,7 +61,11 @@ export const MARK_PO_AS_ORDERED = gql`
       status
       orderedAt
       updatedAt
-      vendorName
+      vendor {
+        id
+        name
+        contactName
+      }
       vendorQuoteNumber
       notes
       lineItems {
@@ -390,8 +399,13 @@ export const CREATE_PO = gql`
       requestNumber
       projectId
       status
-      vendorName
-      vendorContact
+      vendor {
+        id
+        name
+        contactName
+        email
+        phone
+      }
       notes
       createdAt
       updatedAt
@@ -535,6 +549,42 @@ export const UPDATE_USER_ROLES = gql`
       roles
       imageUrl
     }
+  }
+`;
+
+export const CREATE_VENDOR = gql`
+  mutation CreateVendor($input: CreateVendorInput!) {
+    createVendor(input: $input) {
+      id
+      name
+      contactName
+      email
+      phone
+      notes
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const UPDATE_VENDOR = gql`
+  mutation UpdateVendor($id: ID!, $input: UpdateVendorInput!) {
+    updateVendor(id: $id, input: $input) {
+      id
+      name
+      contactName
+      email
+      phone
+      notes
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const DELETE_VENDOR = gql`
+  mutation DeleteVendor($id: ID!) {
+    deleteVendor(id: $id)
   }
 `;
 

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -37,8 +37,13 @@ export const GET_PURCHASE_ORDERS = gql`
       requestNumber
       projectId
       status
-      vendorName
-      vendorContact
+      vendor {
+        id
+        name
+        contactName
+        email
+        phone
+      }
       vendorQuoteNumber
       notes
       expectedDeliveryDate
@@ -175,7 +180,10 @@ export const GET_OPEN_POS = gql`
       poNumber
       projectId
       status
-      vendorName
+      vendor {
+        id
+        name
+      }
       notes
       orderedAt
       expectedDeliveryDate
@@ -237,7 +245,11 @@ export const GET_PO_RECEIVING_DETAILS = gql`
       id
       poNumber
       requestNumber
-      vendorName
+      vendor {
+        id
+        name
+        contactName
+      }
       notes
       status
       lineItems {
@@ -481,6 +493,21 @@ export const GET_USERS = gql`
   }
 `;
 
+export const GET_VENDORS = gql`
+  query GetVendors {
+    vendors {
+      id
+      name
+      contactName
+      email
+      phone
+      notes
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
 export const GET_INVENTORY_BY_VENDOR = gql`
   query GetInventoryByVendor($projectId: ID) {
     inventoryByVendor(projectId: $projectId) {
@@ -543,7 +570,10 @@ export const GET_EXPECTED_DELIVERIES = gql`
       id
       poNumber
       requestNumber
-      vendorName
+      vendor {
+        id
+        name
+      }
       expectedDeliveryDate
       orderedAt
       status

--- a/frontend/src/modules/admin/VendorEditDialog.tsx
+++ b/frontend/src/modules/admin/VendorEditDialog.tsx
@@ -1,0 +1,189 @@
+import { useState, useCallback } from 'react';
+import { Button, Stack, TextField } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../components/Modal';
+import { useToast } from '../../components/Toast';
+import { CREATE_VENDOR, UPDATE_VENDOR } from '../../graphql/mutations';
+import { GET_VENDORS } from '../../graphql/queries';
+
+export interface VendorFormValue {
+  id?: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  notes: string | null;
+}
+
+interface VendorEditDialogProps {
+  open: boolean;
+  vendor: VendorFormValue | null;
+  onClose: () => void;
+  onSaved?: (vendor: { id: string; name: string }) => void;
+}
+
+const EMPTY: VendorFormValue = {
+  name: '',
+  contactName: '',
+  email: '',
+  phone: '',
+  notes: '',
+};
+
+interface ContentProps {
+  initialVendor: VendorFormValue | null;
+  onClose: () => void;
+  onSaved?: (vendor: { id: string; name: string }) => void;
+}
+
+function VendorEditDialogContent({ initialVendor, onClose, onSaved }: ContentProps) {
+  const { showToast } = useToast();
+  const [form, setForm] = useState<VendorFormValue>(() =>
+    initialVendor
+      ? {
+          id: initialVendor.id,
+          name: initialVendor.name,
+          contactName: initialVendor.contactName ?? '',
+          email: initialVendor.email ?? '',
+          phone: initialVendor.phone ?? '',
+          notes: initialVendor.notes ?? '',
+        }
+      : EMPTY,
+  );
+  const [nameError, setNameError] = useState('');
+
+  const [createVendor, { loading: creating }] = useMutation<{ createVendor: { id: string; name: string } }>(
+    CREATE_VENDOR,
+    {
+      refetchQueries: [{ query: GET_VENDORS }],
+      onCompleted: (data) => {
+        showToast('Vendor created', 'success');
+        onSaved?.(data.createVendor);
+        onClose();
+      },
+      onError: (err) => {
+        if (err.message.toLowerCase().includes('already exists')) {
+          setNameError(err.message);
+        } else {
+          showToast(err.message, 'error');
+        }
+      },
+    },
+  );
+
+  const [updateVendor, { loading: updating }] = useMutation<{ updateVendor: { id: string; name: string } }>(
+    UPDATE_VENDOR,
+    {
+      refetchQueries: [{ query: GET_VENDORS }],
+      onCompleted: (data) => {
+        showToast('Vendor updated', 'success');
+        onSaved?.(data.updateVendor);
+        onClose();
+      },
+      onError: (err) => {
+        if (err.message.toLowerCase().includes('already exists')) {
+          setNameError(err.message);
+        } else {
+          showToast(err.message, 'error');
+        }
+      },
+    },
+  );
+
+  const loading = creating || updating;
+
+  const handleSubmit = useCallback(() => {
+    const trimmedName = form.name.trim();
+    if (!trimmedName) {
+      setNameError('Vendor name is required');
+      return;
+    }
+    const payload = {
+      name: trimmedName,
+      contactName: form.contactName?.trim() || null,
+      email: form.email?.trim() || null,
+      phone: form.phone?.trim() || null,
+      notes: form.notes?.trim() || null,
+    };
+    if (form.id) {
+      updateVendor({ variables: { id: form.id, input: payload } });
+    } else {
+      createVendor({ variables: { input: payload } });
+    }
+  }, [form, createVendor, updateVendor]);
+
+  const actions = (
+    <Stack direction="row" spacing={1}>
+      <Button onClick={onClose} disabled={loading}>
+        Cancel
+      </Button>
+      <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+        {loading ? 'Saving...' : form.id ? 'Save' : 'Create'}
+      </Button>
+    </Stack>
+  );
+
+  return (
+    <Modal
+      open
+      title={form.id ? 'Edit Vendor' : 'Create Vendor'}
+      onClose={onClose}
+      actions={actions}
+      maxWidth="sm"
+    >
+      <Stack spacing={2} sx={{ pt: 1 }}>
+        <TextField
+          label="Name"
+          value={form.name}
+          onChange={(e) => {
+            setForm((f) => ({ ...f, name: e.target.value }));
+            if (nameError) setNameError('');
+          }}
+          required
+          autoFocus
+          fullWidth
+          size="small"
+          error={!!nameError}
+          helperText={nameError}
+        />
+        <TextField
+          label="Contact Name"
+          value={form.contactName ?? ''}
+          onChange={(e) => setForm((f) => ({ ...f, contactName: e.target.value }))}
+          fullWidth
+          size="small"
+        />
+        <TextField
+          label="Email"
+          type="email"
+          value={form.email ?? ''}
+          onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+          fullWidth
+          size="small"
+        />
+        <TextField
+          label="Phone"
+          value={form.phone ?? ''}
+          onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
+          fullWidth
+          size="small"
+        />
+        <TextField
+          label="Notes"
+          value={form.notes ?? ''}
+          onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+          fullWidth
+          size="small"
+          multiline
+          minRows={2}
+          maxRows={6}
+        />
+      </Stack>
+    </Modal>
+  );
+}
+
+export default function VendorEditDialog({ open, vendor, onClose, onSaved }: VendorEditDialogProps) {
+  if (!open) return null;
+  return <VendorEditDialogContent initialVendor={vendor} onClose={onClose} onSaved={onSaved} />;
+}

--- a/frontend/src/modules/admin/VendorsPage.tsx
+++ b/frontend/src/modules/admin/VendorsPage.tsx
@@ -1,0 +1,178 @@
+import { useState, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  Stack,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { GET_VENDORS } from '../../graphql/queries';
+import { DELETE_VENDOR } from '../../graphql/mutations';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import VendorEditDialog, { type VendorFormValue } from './VendorEditDialog';
+
+interface Vendor {
+  id: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function VendorsPage() {
+  const { isAdmin } = useIdentity();
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState<VendorFormValue | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<Vendor | null>(null);
+
+  const { data, loading } = useQuery<{ vendors: Vendor[] }>(GET_VENDORS);
+  const vendors = useMemo(() => data?.vendors ?? [], [data]);
+
+  const [deleteVendor, { loading: deleting }] = useMutation(DELETE_VENDOR, {
+    refetchQueries: [{ query: GET_VENDORS }],
+    onCompleted: () => {
+      showToast('Vendor deleted', 'success');
+      setPendingDelete(null);
+    },
+    onError: (err) => {
+      showToast(err.message, 'error');
+      setPendingDelete(null);
+    },
+  });
+
+  const handleRowClick = useCallback((params: GridRowParams<Vendor>) => {
+    setEditing({
+      id: params.row.id,
+      name: params.row.name,
+      contactName: params.row.contactName,
+      email: params.row.email,
+      phone: params.row.phone,
+      notes: params.row.notes,
+    });
+    setEditOpen(true);
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    setEditing(null);
+    setEditOpen(true);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (pendingDelete) {
+      deleteVendor({ variables: { id: pendingDelete.id } });
+    }
+  }, [pendingDelete, deleteVendor]);
+
+  const columns: GridColDef[] = useMemo(() => {
+    const cols: GridColDef[] = [
+      { field: 'name', headerName: 'Name', flex: 1.2, minWidth: 160 },
+      {
+        field: 'contactName',
+        headerName: 'Contact',
+        flex: 1,
+        minWidth: 140,
+        valueFormatter: (v: string | null) => v ?? '—',
+      },
+      {
+        field: 'email',
+        headerName: 'Email',
+        flex: 1.2,
+        minWidth: 180,
+        valueFormatter: (v: string | null) => v ?? '—',
+      },
+      {
+        field: 'phone',
+        headerName: 'Phone',
+        flex: 0.8,
+        minWidth: 120,
+        valueFormatter: (v: string | null) => v ?? '—',
+      },
+    ];
+    if (isAdmin) {
+      cols.push({
+        field: 'actions',
+        headerName: '',
+        width: 60,
+        sortable: false,
+        filterable: false,
+        renderCell: (params) => (
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              setPendingDelete(params.row as Vendor);
+            }}
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        ),
+      });
+    }
+    return cols;
+  }, [isAdmin]);
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Box>
+          <Typography variant="h5" gutterBottom>
+            Vendors
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Companies we buy from. Click a row to edit.
+          </Typography>
+        </Box>
+        <Button variant="contained" onClick={handleCreate}>
+          Create Vendor
+        </Button>
+      </Stack>
+
+      <DataGrid
+        rows={vendors}
+        columns={columns}
+        loading={loading}
+        onRowClick={handleRowClick}
+        autoHeight
+        disableRowSelectionOnClick
+        pageSizeOptions={[10, 25, 50]}
+        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+        sx={{ cursor: 'pointer' }}
+      />
+
+      <VendorEditDialog
+        open={editOpen}
+        vendor={editing}
+        onClose={() => setEditOpen(false)}
+      />
+
+      <Dialog open={!!pendingDelete} onClose={() => setPendingDelete(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete vendor?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete <strong>{pendingDelete?.name}</strong>? This cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingDelete(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button color="error" variant="contained" onClick={handleConfirmDelete} disabled={deleting}>
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -3,10 +3,12 @@ import { Box, Tabs, Tab, Typography } from '@mui/material';
 import HardwareSummaryTab from './HardwareSummaryTab';
 import OpeningStatusTab from './OpeningStatusTab';
 import UserManagementPage from './UserManagementPage';
+import VendorsPage from './VendorsPage';
 
 const SUB_ROUTES = [
   { label: 'Hardware Summary', path: 'hardware-summary' },
   { label: 'Opening Status', path: 'opening-status' },
+  { label: 'Vendors', path: 'vendors' },
   { label: 'User Management', path: 'users' },
 ];
 
@@ -26,6 +28,7 @@ export default function AdminModule() {
       <Routes>
         <Route path="hardware-summary" element={<HardwareSummaryTab />} />
         <Route path="opening-status" element={<OpeningStatusTab />} />
+        <Route path="vendors" element={<VendorsPage />} />
         <Route path="users" element={<UserManagementPage />} />
         <Route index element={<Navigate to="hardware-summary" replace />} />
       </Routes>

--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -43,7 +43,7 @@ export type GroupByField = 'hardwareCategory' | 'vendorNo' | 'productCode' | 'op
 
 const GROUP_BY_OPTIONS: { value: GroupByField; label: string }[] = [
   { value: 'hardwareCategory', label: 'Hardware Category' },
-  { value: 'vendorNo', label: 'Vendor' },
+  { value: 'vendorNo', label: 'Manufacturer' },
   { value: 'productCode', label: 'Product Code' },
   { value: 'openingNumber', label: 'Opening Number' },
   { value: 'unitCost', label: 'Unit Cost' },
@@ -105,7 +105,7 @@ const ALL_COLUMNS: GridColDef[] = [
   { field: 'openingNumber', headerName: 'Opening #', flex: 0.7 },
   { field: 'productCode', headerName: 'Product Code', flex: 1 },
   { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
-  { field: 'vendorNo', headerName: 'Vendor', flex: 0.8 },
+  { field: 'vendorNo', headerName: 'Manufacturer', flex: 0.8 },
   {
     field: 'listPrice',
     headerName: 'List Price',

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -103,7 +103,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // Action step state
   const [selectedVendors, setSelectedVendors] = useState<Set<string>>(new Set());
-  const [vendorPOInfo, setVendorPOInfo] = useState<Map<string, { vendorContact: string; notes: string }>>(new Map());
+  const [vendorPOInfo, setVendorPOInfo] = useState<Map<string, { vendorId: string | null; notes: string }>>(new Map());
   const [unitCostOverrides, setUnitCostOverrides] = useState<Map<string, number>>(new Map());
   const [classifications, setClassifications] = useState<Map<string, string>>(new Map());
   const [orderAsValues, setOrderAsValues] = useState<Map<string, string>>(new Map());
@@ -311,7 +311,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         openingNumber: hi.opening_number,
         productCode: hi.product_code,
         hardwareCategory: hi.hardware_category,
-        vendorNo: hi.vendor_no ?? '(No Vendor)',
+        vendorNo: hi.vendor_no ?? '(No Manufacturer)',
         listPrice: hi.list_price,
         vendorDiscount: hi.vendor_discount,
         unitCost: hi.unit_cost ?? 0,
@@ -331,7 +331,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         const ck = classificationKey(hi);
         if (classifications.get(ck) === 'BY_OTHERS') continue;
       }
-      const vendor = hi.vendor_no ?? '(No Vendor)';
+      const vendor = hi.vendor_no ?? '(No Manufacturer)';
       if (!map.has(vendor)) map.set(vendor, []);
       map.get(vendor)!.push(hi);
     }
@@ -440,15 +440,22 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     });
   }, []);
 
-  // Vendor PO info
-  const updateVendorPO = useCallback((vendorNo: string, field: 'vendorContact' | 'notes', value: string) => {
-    setVendorPOInfo((prev) => {
-      const next = new Map(prev);
-      const existing = next.get(vendorNo) ?? { vendorContact: '', notes: '' };
-      next.set(vendorNo, { ...existing, [field]: value });
-      return next;
-    });
-  }, []);
+  // Manufacturer-group PO info
+  const updateVendorPO = useCallback(
+    (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => {
+      setVendorPOInfo((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(manufacturerKey) ?? { vendorId: null, notes: '' };
+        if (field === 'vendorId') {
+          next.set(manufacturerKey, { ...existing, vendorId: value });
+        } else {
+          next.set(manufacturerKey, { ...existing, notes: value ?? '' });
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
   // Unit cost overrides
   const updateUnitCost = useCallback((vendor: string, productCode: string, hardwareCategory: string, value: number) => {
@@ -580,9 +587,9 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       openings: selectedOpeningsList.map((o) => snakeToCamel(o as unknown as Record<string, unknown>)),
       hardwareItems: purpose === 'po'
         ? aggregatedHardwareItems
-            .filter((hi) => selectedVendors.has(hi.vendor_no ?? '(No Vendor)') && !isByOthers(hi))
+            .filter((hi) => selectedVendors.has(hi.vendor_no ?? '(No Manufacturer)') && !isByOthers(hi))
             .map((hi) => {
-              const vendor = hi.vendor_no ?? '(No Vendor)';
+              const vendor = hi.vendor_no ?? '(No Manufacturer)';
               const overrideKey = `${vendor}|${hi.product_code}|${hi.hardware_category}`;
               const overriddenCost = unitCostOverrides.get(overrideKey);
               const item = overriddenCost !== undefined
@@ -598,8 +605,8 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               // Filter out BY_OTHERS items from this vendor's PO draft
               const inScopeItems = items.filter((hi) => !isByOthers(hi));
               if (inScopeItems.length === 0) return null;
-              const info = vendorPOInfo.get(vendor) ?? { vendorContact: '', notes: '' };
-              // Collect aliases for this vendor's aggregated line items
+              const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '' };
+              // Collect aliases for this manufacturer group's aggregated line items
               const seenKeys = new Set<string>();
               const lineItemAliases: Array<{ hardwareCategory: string; productCode: string; orderAs: string }> = [];
               for (const hi of inScopeItems) {
@@ -618,8 +625,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               }
               return {
                 poNumber: null,
-                vendorName: vendor !== '(No Vendor)' ? vendor : null,
-                vendorContact: info.vendorContact || null,
+                vendorId: info.vendorId,
                 notes: info.notes || null,
                 hardwareItemRefs: inScopeItems.map((hi) => ({
                   openingNumber: hi.opening_number,
@@ -1075,7 +1081,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
                 {purpose === 'po' && (
                   <Box sx={{ mb: 1 }}>
                     <Typography variant="body1">
-                      {selectedVendors.size} Purchase Order(s) across {selectedVendors.size} vendor(s)
+                      {selectedVendors.size} Purchase Order(s) across {selectedVendors.size} manufacturer group(s)
                     </Typography>
                   </Box>
                 )}

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Box, Button, Checkbox, FormControlLabel, InputAdornment, Paper, TextField, Typography } from '@mui/material';
+import VendorSelect from '../../components/VendorSelect';
 import type { AggregatedHardwareItem } from './types';
 
 // ---- Aggregation Types ----
@@ -16,12 +17,12 @@ interface AggregatedLineItem {
 
 interface PurchaseOrdersStepProps {
   vendorGroups: Map<string, AggregatedHardwareItem[]>;
-  vendorPOInfo: Map<string, { vendorContact: string; notes: string }>;
+  vendorPOInfo: Map<string, { vendorId: string | null; notes: string }>;
   selectedVendors: Set<string>;
   unitCostOverrides: Map<string, number>;
   orderAsValues: Map<string, string>;
   onToggleVendor: (vendor: string) => void;
-  onUpdateVendorPO: (vendorNo: string, field: 'vendorContact' | 'notes', value: string) => void;
+  onUpdateVendorPO: (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => void;
   onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
   onUpdateOrderAs: (key: string, value: string) => void;
   onNext: () => void;
@@ -93,18 +94,18 @@ export default function PurchaseOrdersStep({
         Purchase Orders
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        {vendorGroups.size} vendor(s). Select which vendors to create purchase orders for. PO numbers can be assigned later from Microsoft GP.
+        {vendorGroups.size} manufacturer group(s). Select which to create purchase orders for, and pick a vendor (the company you buy from). PO numbers can be assigned later from Microsoft GP.
       </Typography>
 
       {sortedVendors.map(([vendor, items]) => {
-        const info = vendorPOInfo.get(vendor) ?? { vendorContact: '', notes: '' };
+        const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '' };
         const aggregated = aggregateLineItems(items, vendor, unitCostOverrides);
         const poTotal = aggregated.reduce((sum, line) => sum + line.totalCost, 0);
         const isSelected = selectedVendors.has(vendor);
 
         return (
           <Paper key={vendor} variant="outlined" sx={{ p: 2, mb: 2, opacity: isSelected ? 1 : 0.5 }}>
-            {/* Header: checkbox + vendor name + PO total */}
+            {/* Header: checkbox + manufacturer label + PO total */}
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
               <FormControlLabel
                 control={
@@ -114,9 +115,14 @@ export default function PurchaseOrdersStep({
                   />
                 }
                 label={
-                  <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                    {vendor}
-                  </Typography>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Manufacturer
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                      {vendor}
+                    </Typography>
+                  </Box>
                 }
               />
               <Typography variant="subtitle1" color="primary">
@@ -124,16 +130,15 @@ export default function PurchaseOrdersStep({
               </Typography>
             </Box>
 
-            {/* Vendor Contact + Notes fields */}
+            {/* Vendor select + Notes fields */}
             <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-              <TextField
-                label="Vendor Contact"
-                size="small"
-                disabled={!isSelected}
-                value={info.vendorContact}
-                onChange={(e) => onUpdateVendorPO(vendor, 'vendorContact', e.target.value)}
-                sx={{ flex: 1 }}
-              />
+              <Box sx={{ flex: 1 }}>
+                <VendorSelect
+                  value={info.vendorId}
+                  onChange={(id) => onUpdateVendorPO(vendor, 'vendorId', id)}
+                  disabled={!isSelected}
+                />
+              </Box>
               <TextField
                 label="Notes"
                 size="small"

--- a/frontend/src/modules/import/SelectOpeningsHardwareStep.tsx
+++ b/frontend/src/modules/import/SelectOpeningsHardwareStep.tsx
@@ -367,7 +367,7 @@ export default function SelectOpeningsHardwareStep({
                           {productCode}
                         </Typography>
                         <Chip label={category} size="small" variant="outlined" />
-                        <Chip label={items[0].vendor_no ?? '(No Vendor)'} size="small" variant="outlined" />
+                        <Chip label={items[0].vendor_no ?? '(No Manufacturer)'} size="small" variant="outlined" />
                         <Chip
                           label={items[0].unit_cost != null ? `$${items[0].unit_cost.toFixed(2)}` : '\u2014'}
                           size="small"

--- a/frontend/src/modules/po/CreatePODialog.tsx
+++ b/frontend/src/modules/po/CreatePODialog.tsx
@@ -12,6 +12,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import { useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
+import VendorSelect from '../../components/VendorSelect';
 import { useToast } from '../../components/Toast';
 import { CREATE_PO } from '../../graphql/mutations';
 import { GET_PROJECTS } from '../../graphql/queries';
@@ -62,8 +63,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
 
   // Form state
   const [projectId, setProjectId] = useState(defaultProjectId ?? '');
-  const [vendorName, setVendorName] = useState('');
-  const [vendorContact, setVendorContact] = useState('');
+  const [vendorId, setVendorId] = useState<string | null>(null);
   const [notes, setNotes] = useState('');
   const [nextKey, setNextKey] = useState(2);
   const [lineItems, setLineItems] = useState<LineItemRow[]>([
@@ -113,8 +113,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
 
   const handleReset = useCallback(() => {
     setProjectId(defaultProjectId ?? '');
-    setVendorName('');
-    setVendorContact('');
+    setVendorId(null);
     setNotes('');
     setLineItems([{ key: 1, ...EMPTY_LINE_ITEM }]);
     setNextKey(2);
@@ -126,8 +125,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
 
     const input = {
       projectId: projectId || null,
-      vendorName: vendorName.trim() || null,
-      vendorContact: vendorContact.trim() || null,
+      vendorId: vendorId || null,
       notes: notes.trim() || null,
       lineItems: lineItems.map((li) => ({
         hardwareCategory: li.hardwareCategory.trim(),
@@ -148,7 +146,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
       const message = err instanceof Error ? err.message : 'Failed to create PO';
       showToast(message, 'error');
     }
-  }, [validate, projectId, vendorName, vendorContact, notes, lineItems, createPO, showToast, onCreated, handleReset]);
+  }, [validate, projectId, vendorId, notes, lineItems, createPO, showToast, onCreated, handleReset]);
 
   const handleClose = useCallback(() => {
     handleReset();
@@ -188,22 +186,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
           ))}
         </TextField>
 
-        <Stack direction="row" spacing={2}>
-          <TextField
-            label="Vendor Name"
-            value={vendorName}
-            onChange={(e) => setVendorName(e.target.value)}
-            size="small"
-            fullWidth
-          />
-          <TextField
-            label="Vendor Contact"
-            value={vendorContact}
-            onChange={(e) => setVendorContact(e.target.value)}
-            size="small"
-            fullWidth
-          />
-        </Stack>
+        <VendorSelect value={vendorId} onChange={setVendorId} />
         <TextField
           label="Notes"
           value={notes}

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -32,6 +32,7 @@ import type { GridColDef } from '@mui/x-data-grid';
 import Modal from '../../components/Modal';
 import DataTable from '../../components/DataTable';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import VendorSelect from '../../components/VendorSelect';
 import { useToast } from '../../components/Toast';
 import {
   UPDATE_PO,
@@ -154,12 +155,11 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
   // Edit mode state
   const [editing, setEditing] = useState(false);
   const [poNumber, setPoNumber] = useState(po.poNumber ?? '');
-  const [vendorName, setVendorName] = useState(po.vendorName ?? '');
-  const [vendorContact, setVendorContact] = useState(po.vendorContact ?? '');
+  const [vendorId, setVendorId] = useState<string | null>(po.vendor?.id ?? null);
   const [vendorQuoteNumber, setVendorQuoteNumber] = useState(po.vendorQuoteNumber ?? '');
   const [expectedDeliveryDate, setExpectedDeliveryDate] = useState(po.expectedDeliveryDate ?? '');
   const [notes, setNotes] = useState(po.notes ?? '');
-  const [vendorNameError, setVendorNameError] = useState('');
+  const [vendorIdError, setVendorIdError] = useState('');
   const [poNumberError, setPoNumberError] = useState('');
   const [aliasEdits, setAliasEdits] = useState<Record<string, string>>({});
   const [unitCostEdits, setUnitCostEdits] = useState<Record<string, string>>({});
@@ -186,8 +186,8 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
         const code = error.errors?.[0]?.extensions?.code;
         if (code === 'VALIDATION_ERROR') {
           const field = error.errors?.[0]?.extensions?.field;
-          if (field === 'vendor_name') {
-            setVendorNameError('Vendor name is required');
+          if (field === 'vendor_id') {
+            setVendorIdError('Vendor is required');
           } else if (field === 'po_number') {
             setPoNumberError(error.errors?.[0]?.message ?? 'Invalid PO number');
           } else {
@@ -262,12 +262,11 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
 
   const handleStartEdit = () => {
     setPoNumber(po.poNumber ?? '');
-    setVendorName(po.vendorName ?? '');
-    setVendorContact(po.vendorContact ?? '');
+    setVendorId(po.vendor?.id ?? null);
     setVendorQuoteNumber(po.vendorQuoteNumber ?? '');
     setExpectedDeliveryDate(po.expectedDeliveryDate ?? '');
     setNotes(po.notes ?? '');
-    setVendorNameError('');
+    setVendorIdError('');
     setPoNumberError('');
     const initialAliases: Record<string, string> = {};
     const initialUnitCosts: Record<string, string> = {};
@@ -282,12 +281,12 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
 
   const handleCancelEdit = () => {
     setEditing(false);
-    setVendorNameError('');
+    setVendorIdError('');
     setPoNumberError('');
   };
 
   const handleSave = async () => {
-    setVendorNameError('');
+    setVendorIdError('');
     setPoNumberError('');
 
     // Save line item changes (alias + unit cost)
@@ -327,8 +326,7 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
     updatePo({
       variables: {
         id: po.id,
-        vendorName: vendorName || null,
-        vendorContact: vendorContact || null,
+        vendorId: vendorId || null,
         expectedDeliveryDate: expectedDeliveryDate || null,
         poNumber: poNumber || null,
         vendorQuoteNumber: vendorQuoteNumber || null,
@@ -435,9 +433,9 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
   const missingRequirements = useMemo(() => {
     const missing: string[] = [];
     if (!po.poNumber) missing.push('PO Number');
-    if (!po.vendorName) missing.push('Vendor Name');
+    if (!po.vendor?.id) missing.push('Vendor');
     return missing;
-  }, [po.poNumber, po.vendorName]);
+  }, [po.poNumber, po.vendor?.id]);
 
   const markAsOrderedEnabled = canMarkAsOrdered && missingRequirements.length === 0;
 
@@ -545,24 +543,14 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
               fullWidth
               size="small"
             />
-            <TextField
-              label="Vendor Name"
-              value={vendorName}
-              onChange={(e) => {
-                setVendorName(e.target.value);
-                if (vendorNameError) setVendorNameError('');
+            <VendorSelect
+              value={vendorId}
+              onChange={(id) => {
+                setVendorId(id);
+                if (vendorIdError) setVendorIdError('');
               }}
-              error={!!vendorNameError}
-              helperText={vendorNameError}
-              fullWidth
-              size="small"
-            />
-            <TextField
-              label="Vendor Contact"
-              value={vendorContact}
-              onChange={(e) => setVendorContact(e.target.value)}
-              fullWidth
-              size="small"
+              error={!!vendorIdError}
+              helperText={vendorIdError}
             />
             <TextField
               label="Vendor Quote Number"
@@ -594,8 +582,8 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
         ) : (
           <Box sx={{ mb: 3 }}>
             <InfoRow label="PO Number" value={po.poNumber || '(Not assigned)'} />
-            <InfoRow label="Vendor Name" value={po.vendorName || '-'} />
-            <InfoRow label="Vendor Contact" value={po.vendorContact || '-'} />
+            <InfoRow label="Vendor" value={po.vendor?.name || '-'} />
+            <InfoRow label="Vendor Contact" value={po.vendor?.contactName || '-'} />
             <InfoRow label="Vendor Quote #" value={po.vendorQuoteNumber || '-'} />
             <InfoRow label="Expected Delivery Date" value={formatDate(po.expectedDeliveryDate)} />
             <InfoRow label="Order Date" value={formatDate(po.orderedAt)} />
@@ -608,9 +596,9 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
               </Box>
             )}
             {!po.projectId && <InfoRow label="Project" value="No Project" />}
-            {vendorNameError && (
+            {vendorIdError && (
               <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-                {vendorNameError}
+                {vendorIdError}
               </Typography>
             )}
           </Box>

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -68,14 +68,21 @@ export interface PODocumentInfo {
   downloadUrl: string;
 }
 
+export interface VendorRef {
+  id: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
 export interface PurchaseOrder {
   id: string;
   poNumber: string | null;
   requestNumber: string;
   projectId: string | null;
   status: string;
-  vendorName: string | null;
-  vendorContact: string | null;
+  vendor: VendorRef | null;
   vendorQuoteNumber: string | null;
   notes: string | null;
   expectedDeliveryDate: string | null;
@@ -171,11 +178,11 @@ const columns: GridColDef[] = [
     ),
   },
   {
-    field: 'vendorName',
+    field: 'vendor',
     headerName: 'Vendor',
     flex: 1,
     minWidth: 160,
-    valueGetter: (_value: unknown, row: PurchaseOrder) => row.vendorName || '-',
+    valueGetter: (_value: unknown, row: PurchaseOrder) => row.vendor?.name || '-',
   },
   {
     field: 'orderedAt',

--- a/frontend/src/modules/warehouse/DeliveriesView.tsx
+++ b/frontend/src/modules/warehouse/DeliveriesView.tsx
@@ -33,7 +33,7 @@ interface ExpectedDeliveryPO {
   id: string;
   poNumber: string | null;
   requestNumber: string;
-  vendorName: string | null;
+  vendor: { id: string; name: string } | null;
   expectedDeliveryDate: string | null;
   orderedAt: string | null;
   status: string;
@@ -162,7 +162,7 @@ function UpcomingView({ projectId }: { projectId: string }) {
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, mr: 2 }}>
                 <Typography sx={{ fontWeight: 600 }}>{po.poNumber ?? po.requestNumber}</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {po.vendorName ?? 'No vendor'}
+                  {po.vendor?.name ?? 'No vendor'}
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto' }}>
                   {formatDate(po.expectedDeliveryDate)}

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -36,7 +36,7 @@ interface PODetailLineItem {
 interface PODetails {
   id: string;
   poNumber: string | null;
-  vendorName: string | null;
+  vendor: { id: string; name: string; contactName: string | null } | null;
   notes: string | null;
   status: string;
   lineItems: PODetailLineItem[];
@@ -297,7 +297,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         {showHeader && (
           <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: details.notes ? 0.5 : 1 }}>
             {details.poNumber ?? 'Unknown PO'}
-            {details.vendorName ? ` \u2014 ${details.vendorName}` : ''}
+            {details.vendor ? ` \u2014 ${details.vendor.name}` : ''}
           </Typography>
         )}
         {details.notes && (

--- a/frontend/src/modules/warehouse/ReceivingPage.tsx
+++ b/frontend/src/modules/warehouse/ReceivingPage.tsx
@@ -37,7 +37,7 @@ interface OpenPO {
   poNumber: string | null;
   projectId: string;
   status: string;
-  vendorName: string | null;
+  vendor: { id: string; name: string } | null;
   orderedAt: string | null;
   expectedDeliveryDate: string | null;
   lineItems: OpenPOLineItem[];
@@ -175,7 +175,7 @@ export default function ReceivingPage() {
         return {
           id: po.id,
           poNumber: po.poNumber ?? '\u2014',
-          vendorName: po.vendorName ?? '\u2014',
+          vendorName: po.vendor?.name ?? '\u2014',
           projectName: projectMap.get(po.projectId) ?? '\u2014',
           expectedDeliveryDate: po.expectedDeliveryDate,
           pendingLines,


### PR DESCRIPTION
## Summary

- Adds a managed `Vendor` entity (CRUD UI under Admin) and replaces `purchase_orders.vendor_name`/`vendor_contact` free-text with a `vendor_id` FK (`ON DELETE RESTRICT`).
- Migration 025 backfills `Vendor` rows from existing distinct `vendor_name` values, maps each PO to its backfilled vendor, then drops both legacy columns.
- Tightens UI labeling: import step 5 now labels groups as **Manufacturer** (TITAN's `Vendor_No`, the maker) rather than vendor; each manufacturer group gets a per-group **Vendor** select with inline "Create new vendor…".
- Hard-delete is blocked when any PO references the vendor; only Admin/Manager can delete (matches existing frontend-gated pattern in `UserManagementPage`). PO Users can create + edit.

## Notes

- `purchase_orders.vendor_contact` data is dropped (dev-only, confirmed). Per-PO contact now comes from `Vendor.contact_name`.
- Hardware `vendor_no` column name unchanged (faithful to TITAN XML); only UI labels changed.
- `inventoryByVendor` GraphQL field still emits `vendor_name: str` for backward compatibility — sourced from joined `Vendor.name`.