### PR TITLE
Auto-recover from stale lazy-chunk loads after deploys

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,8 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # SPA fallback. index.html (and other non-hashed root files) must never
+    # be cached, otherwise stale tabs hold references to chunk filenames
+    # that no longer exist after a redeploy.
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, must-revalidate" always;
     }
 
     location /assets/ {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Box, Typography, CircularProgress, Container, Grid, Card, CardContent, CardActionArea } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -10,6 +10,7 @@ import BuildIcon from '@mui/icons-material/Build';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import AppLayout from './components/AppLayout';
+import { LazyRoute } from './components/LazyBoundary';
 
 // Lazy-loaded module imports
 const ImportModule = React.lazy(() => import('./modules/import'));
@@ -105,12 +106,12 @@ function App() {
         }
       >
         <Route index element={<ModuleSelector />} />
-        <Route path="import/*" element={<Suspense fallback={<SuspenseFallback />}><ImportModule /></Suspense>} />
-        <Route path="po/*" element={<Suspense fallback={<SuspenseFallback />}><POModule /></Suspense>} />
-        <Route path="warehouse/*" element={<Suspense fallback={<SuspenseFallback />}><WarehouseModule /></Suspense>} />
-        <Route path="shop-assembly/*" element={<Suspense fallback={<SuspenseFallback />}><ShopAssemblyModule /></Suspense>} />
-        <Route path="shipping/*" element={<Suspense fallback={<SuspenseFallback />}><ShippingModule /></Suspense>} />
-        <Route path="admin/*" element={<Suspense fallback={<SuspenseFallback />}><AdminModule /></Suspense>} />
+        <Route path="import/*" element={<LazyRoute fallback={<SuspenseFallback />}><ImportModule /></LazyRoute>} />
+        <Route path="po/*" element={<LazyRoute fallback={<SuspenseFallback />}><POModule /></LazyRoute>} />
+        <Route path="warehouse/*" element={<LazyRoute fallback={<SuspenseFallback />}><WarehouseModule /></LazyRoute>} />
+        <Route path="shop-assembly/*" element={<LazyRoute fallback={<SuspenseFallback />}><ShopAssemblyModule /></LazyRoute>} />
+        <Route path="shipping/*" element={<LazyRoute fallback={<SuspenseFallback />}><ShippingModule /></LazyRoute>} />
+        <Route path="admin/*" element={<LazyRoute fallback={<SuspenseFallback />}><AdminModule /></LazyRoute>} />
       </Route>
       <Route path="*" element={<Navigate to="/app" replace />} />
     </Routes>

--- a/frontend/src/components/LazyBoundary.tsx
+++ b/frontend/src/components/LazyBoundary.tsx
@@ -1,0 +1,63 @@
+import { Component, Suspense, type ReactNode } from 'react';
+
+const RELOAD_KEY = 'uc-nexus:lazy-chunk-reload-at';
+const RELOAD_COOLDOWN_MS = 60_000;
+
+function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'ChunkLoadError') return true;
+  const message = error.message || '';
+  return (
+    /Loading chunk \d+ failed/.test(message) ||
+    /Failed to fetch dynamically imported module/.test(message) ||
+    /Importing a module script failed/.test(message) ||
+    /error loading dynamically imported module/i.test(message)
+  );
+}
+
+interface LazyBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface LazyBoundaryState {
+  errored: boolean;
+}
+
+// Triggered when a stale tab tries to load a module chunk whose hashed
+// filename no longer exists after a redeploy. Reloads the page so the
+// browser fetches a fresh index.html (and the current chunk hashes).
+export class LazyBoundary extends Component<LazyBoundaryProps, LazyBoundaryState> {
+  state: LazyBoundaryState = { errored: false };
+
+  static getDerivedStateFromError(): LazyBoundaryState {
+    return { errored: true };
+  }
+
+  componentDidCatch(error: unknown): void {
+    if (!isChunkLoadError(error)) return;
+    const lastReloadAt = Number(window.sessionStorage.getItem(RELOAD_KEY) ?? 0);
+    if (Date.now() - lastReloadAt > RELOAD_COOLDOWN_MS) {
+      window.sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+      window.location.reload();
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.errored) return this.props.fallback;
+    return this.props.children;
+  }
+}
+
+interface LazyRouteProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+export function LazyRoute({ children, fallback }: LazyRouteProps) {
+  return (
+    <LazyBoundary fallback={fallback}>
+      <Suspense fallback={fallback}>{children}</Suspense>
+    </LazyBoundary>
+  );
+}


### PR DESCRIPTION
## Summary

- Tabs left open across a Railway redeploy hit a white page on the first navigation to a not-yet-loaded `React.lazy` route — the in-memory module graph still references the previous build's hashed chunk filename (e.g. `po-module-OLDHASH.js`), the dynamic import 404s, the promise rejects inside `<Suspense>`, and with no error boundary anywhere in `frontend/src/` the entire React tree unmounts. Manual browser reload was the only recovery.
- `LazyBoundary` (new, in `frontend/src/components/LazyBoundary.tsx`) catches `ChunkLoadError` / `Failed to fetch dynamically imported module` / `Importing a module script failed` and triggers a single `window.location.reload()`. A `sessionStorage` cooldown (`uc-nexus:lazy-chunk-reload-at`, 60s) prevents reload loops if the chunk is genuinely missing.
- A small `LazyRoute` helper wraps the existing `Suspense` and swaps in for every module route in `App.tsx`.
- `nginx.conf` now serves the SPA fallback (`location /`) with `Cache-Control: no-cache, must-revalidate`. Hashed bundles in `/assets/` keep their `public, immutable` 1y expiry — that's still correct because the hash is content-addressed.

## Notes for reviewers

- Non-chunk errors hitting the boundary also surface the fallback spinner (rather than blanking the page). If we want richer recovery for non-chunk errors later, the same boundary can be extended.
- The cooldown deliberately does NOT auto-clear on successful child render. A second back-to-back chunk failure within 60s shows the fallback instead of looping. The next browser session (new tab / hard refresh) starts fresh.
- Headers verified via `curl -I` against `frontend-production-34fc.up.railway.app/` once deployed.