### PR TITLE
Require ordered-as on manual PO creation (#129)

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -73,6 +73,10 @@ def create_po(
         if isinstance(classification_val, str):
             classification_val = Classification(classification_val)
 
+        order_as_raw = li_data.get("order_as")
+        if not order_as_raw or not order_as_raw.strip():
+            raise ValidationError("Order as is required for every line item", field="order_as")
+
         poli = POLineItem(
             id=uuid.uuid4(),
             po_id=po.id,
@@ -82,7 +86,7 @@ def create_po(
             received_quantity=0,
             unit_cost=Decimal(str(li_data["unit_cost"])) if li_data.get("unit_cost") else Decimal("0"),
             classification=classification_val,
-            order_as=li_data.get("order_as"),
+            order_as=order_as_raw.strip(),
         )
         session.add(poli)
 

--- a/backend/tests/test_po_repository_create_po.py
+++ b/backend/tests/test_po_repository_create_po.py
@@ -1,0 +1,92 @@
+import uuid
+
+import pytest
+
+from app.errors import ValidationError
+from app.models.vendor import Vendor
+from app.repositories import po_repository
+
+
+def _make_vendor(session, name: str = "Acme") -> Vendor:
+    v = Vendor(id=uuid.uuid4(), name=f"{name}-{uuid.uuid4().hex[:6]}")
+    session.add(v)
+    session.flush()
+    return v
+
+
+def _line_item(order_as: str | None) -> dict:
+    return {
+        "hardware_category": "HINGE",
+        "product_code": "AB123",
+        "ordered_quantity": 1,
+        "unit_cost": 12.50,
+        "classification": None,
+        "order_as": order_as,
+    }
+
+
+def test_create_po_succeeds_with_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    po = po_repository.create_po(
+        db_session,
+        line_items=[_line_item("ML2010")],
+        vendor_id=vendor.id,
+    )
+    db_session.refresh(po)
+    assert len(po.line_items) == 1
+    assert po.line_items[0].order_as == "ML2010"
+
+
+def test_create_po_strips_order_as_whitespace(db_session):
+    vendor = _make_vendor(db_session)
+    po = po_repository.create_po(
+        db_session,
+        line_items=[_line_item("  ML2010  ")],
+        vendor_id=vendor.id,
+    )
+    db_session.refresh(po)
+    assert po.line_items[0].order_as == "ML2010"
+
+
+def test_create_po_rejects_missing_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    with pytest.raises(ValidationError) as exc:
+        po_repository.create_po(
+            db_session,
+            line_items=[_line_item(None)],
+            vendor_id=vendor.id,
+        )
+    assert exc.value.field == "order_as"
+
+
+def test_create_po_rejects_empty_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    with pytest.raises(ValidationError) as exc:
+        po_repository.create_po(
+            db_session,
+            line_items=[_line_item("")],
+            vendor_id=vendor.id,
+        )
+    assert exc.value.field == "order_as"
+
+
+def test_create_po_rejects_whitespace_only_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    with pytest.raises(ValidationError) as exc:
+        po_repository.create_po(
+            db_session,
+            line_items=[_line_item("   ")],
+            vendor_id=vendor.id,
+        )
+    assert exc.value.field == "order_as"
+
+
+def test_create_po_rejects_when_any_line_item_missing_order_as(db_session):
+    vendor = _make_vendor(db_session)
+    with pytest.raises(ValidationError) as exc:
+        po_repository.create_po(
+            db_session,
+            line_items=[_line_item("ML2010"), _line_item(None)],
+            vendor_id=vendor.id,
+        )
+    assert exc.value.field == "order_as"

--- a/frontend/src/modules/po/CreatePODialog.tsx
+++ b/frontend/src/modules/po/CreatePODialog.tsx
@@ -106,6 +106,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
       if (isNaN(qty) || qty < 1) errs[`li_${i}_qty`] = 'Must be >= 1';
       const cost = parseFloat(li.unitCost);
       if (isNaN(cost) || cost < 0) errs[`li_${i}_cost`] = 'Must be >= 0';
+      if (!li.orderAs.trim()) errs[`li_${i}_orderAs`] = 'Required';
     }
     setErrors(errs);
     return Object.keys(errs).length === 0;
@@ -133,7 +134,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
         orderedQuantity: parseInt(li.orderedQuantity, 10),
         unitCost: parseFloat(li.unitCost),
         classification: li.classification || null,
-        orderAs: li.orderAs.trim() || null,
+        orderAs: li.orderAs.trim(),
       })),
     };
 
@@ -294,9 +295,12 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
           </TextField>
           <TextField
             size="small"
+            required
             value={li.orderAs}
             onChange={(e) => updateLineItem(li.key, 'orderAs', e.target.value)}
-            placeholder="Optional"
+            error={!!errors[`li_${idx}_orderAs`]}
+            helperText={errors[`li_${idx}_orderAs`]}
+            placeholder="e.g. ML2010"
           />
           <IconButton
             size="small"


### PR DESCRIPTION
Closes #129.

## Summary
- Manual Create PO modal now requires a non-empty Order As on every line item — `validate()` flags missing/whitespace-only values and the TextField shows an inline "Required" helper.
- Backend `create_po` repository function raises `ValidationError(field="order_as")` if any line item has missing/empty/whitespace-only `order_as`, and the stored value is trimmed.
- Added `backend/tests/test_po_repository_create_po.py` covering happy path, whitespace trimming, missing, empty, whitespace-only, and "any line item missing" cases.

## Notes
- `CreatePOLineItemInput.order_as` stays nullable at the GraphQL schema level so we get a structured `AppError` with `field: "order_as"` instead of a generic Strawberry parse error. This matches the pattern used by `update_po` for `vendor_id`.
- `create_po` (repo + mutation) is only called from this modal; `PODraftInput` (PR-driven PO draft) is a separate path and is unaffected.