### PR TITLE
Remove hardware-level selection from import wizard step 3 (closes #98)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -45,7 +45,7 @@ import { aggregationKey, classificationKey } from './types';
 import type { Project } from '../../types/project';
 import type { ProjectHardwareScheduleResponse } from './hydrateSchedule';
 import { mapScheduleResponseToParseResult } from './hydrateSchedule';
-import SelectOpeningsHardwareStep from './SelectOpeningsHardwareStep';
+import SelectOpeningsStep from './SelectOpeningsStep';
 import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
 import PurchaseOrdersStep from './PurchaseOrdersStep';
@@ -113,7 +113,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
   const [selectedReconItems, setSelectedReconItems] = useState<Set<string>>(new Set());
-  const [selectedItemKeys, setSelectedItemKeys] = useState<Set<string>>(new Set());
 
   // Finalize state
   const [finalizeLoading, setFinalizeLoading] = useState(false);
@@ -128,7 +127,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     const base: StepDescriptor[] = [
       { id: 'upload', label: 'Upload File' },
       { id: 'purpose', label: 'Purpose' },
-      { id: 'openings', label: 'Select Openings/Hardware' },
+      { id: 'openings', label: 'Select Openings' },
       { id: 'reconciliation', label: 'Reconciliation' },
     ];
     if (purpose === 'po' || purpose === 'assembly') {
@@ -300,7 +299,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     return selectedHardwareItems;
   }, [selectedHardwareItems, selectedReconItems, purpose, isReimport, reconciliationRows]);
 
-  const allAggregatedItems = useMemo<AggregatedHardwareItem[]>(() => {
+  const aggregatedHardwareItems = useMemo<AggregatedHardwareItem[]>(() => {
     const map = new Map<string, AggregatedHardwareItem>();
     for (const hi of reconFilteredHardwareItems) {
       const key = aggregationKey(hi);
@@ -315,11 +314,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     }
     return Array.from(map.values());
   }, [reconFilteredHardwareItems]);
-
-  const aggregatedHardwareItems = useMemo(
-    () => allAggregatedItems.filter((hi) => selectedItemKeys.has(aggregationKey(hi))),
-    [allAggregatedItems, selectedItemKeys],
-  );
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
@@ -407,7 +401,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     setSarRequestNumber('');
     setShippingPRDrafts([]);
     setSelectedReconItems(new Set());
-    setSelectedItemKeys(new Set());
     setMutationError(null);
     setFinalizeResult(null);
   }, []);
@@ -460,24 +453,9 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // ---- Step-specific handlers ----
 
-  // Opening selection — auto-manage selectedItemKeys when openings change
   const handleOpeningSelectionChange = useCallback((newSelected: Set<string>) => {
-    const added = new Set([...newSelected].filter((o) => !selectedOpenings.has(o)));
-    const removed = new Set([...selectedOpenings].filter((o) => !newSelected.has(o)));
     setSelectedOpenings(newSelected);
-    setSelectedItemKeys((prev) => {
-      const next = new Set(prev);
-      // Remove items from unchecked openings
-      for (const key of prev) {
-        if (removed.has(key.split('|')[0])) next.delete(key);
-      }
-      // Auto-add items from newly checked openings
-      for (const hi of hardwareItems) {
-        if (added.has(hi.opening_number)) next.add(aggregationKey(hi));
-      }
-      return next;
-    });
-  }, [selectedOpenings, hardwareItems]);
+  }, []);
 
   // Vendor selection
   const toggleVendor = useCallback((vendor: string) => {
@@ -607,7 +585,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       (o) => selectedOpenings.has(o.opening_number) && openingNumbersFromItems.has(o.opening_number),
     );
     const filteredHardwareItems = parsed.hardwareItems.filter(
-      (hi) => selectedOpenings.has(hi.opening_number) && selectedItemKeys.has(aggregationKey(hi)),
+      (hi) => selectedOpenings.has(hi.opening_number),
     );
 
     // Build set of BY_OTHERS classificationKeys for PO filtering
@@ -744,7 +722,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             .filter(Boolean)
         : null,
     };
-  }, [parsed, project.id, selectedOpenings, selectedItemKeys, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, project.id, selectedOpenings, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -801,7 +779,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   const canProceedStep0 = parser.state === 'done';
   const canProceedStep1 = purpose !== null;
-  const canProceedStep2 = selectedOpenings.size > 0 && selectedItemKeys.size > 0;
+  const canProceedStep2 = selectedOpenings.size > 0;
   const canProceedStep3 = useMemo(() => {
     if (!isReimport) return true;
     if (purpose === 'po') return selectedReconItems.size > 0;
@@ -1077,16 +1055,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             </Box>
           )}
 
-          {/* ============ Step: Select Openings/Hardware ============ */}
+          {/* ============ Step: Select Openings ============ */}
           {effectiveStepId === 'openings' && (
-            <SelectOpeningsHardwareStep
+            <SelectOpeningsStep
               openings={openings}
               selectedOpenings={selectedOpenings}
               preReconAggregatedItems={preReconAggregatedItems}
-              selectedItemKeys={selectedItemKeys}
               hardwareCountByOpening={hardwareCountByOpening}
               onOpeningSelectionChange={handleOpeningSelectionChange}
-              onItemSelectionChange={setSelectedItemKeys}
               canProceed={canProceedStep2}
               onNext={handleNext}
               onBack={handleBack}

--- a/frontend/src/modules/import/SelectOpeningsStep.tsx
+++ b/frontend/src/modules/import/SelectOpeningsStep.tsx
@@ -6,7 +6,6 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Checkbox,
   Chip,
   TextField,
   Table,
@@ -31,14 +30,12 @@ interface OpeningRow extends ParsedOpening {
 
 // ---- Props ----
 
-interface SelectOpeningsHardwareStepProps {
+interface SelectOpeningsStepProps {
   openings: ParsedOpening[];
   selectedOpenings: Set<string>;
   preReconAggregatedItems: AggregatedHardwareItem[];
-  selectedItemKeys: Set<string>;
   hardwareCountByOpening: Map<string, number>;
   onOpeningSelectionChange: (selected: Set<string>) => void;
-  onItemSelectionChange: (selected: Set<string>) => void;
   canProceed: boolean;
   onNext: () => void;
   onBack: () => void;
@@ -46,18 +43,16 @@ interface SelectOpeningsHardwareStepProps {
 
 // ---- Main Component ----
 
-export default function SelectOpeningsHardwareStep({
+export default function SelectOpeningsStep({
   openings,
   selectedOpenings,
   preReconAggregatedItems,
-  selectedItemKeys,
   hardwareCountByOpening,
   onOpeningSelectionChange,
-  onItemSelectionChange,
   canProceed,
   onNext,
   onBack,
-}: SelectOpeningsHardwareStepProps) {
+}: SelectOpeningsStepProps) {
   // ---- Left Panel: Openings Filter & DataGrid ----
 
   const [filterText, setFilterText] = useState('');
@@ -167,7 +162,7 @@ export default function SelectOpeningsHardwareStep({
     onOpeningSelectionChange(new Set());
   }, [onOpeningSelectionChange]);
 
-  // ---- Right Panel: Hardware Items Accordion ----
+  // ---- Right Panel: Hardware Items Accordion (read-only preview) ----
 
   const groups = useMemo(() => {
     const map = new Map<string, AggregatedHardwareItem[]>();
@@ -180,52 +175,6 @@ export default function SelectOpeningsHardwareStep({
   }, [preReconAggregatedItems]);
 
   const itemTotalCount = preReconAggregatedItems.length;
-  const itemSelectedCount = useMemo(
-    () => preReconAggregatedItems.filter((hi) => selectedItemKeys.has(aggregationKey(hi))).length,
-    [preReconAggregatedItems, selectedItemKeys],
-  );
-
-  const handleSelectAllItems = useCallback(() => {
-    const next = new Set(selectedItemKeys);
-    for (const hi of preReconAggregatedItems) {
-      next.add(aggregationKey(hi));
-    }
-    onItemSelectionChange(next);
-  }, [preReconAggregatedItems, selectedItemKeys, onItemSelectionChange]);
-
-  const handleDeselectAllItems = useCallback(() => {
-    const keysToRemove = new Set(preReconAggregatedItems.map((hi) => aggregationKey(hi)));
-    const next = new Set([...selectedItemKeys].filter((k) => !keysToRemove.has(k)));
-    onItemSelectionChange(next);
-  }, [preReconAggregatedItems, selectedItemKeys, onItemSelectionChange]);
-
-  const toggleItem = useCallback(
-    (key: string) => {
-      const next = new Set(selectedItemKeys);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      onItemSelectionChange(next);
-    },
-    [selectedItemKeys, onItemSelectionChange],
-  );
-
-  const toggleGroup = useCallback(
-    (groupItems: AggregatedHardwareItem[]) => {
-      const groupKeys = groupItems.map((hi) => aggregationKey(hi));
-      const allSelected = groupKeys.every((k) => selectedItemKeys.has(k));
-      const next = new Set(selectedItemKeys);
-      if (allSelected) {
-        for (const k of groupKeys) next.delete(k);
-      } else {
-        for (const k of groupKeys) next.add(k);
-      }
-      onItemSelectionChange(next);
-    },
-    [selectedItemKeys, onItemSelectionChange],
-  );
 
   return (
     <Box>
@@ -316,23 +265,15 @@ export default function SelectOpeningsHardwareStep({
           </Box>
         </Box>
 
-        {/* ---- Right Panel: Hardware Items ---- */}
+        {/* ---- Right Panel: Hardware Items (read-only preview) ---- */}
         <Box sx={{ flex: '1 1 45%', display: 'flex', flexDirection: 'column', minWidth: 0 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
             <Typography variant="h6">
               Hardware Items
               <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
-                ({itemSelectedCount} of {itemTotalCount} selected)
+                ({itemTotalCount} items)
               </Typography>
             </Typography>
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button size="small" variant="outlined" onClick={handleSelectAllItems} disabled={itemTotalCount === 0}>
-                Select All
-              </Button>
-              <Button size="small" variant="outlined" onClick={handleDeselectAllItems} disabled={itemSelectedCount === 0}>
-                Deselect All
-              </Button>
-            </Box>
           </Box>
 
           <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
@@ -347,29 +288,18 @@ export default function SelectOpeningsHardwareStep({
             ) : (
               groups.map(([groupKey, items]) => {
                 const [category, productCode] = groupKey.split('|');
-                const groupKeys = items.map((hi) => aggregationKey(hi));
-                const selectedInGroup = groupKeys.filter((k) => selectedItemKeys.has(k)).length;
-                const allSelected = selectedInGroup === items.length;
-                const someSelected = selectedInGroup > 0 && !allSelected;
 
                 return (
                   <Accordion key={groupKey} defaultExpanded={false}>
                     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                        <Checkbox
-                          checked={allSelected}
-                          indeterminate={someSelected}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={() => toggleGroup(items)}
-                          size="small"
-                        />
                         <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                           {productCode}
                         </Typography>
                         <Chip label={category} size="small" variant="outlined" />
                         <Chip label={items[0].vendor_no ?? '(No Manufacturer)'} size="small" variant="outlined" />
                         <Chip
-                          label={items[0].unit_cost != null ? `$${items[0].unit_cost.toFixed(2)}` : '\u2014'}
+                          label={items[0].unit_cost != null ? `$${items[0].unit_cost.toFixed(2)}` : '—'}
                           size="small"
                           variant="outlined"
                         />
@@ -379,7 +309,7 @@ export default function SelectOpeningsHardwareStep({
                           variant="outlined"
                         />
                         <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto', mr: 2 }}>
-                          {selectedInGroup}/{items.length}
+                          {items.length}
                         </Typography>
                       </Box>
                     </AccordionSummary>
@@ -387,28 +317,17 @@ export default function SelectOpeningsHardwareStep({
                       <Table size="small">
                         <TableHead>
                           <TableRow>
-                            <TableCell padding="checkbox" />
                             <TableCell>Opening</TableCell>
                             <TableCell align="right">Qty</TableCell>
                           </TableRow>
                         </TableHead>
                         <TableBody>
-                          {items.map((hi) => {
-                            const key = aggregationKey(hi);
-                            return (
-                              <TableRow key={key} hover>
-                                <TableCell padding="checkbox">
-                                  <Checkbox
-                                    checked={selectedItemKeys.has(key)}
-                                    onChange={() => toggleItem(key)}
-                                    size="small"
-                                  />
-                                </TableCell>
-                                <TableCell>{hi.opening_number}</TableCell>
-                                <TableCell align="right">{hi.item_quantity}</TableCell>
-                              </TableRow>
-                            );
-                          })}
+                          {items.map((hi) => (
+                            <TableRow key={aggregationKey(hi)} hover>
+                              <TableCell>{hi.opening_number}</TableCell>
+                              <TableCell align="right">{hi.item_quantity}</TableCell>
+                            </TableRow>
+                          ))}
                         </TableBody>
                       </Table>
                     </AccordionDetails>


### PR DESCRIPTION
## Summary
- Step 3 ("Select Openings") is now opening-selection only. The right-panel preview is read-only — all per-occurrence and group-level checkboxes plus the Select All / Deselect All controls are gone. Header counter now reads `(N items)`.
- `selectedItemKeys` state and its propagation through `ImportWizard.tsx` are removed: `handleOpeningSelectionChange` simplifies to `setSelectedOpenings`, the redundant `aggregatedHardwareItems`/`allAggregatedItems` memos collapse into one, `buildFinalizeInput` no longer filters by `selectedItemKeys`, and `canProceedStep2` only checks `selectedOpenings.size > 0`.
- Component file renamed `SelectOpeningsHardwareStep.tsx` → `SelectOpeningsStep.tsx`; step label changed from "Select Openings/Hardware" → "Select Openings".
- `aggregationKey` stays in `types.ts` — still consumed by `ReconciliationStep` and `ShippingPRsStep`.

Net: -105 lines. Follow-ups #99 and #100 can now be re-scoped against the simpler step.