### PR TITLE
Move project progress dashboard into Inventory tab

### DIFF
--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -228,7 +228,7 @@ type Query {
   pullRequests(projectId: ID!, source: PullRequestSource, status: PullRequestStatus): [PullRequest!]!
   pullRequestDetails(id: ID!): PullRequest!
   shipReadyItems(projectId: ID!): ShipReadyItems!
-  projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
+  projectProgressByProduct(projectId: ID): [ProjectProgressByProduct!]!
   notifications(projectId: ID!, recipientRole: String!, unreadOnly: Boolean, limit: Int = 5): [Notification!]!
 }
 

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -217,26 +217,29 @@ PLACED_PO_STATUSES = (
 )
 
 
-def get_project_progress_by_product(session: Session, project_id: uuid.UUID) -> list[dict]:
-    """Per-project, per-product-code rollup of required (from schedule), ordered, and received quantities.
+def get_project_progress_by_product(session: Session, project_id: uuid.UUID | None = None) -> list[dict]:
+    """Per-product-code rollup of required (from schedule), ordered, and received quantities.
 
-    - required_quantity: sum of hardware_items.item_quantity for the project, grouped by (category, code)
+    - When project_id is given, all aggregates are scoped to that project.
+    - When project_id is None, required sums across all projects' hardware items and
+      ordered/received sum across every placed PO.
+    - required_quantity: sum of hardware_items.item_quantity, grouped by (category, code)
     - ordered_quantity / received_quantity: sum of po_line_items.{ordered,received}_quantity for POs
       with status in PLACED_PO_STATUSES (excludes DRAFT and CANCELLED) and deleted_at IS NULL,
       grouped by (category, code).
     """
-    required_subq = (
-        select(
-            HardwareItemModel.hardware_category.label("hardware_category"),
-            HardwareItemModel.product_code.label("product_code"),
-            func.sum(HardwareItemModel.item_quantity).label("required_quantity"),
-        )
-        .where(HardwareItemModel.project_id == project_id)
-        .group_by(HardwareItemModel.hardware_category, HardwareItemModel.product_code)
-        .subquery()
+    required_stmt = select(
+        HardwareItemModel.hardware_category.label("hardware_category"),
+        HardwareItemModel.product_code.label("product_code"),
+        func.sum(HardwareItemModel.item_quantity).label("required_quantity"),
     )
+    if project_id is not None:
+        required_stmt = required_stmt.where(HardwareItemModel.project_id == project_id)
+    required_subq = required_stmt.group_by(
+        HardwareItemModel.hardware_category, HardwareItemModel.product_code
+    ).subquery()
 
-    po_agg_subq = (
+    po_agg_stmt = (
         select(
             POLineItemModel.hardware_category.label("hardware_category"),
             POLineItemModel.product_code.label("product_code"),
@@ -245,13 +248,13 @@ def get_project_progress_by_product(session: Session, project_id: uuid.UUID) -> 
         )
         .join(POModel, POLineItemModel.po_id == POModel.id)
         .where(
-            POModel.project_id == project_id,
             POModel.deleted_at.is_(None),
             POModel.status.in_(PLACED_PO_STATUSES),
         )
-        .group_by(POLineItemModel.hardware_category, POLineItemModel.product_code)
-        .subquery()
     )
+    if project_id is not None:
+        po_agg_stmt = po_agg_stmt.where(POModel.project_id == project_id)
+    po_agg_subq = po_agg_stmt.group_by(POLineItemModel.hardware_category, POLineItemModel.product_code).subquery()
 
     stmt = (
         select(

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -909,9 +909,11 @@ class Query:
             )
 
     @strawberry.field
-    def project_progress_by_product(self, project_id: strawberry.ID) -> list[ProjectProgressByProduct]:
+    def project_progress_by_product(self, project_id: strawberry.ID | None = None) -> list[ProjectProgressByProduct]:
         with SessionLocal() as session:
-            rows = warehouse_repository.get_project_progress_by_product(session, uuid.UUID(str(project_id)))
+            rows = warehouse_repository.get_project_progress_by_product(
+                session, uuid.UUID(str(project_id)) if project_id else None
+            )
             return [
                 ProjectProgressByProduct(
                     hardware_category=row["hardware_category"],

--- a/backend/tests/test_warehouse_repository_project_progress.py
+++ b/backend/tests/test_warehouse_repository_project_progress.py
@@ -276,3 +276,28 @@ def test_returns_empty_for_project_without_schedule(db_session):
     project = _make_project(db_session)
     rows = warehouse_repository.get_project_progress_by_product(db_session, project.id)
     assert rows == []
+
+
+def test_aggregates_across_projects_when_project_id_is_none(db_session):
+    """project_id=None sums required/ordered/received across all projects, grouped by (category, code)."""
+    p1 = _make_project(db_session)
+    p2 = _make_project(db_session)
+    o1 = _make_opening(db_session, p1.id, "A01")
+    o2 = _make_opening(db_session, p2.id, "B01")
+    vendor = _make_vendor(db_session)
+
+    _make_hardware_item(db_session, project_id=p1.id, opening_id=o1.id, product_code="HG-100", item_quantity=3)
+    _make_hardware_item(db_session, project_id=p2.id, opening_id=o2.id, product_code="HG-100", item_quantity=4)
+
+    po1 = _make_po(db_session, project_id=p1.id, vendor_id=vendor.id, status=POStatus.ORDERED)
+    _make_line_item(db_session, po_id=po1.id, product_code="HG-100", ordered_quantity=2, received_quantity=1)
+    po2 = _make_po(db_session, project_id=p2.id, vendor_id=vendor.id, status=POStatus.PARTIALLY_RECEIVED)
+    _make_line_item(db_session, po_id=po2.id, product_code="HG-100", ordered_quantity=5, received_quantity=4)
+    cancelled = _make_po(db_session, project_id=p2.id, vendor_id=vendor.id, status=POStatus.CANCELLED)
+    _make_line_item(db_session, po_id=cancelled.id, product_code="HG-100", ordered_quantity=99, received_quantity=0)
+
+    rows = warehouse_repository.get_project_progress_by_product(db_session, None)
+    by_code = {(r["hardware_category"], r["product_code"]): r for r in rows}
+    assert by_code[("HINGE", "HG-100")]["required_quantity"] == 7  # 3 + 4
+    assert by_code[("HINGE", "HG-100")]["ordered_quantity"] == 7  # 2 + 5 (cancelled excluded)
+    assert by_code[("HINGE", "HG-100")]["received_quantity"] == 5  # 1 + 4

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -23,6 +23,7 @@ import { GET_INVENTORY_HIERARCHY, GET_INVENTORY_ITEMS, GET_INVENTORY_BY_VENDOR }
 import { useIdentity } from '../../hooks/useIdentity';
 import InventoryCorrectionModal from '../admin/InventoryCorrectionModal';
 import AuditHistoryDrawer from './AuditHistoryDrawer';
+import ProjectProgressDashboard from './ProjectProgressDashboard';
 import SpotCheckModal from './SpotCheckModal';
 
 interface InventoryItem {
@@ -560,6 +561,8 @@ export default function HardwareItemsTab({ projectId }: HardwareItemsTabProps) {
           </Typography>
         </Box>
       </Box>
+
+      <ProjectProgressDashboard projectId={projectId} />
 
       {/* Filtered empty state */}
       {filteredGroups.length === 0 && (

--- a/frontend/src/modules/warehouse/ProjectProgressDashboard.tsx
+++ b/frontend/src/modules/warehouse/ProjectProgressDashboard.tsx
@@ -1,18 +1,8 @@
-import { useMemo, useState } from 'react';
-import {
-  Box,
-  Card,
-  CardContent,
-  Typography,
-  Autocomplete,
-  TextField,
-  Alert,
-  CircularProgress,
-} from '@mui/material';
+import { useMemo } from 'react';
+import { Box, Typography, Alert, CircularProgress } from '@mui/material';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useQuery } from '@apollo/client/react';
-import { GET_PROJECTS, GET_PROJECT_PROGRESS_BY_PRODUCT } from '../../graphql/queries';
-import type { Project } from '../../types/project';
+import { GET_PROJECT_PROGRESS_BY_PRODUCT } from '../../graphql/queries';
 
 interface ProgressRow {
   hardwareCategory: string;
@@ -20,6 +10,10 @@ interface ProgressRow {
   requiredQuantity: number;
   orderedQuantity: number;
   receivedQuantity: number;
+}
+
+interface ProjectProgressDashboardProps {
+  projectId?: string;
 }
 
 const columns: GridColDef[] = [
@@ -54,84 +48,52 @@ const columns: GridColDef[] = [
   },
 ];
 
-export default function ProjectProgressDashboard() {
-  const { data: projectsData, loading: projectsLoading } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-
-  const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
-
-  const {
-    data: progressData,
-    loading: progressLoading,
-    error: progressError,
-  } = useQuery<{ projectProgressByProduct: ProgressRow[] }>(GET_PROJECT_PROGRESS_BY_PRODUCT, {
-    variables: { projectId: selectedProject?.id },
-    skip: !selectedProject,
-    fetchPolicy: 'cache-and-network',
-  });
+export default function ProjectProgressDashboard({ projectId }: ProjectProgressDashboardProps) {
+  const { data, loading, error } = useQuery<{ projectProgressByProduct: ProgressRow[] }>(
+    GET_PROJECT_PROGRESS_BY_PRODUCT,
+    {
+      variables: { projectId: projectId ?? null },
+      fetchPolicy: 'cache-and-network',
+    },
+  );
 
   const rows = useMemo(() => {
-    const list = progressData?.projectProgressByProduct ?? [];
+    const list = data?.projectProgressByProduct ?? [];
     return list.map((r) => ({ id: `${r.hardwareCategory}::${r.productCode}`, ...r }));
-  }, [progressData]);
+  }, [data]);
 
   return (
-    <Card variant="outlined" sx={{ mb: 3 }}>
-      <CardContent sx={{ pb: '12px !important' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-            Project Progress by Product
-          </Typography>
-          <Autocomplete
-            size="small"
-            sx={{ minWidth: 320 }}
-            options={projects}
-            loading={projectsLoading}
-            value={selectedProject}
-            onChange={(_, v) => setSelectedProject(v)}
-            getOptionLabel={(p) => p.description || p.projectId}
-            isOptionEqualToValue={(a, b) => a.id === b.id}
-            renderInput={(params) => (
-              <TextField {...params} label="Project" placeholder="Select a project" />
-            )}
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        Project Progress by Product
+      </Typography>
+
+      {error && <Alert severity="error">Error loading progress: {error.message}</Alert>}
+
+      {!error && loading && !data && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+
+      {!error && !loading && rows.length === 0 && (
+        <Alert severity="info" variant="outlined">
+          No hardware schedule found{projectId ? ' for this project' : ''}.
+        </Alert>
+      )}
+
+      {rows.length > 0 && (
+        <Box sx={{ height: 380, width: '100%' }}>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            density="compact"
+            pageSizeOptions={[10, 25, 50, 100]}
+            initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+            disableRowSelectionOnClick
           />
         </Box>
-
-        {!selectedProject && (
-          <Alert severity="info" variant="outlined">
-            Select a project to see required, ordered, and received quantities per product code.
-          </Alert>
-        )}
-
-        {selectedProject && progressError && (
-          <Alert severity="error">Error loading progress: {progressError.message}</Alert>
-        )}
-
-        {selectedProject && progressLoading && !progressData && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <CircularProgress size={24} />
-          </Box>
-        )}
-
-        {selectedProject && !progressError && !progressLoading && rows.length === 0 && (
-          <Alert severity="info" variant="outlined">
-            No hardware schedule found for this project.
-          </Alert>
-        )}
-
-        {selectedProject && rows.length > 0 && (
-          <Box sx={{ height: 380, width: '100%' }}>
-            <DataGrid
-              rows={rows}
-              columns={columns}
-              density="compact"
-              pageSizeOptions={[10, 25, 50, 100]}
-              initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
-              disableRowSelectionOnClick
-            />
-          </Box>
-        )}
-      </CardContent>
-    </Card>
+      )}
+    </Box>
   );
 }

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -6,7 +6,6 @@ import DashboardCards from './DashboardCards';
 import DeliveriesView from './DeliveriesView';
 import InventoryView from './InventoryView';
 import LocationsTab from './LocationsTab';
-import ProjectProgressDashboard from './ProjectProgressDashboard';
 import ReceivingPage from './ReceivingPage';
 import PullRequestQueue from './PullRequestQueue';
 import PutAwayTab from './PutAwayTab';
@@ -38,7 +37,6 @@ export default function WarehouseModule() {
         </Button>
       </Box>
       <DashboardCards />
-      <ProjectProgressDashboard />
       <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/warehouse/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
         {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
       </Tabs>


### PR DESCRIPTION
## Summary
- Relocates the per-product progress table from the warehouse module header (above the sub-tabs) into the **Hardware Items** sub-tab of the Inventory tab, directly below the existing **Inventory Summary** bar.
- The dashboard now reuses the Inventory tab's project context — a specific project, or All Projects — instead of carrying its own separate project selector. The duplicate-selector UX is gone.
- `project_id` on `warehouse_repository.get_project_progress_by_product` and the `projectProgressByProduct` GraphQL field are now optional. When null, `required`/`ordered`/`received` aggregate across every project, one row per `(category, product_code)`.

## Changes
**Backend**
- `warehouse_repository.get_project_progress_by_product` accepts `project_id: Optional[UUID]`; both the required CTE and the placed-PO CTE drop the project filter when None.
- Strawberry resolver: `projectProgressByProduct(projectId: ID | None = None)`. SDL reference updated.
- New test `test_aggregates_across_projects_when_project_id_is_none` (cancelled POs still excluded).

**Frontend**
- `ProjectProgressDashboard` is now a controlled component taking `projectId?: string`. No internal Autocomplete; no internal empty state.
- Removed from `WarehouseModule` header; rendered inside `HardwareItemsTab` immediately after the Inventory Summary box, receiving the existing `projectId` prop.