### PR TITLE
Clean up PO Detail Modal line items table (closes #105, #106)

### DIFF
--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -87,59 +87,6 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-// --- Line items columns ---
-
-const lineItemColumns: GridColDef[] = [
-  { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 130 },
-  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, minWidth: 150 },
-  {
-    field: 'orderAs',
-    headerName: 'Order As',
-    flex: 1,
-    minWidth: 130,
-    renderCell: (params) => params.value || '\u2014',
-  },
-  {
-    field: 'classification',
-    headerName: 'Classification',
-    flex: 1,
-    minWidth: 130,
-    renderCell: (params) => params.value || '\u2014',
-  },
-  {
-    field: 'orderedQuantity',
-    headerName: 'Ordered Qty',
-    flex: 0.7,
-    minWidth: 110,
-    type: 'number',
-  },
-  {
-    field: 'receivedQuantity',
-    headerName: 'Received Qty',
-    flex: 0.7,
-    minWidth: 110,
-    type: 'number',
-  },
-  {
-    field: 'unitCost',
-    headerName: 'Unit Cost',
-    flex: 0.7,
-    minWidth: 100,
-    type: 'number',
-    valueFormatter: (value: number) => `$${(value ?? 0).toFixed(2)}`,
-  },
-  {
-    field: 'lineTotal',
-    headerName: 'Line Total',
-    flex: 0.7,
-    minWidth: 110,
-    type: 'number',
-    valueGetter: (_value: unknown, row: { orderedQuantity: number; unitCost: number }) =>
-      (row.orderedQuantity ?? 0) * (row.unitCost ?? 0),
-    valueFormatter: (value: number) => `$${(value ?? 0).toFixed(2)}`,
-  },
-];
-
 // --- Props ---
 
 interface PODetailModalProps {
@@ -368,6 +315,57 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
     deleteDocument({ variables: { documentId } });
   };
 
+  // --- Line item columns ---
+
+  const lineItemColumns = useMemo<GridColDef[]>(() => {
+    const allCols: GridColDef[] = [
+      { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 130 },
+      { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, minWidth: 150 },
+      {
+        field: 'orderAs',
+        headerName: 'Order As',
+        flex: 1,
+        minWidth: 130,
+        renderCell: (params) => params.value || '—',
+      },
+      {
+        field: 'orderedQuantity',
+        headerName: 'Ordered Qty',
+        flex: 0.7,
+        minWidth: 110,
+        type: 'number',
+      },
+      {
+        field: 'receivedQuantity',
+        headerName: 'Received Qty',
+        flex: 0.7,
+        minWidth: 110,
+        type: 'number',
+      },
+      {
+        field: 'unitCost',
+        headerName: 'Unit Cost',
+        flex: 0.7,
+        minWidth: 100,
+        type: 'number',
+        valueFormatter: (value: number) => `$${(value ?? 0).toFixed(2)}`,
+      },
+      {
+        field: 'lineTotal',
+        headerName: 'Line Total',
+        flex: 0.7,
+        minWidth: 110,
+        type: 'number',
+        valueGetter: (_value: unknown, row: { orderedQuantity: number; unitCost: number }) =>
+          (row.orderedQuantity ?? 0) * (row.unitCost ?? 0),
+        valueFormatter: (value: number) => `$${(value ?? 0).toFixed(2)}`,
+      },
+    ];
+    return po.receiveRecords.length > 0
+      ? allCols
+      : allCols.filter((c) => c.field !== 'receivedQuantity');
+  }, [po.receiveRecords.length]);
+
   // --- Edit-mode line item columns (with editable Order As + unit cost) ---
 
   const canEditItems = po.status === 'DRAFT';
@@ -435,7 +433,7 @@ export default function PODetailModal({ open, po, onClose, onRefetch }: PODetail
         }
         return col;
       }),
-    [aliasEdits, unitCostEdits, canEditItems, priorMap],
+    [aliasEdits, unitCostEdits, canEditItems, priorMap, lineItemColumns],
   );
 
   // --- Visibility rules ---


### PR DESCRIPTION
## Summary

- Remove the always-empty `Classification` column from the PO Detail Modal line items table (#105). Classification is an assembly-purpose enum and PO-purpose imports never write it (`BY_OTHERS` items are stripped before persistence), so the column was dead noise.
- Hide the `Received Qty` column unless the PO has at least one receive record (#106). Gating on `po.receiveRecords.length > 0` cleanly handles every status: hidden for Draft / Ordered / Cancelled and for Vendor-Confirmed POs that reached that state via vendor-acknowledgement upload alone; shown for Partially Received and Closed.

To make the columns reactive to the current PO, `lineItemColumns` moves from a top-level constant into a `useMemo` inside the component. `editLineItemColumns` continues to map over it and picks up the changes via its dependency array.

Issue #107 (verification only — no code change required) will be closed separately with a comment confirming the rule already holds in code.