### PR TITLE
Suggest prior Order As values via vendor-scoped autocomplete (closes #104)

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -368,6 +368,46 @@ def update_line_item_unit_cost(
     return poli
 
 
+def get_prior_order_as_values(
+    session: Session,
+    vendor_id: uuid.UUID,
+    product_codes: list[str],
+) -> dict[str, list[str]]:
+    """
+    For a given vendor + set of product codes, return distinct non-empty
+    `order_as` values from po_line_items, grouped by product_code,
+    ranked by most recent line item updated_at.
+
+    Excludes CANCELLED POs and soft-deleted POs. Caps each list at 20.
+    """
+    if not product_codes:
+        return {}
+
+    last_used = func.max(POLineItem.updated_at).label("last_used")
+    stmt = (
+        select(POLineItem.product_code, POLineItem.order_as, last_used)
+        .join(PurchaseOrder, PurchaseOrder.id == POLineItem.po_id)
+        .where(
+            PurchaseOrder.vendor_id == vendor_id,
+            POLineItem.product_code.in_(product_codes),
+            POLineItem.order_as.isnot(None),
+            func.trim(POLineItem.order_as) != "",
+            PurchaseOrder.status != POStatus.CANCELLED,
+            PurchaseOrder.deleted_at.is_(None),
+        )
+        .group_by(POLineItem.product_code, POLineItem.order_as)
+        .order_by(POLineItem.product_code, last_used.desc())
+    )
+    rows = session.execute(stmt).all()
+
+    result: dict[str, list[str]] = {}
+    for product_code, order_as, _last_used in rows:
+        bucket = result.setdefault(product_code, [])
+        if len(bucket) < 20:
+            bucket.append(order_as)
+    return result
+
+
 def upload_po_document(
     session: Session,
     po_id: uuid.UUID,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -44,6 +44,7 @@ from .types import (
     PODocumentInfo,
     POLineItem,
     POStatistics,
+    PriorOrderAsForProduct,
     ProductCodeNode,
     Project,
     ProjectExcludedItem,
@@ -564,6 +565,16 @@ class Query:
                 return None
             receive_records = po_repository.get_receive_records_for_po(session, po.id)
             return _po_to_type(po, receive_records)
+
+    @strawberry.field
+    def prior_order_as_values(
+        self,
+        vendor_id: strawberry.ID,
+        product_codes: list[str],
+    ) -> list[PriorOrderAsForProduct]:
+        with SessionLocal() as session:
+            result = po_repository.get_prior_order_as_values(session, uuid.UUID(str(vendor_id)), product_codes)
+            return [PriorOrderAsForProduct(product_code=pc, values=vals) for pc, vals in result.items()]
 
     @strawberry.field
     def po_statistics(self, project_id: strawberry.ID | None = None) -> POStatistics:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -108,6 +108,12 @@ class POLineItem:
 
 
 @strawberry.type
+class PriorOrderAsForProduct:
+    product_code: str
+    values: list[str]
+
+
+@strawberry.type
 class ReceiveLineItem:
     id: strawberry.ID
     receive_record_id: strawberry.ID

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+from alembic.config import Config
+
+from alembic import command
+
+
+@pytest.fixture(scope="session")
+def _migrate_database():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set; skipping DB-backed tests")
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, "head")
+
+
+@pytest.fixture
+def db_session(_migrate_database):
+    from app.database import SessionLocal, engine
+
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = SessionLocal(bind=connection)
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()

--- a/backend/tests/test_po_repository_prior_order_as.py
+++ b/backend/tests/test_po_repository_prior_order_as.py
@@ -1,0 +1,155 @@
+import uuid
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from app.models.enums import POStatus
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.models.vendor import Vendor
+from app.repositories import po_repository
+
+
+def _make_vendor(session, name: str = "Acme") -> Vendor:
+    v = Vendor(id=uuid.uuid4(), name=f"{name}-{uuid.uuid4().hex[:6]}")
+    session.add(v)
+    session.flush()
+    return v
+
+
+def _make_po(
+    session,
+    *,
+    vendor_id: uuid.UUID,
+    status: POStatus = POStatus.DRAFT,
+    deleted_at: datetime | None = None,
+) -> PurchaseOrder:
+    po = PurchaseOrder(
+        id=uuid.uuid4(),
+        request_number=f"PO-REQ-{uuid.uuid4().hex[:8]}",
+        vendor_id=vendor_id,
+        status=status,
+        deleted_at=deleted_at,
+    )
+    session.add(po)
+    session.flush()
+    return po
+
+
+def _make_line_item(
+    session,
+    *,
+    po_id: uuid.UUID,
+    product_code: str = "ABC",
+    order_as: str | None = None,
+    updated_at: datetime | None = None,
+) -> POLineItem:
+    kwargs = {
+        "id": uuid.uuid4(),
+        "po_id": po_id,
+        "hardware_category": "HINGE",
+        "product_code": product_code,
+        "ordered_quantity": 1,
+        "unit_cost": Decimal("1.00"),
+        "order_as": order_as,
+    }
+    if updated_at is not None:
+        kwargs["updated_at"] = updated_at
+    li = POLineItem(**kwargs)
+    session.add(li)
+    session.flush()
+    return li
+
+
+def test_returns_distinct_values_ranked_recent_first(db_session):
+    vendor = _make_vendor(db_session)
+    po1 = _make_po(db_session, vendor_id=vendor.id)
+    po2 = _make_po(db_session, vendor_id=vendor.id)
+    older = datetime.utcnow() - timedelta(days=2)
+    newer = datetime.utcnow()
+    _make_line_item(db_session, po_id=po1.id, product_code="P1", order_as="OLD-SKU", updated_at=older)
+    _make_line_item(db_session, po_id=po2.id, product_code="P1", order_as="NEW-SKU", updated_at=newer)
+
+    result = po_repository.get_prior_order_as_values(db_session, vendor.id, ["P1"])
+    assert result == {"P1": ["NEW-SKU", "OLD-SKU"]}
+
+
+def test_excludes_cancelled_pos(db_session):
+    vendor = _make_vendor(db_session)
+    cancelled_po = _make_po(
+        db_session,
+        vendor_id=vendor.id,
+        status=POStatus.CANCELLED,
+        deleted_at=datetime.utcnow(),
+    )
+    _make_line_item(db_session, po_id=cancelled_po.id, product_code="P2", order_as="CANCELLED-SKU")
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, ["P2"]) == {}
+
+
+def test_excludes_soft_deleted_pos(db_session):
+    vendor = _make_vendor(db_session)
+    soft_deleted_po = _make_po(
+        db_session,
+        vendor_id=vendor.id,
+        status=POStatus.DRAFT,
+        deleted_at=datetime.utcnow(),
+    )
+    _make_line_item(db_session, po_id=soft_deleted_po.id, product_code="P3", order_as="DELETED-SKU")
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, ["P3"]) == {}
+
+
+def test_excludes_empty_and_whitespace_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    po = _make_po(db_session, vendor_id=vendor.id)
+    _make_line_item(db_session, po_id=po.id, product_code="P4", order_as=None)
+    _make_line_item(db_session, po_id=po.id, product_code="P4", order_as="")
+    _make_line_item(db_session, po_id=po.id, product_code="P4", order_as="   ")
+    _make_line_item(db_session, po_id=po.id, product_code="P4", order_as="REAL-SKU")
+
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, ["P4"]) == {"P4": ["REAL-SKU"]}
+
+
+def test_scoped_by_vendor(db_session):
+    vendor_a = _make_vendor(db_session, name="VendorA")
+    vendor_b = _make_vendor(db_session, name="VendorB")
+    po_a = _make_po(db_session, vendor_id=vendor_a.id)
+    po_b = _make_po(db_session, vendor_id=vendor_b.id)
+    _make_line_item(db_session, po_id=po_a.id, product_code="P5", order_as="A-SKU")
+    _make_line_item(db_session, po_id=po_b.id, product_code="P5", order_as="B-SKU")
+
+    assert po_repository.get_prior_order_as_values(db_session, vendor_a.id, ["P5"]) == {"P5": ["A-SKU"]}
+    assert po_repository.get_prior_order_as_values(db_session, vendor_b.id, ["P5"]) == {"P5": ["B-SKU"]}
+
+
+def test_dedupes_same_value_keeps_most_recent(db_session):
+    vendor = _make_vendor(db_session)
+    po1 = _make_po(db_session, vendor_id=vendor.id)
+    po2 = _make_po(db_session, vendor_id=vendor.id)
+    older = datetime.utcnow() - timedelta(days=5)
+    middle = datetime.utcnow() - timedelta(days=3)
+    newer = datetime.utcnow() - timedelta(days=1)
+    _make_line_item(db_session, po_id=po1.id, product_code="P6", order_as="DUP", updated_at=older)
+    _make_line_item(db_session, po_id=po2.id, product_code="P6", order_as="DUP", updated_at=newer)
+    _make_line_item(db_session, po_id=po1.id, product_code="P6", order_as="OTHER", updated_at=middle)
+
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, ["P6"]) == {"P6": ["DUP", "OTHER"]}
+
+
+def test_buckets_by_product_code(db_session):
+    vendor = _make_vendor(db_session)
+    po = _make_po(db_session, vendor_id=vendor.id)
+    _make_line_item(db_session, po_id=po.id, product_code="P7", order_as="P7-SKU")
+    _make_line_item(db_session, po_id=po.id, product_code="P8", order_as="P8-SKU")
+
+    result = po_repository.get_prior_order_as_values(db_session, vendor.id, ["P7", "P8"])
+    assert result == {"P7": ["P7-SKU"], "P8": ["P8-SKU"]}
+
+
+def test_returns_empty_for_empty_product_codes(db_session):
+    vendor = _make_vendor(db_session)
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, []) == {}
+
+
+def test_returns_empty_for_unknown_product_code(db_session):
+    vendor = _make_vendor(db_session)
+    po = _make_po(db_session, vendor_id=vendor.id)
+    _make_line_item(db_session, po_id=po.id, product_code="REAL", order_as="SKU")
+    assert po_repository.get_prior_order_as_values(db_session, vendor.id, ["NOPE"]) == {}

--- a/frontend/src/components/OrderAsAutocomplete.tsx
+++ b/frontend/src/components/OrderAsAutocomplete.tsx
@@ -1,0 +1,49 @@
+import { Autocomplete, TextField } from '@mui/material';
+
+interface OrderAsAutocompleteProps {
+  value: string;
+  onChange: (next: string) => void;
+  options: string[];
+  disabled?: boolean;
+  placeholder?: string;
+  size?: 'small' | 'medium';
+  variant?: 'standard' | 'outlined' | 'filled';
+  fullWidth?: boolean;
+}
+
+export default function OrderAsAutocomplete({
+  value,
+  onChange,
+  options,
+  disabled,
+  placeholder,
+  size = 'small',
+  variant = 'standard',
+  fullWidth = true,
+}: OrderAsAutocompleteProps) {
+  return (
+    <Autocomplete
+      freeSolo
+      disablePortal={false}
+      disabled={disabled}
+      size={size}
+      fullWidth={fullWidth}
+      options={options}
+      value={value || null}
+      inputValue={value}
+      onInputChange={(_, newInput) => onChange(newInput)}
+      onChange={(_, newValue) => {
+        if (typeof newValue === 'string') onChange(newValue);
+        else if (newValue == null) onChange('');
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant={variant}
+          placeholder={placeholder}
+          sx={{ '& .MuiInputBase-input': { fontSize: '0.875rem' } }}
+        />
+      )}
+    />
+  );
+}

--- a/frontend/src/components/__tests__/OrderAsAutocomplete.test.tsx
+++ b/frontend/src/components/__tests__/OrderAsAutocomplete.test.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OrderAsAutocomplete from '../OrderAsAutocomplete';
+
+function Harness({ initial, options }: { initial: string; options: string[] }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <div>
+      <OrderAsAutocomplete value={value} onChange={setValue} options={options} placeholder="Order as" />
+      <div data-testid="current-value">{value}</div>
+    </div>
+  );
+}
+
+describe('OrderAsAutocomplete', () => {
+  it('lets the user pick a suggested option', () => {
+    render(<Harness initial="" options={['ABC-SKU-1', 'ABC-SKU-2']} />);
+
+    const input = screen.getByPlaceholderText('Order as');
+    fireEvent.mouseDown(input);
+
+    const option = screen.getByText('ABC-SKU-2');
+    fireEvent.click(option);
+
+    expect(screen.getByTestId('current-value').textContent).toBe('ABC-SKU-2');
+  });
+
+  it('allows typing a brand-new value not in options (freeSolo)', () => {
+    render(<Harness initial="" options={['ABC-SKU-1']} />);
+
+    const input = screen.getByPlaceholderText('Order as') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'BRAND-NEW' } });
+
+    expect(screen.getByTestId('current-value').textContent).toBe('BRAND-NEW');
+  });
+
+  it('renders the controlled value in the input', () => {
+    render(<Harness initial="EXISTING" options={[]} />);
+
+    const input = screen.getByPlaceholderText('Order as') as HTMLInputElement;
+    expect(input.value).toBe('EXISTING');
+  });
+
+  it('disables the input when disabled prop is set', () => {
+    render(
+      <OrderAsAutocomplete
+        value=""
+        onChange={() => {}}
+        options={['X']}
+        disabled
+        placeholder="Order as"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('Order as') as HTMLInputElement;
+    expect(input).toBeDisabled();
+  });
+
+  it('clears the value when the clear button is pressed', () => {
+    render(<Harness initial="EXISTING" options={['EXISTING']} />);
+
+    const clearButton = screen.getByLabelText('Clear');
+    fireEvent.click(clearButton);
+
+    expect(screen.getByTestId('current-value').textContent).toBe('');
+  });
+});

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -29,6 +29,15 @@ export const GET_PO_STATISTICS = gql`
   }
 `;
 
+export const GET_PRIOR_ORDER_AS_VALUES = gql`
+  query GetPriorOrderAsValues($vendorId: ID!, $productCodes: [String!]!) {
+    priorOrderAsValues(vendorId: $vendorId, productCodes: $productCodes) {
+      productCode
+      values
+    }
+  }
+`;
+
 export const GET_PURCHASE_ORDERS = gql`
   query GetPurchaseOrders($projectId: ID, $status: POStatus) {
     purchaseOrders(projectId: $projectId, status: $status) {

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import { Box, Button, Checkbox, FormControlLabel, InputAdornment, Paper, TextField, Typography } from '@mui/material';
+import { useQuery } from '@apollo/client/react';
 import VendorSelect from '../../components/VendorSelect';
+import OrderAsAutocomplete from '../../components/OrderAsAutocomplete';
+import { GET_PRIOR_ORDER_AS_VALUES } from '../../graphql/queries';
 import type { AggregatedHardwareItem } from './types';
 
 // ---- Aggregation Types ----
@@ -11,6 +14,15 @@ interface AggregatedLineItem {
   totalQuantity: number;
   unitCost: number;
   totalCost: number;
+}
+
+interface PriorOrderAsForProduct {
+  productCode: string;
+  values: string[];
+}
+
+interface PriorOrderAsQueryData {
+  priorOrderAsValues: PriorOrderAsForProduct[];
 }
 
 // ---- Props ----
@@ -64,6 +76,199 @@ function aggregateLineItems(
   });
 }
 
+// ---- Vendor Group Card (per-manufacturer subcomponent so useQuery is hook-safe) ----
+
+interface VendorGroupCardProps {
+  vendor: string;
+  items: AggregatedHardwareItem[];
+  info: { vendorId: string | null; notes: string };
+  isSelected: boolean;
+  unitCostOverrides: Map<string, number>;
+  orderAsValues: Map<string, string>;
+  onToggleVendor: (vendor: string) => void;
+  onUpdateVendorPO: (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => void;
+  onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
+  onUpdateOrderAs: (key: string, value: string) => void;
+}
+
+function VendorGroupCard({
+  vendor,
+  items,
+  info,
+  isSelected,
+  unitCostOverrides,
+  orderAsValues,
+  onToggleVendor,
+  onUpdateVendorPO,
+  onUpdateUnitCost,
+  onUpdateOrderAs,
+}: VendorGroupCardProps) {
+  const aggregated = useMemo(
+    () => aggregateLineItems(items, vendor, unitCostOverrides),
+    [items, vendor, unitCostOverrides],
+  );
+
+  const productCodes = useMemo(
+    () => Array.from(new Set(aggregated.map((l) => l.productCode))),
+    [aggregated],
+  );
+
+  const { data: priorData } = useQuery<PriorOrderAsQueryData>(GET_PRIOR_ORDER_AS_VALUES, {
+    variables: { vendorId: info.vendorId ?? '', productCodes },
+    skip: !info.vendorId || productCodes.length === 0,
+  });
+
+  const priorMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const entry of priorData?.priorOrderAsValues ?? []) {
+      map.set(entry.productCode, entry.values);
+    }
+    return map;
+  }, [priorData]);
+
+  const poTotal = aggregated.reduce((sum, line) => sum + line.totalCost, 0);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2, opacity: isSelected ? 1 : 0.5 }}>
+      {/* Header: checkbox + manufacturer label + PO total */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <FormControlLabel
+          control={<Checkbox checked={isSelected} onChange={() => onToggleVendor(vendor)} />}
+          label={
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Manufacturer
+              </Typography>
+              <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                {vendor}
+              </Typography>
+            </Box>
+          }
+        />
+        <Typography variant="subtitle1" color="primary">
+          PO Total: ${poTotal.toFixed(2)}
+        </Typography>
+      </Box>
+
+      {/* Vendor select + Notes fields */}
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <VendorSelect
+            value={info.vendorId}
+            onChange={(id) => onUpdateVendorPO(vendor, 'vendorId', id)}
+            disabled={!isSelected}
+          />
+        </Box>
+        <TextField
+          label="Notes"
+          size="small"
+          multiline
+          minRows={1}
+          maxRows={3}
+          disabled={!isSelected}
+          value={info.notes}
+          onChange={(e) => onUpdateVendorPO(vendor, 'notes', e.target.value)}
+          sx={{ flex: 1 }}
+          placeholder="Optional notes for this PO"
+        />
+      </Box>
+
+      {/* Line Items subheading */}
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Line Items ({aggregated.length})
+      </Typography>
+
+      {/* Aggregated line items grid */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1.2fr 1.5fr 1.5fr 0.7fr 0.8fr 0.8fr' }}>
+        {/* Header row */}
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Order As
+          </Typography>
+        </Box>
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Product Code
+          </Typography>
+        </Box>
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Hardware Category
+          </Typography>
+        </Box>
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Total Qty
+          </Typography>
+        </Box>
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Unit Cost
+          </Typography>
+        </Box>
+        <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+            Total Cost
+          </Typography>
+        </Box>
+
+        {/* Data rows */}
+        {aggregated.map((line, idx) => {
+          const rowBg = idx % 2 === 0 ? 'background.paper' : 'grey.50';
+          const aliasKey = `${line.productCode}|${line.hardwareCategory}`;
+          const options = priorMap.get(line.productCode) ?? [];
+          return (
+            <Box key={`${line.productCode}-${line.hardwareCategory}`} sx={{ display: 'contents' }}>
+              <Box sx={{ bgcolor: rowBg, p: 0.75, display: 'flex', alignItems: 'center' }}>
+                <OrderAsAutocomplete
+                  value={orderAsValues.get(aliasKey) ?? ''}
+                  onChange={(next) => onUpdateOrderAs(aliasKey, next)}
+                  options={options}
+                  disabled={!isSelected}
+                  placeholder="Order as"
+                />
+              </Box>
+              <Box sx={{ bgcolor: rowBg, p: 0.75 }}>
+                <Typography variant="body2">{line.productCode}</Typography>
+              </Box>
+              <Box sx={{ bgcolor: rowBg, p: 0.75 }}>
+                <Typography variant="body2">{line.hardwareCategory}</Typography>
+              </Box>
+              <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
+                <Typography variant="body2">{line.totalQuantity}</Typography>
+              </Box>
+              <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
+                <TextField
+                  size="small"
+                  type="number"
+                  disabled={!isSelected}
+                  value={line.unitCost}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    if (!isNaN(val) && val >= 0) {
+                      onUpdateUnitCost(vendor, line.productCode, line.hardwareCategory, val);
+                    }
+                  }}
+                  slotProps={{
+                    input: {
+                      startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                    },
+                    htmlInput: { min: 0, step: 0.01 },
+                  }}
+                  sx={{ width: 120 }}
+                />
+              </Box>
+              <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
+                <Typography variant="body2">${line.totalCost.toFixed(2)}</Typography>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Paper>
+  );
+}
+
 // ---- Component ----
 
 export default function PurchaseOrdersStep({
@@ -99,155 +304,21 @@ export default function PurchaseOrdersStep({
 
       {sortedVendors.map(([vendor, items]) => {
         const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '' };
-        const aggregated = aggregateLineItems(items, vendor, unitCostOverrides);
-        const poTotal = aggregated.reduce((sum, line) => sum + line.totalCost, 0);
         const isSelected = selectedVendors.has(vendor);
-
         return (
-          <Paper key={vendor} variant="outlined" sx={{ p: 2, mb: 2, opacity: isSelected ? 1 : 0.5 }}>
-            {/* Header: checkbox + manufacturer label + PO total */}
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={isSelected}
-                    onChange={() => onToggleVendor(vendor)}
-                  />
-                }
-                label={
-                  <Box>
-                    <Typography variant="caption" color="text.secondary">
-                      Manufacturer
-                    </Typography>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                      {vendor}
-                    </Typography>
-                  </Box>
-                }
-              />
-              <Typography variant="subtitle1" color="primary">
-                PO Total: ${poTotal.toFixed(2)}
-              </Typography>
-            </Box>
-
-            {/* Vendor select + Notes fields */}
-            <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-              <Box sx={{ flex: 1 }}>
-                <VendorSelect
-                  value={info.vendorId}
-                  onChange={(id) => onUpdateVendorPO(vendor, 'vendorId', id)}
-                  disabled={!isSelected}
-                />
-              </Box>
-              <TextField
-                label="Notes"
-                size="small"
-                multiline
-                minRows={1}
-                maxRows={3}
-                disabled={!isSelected}
-                value={info.notes}
-                onChange={(e) => onUpdateVendorPO(vendor, 'notes', e.target.value)}
-                sx={{ flex: 1 }}
-                placeholder="Optional notes for this PO"
-              />
-            </Box>
-
-            {/* Line Items subheading */}
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>
-              Line Items ({aggregated.length})
-            </Typography>
-
-            {/* Aggregated line items grid */}
-            <Box sx={{ display: 'grid', gridTemplateColumns: '1.2fr 1.5fr 1.5fr 0.7fr 0.8fr 0.8fr' }}>
-              {/* Header row */}
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Order As
-                </Typography>
-              </Box>
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Product Code
-                </Typography>
-              </Box>
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75 }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Hardware Category
-                </Typography>
-              </Box>
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Total Qty
-                </Typography>
-              </Box>
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Unit Cost
-                </Typography>
-              </Box>
-              <Box sx={{ bgcolor: 'grey.100', p: 0.75, textAlign: 'right' }}>
-                <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                  Total Cost
-                </Typography>
-              </Box>
-
-              {/* Data rows */}
-              {aggregated.map((line, idx) => {
-                const rowBg = idx % 2 === 0 ? 'background.paper' : 'grey.50';
-                const aliasKey = `${line.productCode}|${line.hardwareCategory}`;
-                return (
-                  <Box key={`${line.productCode}-${line.hardwareCategory}`} sx={{ display: 'contents' }}>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75, display: 'flex', alignItems: 'center' }}>
-                      <TextField
-                        size="small"
-                        placeholder="Order as"
-                        disabled={!isSelected}
-                        value={orderAsValues.get(aliasKey) ?? ''}
-                        onChange={(e) => onUpdateOrderAs(aliasKey, e.target.value)}
-                        variant="standard"
-                        fullWidth
-                        slotProps={{ input: { sx: { fontSize: '0.875rem' } } }}
-                      />
-                    </Box>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75 }}>
-                      <Typography variant="body2">{line.productCode}</Typography>
-                    </Box>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75 }}>
-                      <Typography variant="body2">{line.hardwareCategory}</Typography>
-                    </Box>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
-                      <Typography variant="body2">{line.totalQuantity}</Typography>
-                    </Box>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
-                      <TextField
-                        size="small"
-                        type="number"
-                        disabled={!isSelected}
-                        value={line.unitCost}
-                        onChange={(e) => {
-                          const val = parseFloat(e.target.value);
-                          if (!isNaN(val) && val >= 0) {
-                            onUpdateUnitCost(vendor, line.productCode, line.hardwareCategory, val);
-                          }
-                        }}
-                        slotProps={{
-                          input: {
-                            startAdornment: <InputAdornment position="start">$</InputAdornment>,
-                          },
-                          htmlInput: { min: 0, step: 0.01 },
-                        }}
-                        sx={{ width: 120 }}
-                      />
-                    </Box>
-                    <Box sx={{ bgcolor: rowBg, p: 0.75, textAlign: 'right' }}>
-                      <Typography variant="body2">${line.totalCost.toFixed(2)}</Typography>
-                    </Box>
-                  </Box>
-                );
-              })}
-            </Box>
-          </Paper>
+          <VendorGroupCard
+            key={vendor}
+            vendor={vendor}
+            items={items}
+            info={info}
+            isSelected={isSelected}
+            unitCostOverrides={unitCostOverrides}
+            orderAsValues={orderAsValues}
+            onToggleVendor={onToggleVendor}
+            onUpdateVendorPO={onUpdateVendorPO}
+            onUpdateUnitCost={onUpdateUnitCost}
+            onUpdateOrderAs={onUpdateOrderAs}
+          />
         );
       })}
 

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -26,13 +26,14 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import DescriptionIcon from '@mui/icons-material/Description';
-import { useMutation } from '@apollo/client/react';
+import { useMutation, useQuery } from '@apollo/client/react';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import type { GridColDef } from '@mui/x-data-grid';
 import Modal from '../../components/Modal';
 import DataTable from '../../components/DataTable';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import VendorSelect from '../../components/VendorSelect';
+import OrderAsAutocomplete from '../../components/OrderAsAutocomplete';
 import { useToast } from '../../components/Toast';
 import {
   UPDATE_PO,
@@ -43,6 +44,7 @@ import {
   UPLOAD_PO_DOCUMENT,
   DELETE_PO_DOCUMENT,
 } from '../../graphql/mutations';
+import { GET_PRIOR_ORDER_AS_VALUES } from '../../graphql/queries';
 import type { PurchaseOrder } from './index';
 
 // --- Status chip colors ---
@@ -370,6 +372,26 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
 
   const canEditItems = po.status === 'DRAFT';
 
+  const distinctProductCodes = useMemo(
+    () => Array.from(new Set(po.lineItems.map((li) => li.productCode))),
+    [po.lineItems],
+  );
+
+  const { data: priorData } = useQuery<{
+    priorOrderAsValues: { productCode: string; values: string[] }[];
+  }>(GET_PRIOR_ORDER_AS_VALUES, {
+    variables: { vendorId: po.vendor?.id ?? '', productCodes: distinctProductCodes },
+    skip: !canEditItems || !po.vendor?.id || distinctProductCodes.length === 0,
+  });
+
+  const priorMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const entry of priorData?.priorOrderAsValues ?? []) {
+      map.set(entry.productCode, entry.values);
+    }
+    return map;
+  }, [priorData]);
+
   const editLineItemColumns = useMemo<GridColDef[]>(
     () =>
       lineItemColumns.map((col): GridColDef => {
@@ -377,15 +399,13 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
           return {
             ...col,
             renderCell: (params) => (
-              <TextField
-                size="small"
-                variant="standard"
+              <OrderAsAutocomplete
                 value={aliasEdits[params.row.id as string] ?? (params.value as string) ?? ''}
-                onChange={(e) =>
-                  setAliasEdits((prev) => ({ ...prev, [params.row.id as string]: e.target.value }))
+                onChange={(next) =>
+                  setAliasEdits((prev) => ({ ...prev, [params.row.id as string]: next }))
                 }
-                fullWidth
-                slotProps={{ input: { sx: { fontSize: '0.875rem' } } }}
+                options={priorMap.get(params.row.productCode as string) ?? []}
+                placeholder="Order as"
               />
             ),
           };
@@ -415,7 +435,7 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
         }
         return col;
       }),
-    [aliasEdits, unitCostEdits, canEditItems],
+    [aliasEdits, unitCostEdits, canEditItems, priorMap],
   );
 
   // --- Visibility rules ---


### PR DESCRIPTION
## Summary
- Adds GraphQL query `priorOrderAsValues(vendorId, productCodes)` that returns distinct prior `order_as` values per product code, scoped to a vendor and ranked most-recent first; cancelled and soft-deleted POs are excluded.
- Replaces the plain `Order As` text input with a new `OrderAsAutocomplete` (MUI `freeSolo` Autocomplete) on import wizard step 5 and PO line item editing. Suggestions appear once a vendor is bound; users can still type any new value.
- Bootstraps backend pytest DB infrastructure (auto-migrating session fixture + per-test transaction rollback) and adds 9 repository test cases.