### PR TITLE
Rename module tile 'Import' to 'Start a task' (closes #97)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ function SuspenseFallback() {
 }
 
 const MODULE_LINKS = [
-  { path: '/app/import', label: 'Import', icon: <UploadFileIcon sx={{ fontSize: 40 }} />, description: 'Import hardware schedules' },
+  { path: '/app/import', label: 'Start a task', icon: <UploadFileIcon sx={{ fontSize: 40 }} />, description: 'Create a POR, SAR, or shipping PR' },
   { path: '/app/po', label: 'Purchase Orders', icon: <ReceiptLongIcon sx={{ fontSize: 40 }} />, description: 'Manage purchase orders' },
   { path: '/app/warehouse', label: 'Warehouse', icon: <WarehouseIcon sx={{ fontSize: 40 }} />, description: 'Inventory and receiving' },
   { path: '/app/shop-assembly', label: 'Shop Assembly', icon: <BuildIcon sx={{ fontSize: 40 }} />, description: 'Assembly requests and tracking' },


### PR DESCRIPTION
## Summary
- Renames the home-page module tile label from `Import` to `Start a task` and updates its description from `Import hardware schedules` to `Create a POR, SAR, or shipping PR`, reflecting the broader meaning of the module after #94 and #96.
- Single-line edit in `frontend/src/App.tsx`. Path, icon, and route are unchanged. The in-module 'Start Import' button and the breadcrumb (derived from the URL) are intentionally untouched per the issue's scope.

Closes #97