### PR TITLE
Add pool_pre_ping to DB engine and reuse boto3/httpx clients

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,7 +3,11 @@ from sqlalchemy.orm import sessionmaker
 
 from .config import DATABASE_URL
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    pool_recycle=300,
+)
 SessionLocal = sessionmaker(bind=engine)
 
 

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -7,6 +7,8 @@ from app.errors import AppError
 
 CLERK_API_BASE = "https://api.clerk.com/v1"
 
+_client = httpx.Client(base_url=CLERK_API_BASE, timeout=30.0)
+
 
 def _headers() -> dict[str, str]:
     if not CLERK_SECRET_KEY:
@@ -24,8 +26,8 @@ def list_users() -> list[dict]:
     limit = 100
 
     while True:
-        resp = httpx.get(
-            f"{CLERK_API_BASE}/users",
+        resp = _client.get(
+            "/users",
             headers=_headers(),
             params={"limit": limit, "offset": offset, "order_by": "-created_at"},
         )
@@ -61,8 +63,8 @@ def list_users() -> list[dict]:
 
 def update_user_roles(user_id: str, roles: list[str]) -> dict:
     """Update a Clerk user's roles in publicMetadata."""
-    resp = httpx.patch(
-        f"{CLERK_API_BASE}/users/{user_id}",
+    resp = _client.patch(
+        f"/users/{user_id}",
         headers=_headers(),
         json={"public_metadata": {"roles": roles}},
     )

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -5,15 +5,20 @@ from botocore.config import Config as BotoConfig
 
 from app.config import BUCKET_ACCESS_KEY_ID, BUCKET_ENDPOINT, BUCKET_NAME, BUCKET_SECRET_ACCESS_KEY
 
+_client = None
+
 
 def _get_client():
-    return boto3.client(
-        "s3",
-        endpoint_url=BUCKET_ENDPOINT,
-        aws_access_key_id=BUCKET_ACCESS_KEY_ID,
-        aws_secret_access_key=BUCKET_SECRET_ACCESS_KEY,
-        config=BotoConfig(signature_version="s3v4"),
-    )
+    global _client
+    if _client is None:
+        _client = boto3.client(
+            "s3",
+            endpoint_url=BUCKET_ENDPOINT,
+            aws_access_key_id=BUCKET_ACCESS_KEY_ID,
+            aws_secret_access_key=BUCKET_SECRET_ACCESS_KEY,
+            config=BotoConfig(signature_version="s3v4"),
+        )
+    return _client
 
 
 def upload_file(key: str, data: bytes, content_type: str) -> str:


### PR DESCRIPTION
## Summary

Prevent the backend from silently wedging on Railway after long idle periods.

## Background

The backend was returning `502 X-Railway-Fallback: true` and had not logged any requests for ~2.5 weeks while still appearing "running." Root cause: SQLAlchemy's default pool config (no `pool_pre_ping`, no `pool_recycle`) hands out dead TCP connections after Railway's internal networking silently closes idle ones. Requests then back up waiting on dead sockets until the threadpool fills and the edge proxy pulls the service out of routing.

## Changes

- **`backend/app/database.py`** — `create_engine(DATABASE_URL, pool_pre_ping=True, pool_recycle=300)`. Validates each connection at checkout and recycles every 5 minutes (well under any reasonable idle-drop threshold).
- **`backend/app/services/storage.py`** — Cache the boto3 S3 client at module level (lazy init) instead of building one per call. Avoids redundant credential resolution and connection-pool setup on every upload/download.
- **`backend/app/repositories/user_repository.py`** — Use a module-level `httpx.Client(base_url=CLERK_API_BASE, timeout=30.0)` so HTTP/1.1 keep-alive can actually reuse connections to Clerk instead of opening a fresh TCP+TLS handshake on every call.

The `/testing/clerk-sign-in` endpoint in `main.py` still uses one-off `httpx.get/post` — it is gated on `TESTING_ENABLED` and fires once per test session, so it is not worth the extra surface area.

## Why no behavior change tests

These are infrastructure/config changes with no externally observable behavior change on the happy path. The leak-style failure they prevent only manifests on a live deploy under sustained idle traffic.