### PR TITLE
Persist full hardware schedule; add replace-schedule override

### DIFF
--- a/backend/alembic/versions/026_persist_full_schedule.py
+++ b/backend/alembic/versions/026_persist_full_schedule.py
@@ -1,0 +1,104 @@
+"""Persist full hardware schedule: add AVAILABLE state, snapshot opening on SAR, drop opening FKs
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-06-01
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "026"
+down_revision = "025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add AVAILABLE to hardware_item_state enum (idempotent; ordered before IN_PO to
+    #    match the Python enum declaration order so alembic check sees no drift)
+    op.execute("ALTER TYPE hardware_item_state ADD VALUE IF NOT EXISTS 'AVAILABLE' BEFORE 'IN_PO'")
+
+    # 2. Add snapshot columns to shop_assembly_openings (nullable for backfill)
+    op.add_column("shop_assembly_openings", sa.Column("opening_number", sa.String(), nullable=True))
+    op.add_column("shop_assembly_openings", sa.Column("building", sa.String(), nullable=True))
+    op.add_column("shop_assembly_openings", sa.Column("floor", sa.String(), nullable=True))
+    op.add_column("shop_assembly_openings", sa.Column("location", sa.String(), nullable=True))
+
+    # 3. Backfill snapshot columns from openings table
+    op.execute(
+        """
+        UPDATE shop_assembly_openings sao
+        SET opening_number = o.opening_number,
+            building       = o.building,
+            floor          = o.floor,
+            location       = o.location
+        FROM openings o
+        WHERE sao.opening_id = o.id
+        """
+    )
+
+    # 4. Make opening_number NOT NULL now that it's backfilled
+    op.alter_column("shop_assembly_openings", "opening_number", nullable=False)
+
+    # 5. Drop FK from shop_assembly_openings.opening_id -> openings.id
+    #    (column stays NOT NULL as historical UUID; just no longer enforced referentially)
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'shop_assembly_openings_opening_id_fkey'
+            ) THEN
+                ALTER TABLE shop_assembly_openings
+                DROP CONSTRAINT shop_assembly_openings_opening_id_fkey;
+            END IF;
+        END $$;
+        """
+    )
+
+    # 6. Drop FK from opening_items.opening_id -> openings.id
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'opening_items_opening_id_fkey'
+            ) THEN
+                ALTER TABLE opening_items
+                DROP CONSTRAINT opening_items_opening_id_fkey;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Reverse FK drops (re-create with original implicit names)
+    op.create_foreign_key(
+        "opening_items_opening_id_fkey",
+        "opening_items",
+        "openings",
+        ["opening_id"],
+        ["id"],
+    )
+
+    op.create_foreign_key(
+        "shop_assembly_openings_opening_id_fkey",
+        "shop_assembly_openings",
+        "openings",
+        ["opening_id"],
+        ["id"],
+    )
+
+    # Drop snapshot columns
+    op.drop_column("shop_assembly_openings", "location")
+    op.drop_column("shop_assembly_openings", "floor")
+    op.drop_column("shop_assembly_openings", "building")
+    op.drop_column("shop_assembly_openings", "opening_number")
+
+    # AVAILABLE enum value is intentionally left in place; Postgres cannot drop enum
+    # values cleanly, and adding it back later is idempotent via IF NOT EXISTS.

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -7,6 +7,7 @@ class Classification(str, enum.Enum):
 
 
 class HardwareItemState(str, enum.Enum):
+    AVAILABLE = "AVAILABLE"
     IN_PO = "IN_PO"
 
 

--- a/backend/app/models/opening_item.py
+++ b/backend/app/models/opening_item.py
@@ -18,7 +18,9 @@ class OpeningItem(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), nullable=False)
-    opening_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("openings.id"), nullable=False)
+    # Historical UUID of the source opening at assembly time. Not FK-enforced; the source
+    # Opening row may be deleted in a later re-upload, but this stamp is preserved.
+    opening_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
     opening_number: Mapped[str] = mapped_column(String, nullable=False)
     building: Mapped[str | None] = mapped_column(String, nullable=True)
     floor: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -50,7 +50,13 @@ class ShopAssemblyOpening(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     shop_assembly_request_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("shop_assembly_requests.id"), nullable=False)
-    opening_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("openings.id"), nullable=False)
+    # Historical UUID of the source opening at request time. Not FK-enforced; the source
+    # Opening row may be deleted in a later re-upload, but this stamp is preserved.
+    opening_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    opening_number: Mapped[str] = mapped_column(String, nullable=False)
+    building: Mapped[str | None] = mapped_column(String, nullable=True)
+    floor: Mapped[str | None] = mapped_column(String, nullable=True)
+    location: Mapped[str | None] = mapped_column(String, nullable=True)
     pull_status: Mapped[PullStatus] = mapped_column(
         Enum(PullStatus, name="pull_status", create_constraint=True),
         nullable=False,

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from decimal import Decimal
 from math import floor
 
-from sqlalchemy import func, select, tuple_
+from sqlalchemy import delete, func, select, tuple_
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import ConflictError, NotFoundError
@@ -300,6 +300,27 @@ def reconcile_schedule(
     return results
 
 
+def _apply_opening_fields(opening: OpeningModel, opening_input: dict) -> None:
+    """Copy mutable fields from input dict onto an Opening model."""
+    opening.building = opening_input.get("building")
+    opening.floor = opening_input.get("floor")
+    opening.location = opening_input.get("location")
+    opening.location_to = opening_input.get("location_to")
+    opening.location_from = opening_input.get("location_from")
+    opening.hand = opening_input.get("hand")
+    opening.width = opening_input.get("width")
+    opening.length = opening_input.get("length")
+    opening.door_thickness = opening_input.get("door_thickness")
+    opening.jamb_thickness = opening_input.get("jamb_thickness")
+    opening.door_type = opening_input.get("door_type")
+    opening.frame_type = opening_input.get("frame_type")
+    opening.interior_exterior = opening_input.get("interior_exterior")
+    opening.keying = opening_input.get("keying")
+    opening.heading_no = opening_input.get("heading_no")
+    opening.single_pair = opening_input.get("single_pair")
+    opening.assignment_multiplier = opening_input.get("assignment_multiplier")
+
+
 def finalize_import_session(
     session: Session,
     input_data: dict,
@@ -315,6 +336,7 @@ def finalize_import_session(
     include_sar = input_data.get("include_shop_assembly_request", False)
     sar_request_number = input_data.get("shop_assembly_request_number")
     sar_openings_input = input_data.get("shop_assembly_openings") or []
+    replace_schedule = bool(input_data.get("replace_schedule", False))
 
     # 1. Project lookup (must already exist)
     project_stmt = (
@@ -325,38 +347,61 @@ def finalize_import_session(
     if project is None:
         raise NotFoundError(f"Project {project_id} not found")
 
-    # Create any NEW openings from this import (idempotent across re-imports)
-    existing_opening_numbers = {o.opening_number for o in project.openings}
+    # 2. Wipe AVAILABLE hardware items for this project — they are pure XML-derived rows
+    # that will be regenerated from the current input. Existing IN_PO rows (attached to
+    # prior POs) are preserved unless replace_schedule=True.
+    session.execute(
+        delete(HardwareItemModel).where(
+            HardwareItemModel.project_id == project.id,
+            HardwareItemModel.state == HardwareItemState.AVAILABLE,
+        )
+    )
+    session.flush()
+
+    if replace_schedule:
+        # Full override: wipe every HardwareItem (including IN_PO) and drop openings
+        # not present in the new schedule. Downstream PO/receiving/SAR/inventory
+        # aggregates are preserved; only the per-opening source trail is lost.
+        session.execute(delete(HardwareItemModel).where(HardwareItemModel.project_id == project.id))
+        session.flush()
+
+        new_opening_numbers = {o["opening_number"] for o in openings_input}
+        # ORM-aware delete so identity map / project.openings stay consistent.
+        for opening in list(project.openings):
+            if opening.opening_number not in new_opening_numbers:
+                session.delete(opening)
+        session.flush()
+        session.refresh(project, attribute_names=["openings"])
+
+    # 3. Upsert openings from input: add new ones; for replace mode also refresh existing fields.
+    existing_openings_by_number = {o.opening_number: o for o in project.openings}
     for opening_input in openings_input:
-        if opening_input["opening_number"] not in existing_opening_numbers:
+        opening_number = opening_input["opening_number"]
+        existing = existing_openings_by_number.get(opening_number)
+        if existing is None:
             opening = OpeningModel(
                 id=uuid.uuid4(),
                 project_id=project.id,
-                opening_number=opening_input["opening_number"],
-                building=opening_input.get("building"),
-                floor=opening_input.get("floor"),
-                location=opening_input.get("location"),
-                location_to=opening_input.get("location_to"),
-                location_from=opening_input.get("location_from"),
-                hand=opening_input.get("hand"),
-                width=opening_input.get("width"),
-                length=opening_input.get("length"),
-                door_thickness=opening_input.get("door_thickness"),
-                jamb_thickness=opening_input.get("jamb_thickness"),
-                door_type=opening_input.get("door_type"),
-                frame_type=opening_input.get("frame_type"),
-                interior_exterior=opening_input.get("interior_exterior"),
-                keying=opening_input.get("keying"),
-                heading_no=opening_input.get("heading_no"),
-                single_pair=opening_input.get("single_pair"),
-                assignment_multiplier=opening_input.get("assignment_multiplier"),
+                opening_number=opening_number,
             )
+            _apply_opening_fields(opening, opening_input)
             session.add(opening)
             project.openings.append(opening)
+            existing_openings_by_number[opening_number] = opening
+        elif replace_schedule:
+            _apply_opening_fields(existing, opening_input)
     session.flush()
 
     # Build opening_map: opening_number -> Opening.id
     opening_map: dict[str, uuid.UUID] = {o.opening_number: o.id for o in project.openings}
+
+    # Track existing IN_PO HardwareItem keys so we don't re-create them as AVAILABLE.
+    # (After the AVAILABLE wipe above and the optional full wipe under replace_schedule,
+    # any remaining rows are IN_PO from prior sessions.)
+    existing_in_po_keys: set[tuple[uuid.UUID, str, str]] = {
+        (hi.opening_id, hi.product_code, hi.hardware_category)
+        for hi in session.scalars(select(HardwareItemModel).where(HardwareItemModel.project_id == project.id)).all()
+    }
 
     # 2. Build classification map
     classification_map: dict[tuple[str, str, float], Classification] = {}
@@ -393,7 +438,13 @@ def finalize_import_session(
 
         session.flush()
 
-    # 3. PO creation
+    # Collect PO ref keys so the AVAILABLE step below knows which items the PO block will claim.
+    po_ref_keys: set[tuple[str, str, str]] = set()
+    for po_draft in po_drafts:
+        for ref in po_draft.get("hardware_item_refs", []):
+            po_ref_keys.add((ref["opening_number"], ref["product_code"], ref["hardware_category"]))
+
+    # 4. PO creation
     created_pos: list[POModel] = []
     if po_drafts:
         # Build hardware items lookup: (opening_number, product_code, hardware_category) -> hardware item data
@@ -535,7 +586,52 @@ def finalize_import_session(
 
             created_pos.append(po)
 
-    # 4. Shipping Out PRs
+    # 5. Persist remaining hardware items as AVAILABLE (everything in input not claimed by a PO).
+    #    Skips items whose (opening_id, product, category) tuple already exists as IN_PO from
+    #    a prior session, to avoid duplicating rows.
+    available_keys_seen: set[tuple[uuid.UUID, str, str]] = set()
+    for hi in hardware_items_input:
+        ref_key = (hi["opening_number"], hi["product_code"], hi["hardware_category"])
+        if ref_key in po_ref_keys:
+            continue
+        opening_id = opening_map.get(hi["opening_number"])
+        if opening_id is None:
+            continue
+        key_with_id = (opening_id, hi["product_code"], hi["hardware_category"])
+        if key_with_id in existing_in_po_keys or key_with_id in available_keys_seen:
+            continue
+        available_keys_seen.add(key_with_id)
+
+        unit_cost_val = hi.get("unit_cost") or 0.0
+        class_key = (hi["hardware_category"], hi["product_code"], unit_cost_val)
+        classification = classification_map.get(class_key)
+
+        session.add(
+            HardwareItemModel(
+                id=uuid.uuid4(),
+                project_id=project.id,
+                opening_id=opening_id,
+                hardware_category=hi["hardware_category"],
+                product_code=hi["product_code"],
+                material_id=hi.get("material_id"),
+                item_quantity=hi["item_quantity"],
+                unit_cost=Decimal(str(unit_cost_val)) if unit_cost_val else None,
+                unit_price=Decimal(str(hi["unit_price"])) if hi.get("unit_price") else None,
+                list_price=Decimal(str(hi["list_price"])) if hi.get("list_price") else None,
+                vendor_discount=Decimal(str(hi["vendor_discount"])) if hi.get("vendor_discount") else None,
+                markup_pct=Decimal(str(hi["markup_pct"])) if hi.get("markup_pct") else None,
+                vendor_no=hi.get("vendor_no"),
+                phase_code=hi.get("phase_code"),
+                item_category_code=hi.get("item_category_code"),
+                product_group_code=hi.get("product_group_code"),
+                submittal_id=hi.get("submittal_id"),
+                classification=classification,
+                state=HardwareItemState.AVAILABLE,
+            )
+        )
+    session.flush()
+
+    # 6. Shipping Out PRs
     created_prs: list[PullRequestModel] = []
     if shipping_pr_drafts:
         for pr_draft in shipping_pr_drafts:
@@ -578,7 +674,7 @@ def finalize_import_session(
 
             created_prs.append(pr)
 
-    # 5. SAR creation
+    # 7. SAR creation
     sar = None
     if include_sar and sar_request_number:
         # Validate uniqueness
@@ -600,14 +696,20 @@ def finalize_import_session(
         session.flush()
 
         for sa_opening_input in sar_openings_input:
-            opening_id = opening_map.get(sa_opening_input["opening_number"])
+            opening_number = sa_opening_input["opening_number"]
+            opening_id = opening_map.get(opening_number)
             if opening_id is None:
-                raise NotFoundError(f"Opening {sa_opening_input['opening_number']} not found in project")
+                raise NotFoundError(f"Opening {opening_number} not found in project")
 
+            opening_row = existing_openings_by_number.get(opening_number)
             sa_opening = SAOModel(
                 id=uuid.uuid4(),
                 shop_assembly_request_id=sar.id,
                 opening_id=opening_id,
+                opening_number=opening_number,
+                building=opening_row.building if opening_row else None,
+                floor=opening_row.floor if opening_row else None,
+                location=opening_row.location if opening_row else None,
                 pull_status=PullStatus.NOT_PULLED,
                 assembly_status=AssemblyStatus.PENDING,
             )

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -19,7 +19,6 @@ from app.models.enums import (
 )
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.opening_item import OpeningItemHardware as OIHModel
-from app.models.project import Opening as OpeningModel
 from app.models.pull_request import (
     PullRequest as PullRequestModel,
 )
@@ -54,45 +53,42 @@ def get_shop_assembly_requests(
 def get_assemble_list(
     session: Session,
     project_id: uuid.UUID | None = None,
-) -> list[tuple[ShopAssemblyOpening, OpeningModel]]:
-    """Query ShopAssemblyOpenings from Approved SARs, optionally filtered by project, with Opening data."""
+) -> list[ShopAssemblyOpening]:
+    """Query ShopAssemblyOpenings from Approved SARs, optionally filtered by project."""
     stmt = (
-        select(ShopAssemblyOpening, OpeningModel)
+        select(ShopAssemblyOpening)
         .join(
             ShopAssemblyRequest,
             ShopAssemblyOpening.shop_assembly_request_id == ShopAssemblyRequest.id,
         )
-        .join(OpeningModel, ShopAssemblyOpening.opening_id == OpeningModel.id)
         .options(selectinload(ShopAssemblyOpening.items))
         .where(ShopAssemblyRequest.status == ShopAssemblyRequestStatus.APPROVED)
     )
     if project_id is not None:
         stmt = stmt.where(ShopAssemblyRequest.project_id == project_id)
-    return list(session.execute(stmt).unique().all())
+    return list(session.scalars(stmt).unique().all())
 
 
 def get_my_work(
     session: Session,
     assigned_to: str,
-) -> list[tuple[ShopAssemblyOpening, OpeningModel]]:
-    """Query ShopAssemblyOpenings assigned to a user with Pending assembly_status.
-    Returns list of (ShopAssemblyOpening, Opening) tuples for resolving opening fields."""
+) -> list[ShopAssemblyOpening]:
+    """Query ShopAssemblyOpenings assigned to a user with Pending assembly_status."""
     stmt = (
-        select(ShopAssemblyOpening, OpeningModel)
+        select(ShopAssemblyOpening)
         .join(
             ShopAssemblyRequest,
             ShopAssemblyOpening.shop_assembly_request_id == ShopAssemblyRequest.id,
         )
-        .join(OpeningModel, ShopAssemblyOpening.opening_id == OpeningModel.id)
         .options(selectinload(ShopAssemblyOpening.items))
         .where(
             ShopAssemblyOpening.assigned_to == assigned_to,
             ShopAssemblyOpening.assembly_status == AssemblyStatus.PENDING,
             ShopAssemblyRequest.status == ShopAssemblyRequestStatus.APPROVED,
         )
-        .order_by(OpeningModel.opening_number.asc())
+        .order_by(ShopAssemblyOpening.opening_number.asc())
     )
-    return list(session.execute(stmt).unique().all())
+    return list(session.scalars(stmt).unique().all())
 
 
 def approve_shop_assembly_request(
@@ -144,20 +140,14 @@ def approve_shop_assembly_request(
     session.add(pr)
     session.flush()  # Get pr.id for PullRequestItems
 
-    # Create PullRequestItems for each opening's items
+    # Create PullRequestItems for each opening's items (use snapshot opening_number)
     for sa_opening in sar.openings:
-        # Look up the Opening model to get opening_number
-        opening_stmt = select(OpeningModel).where(OpeningModel.id == sa_opening.opening_id)
-        opening = session.scalars(opening_stmt).first()
-        if opening is None:
-            raise NotFoundError(f"Opening {sa_opening.opening_id} not found")
-
         for item in sa_opening.items:
             pr_item = PullRequestItemModel(
                 id=uuid.uuid4(),
                 pull_request_id=pr.id,
                 item_type=PullRequestItemType.LOOSE,
-                opening_number=opening.opening_number,
+                opening_number=sa_opening.opening_number,
                 hardware_category=item.hardware_category,
                 product_code=item.product_code,
                 requested_quantity=item.quantity,
@@ -293,17 +283,12 @@ def complete_opening(
             field="assigned_to",
         )
 
-    # 2. Load the Opening for opening_number, building, floor, location
-    opening = session.get(OpeningModel, sa_opening.opening_id)
-    if opening is None:
-        raise NotFoundError(f"Opening {sa_opening.opening_id} not found")
-
-    # 3. Load the SAR for project_id and request_number
+    # 2. Load the SAR for project_id and request_number
     sar = session.get(ShopAssemblyRequest, sa_opening.shop_assembly_request_id)
     if sar is None:
         raise NotFoundError(f"ShopAssemblyRequest {sa_opening.shop_assembly_request_id} not found")
 
-    # 4. Derive the auto-generated PR number and find the completed PR
+    # 3. Derive the auto-generated PR number and find the completed PR
     pr_number = f"PR-{sar.request_number}"
     pr_stmt = (
         select(PullRequestModel)
@@ -318,19 +303,19 @@ def complete_opening(
     if pr is None:
         raise NotFoundError(f"Completed PullRequest {pr_number} not found")
 
-    # 5. Filter PR items for this opening's opening_number
-    opening_pr_items = [item for item in pr.items if item.opening_number == opening.opening_number]
+    # 4. Filter PR items for this opening's opening_number (snapshot)
+    opening_pr_items = [item for item in pr.items if item.opening_number == sa_opening.opening_number]
 
-    # 6. Create OpeningItem
+    # 5. Create OpeningItem (snapshot opening identity from SAR row)
     now = datetime.utcnow()
     opening_item = OpeningItemModel(
         id=uuid.uuid4(),
         project_id=sar.project_id,
         opening_id=sa_opening.opening_id,
-        opening_number=opening.opening_number,
-        building=opening.building,
-        floor=opening.floor,
-        location=opening.location,
+        opening_number=sa_opening.opening_number,
+        building=sa_opening.building,
+        floor=sa_opening.floor,
+        location=sa_opening.location,
         quantity=1,
         assembly_completed_at=now,
         state=OpeningItemState.IN_INVENTORY,
@@ -341,7 +326,7 @@ def complete_opening(
     session.add(opening_item)
     session.flush()  # Get opening_item.id for OpeningItemHardware FK
 
-    # 7. Create OpeningItemHardware for each PR item
+    # 6. Create OpeningItemHardware for each PR item
     for pr_item in opening_pr_items:
         oih = OIHModel(
             id=uuid.uuid4(),
@@ -352,7 +337,7 @@ def complete_opening(
         )
         session.add(oih)
 
-    # 8. Mark ShopAssemblyOpening as Completed
+    # 7. Mark ShopAssemblyOpening as Completed
     sa_opening.assembly_status = AssemblyStatus.COMPLETED
     sa_opening.completed_at = now
 

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -129,6 +129,10 @@ class FinalizeImportSessionInput:
     include_shop_assembly_request: bool = False
     shop_assembly_request_number: str | None = None
     shop_assembly_openings: list[SAROpeningInput] | None = None
+    # When true, this finalize overrides the existing schedule: existing HardwareItem
+    # rows are wiped (including IN_PO ones) and openings absent from the new input
+    # are deleted. Downstream POs/receiving/SAR/inventory aggregates are preserved.
+    replace_schedule: bool = False
 
 
 @strawberry.input

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -238,6 +238,7 @@ class Mutation:
             ]
             if input.shop_assembly_openings
             else None,
+            "replace_schedule": input.replace_schedule,
         }
 
         with SessionLocal() as session:
@@ -730,20 +731,13 @@ class Mutation:
         with SessionLocal() as session:
             result = shop_assembly_repository.assign_openings(session, opening_ids, input.assigned_to)
             session.commit()
-            # Re-load with items + join Opening for opening_number/building/floor
             from sqlalchemy.orm import selectinload
 
-            from app.models.project import Opening as OpeningModel
             from app.models.shop_assembly import ShopAssemblyOpening as SAOModel
 
-            stmt = (
-                select(SAOModel, OpeningModel)
-                .join(OpeningModel, SAOModel.opening_id == OpeningModel.id)
-                .options(selectinload(SAOModel.items))
-                .where(SAOModel.id.in_([o.id for o in result]))
-            )
-            rows = list(session.execute(stmt).unique().all())
-            return [_shop_assembly_opening_to_type(sao, opening_model=opening) for sao, opening in rows]
+            stmt = select(SAOModel).options(selectinload(SAOModel.items)).where(SAOModel.id.in_([o.id for o in result]))
+            saos = list(session.scalars(stmt).unique().all())
+            return [_shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.mutation
     def remove_opening_from_user(self, opening_id: strawberry.ID) -> ShopAssemblyOpening:
@@ -751,21 +745,13 @@ class Mutation:
             result = shop_assembly_repository.remove_opening_from_user(session, uuid.UUID(str(opening_id)))
             session.commit()
             session.refresh(result)
-            # Re-load with items + join Opening for opening_number/building/floor
             from sqlalchemy.orm import selectinload
 
-            from app.models.project import Opening as OpeningModel
             from app.models.shop_assembly import ShopAssemblyOpening as SAOModel
 
-            stmt = (
-                select(SAOModel, OpeningModel)
-                .join(OpeningModel, SAOModel.opening_id == OpeningModel.id)
-                .options(selectinload(SAOModel.items))
-                .where(SAOModel.id == result.id)
-            )
-            row = session.execute(stmt).unique().first()
-            refreshed, opening = row
-            return _shop_assembly_opening_to_type(refreshed, opening_model=opening)
+            stmt = select(SAOModel).options(selectinload(SAOModel.items)).where(SAOModel.id == result.id)
+            refreshed = session.scalars(stmt).unique().first()
+            return _shop_assembly_opening_to_type(refreshed)
 
     @strawberry.mutation
     def complete_opening(self, input: CompleteOpeningInput) -> OpeningItem:

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -315,7 +315,7 @@ def _shop_assembly_opening_item_to_type(item) -> ShopAssemblyOpeningItem:
     )
 
 
-def _shop_assembly_opening_to_type(opening, opening_model=None) -> ShopAssemblyOpening:
+def _shop_assembly_opening_to_type(opening) -> ShopAssemblyOpening:
     return ShopAssemblyOpening(
         id=strawberry.ID(str(opening.id)),
         shop_assembly_request_id=strawberry.ID(str(opening.shop_assembly_request_id)),
@@ -325,9 +325,9 @@ def _shop_assembly_opening_to_type(opening, opening_model=None) -> ShopAssemblyO
         assembly_status=opening.assembly_status,
         completed_at=opening.completed_at,
         items=[_shop_assembly_opening_item_to_type(i) for i in opening.items],
-        opening_number=opening_model.opening_number if opening_model else None,
-        building=opening_model.building if opening_model else None,
-        floor=opening_model.floor if opening_model else None,
+        opening_number=opening.opening_number,
+        building=opening.building,
+        floor=opening.floor,
     )
 
 
@@ -783,16 +783,16 @@ class Query:
     @strawberry.field
     def assemble_list(self, project_id: strawberry.ID | None = None) -> list[ShopAssemblyOpening]:
         with SessionLocal() as session:
-            rows = shop_assembly_repository.get_assemble_list(
+            saos = shop_assembly_repository.get_assemble_list(
                 session, uuid.UUID(str(project_id)) if project_id else None
             )
-            return [_shop_assembly_opening_to_type(sao, opening_model=opening) for sao, opening in rows]
+            return [_shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.field
     def my_work(self, assigned_to: str) -> list[ShopAssemblyOpening]:
         with SessionLocal() as session:
-            rows = shop_assembly_repository.get_my_work(session, assigned_to)
-            return [_shop_assembly_opening_to_type(sao, opening_model=opening) for sao, opening in rows]
+            saos = shop_assembly_repository.get_my_work(session, assigned_to)
+            return [_shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.field
     def hardware_summary(self, project_id: strawberry.ID | None = None) -> list[HardwareSummaryRow]:

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -1,0 +1,489 @@
+"""Tests for full-schedule persistence and replace-schedule override semantics."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+
+from app.models.enums import (
+    HardwareItemState,
+    OpeningItemState,
+    PullStatus,
+    ShopAssemblyRequestStatus,
+)
+from app.models.hardware import HardwareItem
+from app.models.opening_item import OpeningItem
+from app.models.project import Opening, Project
+from app.models.purchase_order import PurchaseOrder
+from app.models.shop_assembly import (
+    ShopAssemblyOpening,
+    ShopAssemblyRequest,
+)
+from app.models.vendor import Vendor
+from app.repositories import import_repository, shop_assembly_repository
+
+
+def _make_project(session, project_id: str = "PROJ-001") -> Project:
+    p = Project(
+        id=uuid.uuid4(),
+        project_id=f"{project_id}-{uuid.uuid4().hex[:6]}",
+        description="Test",
+    )
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_vendor(session, name: str = "Acme") -> Vendor:
+    v = Vendor(id=uuid.uuid4(), name=f"{name}-{uuid.uuid4().hex[:6]}")
+    session.add(v)
+    session.flush()
+    return v
+
+
+def _opening_input(opening_number: str, **overrides) -> dict:
+    base = {
+        "opening_number": opening_number,
+        "building": overrides.get("building", "B1"),
+        "floor": overrides.get("floor", "F1"),
+        "location": overrides.get("location", "Lobby"),
+        "location_to": None,
+        "location_from": None,
+        "hand": None,
+        "width": None,
+        "length": None,
+        "door_thickness": None,
+        "jamb_thickness": None,
+        "door_type": None,
+        "frame_type": None,
+        "interior_exterior": None,
+        "keying": None,
+        "heading_no": None,
+        "single_pair": None,
+        "assignment_multiplier": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _hardware_item_input(opening_number: str, product_code: str, **overrides) -> dict:
+    base = {
+        "opening_number": opening_number,
+        "product_code": product_code,
+        "hardware_category": overrides.get("hardware_category", "HINGE"),
+        "item_quantity": overrides.get("item_quantity", 1),
+        "unit_cost": overrides.get("unit_cost", 10.0),
+        "unit_price": None,
+        "list_price": None,
+        "vendor_discount": None,
+        "markup_pct": None,
+        "vendor_no": overrides.get("vendor_no", "V1"),
+        "phase_code": None,
+        "item_category_code": None,
+        "product_group_code": None,
+        "submittal_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_persists_full_schedule_as_available_when_no_pos(db_session):
+    """Items with no PO drafts should all be persisted as AVAILABLE."""
+    project = _make_project(db_session)
+    db_session.commit()
+
+    result = import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01"), _opening_input("A02")],
+            "hardware_items": [
+                _hardware_item_input("A01", "HG-100"),
+                _hardware_item_input("A01", "HG-200"),
+                _hardware_item_input("A02", "HG-100"),
+            ],
+        },
+    )
+    db_session.flush()
+    assert result["project"].id == project.id
+
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    assert len(items) == 3
+    assert all(hi.state == HardwareItemState.AVAILABLE for hi in items)
+    assert all(hi.po_line_item_id is None for hi in items)
+
+
+def test_persists_full_schedule_with_mixed_po_and_available(db_session):
+    """Items in PO drafts become IN_PO; remaining items become AVAILABLE."""
+    project = _make_project(db_session)
+    vendor = _make_vendor(db_session)
+    db_session.commit()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01"), _opening_input("A02")],
+            "hardware_items": [
+                _hardware_item_input("A01", "HG-100"),
+                _hardware_item_input("A01", "HG-200"),
+                _hardware_item_input("A02", "HG-100"),
+            ],
+            "po_drafts": [
+                {
+                    "po_number": "PO-1",
+                    "vendor_id": str(vendor.id),
+                    "notes": None,
+                    "hardware_item_refs": [
+                        {"opening_number": "A01", "product_code": "HG-100", "hardware_category": "HINGE"},
+                    ],
+                    "line_item_aliases": [],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    by_key = {(hi.product_code, hi.state): hi for hi in items}
+    assert len(items) == 3
+    assert ("HG-100", HardwareItemState.IN_PO) in by_key
+    assert ("HG-200", HardwareItemState.AVAILABLE) in by_key
+    # The second A02/HG-100 entry should be AVAILABLE
+    available_hg100 = [hi for hi in items if hi.product_code == "HG-100" and hi.state == HardwareItemState.AVAILABLE]
+    assert len(available_hg100) == 1
+
+
+def test_resume_does_not_duplicate_in_po_items(db_session):
+    """Re-running finalize with same input must not create duplicate AVAILABLE rows for items already IN_PO."""
+    project = _make_project(db_session)
+    vendor = _make_vendor(db_session)
+    db_session.commit()
+
+    base_input = {
+        "project_id": str(project.id),
+        "openings": [_opening_input("A01")],
+        "hardware_items": [_hardware_item_input("A01", "HG-100")],
+        "po_drafts": [
+            {
+                "po_number": "PO-1",
+                "vendor_id": str(vendor.id),
+                "notes": None,
+                "hardware_item_refs": [
+                    {"opening_number": "A01", "product_code": "HG-100", "hardware_category": "HINGE"},
+                ],
+                "line_item_aliases": [],
+            },
+        ],
+    }
+    import_repository.finalize_import_session(db_session, base_input)
+    db_session.flush()
+
+    # Re-run without po_drafts (simulating "Start from latest" then closing wizard)
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01")],
+            "hardware_items": [_hardware_item_input("A01", "HG-100")],
+        },
+    )
+    db_session.flush()
+
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    assert len(items) == 1
+    assert items[0].state == HardwareItemState.IN_PO
+
+
+def test_replace_schedule_wipes_all_hardware_items(db_session):
+    """replace_schedule=True wipes all HardwareItems including IN_PO, then recreates from new input."""
+    project = _make_project(db_session)
+    vendor = _make_vendor(db_session)
+    db_session.commit()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01"), _opening_input("A02")],
+            "hardware_items": [
+                _hardware_item_input("A01", "HG-100"),
+                _hardware_item_input("A02", "HG-200"),
+            ],
+            "po_drafts": [
+                {
+                    "po_number": "PO-1",
+                    "vendor_id": str(vendor.id),
+                    "notes": None,
+                    "hardware_item_refs": [
+                        {"opening_number": "A01", "product_code": "HG-100", "hardware_category": "HINGE"},
+                    ],
+                    "line_item_aliases": [],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+
+    # PO and its line items should exist
+    po_count_before = db_session.scalars(select(PurchaseOrder).where(PurchaseOrder.project_id == project.id)).all()
+    assert len(po_count_before) == 1
+
+    # Re-upload a different schedule with replace_schedule=True
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A03")],
+            "hardware_items": [_hardware_item_input("A03", "HG-999")],
+            "replace_schedule": True,
+        },
+    )
+    db_session.flush()
+
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    assert len(items) == 1
+    assert items[0].product_code == "HG-999"
+    assert items[0].state == HardwareItemState.AVAILABLE
+
+    # PO is preserved (downstream aggregate untouched)
+    po_count_after = db_session.scalars(select(PurchaseOrder).where(PurchaseOrder.project_id == project.id)).all()
+    assert len(po_count_after) == 1
+
+    # Openings missing from new XML are deleted
+    openings = db_session.scalars(select(Opening).where(Opening.project_id == project.id)).all()
+    opening_numbers = {o.opening_number for o in openings}
+    assert opening_numbers == {"A03"}
+
+
+def test_replace_schedule_preserves_inventory(db_session):
+    """An OpeningItem in inventory survives a replace_schedule that removes its source opening."""
+    project = _make_project(db_session)
+    db_session.commit()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01", building="B1", floor="F2", location="Lobby")],
+            "hardware_items": [],
+        },
+    )
+    db_session.flush()
+    a01 = db_session.scalar(select(Opening).where(Opening.project_id == project.id, Opening.opening_number == "A01"))
+
+    # Simulate an OpeningItem in inventory for A01
+    oi = OpeningItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=a01.id,
+        opening_number="A01",
+        building="B1",
+        floor="F2",
+        location="Lobby",
+        quantity=1,
+        assembly_completed_at=datetime.utcnow(),
+        state=OpeningItemState.IN_INVENTORY,
+        aisle="A1",
+        bay="B1",
+        bin="01",
+    )
+    db_session.add(oi)
+    db_session.flush()
+
+    # Re-upload a schedule without A01
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A02")],
+            "hardware_items": [],
+            "replace_schedule": True,
+        },
+    )
+    db_session.flush()
+
+    # Opening row is gone
+    assert db_session.scalar(select(Opening).where(Opening.id == a01.id)) is None
+
+    # OpeningItem still exists, with full snapshot
+    refreshed_oi = db_session.scalar(select(OpeningItem).where(OpeningItem.id == oi.id))
+    assert refreshed_oi is not None
+    assert refreshed_oi.opening_number == "A01"
+    assert refreshed_oi.building == "B1"
+    assert refreshed_oi.floor == "F2"
+    assert refreshed_oi.location == "Lobby"
+    assert refreshed_oi.aisle == "A1"
+    assert refreshed_oi.quantity == 1
+
+
+def test_sar_opening_carries_snapshot(db_session):
+    """ShopAssemblyOpening created via finalize should have snapshot opening identity columns populated."""
+    project = _make_project(db_session)
+    db_session.commit()
+
+    sar_number = f"SAR-{uuid.uuid4().hex[:6]}"
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01", building="B1", floor="F2", location="Lobby")],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": sar_number,
+            "shop_assembly_openings": [
+                {
+                    "opening_number": "A01",
+                    "items": [
+                        {"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 2},
+                    ],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+
+    sao = db_session.scalar(
+        select(ShopAssemblyOpening)
+        .join(ShopAssemblyRequest, ShopAssemblyOpening.shop_assembly_request_id == ShopAssemblyRequest.id)
+        .where(ShopAssemblyRequest.request_number == sar_number)
+    )
+    assert sao is not None
+    assert sao.opening_number == "A01"
+    assert sao.building == "B1"
+    assert sao.floor == "F2"
+    assert sao.location == "Lobby"
+
+
+def test_sar_queries_work_after_opening_deleted(db_session):
+    """get_assemble_list / get_my_work must work even when the source Opening row was deleted."""
+    project = _make_project(db_session)
+    db_session.commit()
+
+    sar_number = f"SAR-{uuid.uuid4().hex[:6]}"
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01")],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": sar_number,
+            "shop_assembly_openings": [
+                {
+                    "opening_number": "A01",
+                    "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 1}],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+
+    # Approve SAR so it shows up in assemble_list (assigned_to needs setting for my_work)
+    sar = db_session.scalar(select(ShopAssemblyRequest).where(ShopAssemblyRequest.request_number == sar_number))
+    sar.status = ShopAssemblyRequestStatus.APPROVED
+    sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id))
+    sao.pull_status = PullStatus.PULLED
+    sao.assigned_to = "tester"
+    db_session.flush()
+
+    # Re-upload removing A01
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A02")],
+            "hardware_items": [],
+            "replace_schedule": True,
+        },
+    )
+    db_session.flush()
+
+    # Opening A01 is deleted
+    assert (
+        db_session.scalar(select(Opening).where(Opening.project_id == project.id, Opening.opening_number == "A01"))
+        is None
+    )
+
+    # Both repository functions should still return the SAR opening with snapshot data
+    assemble_rows = shop_assembly_repository.get_assemble_list(db_session, project.id)
+    assert len(assemble_rows) == 1
+    assert assemble_rows[0].opening_number == "A01"
+
+    my_work_rows = shop_assembly_repository.get_my_work(db_session, "tester")
+    assert len(my_work_rows) == 1
+    assert my_work_rows[0].opening_number == "A01"
+
+
+def test_existing_openings_updated_on_replace(db_session):
+    """replace_schedule refreshes existing opening field values from the new XML."""
+    project = _make_project(db_session)
+    db_session.commit()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01", building="B1", floor="F1", door_type="HM")],
+            "hardware_items": [],
+        },
+    )
+    db_session.flush()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01", building="B2", floor="F3", door_type="WD")],
+            "hardware_items": [],
+            "replace_schedule": True,
+        },
+    )
+    db_session.flush()
+
+    a01 = db_session.scalar(select(Opening).where(Opening.project_id == project.id, Opening.opening_number == "A01"))
+    assert a01.building == "B2"
+    assert a01.floor == "F3"
+    assert a01.door_type == "WD"
+
+
+def test_get_project_hardware_schedule_returns_all_items(db_session):
+    """get_project_hardware_schedule must return the full persisted set (including AVAILABLE)."""
+    project = _make_project(db_session)
+    vendor = _make_vendor(db_session)
+    db_session.commit()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01"), _opening_input("A02")],
+            "hardware_items": [
+                _hardware_item_input("A01", "HG-100"),
+                _hardware_item_input("A02", "HG-200"),
+                _hardware_item_input("A02", "HG-300"),
+            ],
+            "po_drafts": [
+                {
+                    "po_number": "PO-1",
+                    "vendor_id": str(vendor.id),
+                    "notes": None,
+                    "hardware_item_refs": [
+                        {"opening_number": "A01", "product_code": "HG-100", "hardware_category": "HINGE"},
+                    ],
+                    "line_item_aliases": [],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+
+    schedule = import_repository.get_project_hardware_schedule(db_session, project.id)
+    assert schedule is not None
+    opening_numbers = {o.opening_number for o in schedule["openings"]}
+    assert opening_numbers == {"A01", "A02"}
+
+    hw_items = schedule["hardware_items"]
+    assert len(hw_items) == 3
+    product_codes = {hi["product_code"] for hi in hw_items}
+    assert product_codes == {"HG-100", "HG-200", "HG-300"}

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -580,10 +580,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   const buildFinalizeInput = useCallback(() => {
     if (!parsed) return null;
-    const openingNumbersFromItems = new Set(aggregatedHardwareItems.map((hi) => hi.opening_number));
-    const selectedOpeningsList = parsed.openings.filter(
-      (o) => selectedOpenings.has(o.opening_number) && openingNumbersFromItems.has(o.opening_number),
-    );
     const filteredHardwareItems = parsed.hardwareItems.filter(
       (hi) => selectedOpenings.has(hi.opening_number),
     );
@@ -612,22 +608,37 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         ).values())
       : null;
 
+    // Full-schedule hardware items: aggregate ALL parsed items by (opening, product, category).
+    // The backend persists every entry — items referenced by a PO draft become IN_PO; the rest
+    // become AVAILABLE so the persisted schedule is byte-equivalent to a fresh XML upload.
+    const fullScheduleAggMap = new Map<string, AggregatedHardwareItem>();
+    for (const hi of parsed.hardwareItems) {
+      const aggKey = `${hi.opening_number}|${hi.hardware_category}|${hi.product_code}`;
+      const existing = fullScheduleAggMap.get(aggKey);
+      if (existing) {
+        existing.item_quantity += hi.item_quantity;
+      } else {
+        const { material_id, ...rest } = hi;
+        void material_id;
+        fullScheduleAggMap.set(aggKey, { ...rest });
+      }
+    }
+    const fullScheduleHardwareItems = Array.from(fullScheduleAggMap.values()).map((hi) => {
+      // Apply any unit-cost overrides from the PO step so the persisted row matches what
+      // the user reviewed at finalize time.
+      const vendor = hi.vendor_no ?? '(No Manufacturer)';
+      const overrideKey = `${vendor}|${hi.product_code}|${hi.hardware_category}`;
+      const overriddenCost = unitCostOverrides.get(overrideKey);
+      const item = overriddenCost !== undefined
+        ? { ...hi, unit_cost: overriddenCost }
+        : hi;
+      return snakeToCamel(item as unknown as Record<string, unknown>);
+    });
+
     return {
       projectId: project.id,
-      openings: selectedOpeningsList.map((o) => snakeToCamel(o as unknown as Record<string, unknown>)),
-      hardwareItems: purpose === 'po'
-        ? aggregatedHardwareItems
-            .filter((hi) => selectedVendors.has(hi.vendor_no ?? '(No Manufacturer)') && !isByOthers(hi))
-            .map((hi) => {
-              const vendor = hi.vendor_no ?? '(No Manufacturer)';
-              const overrideKey = `${vendor}|${hi.product_code}|${hi.hardware_category}`;
-              const overriddenCost = unitCostOverrides.get(overrideKey);
-              const item = overriddenCost !== undefined
-                ? { ...hi, unit_cost: overriddenCost }
-                : hi;
-              return snakeToCamel(item as unknown as Record<string, unknown>);
-            })
-        : null,
+      openings: parsed.openings.map((o) => snakeToCamel(o as unknown as Record<string, unknown>)),
+      hardwareItems: fullScheduleHardwareItems,
       poDrafts: purpose === 'po'
         ? Array.from(vendorGroups.entries())
             .filter(([vendor]) => selectedVendors.has(vendor))
@@ -690,8 +701,13 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         : null,
       includeShopAssemblyRequest: purpose === 'assembly',
       shopAssemblyRequestNumber: purpose === 'assembly' ? sarRequestNumber : null,
+      // True when the user uploaded a fresh XML on a project that already has a persisted
+      // schedule (i.e., they did not pick "Use latest schedule"). The backend wipes all
+      // existing HardwareItems and openings absent from the new input.
+      replaceSchedule: canStartFromLatest && !hydratedFromPersisted,
       shopAssemblyOpenings: purpose === 'assembly'
-        ? selectedOpeningsList
+        ? parsed.openings
+            .filter((o) => selectedOpenings.has(o.opening_number))
             .map((opening) => {
               const shopItems = filteredHardwareItems.filter((hi) => {
                 if (hi.opening_number !== opening.opening_number) return false;
@@ -722,7 +738,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             .filter(Boolean)
         : null,
     };
-  }, [parsed, project.id, selectedOpenings, purpose, aggregatedHardwareItems, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber]);
+  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1227,9 +1243,13 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       {/* Confirm Dialog */}
       <ConfirmDialog
         open={confirmOpen}
-        title="Finalize Import"
-        message="This will create the selected purchase orders, assembly requests, and shipping pull requests. Continue?"
-        confirmLabel="Finalize"
+        title={canStartFromLatest && !hydratedFromPersisted ? 'Replace Hardware Schedule' : 'Finalize Import'}
+        message={
+          canStartFromLatest && !hydratedFromPersisted
+            ? "You're uploading a NEW hardware schedule that will REPLACE the previously stored one. Existing purchase orders, receiving records, shop assembly requests, and warehouse inventory will be preserved, but the per-opening source trail of prior POs will be lost. Openings absent from the new schedule will be removed. Continue?"
+            : 'This will create the selected purchase orders, assembly requests, and shipping pull requests. Continue?'
+        }
+        confirmLabel={canStartFromLatest && !hydratedFromPersisted ? 'Replace Schedule' : 'Finalize'}
         onConfirm={handleFinalize}
         onCancel={() => setConfirmOpen(false)}
       />


### PR DESCRIPTION
## Summary

The `hardware_items` table previously stored only PO-attached items, so **Start from latest hardware schedule** returned a partial set — most openings showed 0 hardware items in import step 3 because their items had never been persisted.

This change makes the persisted schedule a complete, byte-equivalent representation of the parsed XML, and adds an explicit override path for re-uploading a new XML version.

## Behavior

- After finalize, every parsed hardware item is persisted. Items referenced by a PO draft become `IN_PO`; the rest become a new state `AVAILABLE`.
- "Start from latest" now reproduces a fresh XML upload exactly.
- When the user uploads a NEW XML on a project that already has a persisted schedule, the wizard sets `replaceSchedule=true` on finalize. The backend wipes all `HardwareItem` rows and deletes openings absent from the new XML.
- Downstream POs, receiving records, shop assembly requests, packing slips, and warehouse inventory are preserved across an override. Only the per-opening source trail of prior POs is lost (aggregate state on POLineItem stays intact).
- A confirmation modal lists what is preserved vs. lost before the override.

## Schema changes (migration 026)

- Add `AVAILABLE` to `hardware_item_state` enum (placed before `IN_PO` for declaration-order parity with the Python enum).
- Add `opening_number`, `building`, `floor`, `location` snapshot columns to `shop_assembly_openings`. Backfill from `openings`.
- Drop FK on `shop_assembly_openings.opening_id` → `openings.id` (column kept as historical UUID).
- Drop FK on `opening_items.opening_id` → `openings.id` (column kept as historical UUID). The existing snapshot columns on `opening_items` already covered everything downstream queries read.

## Key files

- `backend/alembic/versions/026_persist_full_schedule.py`
- `backend/app/repositories/import_repository.py`: persistence + override semantics
- `backend/app/repositories/shop_assembly_repository.py`: snapshot reads instead of Opening joins
- `backend/app/schemas/inputs.py`: `replace_schedule` flag
- `frontend/src/modules/import/ImportWizard.tsx`: send full schedule, track override path, confirmation message