### PR TITLE
Add project progress by product dashboard to warehouse module

### DIFF
--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -208,6 +208,14 @@ type RecentReceiveRecord {
   total_items_received: Int!
 }
 
+type ProjectProgressByProduct {
+  hardware_category: String!
+  product_code: String!
+  required_quantity: Int!
+  ordered_quantity: Int!
+  received_quantity: Int!
+}
+
 type Query {
   openPOs(projectId: ID): [PurchaseOrder!]!
   poReceivingDetails(poId: ID!): PurchaseOrder!
@@ -220,6 +228,7 @@ type Query {
   pullRequests(projectId: ID!, source: PullRequestSource, status: PullRequestStatus): [PullRequest!]!
   pullRequestDetails(id: ID!): PullRequest!
   shipReadyItems(projectId: ID!): ShipReadyItems!
+  projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
   notifications(projectId: ID!, recipientRole: String!, unreadOnly: Boolean, limit: Int = 5): [Notification!]!
 }
 

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -20,6 +20,7 @@ from app.models.enums import (
     PullRequestStatus,
     PullStatus,
 )
+from app.models.hardware import HardwareItem as HardwareItemModel
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.pull_request import PullRequest as PullRequestModel
@@ -205,6 +206,81 @@ def get_back_ordered_items(session: Session, project_id: uuid.UUID | None = None
             "outstanding_quantity": row[0].ordered_quantity - row[0].received_quantity,
         }
         for row in rows
+    ]
+
+
+PLACED_PO_STATUSES = (
+    POStatus.ORDERED,
+    POStatus.VENDOR_CONFIRMED,
+    POStatus.PARTIALLY_RECEIVED,
+    POStatus.CLOSED,
+)
+
+
+def get_project_progress_by_product(session: Session, project_id: uuid.UUID) -> list[dict]:
+    """Per-project, per-product-code rollup of required (from schedule), ordered, and received quantities.
+
+    - required_quantity: sum of hardware_items.item_quantity for the project, grouped by (category, code)
+    - ordered_quantity / received_quantity: sum of po_line_items.{ordered,received}_quantity for POs
+      with status in PLACED_PO_STATUSES (excludes DRAFT and CANCELLED) and deleted_at IS NULL,
+      grouped by (category, code).
+    """
+    required_subq = (
+        select(
+            HardwareItemModel.hardware_category.label("hardware_category"),
+            HardwareItemModel.product_code.label("product_code"),
+            func.sum(HardwareItemModel.item_quantity).label("required_quantity"),
+        )
+        .where(HardwareItemModel.project_id == project_id)
+        .group_by(HardwareItemModel.hardware_category, HardwareItemModel.product_code)
+        .subquery()
+    )
+
+    po_agg_subq = (
+        select(
+            POLineItemModel.hardware_category.label("hardware_category"),
+            POLineItemModel.product_code.label("product_code"),
+            func.sum(POLineItemModel.ordered_quantity).label("ordered_quantity"),
+            func.sum(POLineItemModel.received_quantity).label("received_quantity"),
+        )
+        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .where(
+            POModel.project_id == project_id,
+            POModel.deleted_at.is_(None),
+            POModel.status.in_(PLACED_PO_STATUSES),
+        )
+        .group_by(POLineItemModel.hardware_category, POLineItemModel.product_code)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            required_subq.c.hardware_category,
+            required_subq.c.product_code,
+            required_subq.c.required_quantity,
+            func.coalesce(po_agg_subq.c.ordered_quantity, 0).label("ordered_quantity"),
+            func.coalesce(po_agg_subq.c.received_quantity, 0).label("received_quantity"),
+        )
+        .select_from(required_subq)
+        .outerjoin(
+            po_agg_subq,
+            and_(
+                required_subq.c.hardware_category == po_agg_subq.c.hardware_category,
+                required_subq.c.product_code == po_agg_subq.c.product_code,
+            ),
+        )
+        .order_by(required_subq.c.hardware_category, required_subq.c.product_code)
+    )
+
+    return [
+        {
+            "hardware_category": row.hardware_category,
+            "product_code": row.product_code,
+            "required_quantity": int(row.required_quantity),
+            "ordered_quantity": int(row.ordered_quantity),
+            "received_quantity": int(row.received_quantity),
+        }
+        for row in session.execute(stmt).all()
     ]
 
 

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -49,6 +49,7 @@ from .types import (
     Project,
     ProjectExcludedItem,
     ProjectHardwareSchedule,
+    ProjectProgressByProduct,
     ProjectScheduleHardwareItem,
     PullRequest,
     PullRequestItem,
@@ -906,6 +907,21 @@ class Query:
                 received_last_7_days=d["received_last_7_days"],
                 back_ordered_count=d["back_ordered_count"],
             )
+
+    @strawberry.field
+    def project_progress_by_product(self, project_id: strawberry.ID) -> list[ProjectProgressByProduct]:
+        with SessionLocal() as session:
+            rows = warehouse_repository.get_project_progress_by_product(session, uuid.UUID(str(project_id)))
+            return [
+                ProjectProgressByProduct(
+                    hardware_category=row["hardware_category"],
+                    product_code=row["product_code"],
+                    required_quantity=row["required_quantity"],
+                    ordered_quantity=row["ordered_quantity"],
+                    received_quantity=row["received_quantity"],
+                )
+                for row in rows
+            ]
 
     @strawberry.field
     def inventory_by_vendor(self, project_id: strawberry.ID | None = None) -> list[VendorInventoryNode]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -539,6 +539,15 @@ class WarehouseDashboard:
 
 
 @strawberry.type
+class ProjectProgressByProduct:
+    hardware_category: str
+    product_code: str
+    required_quantity: int
+    ordered_quantity: int
+    received_quantity: int
+
+
+@strawberry.type
 class WarehouseBinType:
     id: strawberry.ID
     bay_id: strawberry.ID

--- a/backend/tests/test_warehouse_repository_project_progress.py
+++ b/backend/tests/test_warehouse_repository_project_progress.py
@@ -1,0 +1,278 @@
+"""Tests for warehouse_repository.get_project_progress_by_product."""
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from app.models.enums import HardwareItemState, POStatus
+from app.models.hardware import HardwareItem
+from app.models.project import Opening, Project
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.models.vendor import Vendor
+from app.repositories import warehouse_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(
+        id=uuid.uuid4(),
+        project_id=f"PROJ-{uuid.uuid4().hex[:8]}",
+        description="Test",
+    )
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_opening(session, project_id: uuid.UUID, opening_number: str = "A01") -> Opening:
+    o = Opening(id=uuid.uuid4(), project_id=project_id, opening_number=opening_number)
+    session.add(o)
+    session.flush()
+    return o
+
+
+def _make_vendor(session) -> Vendor:
+    v = Vendor(id=uuid.uuid4(), name=f"V-{uuid.uuid4().hex[:6]}")
+    session.add(v)
+    session.flush()
+    return v
+
+
+def _make_hardware_item(
+    session,
+    *,
+    project_id: uuid.UUID,
+    opening_id: uuid.UUID,
+    product_code: str,
+    hardware_category: str = "HINGE",
+    item_quantity: int = 1,
+) -> HardwareItem:
+    hi = HardwareItem(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        opening_id=opening_id,
+        hardware_category=hardware_category,
+        product_code=product_code,
+        item_quantity=item_quantity,
+        state=HardwareItemState.AVAILABLE,
+    )
+    session.add(hi)
+    session.flush()
+    return hi
+
+
+def _make_po(
+    session,
+    *,
+    project_id: uuid.UUID,
+    vendor_id: uuid.UUID,
+    status: POStatus,
+    deleted_at: datetime | None = None,
+) -> PurchaseOrder:
+    po = PurchaseOrder(
+        id=uuid.uuid4(),
+        request_number=f"REQ-{uuid.uuid4().hex[:8]}",
+        project_id=project_id,
+        vendor_id=vendor_id,
+        status=status,
+        deleted_at=deleted_at,
+    )
+    session.add(po)
+    session.flush()
+    return po
+
+
+def _make_line_item(
+    session,
+    *,
+    po_id: uuid.UUID,
+    product_code: str,
+    hardware_category: str = "HINGE",
+    ordered_quantity: int = 1,
+    received_quantity: int = 0,
+) -> POLineItem:
+    li = POLineItem(
+        id=uuid.uuid4(),
+        po_id=po_id,
+        hardware_category=hardware_category,
+        product_code=product_code,
+        ordered_quantity=ordered_quantity,
+        received_quantity=received_quantity,
+        unit_cost=Decimal("1.00"),
+    )
+    session.add(li)
+    session.flush()
+    return li
+
+
+def test_returns_required_only_when_no_pos(db_session):
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-100", item_quantity=3
+    )
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-200", item_quantity=2
+    )
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    by_code = {r["product_code"]: r for r in rows}
+
+    assert set(by_code.keys()) == {"HG-100", "HG-200"}
+    assert by_code["HG-100"]["required_quantity"] == 3
+    assert by_code["HG-100"]["ordered_quantity"] == 0
+    assert by_code["HG-100"]["received_quantity"] == 0
+    assert by_code["HG-200"]["required_quantity"] == 2
+    assert by_code["HG-200"]["ordered_quantity"] == 0
+    assert by_code["HG-200"]["received_quantity"] == 0
+
+
+def test_aggregates_required_across_openings(db_session):
+    project = _make_project(db_session)
+    o1 = _make_opening(db_session, project.id, "A01")
+    o2 = _make_opening(db_session, project.id, "A02")
+    _make_hardware_item(db_session, project_id=project.id, opening_id=o1.id, product_code="HG-100", item_quantity=4)
+    _make_hardware_item(db_session, project_id=project.id, opening_id=o2.id, product_code="HG-100", item_quantity=6)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0]["product_code"] == "HG-100"
+    assert rows[0]["required_quantity"] == 10
+
+
+def test_counts_ordered_received_for_placed_pos(db_session):
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    vendor = _make_vendor(db_session)
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-100", item_quantity=10
+    )
+
+    for status in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED):
+        po = _make_po(db_session, project_id=project.id, vendor_id=vendor.id, status=status)
+        _make_line_item(db_session, po_id=po.id, product_code="HG-100", ordered_quantity=2, received_quantity=1)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0]["ordered_quantity"] == 8  # 2 * 4 placed statuses
+    assert rows[0]["received_quantity"] == 4  # 1 * 4 placed statuses
+
+
+def test_excludes_draft_and_cancelled_pos(db_session):
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    vendor = _make_vendor(db_session)
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-100", item_quantity=10
+    )
+
+    draft = _make_po(db_session, project_id=project.id, vendor_id=vendor.id, status=POStatus.DRAFT)
+    _make_line_item(db_session, po_id=draft.id, product_code="HG-100", ordered_quantity=5, received_quantity=0)
+
+    cancelled = _make_po(
+        db_session,
+        project_id=project.id,
+        vendor_id=vendor.id,
+        status=POStatus.CANCELLED,
+        deleted_at=datetime.utcnow(),
+    )
+    _make_line_item(db_session, po_id=cancelled.id, product_code="HG-100", ordered_quantity=7, received_quantity=0)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0]["ordered_quantity"] == 0
+    assert rows[0]["received_quantity"] == 0
+
+
+def test_excludes_soft_deleted_pos(db_session):
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    vendor = _make_vendor(db_session)
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-100", item_quantity=10
+    )
+
+    po = _make_po(
+        db_session,
+        project_id=project.id,
+        vendor_id=vendor.id,
+        status=POStatus.ORDERED,
+        deleted_at=datetime.utcnow(),
+    )
+    _make_line_item(db_session, po_id=po.id, product_code="HG-100", ordered_quantity=5, received_quantity=2)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert rows[0]["ordered_quantity"] == 0
+    assert rows[0]["received_quantity"] == 0
+
+
+def test_omits_product_codes_not_in_schedule(db_session):
+    """PO line items for codes not present in the schedule should not introduce rows."""
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    vendor = _make_vendor(db_session)
+    _make_hardware_item(
+        db_session, project_id=project.id, opening_id=opening.id, product_code="HG-100", item_quantity=5
+    )
+
+    po = _make_po(db_session, project_id=project.id, vendor_id=vendor.id, status=POStatus.ORDERED)
+    _make_line_item(db_session, po_id=po.id, product_code="HG-100", ordered_quantity=3)
+    _make_line_item(db_session, po_id=po.id, product_code="UNKNOWN", ordered_quantity=9)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0]["product_code"] == "HG-100"
+    assert rows[0]["ordered_quantity"] == 3
+
+
+def test_scoped_by_project(db_session):
+    """POs and hardware items from another project must not bleed in."""
+    p1 = _make_project(db_session)
+    p2 = _make_project(db_session)
+    o1 = _make_opening(db_session, p1.id, "A01")
+    o2 = _make_opening(db_session, p2.id, "B01")
+    vendor = _make_vendor(db_session)
+
+    _make_hardware_item(db_session, project_id=p1.id, opening_id=o1.id, product_code="HG-100", item_quantity=5)
+    _make_hardware_item(db_session, project_id=p2.id, opening_id=o2.id, product_code="HG-100", item_quantity=99)
+
+    po_p2 = _make_po(db_session, project_id=p2.id, vendor_id=vendor.id, status=POStatus.ORDERED)
+    _make_line_item(db_session, po_id=po_p2.id, product_code="HG-100", ordered_quantity=99, received_quantity=42)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, p1.id)
+    assert len(rows) == 1
+    assert rows[0]["required_quantity"] == 5
+    assert rows[0]["ordered_quantity"] == 0
+    assert rows[0]["received_quantity"] == 0
+
+
+def test_groups_by_category_and_product_code(db_session):
+    """Same product code under different categories yields separate rows."""
+    project = _make_project(db_session)
+    opening = _make_opening(db_session, project.id)
+    _make_hardware_item(
+        db_session,
+        project_id=project.id,
+        opening_id=opening.id,
+        product_code="HG-100",
+        hardware_category="HINGE",
+        item_quantity=3,
+    )
+    _make_hardware_item(
+        db_session,
+        project_id=project.id,
+        opening_id=opening.id,
+        product_code="HG-100",
+        hardware_category="LOCK",
+        item_quantity=2,
+    )
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    by_cat = {r["hardware_category"]: r for r in rows}
+    assert by_cat["HINGE"]["required_quantity"] == 3
+    assert by_cat["LOCK"]["required_quantity"] == 2
+
+
+def test_returns_empty_for_project_without_schedule(db_session):
+    project = _make_project(db_session)
+    rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
+    assert rows == []

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -688,6 +688,18 @@ export const GET_WAREHOUSE_DASHBOARD = gql`
   }
 `;
 
+export const GET_PROJECT_PROGRESS_BY_PRODUCT = gql`
+  query GetProjectProgressByProduct($projectId: ID!) {
+    projectProgressByProduct(projectId: $projectId) {
+      hardwareCategory
+      productCode
+      requiredQuantity
+      orderedQuantity
+      receivedQuantity
+    }
+  }
+`;
+
 export const GET_WAREHOUSE_AISLES = gql`
   query GetWarehouseAisles($activeOnly: Boolean) {
     warehouseAisles(activeOnly: $activeOnly) {

--- a/frontend/src/modules/warehouse/ProjectProgressDashboard.tsx
+++ b/frontend/src/modules/warehouse/ProjectProgressDashboard.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Autocomplete,
+  TextField,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery } from '@apollo/client/react';
+import { GET_PROJECTS, GET_PROJECT_PROGRESS_BY_PRODUCT } from '../../graphql/queries';
+import type { Project } from '../../types/project';
+
+interface ProgressRow {
+  hardwareCategory: string;
+  productCode: string;
+  requiredQuantity: number;
+  orderedQuantity: number;
+  receivedQuantity: number;
+}
+
+const columns: GridColDef[] = [
+  { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 140 },
+  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, minWidth: 160 },
+  {
+    field: 'requiredQuantity',
+    headerName: 'Required',
+    flex: 0.6,
+    minWidth: 110,
+    type: 'number',
+    headerAlign: 'right',
+    align: 'right',
+  },
+  {
+    field: 'orderedQuantity',
+    headerName: 'Ordered',
+    flex: 0.6,
+    minWidth: 110,
+    type: 'number',
+    headerAlign: 'right',
+    align: 'right',
+  },
+  {
+    field: 'receivedQuantity',
+    headerName: 'Received',
+    flex: 0.6,
+    minWidth: 110,
+    type: 'number',
+    headerAlign: 'right',
+    align: 'right',
+  },
+];
+
+export default function ProjectProgressDashboard() {
+  const { data: projectsData, loading: projectsLoading } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+
+  const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
+
+  const {
+    data: progressData,
+    loading: progressLoading,
+    error: progressError,
+  } = useQuery<{ projectProgressByProduct: ProgressRow[] }>(GET_PROJECT_PROGRESS_BY_PRODUCT, {
+    variables: { projectId: selectedProject?.id },
+    skip: !selectedProject,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const rows = useMemo(() => {
+    const list = progressData?.projectProgressByProduct ?? [];
+    return list.map((r) => ({ id: `${r.hardwareCategory}::${r.productCode}`, ...r }));
+  }, [progressData]);
+
+  return (
+    <Card variant="outlined" sx={{ mb: 3 }}>
+      <CardContent sx={{ pb: '12px !important' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            Project Progress by Product
+          </Typography>
+          <Autocomplete
+            size="small"
+            sx={{ minWidth: 320 }}
+            options={projects}
+            loading={projectsLoading}
+            value={selectedProject}
+            onChange={(_, v) => setSelectedProject(v)}
+            getOptionLabel={(p) => p.description || p.projectId}
+            isOptionEqualToValue={(a, b) => a.id === b.id}
+            renderInput={(params) => (
+              <TextField {...params} label="Project" placeholder="Select a project" />
+            )}
+          />
+        </Box>
+
+        {!selectedProject && (
+          <Alert severity="info" variant="outlined">
+            Select a project to see required, ordered, and received quantities per product code.
+          </Alert>
+        )}
+
+        {selectedProject && progressError && (
+          <Alert severity="error">Error loading progress: {progressError.message}</Alert>
+        )}
+
+        {selectedProject && progressLoading && !progressData && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+
+        {selectedProject && !progressError && !progressLoading && rows.length === 0 && (
+          <Alert severity="info" variant="outlined">
+            No hardware schedule found for this project.
+          </Alert>
+        )}
+
+        {selectedProject && rows.length > 0 && (
+          <Box sx={{ height: 380, width: '100%' }}>
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              density="compact"
+              pageSizeOptions={[10, 25, 50, 100]}
+              initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+              disableRowSelectionOnClick
+            />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -6,6 +6,7 @@ import DashboardCards from './DashboardCards';
 import DeliveriesView from './DeliveriesView';
 import InventoryView from './InventoryView';
 import LocationsTab from './LocationsTab';
+import ProjectProgressDashboard from './ProjectProgressDashboard';
 import ReceivingPage from './ReceivingPage';
 import PullRequestQueue from './PullRequestQueue';
 import PutAwayTab from './PutAwayTab';
@@ -37,6 +38,7 @@ export default function WarehouseModule() {
         </Button>
       </Box>
       <DashboardCards />
+      <ProjectProgressDashboard />
       <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/warehouse/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
         {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
       </Tabs>


### PR DESCRIPTION
## Summary
- Adds a project-scoped progress table directly below the warehouse stat cards (`<DashboardCards />`) on the main warehouse page.
- One row per unique `(hardware_category, product_code)` from the selected project's hardware schedule, with three numeric columns: Required (from `HardwareItem.item_quantity`), Ordered, and Received.
- Ordered/Received aggregate `POLineItem.ordered_quantity` / `received_quantity` across that project's POs whose status is one of `ORDERED`, `VENDOR_CONFIRMED`, `PARTIALLY_RECEIVED`, or `CLOSED`. `DRAFT`, `CANCELLED`, and soft-deleted POs are excluded.

## Changes
**Backend**
- `warehouse_repository.get_project_progress_by_product(session, project_id)` — required CTE LEFT JOIN PO aggregate, grouped by `(hardware_category, product_code)`.
- New Strawberry type `ProjectProgressByProduct` and query `projectProgressByProduct(projectId: ID!)`.
- SDL reference `app/graphql/warehouse.graphql` updated.
- 9 repository tests covering placed-PO inclusion, DRAFT/CANCELLED/soft-delete exclusion, project scoping, and category+code grouping.

**Frontend**
- `GET_PROJECT_PROGRESS_BY_PRODUCT` Apollo query.
- New `ProjectProgressDashboard.tsx`: MUI Autocomplete for project selection + `DataGrid` with sortable, paginated columns.
- Wired into `WarehouseModule` between `<DashboardCards />` and the sub-tabs.