### PR TITLE
Fix: make $projectId nullable in GET_PROJECT_PROGRESS_BY_PRODUCT

### DIFF
--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -689,7 +689,7 @@ export const GET_WAREHOUSE_DASHBOARD = gql`
 `;
 
 export const GET_PROJECT_PROGRESS_BY_PRODUCT = gql`
-  query GetProjectProgressByProduct($projectId: ID!) {
+  query GetProjectProgressByProduct($projectId: ID) {
     projectProgressByProduct(projectId: $projectId) {
       hardwareCategory
       productCode


### PR DESCRIPTION
## Summary
- PR #124 made the `projectProgressByProduct` GraphQL field accept a nullable `projectId` so the dashboard could aggregate across projects when the Inventory tab is in "All Projects" mode, but the Apollo query declaration in `queries.ts` still required `ID!`.
- Apollo refused to send `null` and the dashboard rendered an error (`Variable '$projectId' of non-null type 'ID!' must not be null.`) in the All Projects view.
- Changes `$projectId: ID!` → `$projectId: ID` in `GET_PROJECT_PROGRESS_BY_PRODUCT`.