### PR TITLE
Stop truncating product code in import step 4 classification (closes #102)

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -103,8 +103,8 @@ function buildGroupTree(rows: ClassificationRow[], fields: GroupByField[]): Map<
 
 const ALL_COLUMNS: GridColDef[] = [
   { field: 'openingNumber', headerName: 'Opening #', flex: 0.7 },
-  { field: 'productCode', headerName: 'Product Code', flex: 1 },
-  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
+  { field: 'productCode', headerName: 'Product Code', flex: 1, cellClassName: 'wrap-cell' },
+  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, cellClassName: 'wrap-cell' },
   { field: 'vendorNo', headerName: 'Manufacturer', flex: 0.8 },
   {
     field: 'listPrice',
@@ -171,11 +171,19 @@ function LeafGrid({ rows, columns, options, onClassify, readOnly }: LeafGridProp
       columns={columns}
       checkboxSelection={!readOnly}
       density="compact"
-      rowHeight={42}
+      getRowHeight={() => 'auto'}
       hideFooter
       disableRowSelectionOnClick
       rowSelectionModel={selectionModel}
       onRowSelectionModelChange={setSelectionModel}
+      sx={{
+        '& .MuiDataGrid-cell.wrap-cell': {
+          whiteSpace: 'normal',
+          wordBreak: 'break-word',
+          lineHeight: 1.4,
+          py: 0.75,
+        },
+      }}
       slots={{
         toolbar: !readOnly && selectedCount > 0
           ? () => (


### PR DESCRIPTION
## Summary
- Tag the Product Code and Hardware Category columns of the Step 4 classification DataGrid with a `wrap-cell` class.
- Switch the grid to `getRowHeight={() => 'auto'}` and add an `sx` rule that wraps tagged cells with `whiteSpace: normal`, `wordBreak: break-word`, a comfortable `lineHeight`, and small vertical padding.
- Numeric columns (List Price, Discount, Unit Cost, Qty, Opening #, Manufacturer) are unaffected and keep their single-line layout.