### PR TITLE
Replace landing screen with sidebar and per-module landings

### DIFF
--- a/backend/app/repositories/dashboard_repository.py
+++ b/backend/app/repositories/dashboard_repository.py
@@ -1,0 +1,139 @@
+"""Cross-domain dashboard aggregations for Home, Shop Assembly, and Admin landings.
+
+All counts use scalar `func.count()` / `func.sum()` queries with no relationship
+loads, per the project's N+1 avoidance rules.
+"""
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.enums import (
+    POStatus,
+    PullRequestSource,
+    PullRequestStatus,
+    ShopAssemblyRequestStatus,
+)
+from app.models.hardware import HardwareItem
+from app.models.project import Opening, Project
+from app.models.pull_request import PullRequest
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.models.shop_assembly import ShopAssemblyRequest
+from app.models.vendor import Vendor
+
+OPEN_PO_STATUSES = (
+    POStatus.ORDERED,
+    POStatus.VENDOR_CONFIRMED,
+    POStatus.PARTIALLY_RECEIVED,
+)
+
+
+def get_home_dashboard_stats(session: Session) -> dict:
+    """Cross-app KPIs for the Home dashboard."""
+    open_pos = (
+        session.scalar(
+            select(func.count())
+            .select_from(PurchaseOrder)
+            .where(
+                PurchaseOrder.deleted_at.is_(None),
+                PurchaseOrder.status.in_(OPEN_PO_STATUSES),
+            )
+        )
+        or 0
+    )
+
+    pending_pulls = (
+        session.scalar(
+            select(func.count())
+            .select_from(PullRequest)
+            .where(
+                PullRequest.deleted_at.is_(None),
+                PullRequest.status == PullRequestStatus.PENDING,
+            )
+        )
+        or 0
+    )
+
+    items_pending = (
+        session.scalar(
+            select(func.coalesce(func.sum(POLineItem.ordered_quantity - POLineItem.received_quantity), 0))
+            .select_from(POLineItem)
+            .join(PurchaseOrder, POLineItem.po_id == PurchaseOrder.id)
+            .where(
+                PurchaseOrder.deleted_at.is_(None),
+                PurchaseOrder.status.in_(OPEN_PO_STATUSES),
+                POLineItem.ordered_quantity > POLineItem.received_quantity,
+            )
+        )
+        or 0
+    )
+
+    project_count = session.scalar(select(func.count()).select_from(Project)) or 0
+
+    return {
+        "open_po_count": int(open_pos),
+        "pending_pull_request_count": int(pending_pulls),
+        "items_pending_receiving": int(items_pending),
+        "project_count": int(project_count),
+    }
+
+
+def get_shop_assembly_stats(session: Session) -> dict:
+    """KPIs for the Shop Assembly landing."""
+    pending_sars = (
+        session.scalar(
+            select(func.count())
+            .select_from(ShopAssemblyRequest)
+            .where(ShopAssemblyRequest.status == ShopAssemblyRequestStatus.PENDING)
+        )
+        or 0
+    )
+
+    approved_sars = (
+        session.scalar(
+            select(func.count())
+            .select_from(ShopAssemblyRequest)
+            .where(ShopAssemblyRequest.status == ShopAssemblyRequestStatus.APPROVED)
+        )
+        or 0
+    )
+
+    active_shop_pulls = (
+        session.scalar(
+            select(func.count())
+            .select_from(PullRequest)
+            .where(
+                PullRequest.deleted_at.is_(None),
+                PullRequest.source == PullRequestSource.SHOP_ASSEMBLY,
+                PullRequest.status.in_((PullRequestStatus.PENDING, PullRequestStatus.IN_PROGRESS)),
+            )
+        )
+        or 0
+    )
+
+    return {
+        "pending_sar_count": int(pending_sars),
+        "approved_sar_count": int(approved_sars),
+        "active_pull_request_count": int(active_shop_pulls),
+    }
+
+
+def get_admin_stats(session: Session, user_count: int) -> dict:
+    """KPIs for the Admin landing. `user_count` is injected since users live in Clerk."""
+    vendor_count = session.scalar(select(func.count()).select_from(Vendor)) or 0
+
+    # Distinct (category, code) pairs via subquery — portable across dialects.
+    distinct_pairs_subq = (
+        select(HardwareItem.hardware_category, HardwareItem.product_code)
+        .group_by(HardwareItem.hardware_category, HardwareItem.product_code)
+        .subquery()
+    )
+    hardware_item_count = session.scalar(select(func.count()).select_from(distinct_pairs_subq)) or 0
+
+    opening_count = session.scalar(select(func.count()).select_from(Opening)) or 0
+
+    return {
+        "vendor_count": int(vendor_count),
+        "user_count": int(user_count),
+        "hardware_item_count": int(hardware_item_count),
+        "opening_count": int(opening_count),
+    }

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -10,6 +10,7 @@ from app.models.project import Opening as OpeningModel
 from app.models.project import Project as ProjectModel
 from app.repositories import (
     admin_repository,
+    dashboard_repository,
     notification_repository,
     po_repository,
     shipping_repository,
@@ -29,10 +30,12 @@ from .enums import (
 )
 from .inputs import ReconciliationItemInput
 from .types import (
+    AdminStats,
     AuditLogEntry,
     BackOrderedItem,
     ClerkUser,
     HardwareSummaryRow,
+    HomeDashboardStats,
     InventoryHierarchyNode,
     InventoryItemDetail,
     LocationContents,
@@ -66,6 +69,7 @@ from .types import (
     ShopAssemblyOpening,
     ShopAssemblyOpeningItem,
     ShopAssemblyRequest,
+    ShopAssemblyStats,
     Vendor,
     VendorInventoryNode,
     WarehouseAisleType,
@@ -931,6 +935,39 @@ class Query:
                 pending_pull_shipping=d["pending_pull_shipping"],
                 received_last_7_days=d["received_last_7_days"],
                 back_ordered_count=d["back_ordered_count"],
+            )
+
+    @strawberry.field
+    def home_dashboard_stats(self) -> HomeDashboardStats:
+        with SessionLocal() as session:
+            d = dashboard_repository.get_home_dashboard_stats(session)
+            return HomeDashboardStats(
+                open_po_count=d["open_po_count"],
+                pending_pull_request_count=d["pending_pull_request_count"],
+                items_pending_receiving=d["items_pending_receiving"],
+                project_count=d["project_count"],
+            )
+
+    @strawberry.field
+    def shop_assembly_stats(self) -> ShopAssemblyStats:
+        with SessionLocal() as session:
+            d = dashboard_repository.get_shop_assembly_stats(session)
+            return ShopAssemblyStats(
+                pending_sar_count=d["pending_sar_count"],
+                approved_sar_count=d["approved_sar_count"],
+                active_pull_request_count=d["active_pull_request_count"],
+            )
+
+    @strawberry.field
+    def admin_stats(self) -> AdminStats:
+        users = user_repository.list_users()
+        with SessionLocal() as session:
+            d = dashboard_repository.get_admin_stats(session, user_count=len(users))
+            return AdminStats(
+                vendor_count=d["vendor_count"],
+                user_count=d["user_count"],
+                hardware_item_count=d["hardware_item_count"],
+                opening_count=d["opening_count"],
             )
 
     @strawberry.field

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -629,3 +629,26 @@ class ClerkUser:
     email: str
     roles: list[str]
     image_url: str
+
+
+@strawberry.type
+class HomeDashboardStats:
+    open_po_count: int
+    pending_pull_request_count: int
+    items_pending_receiving: int
+    project_count: int
+
+
+@strawberry.type
+class ShopAssemblyStats:
+    pending_sar_count: int
+    approved_sar_count: int
+    active_pull_request_count: int
+
+
+@strawberry.type
+class AdminStats:
+    vendor_count: int
+    user_count: int
+    hardware_item_count: int
+    opening_count: int

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { Box, Typography, CircularProgress, Container, Grid, Card, CardContent, CardActionArea } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Box, CircularProgress } from '@mui/material';
 import { SignedIn, SignedOut, SignIn, RedirectToSignIn } from '@clerk/clerk-react';
-import UploadFileIcon from '@mui/icons-material/UploadFile';
-import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
-import WarehouseIcon from '@mui/icons-material/Warehouse';
-import BuildIcon from '@mui/icons-material/Build';
-import LocalShippingIcon from '@mui/icons-material/LocalShipping';
-import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import AppLayout from './components/AppLayout';
 import { LazyRoute } from './components/LazyBoundary';
 
 // Lazy-loaded module imports
+const HomeModule = React.lazy(() => import('./modules/home'));
 const ImportModule = React.lazy(() => import('./modules/import'));
 const POModule = React.lazy(() => import('./modules/po'));
 const WarehouseModule = React.lazy(() => import('./modules/warehouse'));
@@ -34,49 +28,6 @@ function SuspenseFallback() {
     <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
       <CircularProgress />
     </Box>
-  );
-}
-
-const MODULE_LINKS = [
-  { path: '/app/import', label: 'Start a task', icon: <UploadFileIcon sx={{ fontSize: 40 }} />, description: 'Create a POR, SAR, or shipping PR' },
-  { path: '/app/po', label: 'Purchase Orders', icon: <ReceiptLongIcon sx={{ fontSize: 40 }} />, description: 'Manage purchase orders' },
-  { path: '/app/warehouse', label: 'Warehouse', icon: <WarehouseIcon sx={{ fontSize: 40 }} />, description: 'Inventory and receiving' },
-  { path: '/app/shop-assembly', label: 'Shop Assembly', icon: <BuildIcon sx={{ fontSize: 40 }} />, description: 'Assembly requests and tracking' },
-  { path: '/app/shipping', label: 'Shipping', icon: <LocalShippingIcon sx={{ fontSize: 40 }} />, description: 'Shipping out management' },
-  { path: '/app/admin', label: 'Admin', icon: <AdminPanelSettingsIcon sx={{ fontSize: 40 }} />, description: 'Inventory corrections' },
-];
-
-function ModuleSelector() {
-  const navigate = useNavigate();
-
-  return (
-    <Container maxWidth="lg">
-      <Typography variant="h5" gutterBottom>
-        Select a Module
-      </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-        Choose a module from the options below or use the navigation bar.
-      </Typography>
-      <Grid container spacing={3}>
-        {MODULE_LINKS.map((mod) => (
-          <Grid key={mod.path} size={{ xs: 12, sm: 6, md: 4 }}>
-            <Card sx={{ height: '100%', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 6 } }}>
-              <CardActionArea onClick={() => navigate(mod.path)} sx={{ height: '100%', p: 2 }}>
-                <CardContent sx={{ textAlign: 'center' }}>
-                  <Box sx={{ color: 'primary.main', mb: 1 }}>{mod.icon}</Box>
-                  <Typography variant="h6" gutterBottom>
-                    {mod.label}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {mod.description}
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-    </Container>
   );
 }
 
@@ -105,7 +56,7 @@ function App() {
           </ProtectedRoute>
         }
       >
-        <Route index element={<ModuleSelector />} />
+        <Route index element={<LazyRoute fallback={<SuspenseFallback />}><HomeModule /></LazyRoute>} />
         <Route path="import/*" element={<LazyRoute fallback={<SuspenseFallback />}><ImportModule /></LazyRoute>} />
         <Route path="po/*" element={<LazyRoute fallback={<SuspenseFallback />}><POModule /></LazyRoute>} />
         <Route path="warehouse/*" element={<LazyRoute fallback={<SuspenseFallback />}><WarehouseModule /></LazyRoute>} />

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -15,11 +15,13 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
+import MenuIcon from '@mui/icons-material/Menu';
 import { useColorScheme } from '@mui/material/styles';
 import { UserButton } from '@clerk/clerk-react';
 import { useCart } from '../contexts/CartContext';
 import NotificationBell from './NotificationBell';
 import ConfirmDialog from './ConfirmDialog';
+import Sidebar from './Sidebar';
 
 export default function AppLayout() {
   const { mode, setMode } = useColorScheme();
@@ -28,6 +30,7 @@ export default function AppLayout() {
   const location = useLocation();
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const handleResetSchema = async () => {
     setResetConfirmOpen(false);
@@ -56,6 +59,15 @@ export default function AppLayout() {
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <AppBar position="static">
         <Toolbar>
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={() => setDrawerOpen(true)}
+            sx={{ mr: 1 }}
+            aria-label="Open navigation"
+          >
+            <MenuIcon />
+          </IconButton>
           <Typography
             variant="h6"
             sx={{ mr: 3, cursor: 'pointer' }}
@@ -140,6 +152,8 @@ export default function AppLayout() {
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Outlet />
       </Box>
+
+      <Sidebar open={drawerOpen} onClose={() => setDrawerOpen(false)} />
 
       <ConfirmDialog
         open={resetConfirmOpen}

--- a/frontend/src/components/BackToModule.tsx
+++ b/frontend/src/components/BackToModule.tsx
@@ -1,0 +1,23 @@
+import { Box, Button } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { Link as RouterLink } from 'react-router-dom';
+
+interface BackToModuleProps {
+  to: string;
+  label: string;
+}
+
+export default function BackToModule({ to, label }: BackToModuleProps) {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Button
+        component={RouterLink}
+        to={to}
+        size="small"
+        startIcon={<ArrowBackIcon />}
+      >
+        {label}
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,181 @@
+import { useState, type ReactNode } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Collapse,
+  Box,
+  Typography,
+} from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import WarehouseIcon from '@mui/icons-material/Warehouse';
+import BuildIcon from '@mui/icons-material/Build';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useIdentity } from '../hooks/useIdentity';
+
+interface SidebarSubItem {
+  label: string;
+  path: string;
+}
+
+interface SidebarItem {
+  label: string;
+  path: string;
+  icon: ReactNode;
+  requiredRoles: string[];
+  subItems?: SidebarSubItem[];
+}
+
+const SIDEBAR_ITEMS: SidebarItem[] = [
+  { label: 'Home', path: '/app', icon: <HomeIcon />, requiredRoles: [] },
+  {
+    label: 'Start a task',
+    path: '/app/import',
+    icon: <UploadFileIcon />,
+    requiredRoles: ['Hardware Schedule Import'],
+  },
+  {
+    label: 'Purchase Orders',
+    path: '/app/po',
+    icon: <ReceiptLongIcon />,
+    requiredRoles: ['PO User'],
+  },
+  {
+    label: 'Warehouse',
+    path: '/app/warehouse',
+    icon: <WarehouseIcon />,
+    requiredRoles: ['Warehouse Staff'],
+    subItems: [
+      { label: 'Inventory', path: '/app/warehouse/inventory' },
+      { label: 'Locations', path: '/app/warehouse/locations' },
+      { label: 'Deliveries', path: '/app/warehouse/deliveries' },
+      { label: 'Receiving', path: '/app/warehouse/receiving' },
+      { label: 'Put Away', path: '/app/warehouse/put-away' },
+      { label: 'Pull Requests', path: '/app/warehouse/pull-requests' },
+    ],
+  },
+  {
+    label: 'Shop Assembly',
+    path: '/app/shop-assembly',
+    icon: <BuildIcon />,
+    requiredRoles: ['Shop Assembly User', 'Shop Assembly Manager'],
+    subItems: [
+      { label: 'Requests', path: '/app/shop-assembly/requests' },
+      { label: 'Assemble List', path: '/app/shop-assembly/assemble' },
+      { label: 'Assignments', path: '/app/shop-assembly/assign' },
+      { label: 'My Work', path: '/app/shop-assembly/my-work' },
+    ],
+  },
+  {
+    label: 'Shipping',
+    path: '/app/shipping',
+    icon: <LocalShippingIcon />,
+    requiredRoles: ['Shipping Out'],
+  },
+  {
+    label: 'Admin',
+    path: '/app/admin',
+    icon: <AdminPanelSettingsIcon />,
+    requiredRoles: ['Admin/Manager'],
+    subItems: [
+      { label: 'Hardware Summary', path: '/app/admin/hardware-summary' },
+      { label: 'Opening Status', path: '/app/admin/opening-status' },
+      { label: 'Vendors', path: '/app/admin/vendors' },
+      { label: 'User Management', path: '/app/admin/users' },
+    ],
+  },
+];
+
+function isActive(pathname: string, itemPath: string): boolean {
+  if (itemPath === '/app') return pathname === '/app' || pathname === '/app/';
+  return pathname === itemPath || pathname.startsWith(itemPath + '/');
+}
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { hasRole, isAdmin } = useIdentity();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const visibleItems = SIDEBAR_ITEMS.filter((item) => {
+    if (item.requiredRoles.length === 0) return true;
+    if (isAdmin) return true;
+    return item.requiredRoles.some((role) => hasRole(role));
+  });
+
+  const handleParentClick = (item: SidebarItem) => {
+    navigate(item.path);
+    if (item.subItems && item.subItems.length > 0) {
+      setExpanded((prev) => ({ ...prev, [item.path]: !prev[item.path] }));
+    } else {
+      onClose();
+    }
+  };
+
+  const handleSubItemClick = (path: string) => {
+    navigate(path);
+    onClose();
+  };
+
+  return (
+    <Drawer anchor="left" open={open} onClose={onClose}>
+      <Box sx={{ width: 260 }} role="navigation">
+        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
+          <Typography variant="h6">UC Nexus</Typography>
+        </Box>
+        <List>
+          {visibleItems.map((item) => {
+            const active = isActive(location.pathname, item.path);
+            const hasSubItems = !!item.subItems && item.subItems.length > 0;
+            const isExpanded = hasSubItems ? (expanded[item.path] ?? active) : false;
+
+            return (
+              <Box key={item.path}>
+                <ListItem disablePadding>
+                  <ListItemButton selected={active} onClick={() => handleParentClick(item)}>
+                    <ListItemIcon>{item.icon}</ListItemIcon>
+                    <ListItemText primary={item.label} />
+                    {hasSubItems && (isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />)}
+                  </ListItemButton>
+                </ListItem>
+                {hasSubItems && (
+                  <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                    <List component="div" disablePadding>
+                      {item.subItems!.map((sub) => {
+                        const subActive = isActive(location.pathname, sub.path);
+                        return (
+                          <ListItemButton
+                            key={sub.path}
+                            sx={{ pl: 5 }}
+                            selected={subActive}
+                            onClick={() => handleSubItemClick(sub.path)}
+                          >
+                            <ListItemText primary={sub.label} />
+                          </ListItemButton>
+                        );
+                      })}
+                    </List>
+                  </Collapse>
+                )}
+              </Box>
+            );
+          })}
+        </List>
+      </Box>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/StatCard.tsx
+++ b/frontend/src/components/StatCard.tsx
@@ -1,0 +1,34 @@
+import { Box, Card, CardContent, Typography, Skeleton } from '@mui/material';
+import type { ReactNode } from 'react';
+
+export interface StatCardProps {
+  icon: ReactNode;
+  label: string;
+  value: string | number;
+  color?: string;
+}
+
+export function StatCard({ icon, label, value, color }: StatCardProps) {
+  return (
+    <Card variant="outlined" sx={{ flex: '1 1 0', minWidth: 140 }}>
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 1.5, '&:last-child': { pb: 1.5 } }}>
+        <Box sx={{ color: color ?? 'text.secondary', display: 'flex' }}>{icon}</Box>
+        <Box>
+          <Typography variant="h6" sx={{ lineHeight: 1.2 }}>{value}</Typography>
+          <Typography variant="caption" color="text.secondary">{label}</Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function StatCardSkeleton() {
+  return (
+    <Card variant="outlined" sx={{ flex: '1 1 0', minWidth: 140 }}>
+      <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+        <Skeleton width={80} height={28} />
+        <Skeleton width={60} height={16} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -751,3 +751,35 @@ export const GET_AUDIT_LOG = gql`
     }
   }
 `;
+
+export const GET_HOME_DASHBOARD_STATS = gql`
+  query GetHomeDashboardStats {
+    homeDashboardStats {
+      openPoCount
+      pendingPullRequestCount
+      itemsPendingReceiving
+      projectCount
+    }
+  }
+`;
+
+export const GET_SHOP_ASSEMBLY_STATS = gql`
+  query GetShopAssemblyStats {
+    shopAssemblyStats {
+      pendingSarCount
+      approvedSarCount
+      activePullRequestCount
+    }
+  }
+`;
+
+export const GET_ADMIN_STATS = gql`
+  query GetAdminStats {
+    adminStats {
+      vendorCount
+      userCount
+      hardwareItemCount
+      openingCount
+    }
+  }
+`;

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from 'react';
+import { Box, Typography, Card, CardContent, CardActionArea, Grid } from '@mui/material';
+import SummarizeIcon from '@mui/icons-material/Summarize';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import StoreIcon from '@mui/icons-material/Store';
+import GroupIcon from '@mui/icons-material/Group';
+import PeopleIcon from '@mui/icons-material/People';
+import BusinessIcon from '@mui/icons-material/Business';
+import CategoryIcon from '@mui/icons-material/Category';
+import DoorFrontIcon from '@mui/icons-material/DoorFront';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@apollo/client/react';
+import { StatCard, StatCardSkeleton } from '../../components/StatCard';
+import { GET_ADMIN_STATS } from '../../graphql/queries';
+
+interface AdminStatsData {
+  adminStats: {
+    vendorCount: number;
+    userCount: number;
+    hardwareItemCount: number;
+    openingCount: number;
+  };
+}
+
+interface ShortcutCardProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}
+
+function ShortcutCard({ label, icon, onClick }: ShortcutCardProps) {
+  return (
+    <Card variant="outlined" sx={{ height: '100%', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 4 } }}>
+      <CardActionArea onClick={onClick} sx={{ height: '100%', p: 1 }}>
+        <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+          <Typography variant="h6">{label}</Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+const SUB_ROUTES = [
+  { label: 'Hardware Summary', path: '/app/admin/hardware-summary', icon: <SummarizeIcon fontSize="large" /> },
+  { label: 'Opening Status', path: '/app/admin/opening-status', icon: <VisibilityIcon fontSize="large" /> },
+  { label: 'Vendors', path: '/app/admin/vendors', icon: <StoreIcon fontSize="large" /> },
+  { label: 'User Management', path: '/app/admin/users', icon: <GroupIcon fontSize="large" /> },
+];
+
+export default function AdminLanding() {
+  const navigate = useNavigate();
+  const { data, loading } = useQuery<AdminStatsData>(GET_ADMIN_STATS, {
+    fetchPolicy: 'cache-and-network',
+  });
+  const s = data?.adminStats;
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>Admin</Typography>
+      <Box sx={{ display: 'flex', gap: 1.5, mb: 3, flexWrap: 'wrap' }}>
+        {loading && !s ? (
+          Array.from({ length: 4 }).map((_, i) => <StatCardSkeleton key={i} />)
+        ) : s ? (
+          <>
+            <StatCard
+              icon={<BusinessIcon />}
+              label="Vendors"
+              value={s.vendorCount}
+              color="primary.main"
+            />
+            <StatCard
+              icon={<PeopleIcon />}
+              label="Users"
+              value={s.userCount}
+              color="info.main"
+            />
+            <StatCard
+              icon={<CategoryIcon />}
+              label="Hardware Items"
+              value={s.hardwareItemCount}
+              color="text.secondary"
+            />
+            <StatCard
+              icon={<DoorFrontIcon />}
+              label="Openings"
+              value={s.openingCount}
+              color="text.secondary"
+            />
+          </>
+        ) : null}
+      </Box>
+      <Typography variant="h6" sx={{ mb: 2, mt: 1 }}>Go to</Typography>
+      <Grid container spacing={2}>
+        {SUB_ROUTES.map((card) => (
+          <Grid key={card.path} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <ShortcutCard label={card.label} icon={card.icon} onClick={() => navigate(card.path)} />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -1,37 +1,31 @@
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
-import { Box, Tabs, Tab, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { Box } from '@mui/material';
 import HardwareSummaryTab from './HardwareSummaryTab';
 import OpeningStatusTab from './OpeningStatusTab';
 import UserManagementPage from './UserManagementPage';
 import VendorsPage from './VendorsPage';
+import AdminLanding from './AdminLanding';
+import BackToModule from '../../components/BackToModule';
 
-const SUB_ROUTES = [
-  { label: 'Hardware Summary', path: 'hardware-summary' },
-  { label: 'Opening Status', path: 'opening-status' },
-  { label: 'Vendors', path: 'vendors' },
-  { label: 'User Management', path: 'users' },
-];
-
-export default function AdminModule() {
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  const currentSub = location.pathname.split('/').pop();
-  const tabIndex = Math.max(SUB_ROUTES.findIndex((r) => r.path === currentSub), 0);
-
+function AdminSubLayout({ children }: { children: ReactNode }) {
   return (
     <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Admin</Typography>
-      <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/admin/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
-        {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
-      </Tabs>
-      <Routes>
-        <Route path="hardware-summary" element={<HardwareSummaryTab />} />
-        <Route path="opening-status" element={<OpeningStatusTab />} />
-        <Route path="vendors" element={<VendorsPage />} />
-        <Route path="users" element={<UserManagementPage />} />
-        <Route index element={<Navigate to="hardware-summary" replace />} />
-      </Routes>
+      <BackToModule to="/app/admin" label="Admin" />
+      {children}
     </Box>
+  );
+}
+
+export default function AdminModule() {
+  return (
+    <Routes>
+      <Route index element={<AdminLanding />} />
+      <Route path="hardware-summary" element={<AdminSubLayout><HardwareSummaryTab /></AdminSubLayout>} />
+      <Route path="opening-status" element={<AdminSubLayout><OpeningStatusTab /></AdminSubLayout>} />
+      <Route path="vendors" element={<AdminSubLayout><VendorsPage /></AdminSubLayout>} />
+      <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />
+      <Route path="*" element={<Navigate to="" replace />} />
+    </Routes>
   );
 }

--- a/frontend/src/modules/home/HomeDashboard.tsx
+++ b/frontend/src/modules/home/HomeDashboard.tsx
@@ -1,0 +1,171 @@
+import { Box, Typography, Card, CardContent, Skeleton } from '@mui/material';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import DownloadDoneIcon from '@mui/icons-material/DownloadDone';
+import FolderIcon from '@mui/icons-material/Folder';
+import { useQuery } from '@apollo/client/react';
+import { useIdentity } from '../../hooks/useIdentity';
+import { StatCard, StatCardSkeleton } from '../../components/StatCard';
+import { GET_HOME_DASHBOARD_STATS, GET_AUDIT_LOG } from '../../graphql/queries';
+
+interface HomeStatsData {
+  homeDashboardStats: {
+    openPoCount: number;
+    pendingPullRequestCount: number;
+    itemsPendingReceiving: number;
+    projectCount: number;
+  };
+}
+
+interface AuditLogEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  action: string;
+  performedBy: string;
+  createdAt: string;
+}
+
+interface AuditLogData {
+  auditLog: AuditLogEntry[];
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  ADJUSTMENT: 'Adjusted',
+  MOVE: 'Moved',
+  UNLOCATE: 'Unlocated',
+  RECEIVE: 'Received',
+  PULL_DEDUCTION: 'Pulled',
+  SPOT_CHECK: 'Spot-checked',
+  PUT_AWAY: 'Put away',
+};
+
+const ENTITY_LABELS: Record<string, string> = {
+  INVENTORY_LOCATION: 'inventory item',
+  OPENING_ITEM: 'opening item',
+};
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatActionLabel(action: string, entityType: string): string {
+  const a = ACTION_LABELS[action] ?? action;
+  const e = ENTITY_LABELS[entityType] ?? entityType;
+  return `${a} ${e}`;
+}
+
+export default function HomeDashboard() {
+  const { displayName } = useIdentity();
+
+  const { data: statsData, loading: statsLoading } = useQuery<HomeStatsData>(
+    GET_HOME_DASHBOARD_STATS,
+    { fetchPolicy: 'cache-and-network' },
+  );
+  const { data: activityData, loading: activityLoading } = useQuery<AuditLogData>(
+    GET_AUDIT_LOG,
+    { variables: { limit: 10 }, fetchPolicy: 'cache-and-network' },
+  );
+
+  const s = statsData?.homeDashboardStats;
+  const activity = activityData?.auditLog ?? [];
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mb: 1 }}>
+        Welcome back, {displayName}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        Here's what's happening across the warehouse and projects.
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 1.5, mb: 4, flexWrap: 'wrap' }}>
+        {statsLoading && !s ? (
+          Array.from({ length: 4 }).map((_, i) => <StatCardSkeleton key={i} />)
+        ) : s ? (
+          <>
+            <StatCard
+              icon={<ReceiptLongIcon />}
+              label="Open POs"
+              value={s.openPoCount}
+              color="primary.main"
+            />
+            <StatCard
+              icon={<AssignmentIcon />}
+              label="Pending Pull Requests"
+              value={s.pendingPullRequestCount}
+              color={s.pendingPullRequestCount > 0 ? 'info.main' : 'text.secondary'}
+            />
+            <StatCard
+              icon={<DownloadDoneIcon />}
+              label="Items Pending Receiving"
+              value={s.itemsPendingReceiving}
+              color={s.itemsPendingReceiving > 0 ? 'warning.main' : 'text.secondary'}
+            />
+            <StatCard
+              icon={<FolderIcon />}
+              label="Projects"
+              value={s.projectCount}
+              color="text.secondary"
+            />
+          </>
+        ) : null}
+      </Box>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>Recent Activity</Typography>
+          {activityLoading && activity.length === 0 ? (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} variant="text" width="80%" height={32} />
+              ))}
+            </Box>
+          ) : activity.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No recent activity.
+            </Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+              {activity.map((entry) => (
+                <Box
+                  key={entry.id}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    py: 1,
+                    borderBottom: 1,
+                    borderColor: 'divider',
+                    '&:last-child': { borderBottom: 0 },
+                  }}
+                >
+                  <Box>
+                    <Typography variant="body2">
+                      {formatActionLabel(entry.action, entry.entityType)}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      by {entry.performedBy}
+                    </Typography>
+                  </Box>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatRelativeTime(entry.createdAt)}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/modules/home/index.tsx
+++ b/frontend/src/modules/home/index.tsx
@@ -1,0 +1,5 @@
+import HomeDashboard from './HomeDashboard';
+
+export default function HomeModule() {
+  return <HomeDashboard />;
+}

--- a/frontend/src/modules/shop-assembly/ShopAssemblyLanding.tsx
+++ b/frontend/src/modules/shop-assembly/ShopAssemblyLanding.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react';
+import { Box, Typography, Card, CardContent, CardActionArea, Grid } from '@mui/material';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import BuildIcon from '@mui/icons-material/Build';
+import HowToRegIcon from '@mui/icons-material/HowToReg';
+import PersonIcon from '@mui/icons-material/Person';
+import PendingActionsIcon from '@mui/icons-material/PendingActions';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@apollo/client/react';
+import { StatCard, StatCardSkeleton } from '../../components/StatCard';
+import { GET_SHOP_ASSEMBLY_STATS } from '../../graphql/queries';
+
+interface ShopAssemblyStatsData {
+  shopAssemblyStats: {
+    pendingSarCount: number;
+    approvedSarCount: number;
+    activePullRequestCount: number;
+  };
+}
+
+interface ShortcutCardProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}
+
+function ShortcutCard({ label, icon, onClick }: ShortcutCardProps) {
+  return (
+    <Card variant="outlined" sx={{ height: '100%', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 4 } }}>
+      <CardActionArea onClick={onClick} sx={{ height: '100%', p: 1 }}>
+        <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+          <Typography variant="h6">{label}</Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+const SUB_ROUTES = [
+  { label: 'Requests', path: '/app/shop-assembly/requests', icon: <AssignmentIcon fontSize="large" /> },
+  { label: 'Assemble List', path: '/app/shop-assembly/assemble', icon: <BuildIcon fontSize="large" /> },
+  { label: 'Assignments', path: '/app/shop-assembly/assign', icon: <HowToRegIcon fontSize="large" /> },
+  { label: 'My Work', path: '/app/shop-assembly/my-work', icon: <PersonIcon fontSize="large" /> },
+];
+
+export default function ShopAssemblyLanding() {
+  const navigate = useNavigate();
+  const { data, loading } = useQuery<ShopAssemblyStatsData>(GET_SHOP_ASSEMBLY_STATS, {
+    fetchPolicy: 'cache-and-network',
+  });
+  const s = data?.shopAssemblyStats;
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>Shop Assembly</Typography>
+      <Box sx={{ display: 'flex', gap: 1.5, mb: 3, flexWrap: 'wrap' }}>
+        {loading && !s ? (
+          Array.from({ length: 3 }).map((_, i) => <StatCardSkeleton key={i} />)
+        ) : s ? (
+          <>
+            <StatCard
+              icon={<PendingActionsIcon />}
+              label="Pending Requests"
+              value={s.pendingSarCount}
+              color={s.pendingSarCount > 0 ? 'warning.main' : 'text.secondary'}
+            />
+            <StatCard
+              icon={<CheckCircleIcon />}
+              label="Approved (Ready)"
+              value={s.approvedSarCount}
+              color="info.main"
+            />
+            <StatCard
+              icon={<LocalShippingIcon />}
+              label="Active Pull Requests"
+              value={s.activePullRequestCount}
+              color="primary.main"
+            />
+          </>
+        ) : null}
+      </Box>
+      <Typography variant="h6" sx={{ mb: 2, mt: 1 }}>Go to</Typography>
+      <Grid container spacing={2}>
+        {SUB_ROUTES.map((card) => (
+          <Grid key={card.path} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <ShortcutCard label={card.label} icon={card.icon} onClick={() => navigate(card.path)} />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/frontend/src/modules/shop-assembly/index.tsx
+++ b/frontend/src/modules/shop-assembly/index.tsx
@@ -1,37 +1,31 @@
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
-import { Box, Tabs, Tab, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { Box } from '@mui/material';
 import SARListPage from './SARListPage';
 import AssembleListPage from './AssembleListPage';
 import AssignmentBoard from './AssignmentBoard';
 import MyWorkPage from './MyWorkPage';
+import ShopAssemblyLanding from './ShopAssemblyLanding';
+import BackToModule from '../../components/BackToModule';
 
-const SUB_ROUTES = [
-  { label: 'Requests', path: 'requests' },
-  { label: 'Assemble List', path: 'assemble' },
-  { label: 'Assignments', path: 'assign' },
-  { label: 'My Work', path: 'my-work' },
-];
-
-export default function ShopAssemblyModule() {
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  const currentSub = location.pathname.split('/').pop();
-  const tabIndex = Math.max(SUB_ROUTES.findIndex((r) => r.path === currentSub), 0);
-
+function ShopAssemblySubLayout({ children }: { children: ReactNode }) {
   return (
     <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Shop Assembly</Typography>
-      <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/shop-assembly/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
-        {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
-      </Tabs>
-      <Routes>
-        <Route path='requests' element={<SARListPage />} />
-        <Route path='assemble' element={<AssembleListPage />} />
-        <Route path='assign' element={<AssignmentBoard />} />
-        <Route path='my-work' element={<MyWorkPage />} />
-        <Route index element={<Navigate to='requests' replace />} />
-      </Routes>
+      <BackToModule to="/app/shop-assembly" label="Shop Assembly" />
+      {children}
     </Box>
+  );
+}
+
+export default function ShopAssemblyModule() {
+  return (
+    <Routes>
+      <Route index element={<ShopAssemblyLanding />} />
+      <Route path="requests" element={<ShopAssemblySubLayout><SARListPage /></ShopAssemblySubLayout>} />
+      <Route path="assemble" element={<ShopAssemblySubLayout><AssembleListPage /></ShopAssemblySubLayout>} />
+      <Route path="assign" element={<ShopAssemblySubLayout><AssignmentBoard /></ShopAssemblySubLayout>} />
+      <Route path="my-work" element={<ShopAssemblySubLayout><MyWorkPage /></ShopAssemblySubLayout>} />
+      <Route path="*" element={<Navigate to="" replace />} />
+    </Routes>
   );
 }

--- a/frontend/src/modules/warehouse/DashboardCards.tsx
+++ b/frontend/src/modules/warehouse/DashboardCards.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, Typography, Skeleton } from '@mui/material';
+import { Box } from '@mui/material';
 import InventoryIcon from '@mui/icons-material/Inventory2';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import LocationOffIcon from '@mui/icons-material/LocationOff';
@@ -7,6 +7,7 @@ import DownloadDoneIcon from '@mui/icons-material/DownloadDone';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { useQuery } from '@apollo/client/react';
 import { GET_WAREHOUSE_DASHBOARD } from '../../graphql/queries';
+import { StatCard, StatCardSkeleton } from '../../components/StatCard';
 
 interface DashboardData {
   warehouseDashboard: {
@@ -22,38 +23,6 @@ interface DashboardData {
 
 function formatCurrency(value: number): string {
   return value.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
-}
-
-interface StatCardProps {
-  icon: React.ReactNode;
-  label: string;
-  value: string | number;
-  color?: string;
-}
-
-function StatCard({ icon, label, value, color }: StatCardProps) {
-  return (
-    <Card variant="outlined" sx={{ flex: '1 1 0', minWidth: 140 }}>
-      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 1.5, '&:last-child': { pb: 1.5 } }}>
-        <Box sx={{ color: color ?? 'text.secondary', display: 'flex' }}>{icon}</Box>
-        <Box>
-          <Typography variant="h6" sx={{ lineHeight: 1.2 }}>{value}</Typography>
-          <Typography variant="caption" color="text.secondary">{label}</Typography>
-        </Box>
-      </CardContent>
-    </Card>
-  );
-}
-
-function StatCardSkeleton() {
-  return (
-    <Card variant="outlined" sx={{ flex: '1 1 0', minWidth: 140 }}>
-      <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-        <Skeleton width={80} height={28} />
-        <Skeleton width={60} height={16} />
-      </CardContent>
-    </Card>
-  );
 }
 
 export default function DashboardCards() {

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -1,0 +1,68 @@
+import { useState, type ReactNode } from 'react';
+import { Box, Typography, Card, CardContent, CardActionArea, Grid } from '@mui/material';
+import InventoryIcon from '@mui/icons-material/Inventory2';
+import MapIcon from '@mui/icons-material/Map';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import DownloadIcon from '@mui/icons-material/Download';
+import MoveToInboxIcon from '@mui/icons-material/MoveToInbox';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import { useNavigate } from 'react-router-dom';
+import DashboardCards from './DashboardCards';
+import WarehouseMap from './WarehouseMap';
+
+interface ShortcutCardProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}
+
+function ShortcutCard({ label, icon, onClick }: ShortcutCardProps) {
+  return (
+    <Card variant="outlined" sx={{ height: '100%', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 4 } }}>
+      <CardActionArea onClick={onClick} sx={{ height: '100%', p: 1 }}>
+        <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+          <Typography variant="h6">{label}</Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+const SUB_ROUTES = [
+  { label: 'Inventory', path: '/app/warehouse/inventory', icon: <InventoryIcon fontSize="large" /> },
+  { label: 'Locations', path: '/app/warehouse/locations', icon: <LocationOnIcon fontSize="large" /> },
+  { label: 'Deliveries', path: '/app/warehouse/deliveries', icon: <LocalShippingIcon fontSize="large" /> },
+  { label: 'Receiving', path: '/app/warehouse/receiving', icon: <DownloadIcon fontSize="large" /> },
+  { label: 'Put Away', path: '/app/warehouse/put-away', icon: <MoveToInboxIcon fontSize="large" /> },
+  { label: 'Pull Requests', path: '/app/warehouse/pull-requests', icon: <AssignmentIcon fontSize="large" /> },
+];
+
+export default function WarehouseLanding() {
+  const navigate = useNavigate();
+  const [mapOpen, setMapOpen] = useState(false);
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>Warehouse</Typography>
+      <DashboardCards />
+      <Typography variant="h6" sx={{ mb: 2, mt: 1 }}>Go to</Typography>
+      <Grid container spacing={2}>
+        {SUB_ROUTES.map((card) => (
+          <Grid key={card.path} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <ShortcutCard label={card.label} icon={card.icon} onClick={() => navigate(card.path)} />
+          </Grid>
+        ))}
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+          <ShortcutCard
+            label="Warehouse Map"
+            icon={<MapIcon fontSize="large" />}
+            onClick={() => setMapOpen(true)}
+          />
+        </Grid>
+      </Grid>
+      <WarehouseMap open={mapOpen} onClose={() => setMapOpen(false)} />
+    </Box>
+  );
+}

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -1,55 +1,35 @@
-import { useState } from 'react';
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
-import { Box, Tabs, Tab, Typography, Button } from '@mui/material';
-import MapIcon from '@mui/icons-material/Map';
-import DashboardCards from './DashboardCards';
+import type { ReactNode } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { Box } from '@mui/material';
+import WarehouseLanding from './WarehouseLanding';
 import DeliveriesView from './DeliveriesView';
 import InventoryView from './InventoryView';
 import LocationsTab from './LocationsTab';
 import ReceivingPage from './ReceivingPage';
 import PullRequestQueue from './PullRequestQueue';
 import PutAwayTab from './PutAwayTab';
-import WarehouseMap from './WarehouseMap';
+import BackToModule from '../../components/BackToModule';
 
-const SUB_ROUTES = [
-  { label: 'Inventory', path: 'inventory' },
-  { label: 'Locations', path: 'locations' },
-  { label: 'Deliveries', path: 'deliveries' },
-  { label: 'Receiving', path: 'receiving' },
-  { label: 'Put Away', path: 'put-away' },
-  { label: 'Pull Requests', path: 'pull-requests' },
-];
-
-export default function WarehouseModule() {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [mapOpen, setMapOpen] = useState(false);
-
-  const currentSub = location.pathname.split('/').pop();
-  const tabIndex = Math.max(SUB_ROUTES.findIndex((r) => r.path === currentSub), 0);
-
+function WarehouseSubLayout({ children }: { children: ReactNode }) {
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-        <Typography variant="h5">Warehouse</Typography>
-        <Button variant="outlined" startIcon={<MapIcon />} onClick={() => setMapOpen(true)}>
-          Warehouse Map
-        </Button>
-      </Box>
-      <DashboardCards />
-      <Tabs value={tabIndex} onChange={(_, v) => navigate(`/app/warehouse/${SUB_ROUTES[v].path}`)} sx={{ mb: 2 }}>
-        {SUB_ROUTES.map((r) => <Tab key={r.path} label={r.label} />)}
-      </Tabs>
-      <Routes>
-        <Route path="inventory" element={<InventoryView />} />
-        <Route path="locations" element={<LocationsTab />} />
-        <Route path="deliveries" element={<DeliveriesView />} />
-        <Route path="receiving" element={<ReceivingPage />} />
-        <Route path="put-away" element={<PutAwayTab />} />
-        <Route path="pull-requests" element={<PullRequestQueue />} />
-        <Route index element={<Navigate to="inventory" replace />} />
-      </Routes>
-      <WarehouseMap open={mapOpen} onClose={() => setMapOpen(false)} />
+      <BackToModule to="/app/warehouse" label="Warehouse" />
+      {children}
     </Box>
+  );
+}
+
+export default function WarehouseModule() {
+  return (
+    <Routes>
+      <Route index element={<WarehouseLanding />} />
+      <Route path="inventory" element={<WarehouseSubLayout><InventoryView /></WarehouseSubLayout>} />
+      <Route path="locations" element={<WarehouseSubLayout><LocationsTab /></WarehouseSubLayout>} />
+      <Route path="deliveries" element={<WarehouseSubLayout><DeliveriesView /></WarehouseSubLayout>} />
+      <Route path="receiving" element={<WarehouseSubLayout><ReceivingPage /></WarehouseSubLayout>} />
+      <Route path="put-away" element={<WarehouseSubLayout><PutAwayTab /></WarehouseSubLayout>} />
+      <Route path="pull-requests" element={<WarehouseSubLayout><PullRequestQueue /></WarehouseSubLayout>} />
+      <Route path="*" element={<Navigate to="" replace />} />
+    </Routes>
   );
 }


### PR DESCRIPTION
Closes #128.

## Summary
- Removes the `/app` `ModuleSelector` card grid; replaces it with a new Home dashboard (greeting + 4 KPI cards: open POs, pending pull requests, items pending receiving, projects; recent-activity feed sourced from the existing audit log).
- Adds a toggle drawer (`Sidebar.tsx`) opened via a hamburger in the AppBar. Items are filtered by Clerk `publicMetadata.roles`; `Admin/Manager` sees everything. Items with sub-routes (Warehouse, Shop Assembly, Admin) expand inline to show their sub-items.
- Builds landing pages for **Warehouse**, **Shop Assembly**, and **Admin** (module-specific stat cards + sub-feature shortcut card grid). The tab strips inside those modules are removed; each sub-page now has a "← <Module>" back link.
- Extracts `StatCard` / `StatCardSkeleton` into `components/StatCard.tsx` for reuse across the new landings.
- New backend resolvers (`homeDashboardStats`, `shopAssemblyStats`, `adminStats`) use scalar `func.count()` / `func.sum()` aggregates only — no relationship loads (per the project's N+1 rules).
- Import, PO, and Shipping modules are unchanged — they already had a project-picker landing.