### PR TITLE
Fix N+1 in projects() resolver causing multi-minute Railway requests

### DIFF
--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -1,10 +1,12 @@
 import uuid
 
 import strawberry
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
 
 from app.database import SessionLocal
 from app.models.enums import POStatus as DBPOStatus
+from app.models.project import Opening as OpeningModel
 from app.models.project import Project as ProjectModel
 from app.repositories import (
     admin_repository,
@@ -175,27 +177,16 @@ def _po_to_type(po, receive_records=None) -> PurchaseOrder:
     )
 
 
-def _project_to_type(p: ProjectModel) -> Project:
-    return Project(
-        id=strawberry.ID(str(p.id)),
-        project_id=p.project_id,
-        description=p.description,
-        client=p.client,
-        job_site_name=p.job_site_name,
-        address=p.address,
-        city=p.city,
-        state=p.state,
-        zip=p.zip,
-        contractor=p.contractor,
-        project_manager=p.project_manager,
-        application=p.application,
-        submittal_job_no=p.submittal_job_no,
-        submittal_assignment_count=p.submittal_assignment_count,
-        estimator_code=p.estimator_code,
-        titan_user_id=p.titan_user_id,
-        created_at=p.created_at,
-        updated_at=p.updated_at,
-        openings=[
+def _project_to_type(
+    p: ProjectModel,
+    *,
+    include_openings: bool = True,
+    opening_count: int | None = None,
+) -> Project:
+    # When include_openings=False, callers must supply opening_count to avoid
+    # triggering a lazy load of the openings relationship.
+    openings_list = (
+        [
             Opening(
                 id=strawberry.ID(str(o.id)),
                 project_id=strawberry.ID(str(o.project_id)),
@@ -221,7 +212,33 @@ def _project_to_type(p: ProjectModel) -> Project:
                 updated_at=o.updated_at,
             )
             for o in p.openings
-        ],
+        ]
+        if include_openings
+        else []
+    )
+    if opening_count is None:
+        opening_count = len(openings_list) if include_openings else 0
+    return Project(
+        id=strawberry.ID(str(p.id)),
+        project_id=p.project_id,
+        description=p.description,
+        client=p.client,
+        job_site_name=p.job_site_name,
+        address=p.address,
+        city=p.city,
+        state=p.state,
+        zip=p.zip,
+        contractor=p.contractor,
+        project_manager=p.project_manager,
+        application=p.application,
+        submittal_job_no=p.submittal_job_no,
+        submittal_assignment_count=p.submittal_assignment_count,
+        estimator_code=p.estimator_code,
+        titan_user_id=p.titan_user_id,
+        created_at=p.created_at,
+        updated_at=p.updated_at,
+        opening_count=opening_count,
+        openings=openings_list,
         purchase_orders=[],  # Loaded on demand in later tickets
     )
 
@@ -475,13 +492,21 @@ class Query:
     def projects(self) -> list[Project]:
         with SessionLocal() as session:
             stmt = select(ProjectModel).order_by(ProjectModel.created_at.desc())
-            results = session.scalars(stmt).unique().all()
-            return [_project_to_type(p) for p in results]
+            results = list(session.scalars(stmt).unique().all())
+            count_rows = session.execute(
+                select(OpeningModel.project_id, func.count()).group_by(OpeningModel.project_id)
+            ).all()
+            counts: dict[uuid.UUID, int] = {pid: c for pid, c in count_rows}
+            return [_project_to_type(p, include_openings=False, opening_count=counts.get(p.id, 0)) for p in results]
 
     @strawberry.field
     def project_by_schedule_id(self, project_id: str) -> Project | None:
         with SessionLocal() as session:
-            stmt = select(ProjectModel).where(ProjectModel.project_id == project_id)
+            stmt = (
+                select(ProjectModel)
+                .options(selectinload(ProjectModel.openings))
+                .where(ProjectModel.project_id == project_id)
+            )
             p = session.scalars(stmt).unique().first()
             if p is None:
                 return None

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -192,6 +192,7 @@ class Project:
     titan_user_id: str | None
     created_at: datetime
     updated_at: datetime
+    opening_count: int
     openings: list[Opening]
     purchase_orders: list[PurchaseOrder]
 

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -8,9 +8,7 @@ export const GET_PROJECTS = gql`
       description
       client
       jobSiteName
-      openings {
-        id
-      }
+      openingCount
     }
   }
 `;

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -95,7 +95,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   // Selected project context (from prop)
   const existingProjectId = project.id;
   const existingProjectName = project.description || project.projectId;
-  const isReimport = (project.openings?.length ?? 0) > 0;
+  const isReimport = project.openingCount > 0;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Step 2 state

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -4,5 +4,5 @@ export interface Project {
   description: string | null;
   client: string | null;
   jobSiteName: string | null;
-  openings?: Array<{ id: string }>;
+  openingCount: number;
 }


### PR DESCRIPTION
## Summary

- `projects()` lazy-loaded openings and `_project_to_type` built full `Opening` DTOs for every project — producing 3–5 minute `/graphql` durations and DB pool starvation on Railway (visible in HTTP logs as cohorts of 200/499s with 280–298s `duration_ms`).
- The list resolver now runs a single grouped `COUNT(*)` query and passes `include_openings=False` with the precomputed count, so no `Opening` rows are loaded or materialized in the list path.
- `Project.opening_count` replaces `openings { id }` for callers that only need a presence/count signal (e.g. `ImportWizard.isReimport`); detail resolvers (`project_by_schedule_id`, `finalize_import_session`, `_project_hardware_schedule_to_type`) keep the full `openings` list and now use `selectinload` consistently.

## Notes for reviewers

- `_project_to_type` is now keyword-only after the model arg: `_project_to_type(p, *, include_openings=True, opening_count=None)`. Defaults preserve existing behavior; only `projects()` opts into the slim path.
- The grouped count query is a single `SELECT project_id, COUNT(*) FROM openings GROUP BY project_id` — covered by the existing `ix_openings_project_opening` index.
- The corresponding performance rules are documented in the project's local `CLAUDE.md` (gitignored) and saved to memory for future sessions.