### PR TITLE
Load latest persisted hardware schedule (closes #96)

### DIFF
--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -41,6 +41,51 @@ from app.models.shop_assembly import (
 )
 
 
+def get_project_hardware_schedule(
+    session: Session,
+    project_id: uuid.UUID,
+) -> dict | None:
+    """Load a project's persisted hardware schedule (openings + items) for wizard hydration."""
+    project = (
+        session.scalars(
+            select(ProjectModel).where(ProjectModel.id == project_id).options(selectinload(ProjectModel.openings))
+        )
+        .unique()
+        .first()
+    )
+    if project is None:
+        return None
+
+    opening_number_by_id = {o.id: o.opening_number for o in project.openings}
+
+    hardware_items = session.scalars(select(HardwareItemModel).where(HardwareItemModel.project_id == project_id)).all()
+
+    return {
+        "project": project,
+        "openings": list(project.openings),
+        "hardware_items": [
+            {
+                "opening_number": opening_number_by_id.get(hi.opening_id, ""),
+                "product_code": hi.product_code,
+                "material_id": hi.material_id or str(hi.id),
+                "hardware_category": hi.hardware_category,
+                "item_quantity": hi.item_quantity,
+                "unit_cost": float(hi.unit_cost) if hi.unit_cost is not None else None,
+                "unit_price": float(hi.unit_price) if hi.unit_price is not None else None,
+                "list_price": float(hi.list_price) if hi.list_price is not None else None,
+                "vendor_discount": float(hi.vendor_discount) if hi.vendor_discount is not None else None,
+                "markup_pct": float(hi.markup_pct) if hi.markup_pct is not None else None,
+                "vendor_no": hi.vendor_no,
+                "phase_code": hi.phase_code,
+                "item_category_code": hi.item_category_code,
+                "product_group_code": hi.product_group_code,
+                "submittal_id": hi.submittal_id,
+            }
+            for hi in hardware_items
+        ],
+    }
+
+
 def reconcile_schedule(
     session: Session,
     project_id: uuid.UUID,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -47,6 +47,8 @@ from .types import (
     ProductCodeNode,
     Project,
     ProjectExcludedItem,
+    ProjectHardwareSchedule,
+    ProjectScheduleHardwareItem,
     PullRequest,
     PullRequestItem,
     PurchaseOrder,
@@ -219,6 +221,35 @@ def _project_to_type(p: ProjectModel) -> Project:
             for o in p.openings
         ],
         purchase_orders=[],  # Loaded on demand in later tickets
+    )
+
+
+def _project_schedule_hardware_item_to_type(hi: dict) -> ProjectScheduleHardwareItem:
+    return ProjectScheduleHardwareItem(
+        opening_number=hi["opening_number"],
+        product_code=hi["product_code"],
+        material_id=hi["material_id"],
+        hardware_category=hi["hardware_category"],
+        item_quantity=hi["item_quantity"],
+        unit_cost=hi["unit_cost"],
+        unit_price=hi["unit_price"],
+        list_price=hi["list_price"],
+        vendor_discount=hi["vendor_discount"],
+        markup_pct=hi["markup_pct"],
+        vendor_no=hi["vendor_no"],
+        phase_code=hi["phase_code"],
+        item_category_code=hi["item_category_code"],
+        product_group_code=hi["product_group_code"],
+        submittal_id=hi["submittal_id"],
+    )
+
+
+def _project_hardware_schedule_to_type(data: dict) -> ProjectHardwareSchedule:
+    project_type = _project_to_type(data["project"])
+    return ProjectHardwareSchedule(
+        project=project_type,
+        openings=project_type.openings,
+        hardware_items=[_project_schedule_hardware_item_to_type(hi) for hi in data["hardware_items"]],
     )
 
 
@@ -453,6 +484,16 @@ class Query:
             if p is None:
                 return None
             return _project_to_type(p)
+
+    @strawberry.field
+    def project_hardware_schedule(self, project_id: strawberry.ID) -> ProjectHardwareSchedule | None:
+        from app.repositories import import_repository
+
+        with SessionLocal() as session:
+            data = import_repository.get_project_hardware_schedule(session, uuid.UUID(str(project_id)))
+            if data is None:
+                return None
+            return _project_hardware_schedule_to_type(data)
 
     @strawberry.field
     def reconcile_schedule(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -191,6 +191,32 @@ class Project:
 
 
 @strawberry.type
+class ProjectScheduleHardwareItem:
+    opening_number: str
+    product_code: str
+    material_id: str
+    hardware_category: str
+    item_quantity: int
+    unit_cost: float | None
+    unit_price: float | None
+    list_price: float | None
+    vendor_discount: float | None
+    markup_pct: float | None
+    vendor_no: str | None
+    phase_code: str | None
+    item_category_code: str | None
+    product_group_code: str | None
+    submittal_id: str | None
+
+
+@strawberry.type
+class ProjectHardwareSchedule:
+    project: Project
+    openings: list[Opening]
+    hardware_items: list[ProjectScheduleHardwareItem]
+
+
+@strawberry.type
 class InventoryLocation:
     id: strawberry.ID
     project_id: strawberry.ID

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -403,6 +403,66 @@ export const GET_SHIP_READY_ITEMS = gql`
   }
 `;
 
+export const GET_PROJECT_HARDWARE_SCHEDULE = gql`
+  query GetProjectHardwareSchedule($projectId: ID!) {
+    projectHardwareSchedule(projectId: $projectId) {
+      project {
+        projectId
+        description
+        jobSiteName
+        address
+        city
+        state
+        zip
+        contractor
+        projectManager
+        application
+        submittalJobNo
+        submittalAssignmentCount
+        estimatorCode
+        titanUserId
+      }
+      openings {
+        openingNumber
+        building
+        floor
+        location
+        locationTo
+        locationFrom
+        hand
+        width
+        length
+        doorThickness
+        jambThickness
+        doorType
+        frameType
+        interiorExterior
+        keying
+        headingNo
+        singlePair
+        assignmentMultiplier
+      }
+      hardwareItems {
+        openingNumber
+        productCode
+        materialId
+        hardwareCategory
+        itemQuantity
+        unitCost
+        unitPrice
+        listPrice
+        vendorDiscount
+        markupPct
+        vendorNo
+        phaseCode
+        itemCategoryCode
+        productGroupCode
+        submittalId
+      }
+    }
+  }
+`;
+
 export const GET_PROJECT_BY_SCHEDULE_ID = gql`
   query GetProjectByScheduleId($projectId: String!) {
     projectByScheduleId(projectId: $projectId) {

--- a/frontend/src/hooks/__tests__/useHardwareScheduleParser.test.ts
+++ b/frontend/src/hooks/__tests__/useHardwareScheduleParser.test.ts
@@ -163,6 +163,9 @@ describe('useHardwareScheduleParser', () => {
     expect(result.current.error).toBeNull();
     expect(result.current.isLoading).toBe(false);
     expect(typeof result.current.parseFile).toBe('function');
+    expect(typeof result.current.hydrate).toBe('function');
+    expect(typeof result.current.setLoading).toBe('function');
+    expect(typeof result.current.setError).toBe('function');
     expect(typeof result.current.reset).toBe('function');
   });
 
@@ -459,5 +462,74 @@ describe('useHardwareScheduleParser', () => {
     });
     expect(result.current.state).toBe('parsing');
     expect(latestMockWorker.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // 12. hydrate() jumps directly to the done state with the supplied result
+  // -----------------------------------------------------------------------
+  it('hydrate transitions directly to done with the supplied parse result', () => {
+    const { result } = renderHook(() => useHardwareScheduleParser());
+
+    act(() => {
+      result.current.hydrate(mockParseResult);
+    });
+
+    expect(result.current.state).toBe('done');
+    expect(result.current.parseResult).toEqual(mockParseResult);
+    expect(result.current.progress).toEqual({ percent: 100, phase: 'Complete' });
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // 13. setLoading transitions idle -> reading with the supplied phase
+  // -----------------------------------------------------------------------
+  it('setLoading transitions to reading with the supplied phase', () => {
+    const { result } = renderHook(() => useHardwareScheduleParser());
+
+    act(() => {
+      result.current.setLoading('Loading schedule from project history');
+    });
+
+    expect(result.current.state).toBe('reading');
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.progress).toEqual({
+      percent: 0,
+      phase: 'Loading schedule from project history',
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 14. setError transitions to error state with the supplied message
+  // -----------------------------------------------------------------------
+  it('setError transitions to error state with the supplied message', () => {
+    const { result } = renderHook(() => useHardwareScheduleParser());
+
+    act(() => {
+      result.current.setError('Network failure');
+    });
+
+    expect(result.current.state).toBe('error');
+    expect(result.current.error).toBe('Network failure');
+  });
+
+  // -----------------------------------------------------------------------
+  // 15. reset() clears state after hydrate
+  // -----------------------------------------------------------------------
+  it('reset clears state after hydrate', () => {
+    const { result } = renderHook(() => useHardwareScheduleParser());
+
+    act(() => {
+      result.current.hydrate(mockParseResult);
+    });
+    expect(result.current.state).toBe('done');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state).toBe('idle');
+    expect(result.current.parseResult).toBeNull();
   });
 });

--- a/frontend/src/hooks/useHardwareScheduleParser.ts
+++ b/frontend/src/hooks/useHardwareScheduleParser.ts
@@ -15,6 +15,9 @@ export interface UseHardwareScheduleParserReturn {
   error: string | null;
   isLoading: boolean;
   parseFile: (file: File) => void;
+  hydrate: (result: ParseResult) => void;
+  setLoading: (phase: string) => void;
+  setError: (message: string) => void;
   reset: () => void;
 }
 
@@ -22,7 +25,7 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
   const [state, setState] = useState<ParserState>('idle');
   const [progress, setProgress] = useState<ParserProgress>({ percent: 0, phase: '' });
   const [result, setResult] = useState<ParseResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setErrorState] = useState<string | null>(null);
 
   const workerRef = useRef<Worker | null>(null);
 
@@ -34,7 +37,7 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
     setState('reading');
     setProgress({ percent: 0, phase: 'Reading file' });
     setResult(null);
-    setError(null);
+    setErrorState(null);
 
     const reader = new FileReader();
     reader.readAsText(file);
@@ -64,14 +67,14 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
             setProgress({ percent: 100, phase: 'Complete' });
             break;
           case 'error':
-            setError(message.error);
+            setErrorState(message.error);
             setState('error');
             break;
         }
       };
 
       worker.onerror = (event: ErrorEvent) => {
-        setError(event.message);
+        setErrorState(event.message);
         setState('error');
       };
 
@@ -83,10 +86,32 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
     };
 
     reader.onerror = () => {
-      setError('Failed to read file');
+      setErrorState('Failed to read file');
       setState('error');
     };
   }, [state]);
+
+  const hydrate = useCallback((parseResult: ParseResult) => {
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+    setResult(parseResult);
+    setState('done');
+    setProgress({ percent: 100, phase: 'Complete' });
+    setErrorState(null);
+  }, []);
+
+  const setLoading = useCallback((phase: string) => {
+    setState('reading');
+    setProgress({ percent: 0, phase });
+    setErrorState(null);
+  }, []);
+
+  const setError = useCallback((message: string) => {
+    setState('error');
+    setErrorState(message);
+  }, []);
 
   const reset = useCallback(() => {
     if (workerRef.current) {
@@ -97,7 +122,7 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
     setState('idle');
     setProgress({ percent: 0, phase: '' });
     setResult(null);
-    setError(null);
+    setErrorState(null);
   }, []);
 
   useEffect(() => {
@@ -117,6 +142,9 @@ export function useHardwareScheduleParser(): UseHardwareScheduleParserReturn {
     error,
     isLoading,
     parseFile,
+    hydrate,
+    setLoading,
+    setError,
     reset,
   };
 }

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -35,6 +35,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   GET_PROJECTS,
   GET_PROJECT_EXCLUDED_ITEMS,
+  GET_PROJECT_HARDWARE_SCHEDULE,
   RECONCILE_SCHEDULE,
 } from '../../graphql/queries';
 import { FINALIZE_IMPORT_SESSION } from '../../graphql/mutations';
@@ -42,6 +43,8 @@ import type { ClassificationRow } from './ClassificationGrid';
 import type { AggregatedHardwareItem, ImportPurpose, ReconciliationRow, ShippingPRDraft } from './types';
 import { aggregationKey, classificationKey } from './types';
 import type { Project } from '../../types/project';
+import type { ProjectHardwareScheduleResponse } from './hydrateSchedule';
+import { mapScheduleResponseToParseResult } from './hydrateSchedule';
 import SelectOpeningsHardwareStep from './SelectOpeningsHardwareStep';
 import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
@@ -171,6 +174,22 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   const [fetchExcludedItems] = useLazyQuery<{
     projectExcludedItems: Array<{ hardwareCategory: string; productCode: string }>;
   }>(GET_PROJECT_EXCLUDED_ITEMS);
+
+  const [fetchProjectSchedule, { data: scheduleData, loading: scheduleLoading }] = useLazyQuery<{
+    projectHardwareSchedule: ProjectHardwareScheduleResponse | null;
+  }>(GET_PROJECT_HARDWARE_SCHEDULE, { fetchPolicy: 'network-only' });
+
+  // Eagerly fetch the persisted schedule on wizard open for re-import projects so the
+  // upload step can show the "Start from latest" picker (gated on hardware-item presence).
+  useEffect(() => {
+    if (!open || !isReimport) return;
+    fetchProjectSchedule({ variables: { projectId: project.id } });
+  }, [open, isReimport, project.id, fetchProjectSchedule]);
+
+  const persistedHardwareItemCount = scheduleData?.projectHardwareSchedule?.hardwareItems.length ?? 0;
+  const persistedOpeningCount = scheduleData?.projectHardwareSchedule?.openings.length ?? 0;
+  const canStartFromLatest = isReimport && persistedHardwareItemCount > 0;
+  const [hydratedFromPersisted, setHydratedFromPersisted] = useState(false);
 
   const [finalizeImport] = useMutation<{
     finalizeImportSession: {
@@ -365,6 +384,39 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     },
     [handleFileSelect],
   );
+
+  const handleLoadFromLatest = useCallback(() => {
+    const persisted = scheduleData?.projectHardwareSchedule;
+    if (!persisted) {
+      parser.setError('No persisted hardware schedule was found for this project.');
+      return;
+    }
+    parser.setLoading('Loading schedule from project history');
+    parser.hydrate(mapScheduleResponseToParseResult(persisted));
+    setHydratedFromPersisted(true);
+  }, [parser, scheduleData]);
+
+  const resetDownstreamWizardState = useCallback(() => {
+    setPurpose(null);
+    setSelectedOpenings(new Set());
+    setSelectedVendors(new Set());
+    setVendorPOInfo(new Map());
+    setUnitCostOverrides(new Map());
+    setOrderAsValues(new Map());
+    setClassifications(new Map());
+    setSarRequestNumber('');
+    setShippingPRDrafts([]);
+    setSelectedReconItems(new Set());
+    setSelectedItemKeys(new Set());
+    setMutationError(null);
+    setFinalizeResult(null);
+  }, []);
+
+  const handleResetSource = useCallback(() => {
+    parser.reset();
+    resetDownstreamWizardState();
+    setHydratedFromPersisted(false);
+  }, [parser, resetDownstreamWizardState]);
 
   const handleNext = useCallback(async () => {
     const currentIndex = steps.findIndex((s) => s.id === effectiveStepId);
@@ -736,25 +788,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   const handleClose = useCallback(() => {
     setActiveStepId('upload');
-    setPurpose(null);
-    setSelectedOpenings(new Set());
-    setSelectedVendors(new Set());
-    setVendorPOInfo(new Map());
-    setUnitCostOverrides(new Map());
-    setOrderAsValues(new Map());
-    setClassifications(new Map());
-    setSarRequestNumber('');
-    setShippingPRDrafts([]);
-    setSelectedReconItems(new Set());
-    setSelectedItemKeys(new Set());
+    resetDownstreamWizardState();
     setFinalizeLoading(false);
-    setFinalizeResult(null);
     setConfirmOpen(false);
     setPostSuccessOpen(false);
-    setMutationError(null);
+    setHydratedFromPersisted(false);
     parser.reset();
     onClose();
-  }, [onClose, parser]);
+  }, [onClose, parser, resetDownstreamWizardState]);
 
   // ---- Step validations ----
 
@@ -804,10 +845,80 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
           {effectiveStepId === 'upload' && (
             <Box>
               <Typography variant="h6" sx={{ mb: 2 }}>
-                Upload TITAN XML File
+                Hardware Schedule
               </Typography>
 
-              {parser.state === 'idle' && (
+              {parser.state === 'idle' && isReimport && scheduleLoading && (
+                <Box sx={{ mt: 3, display: 'flex', justifyContent: 'center', py: 4 }}>
+                  <CircularProgress />
+                </Box>
+              )}
+
+              {parser.state === 'idle' && canStartFromLatest && !scheduleLoading && (
+                <Box sx={{ display: 'flex', gap: 2, alignItems: 'stretch', flexWrap: 'wrap' }}>
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      flex: '1 1 320px',
+                      p: 4,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      textAlign: 'center',
+                      gap: 1.5,
+                    }}
+                  >
+                    <Typography variant="h6">Start from latest hardware schedule</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Resume from this project's last persisted schedule.
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      {persistedOpeningCount} openings, {persistedHardwareItemCount} hardware items.
+                    </Typography>
+                    <Button variant="contained" onClick={handleLoadFromLatest} sx={{ mt: 'auto' }}>
+                      Use latest schedule
+                    </Button>
+                  </Paper>
+
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      flex: '1 1 320px',
+                      p: 4,
+                      textAlign: 'center',
+                      border: '2px dashed',
+                      borderColor: 'divider',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 1,
+                      '&:hover': { borderColor: 'primary.main', bgcolor: 'action.hover' },
+                    }}
+                    onDrop={handleFileDrop}
+                    onDragOver={(e) => e.preventDefault()}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".xml"
+                      hidden
+                      onChange={handleFileInput}
+                    />
+                    <CloudUploadIcon sx={{ fontSize: 56, color: 'action.disabled' }} />
+                    <Typography variant="h6" color="text.secondary">
+                      Upload new TITAN XML
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Drag and drop an XML file here, or click to browse.
+                    </Typography>
+                  </Paper>
+                </Box>
+              )}
+
+              {parser.state === 'idle' && !canStartFromLatest && !scheduleLoading && (
                 <Paper
                   variant="outlined"
                   sx={{
@@ -848,8 +959,8 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               {parser.state === 'error' && (
                 <Alert severity="error" sx={{ mt: 2 }}>
                   {parser.error}
-                  <Button size="small" onClick={() => parser.reset()} sx={{ ml: 2 }}>
-                    Try Again
+                  <Button size="small" onClick={handleResetSource} sx={{ ml: 2 }}>
+                    {hydratedFromPersisted || canStartFromLatest ? 'Choose Different Source' : 'Try Again'}
                   </Button>
                 </Alert>
               )}
@@ -857,7 +968,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               {parser.state === 'done' && parsed && (
                 <Box sx={{ mt: 2 }}>
                   <Alert severity="success" sx={{ mb: 2 }}>
-                    File parsed successfully!
+                    {hydratedFromPersisted ? 'Loaded latest hardware schedule.' : 'File parsed successfully!'}
                   </Alert>
 
                   <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
@@ -875,10 +986,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
                   <Button
                     size="small"
-                    onClick={() => parser.reset()}
+                    onClick={handleResetSource}
                     sx={{ mt: 2 }}
                   >
-                    Upload Different File
+                    {hydratedFromPersisted ? 'Choose Different Source' : 'Upload Different File'}
                   </Button>
                 </Box>
               )}

--- a/frontend/src/modules/import/hydrateSchedule.ts
+++ b/frontend/src/modules/import/hydrateSchedule.ts
@@ -1,0 +1,148 @@
+import type {
+  ParsedHardwareItem,
+  ParsedOpening,
+  ParsedProject,
+  ParseResult,
+} from '../../types/hardwareSchedule';
+
+export interface ProjectHardwareScheduleProjectResponse {
+  projectId: string;
+  description: string | null;
+  jobSiteName: string | null;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+  contractor: string | null;
+  projectManager: string | null;
+  application: string | null;
+  submittalJobNo: string | null;
+  submittalAssignmentCount: number | null;
+  estimatorCode: string | null;
+  titanUserId: string | null;
+}
+
+export interface ProjectHardwareScheduleOpeningResponse {
+  openingNumber: string;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  locationTo: string | null;
+  locationFrom: string | null;
+  hand: string | null;
+  width: string | null;
+  length: string | null;
+  doorThickness: string | null;
+  jambThickness: string | null;
+  doorType: string | null;
+  frameType: string | null;
+  interiorExterior: string | null;
+  keying: string | null;
+  headingNo: string | null;
+  singlePair: string | null;
+  assignmentMultiplier: string | null;
+}
+
+export interface ProjectHardwareScheduleHardwareItemResponse {
+  openingNumber: string;
+  productCode: string;
+  materialId: string;
+  hardwareCategory: string;
+  itemQuantity: number;
+  unitCost: number | null;
+  unitPrice: number | null;
+  listPrice: number | null;
+  vendorDiscount: number | null;
+  markupPct: number | null;
+  vendorNo: string | null;
+  phaseCode: string | null;
+  itemCategoryCode: string | null;
+  productGroupCode: string | null;
+  submittalId: string | null;
+}
+
+export interface ProjectHardwareScheduleResponse {
+  project: ProjectHardwareScheduleProjectResponse;
+  openings: ProjectHardwareScheduleOpeningResponse[];
+  hardwareItems: ProjectHardwareScheduleHardwareItemResponse[];
+}
+
+function mapProject(p: ProjectHardwareScheduleProjectResponse): ParsedProject {
+  return {
+    project_id: p.projectId,
+    description: p.description,
+    job_site_name: p.jobSiteName,
+    address: p.address,
+    city: p.city,
+    state: p.state,
+    zip: p.zip,
+    contractor: p.contractor,
+    project_manager: p.projectManager,
+    application: p.application,
+    submittal_job_no: p.submittalJobNo,
+    submittal_assignment_count: p.submittalAssignmentCount,
+    estimator_code: p.estimatorCode,
+    titan_user_id: p.titanUserId,
+  };
+}
+
+function mapOpening(o: ProjectHardwareScheduleOpeningResponse): ParsedOpening {
+  return {
+    opening_number: o.openingNumber,
+    building: o.building,
+    floor: o.floor,
+    location: o.location,
+    location_to: o.locationTo,
+    location_from: o.locationFrom,
+    hand: o.hand,
+    width: o.width,
+    length: o.length,
+    door_thickness: o.doorThickness,
+    jamb_thickness: o.jambThickness,
+    door_type: o.doorType,
+    frame_type: o.frameType,
+    interior_exterior: o.interiorExterior,
+    keying: o.keying,
+    heading_no: o.headingNo,
+    single_pair: o.singlePair,
+    assignment_multiplier: o.assignmentMultiplier,
+  };
+}
+
+function mapHardwareItem(hi: ProjectHardwareScheduleHardwareItemResponse): ParsedHardwareItem {
+  return {
+    opening_number: hi.openingNumber,
+    product_code: hi.productCode,
+    material_id: hi.materialId,
+    hardware_category: hi.hardwareCategory,
+    item_quantity: hi.itemQuantity,
+    unit_cost: hi.unitCost,
+    unit_price: hi.unitPrice,
+    list_price: hi.listPrice,
+    vendor_discount: hi.vendorDiscount,
+    markup_pct: hi.markupPct,
+    vendor_no: hi.vendorNo,
+    phase_code: hi.phaseCode,
+    item_category_code: hi.itemCategoryCode,
+    product_group_code: hi.productGroupCode,
+    submittal_id: hi.submittalId,
+  };
+}
+
+export function mapScheduleResponseToParseResult(
+  response: ProjectHardwareScheduleResponse,
+): ParseResult {
+  const openings = response.openings.map(mapOpening);
+  const hardwareItems = response.hardwareItems.map(mapHardwareItem);
+  return {
+    project: mapProject(response.project),
+    openings,
+    hardwareItems,
+    validationSummary: {
+      totalOpenings: openings.length,
+      totalHardwareItems: hardwareItems.length,
+      skippedRows: [],
+      warnings: [],
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a "Start from latest hardware schedule" entry alongside the existing XML uploader on the import wizard's first step. Visible only when the selected project already has persisted hardware items; otherwise the dropzone is the sole entry.
- Backend exposes a new `projectHardwareSchedule(projectId: ID!)` query returning project metadata + openings + hardware items, shaped server-side so the frontend mapper is a straight camel→snake conversion.
- `useHardwareScheduleParser` gains `hydrate`, `setLoading`, and `setError` methods so the wizard can drive the same state machine over a GraphQL response. Downstream wizard state (selected openings, classifications, vendor info, etc.) now resets together when the user switches source mid-step, so a hydrate→reset→upload cycle starts clean.