### PR TITLE
Add non-stock module + deficiency workflow (closes #131)

### DIFF
--- a/backend/alembic/versions/027_deficiency_foundation.py
+++ b/backend/alembic/versions/027_deficiency_foundation.py
@@ -1,0 +1,92 @@
+"""Phase 1: deficiency foundation — deficient_quantity on inventory_locations + audit enum values
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-06-04
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add deficient_quantity column to inventory_locations
+    op.add_column(
+        "inventory_locations",
+        sa.Column("deficient_quantity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    # Drop server_default so model default takes over for new rows
+    op.alter_column("inventory_locations", "deficient_quantity", server_default=None)
+
+    # 2. Add CHECK constraints for the new column
+    op.create_check_constraint(
+        "ck_inventory_locations_deficient_quantity_nonneg",
+        "inventory_locations",
+        "deficient_quantity >= 0",
+    )
+    op.create_check_constraint(
+        "ck_inventory_locations_deficient_within_quantity",
+        "inventory_locations",
+        "deficient_quantity <= quantity",
+    )
+
+    # 3. Extend audit_action enum with new values used by the stock + deficiency flows
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'DESTOCK'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'ALLOCATE_FROM_STOCK'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'RECLASSIFY'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'REPORT_DEFICIENT'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'RESOLVE_DEFICIENT'")
+
+    # 4. Extend audit_entity_type enum so stock items can be referenced as audit subjects
+    op.execute("ALTER TYPE audit_entity_type ADD VALUE IF NOT EXISTS 'STOCK_ITEM'")
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_inventory_locations_deficient_within_quantity",
+        "inventory_locations",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_inventory_locations_deficient_quantity_nonneg",
+        "inventory_locations",
+        type_="check",
+    )
+    op.drop_column("inventory_locations", "deficient_quantity")
+
+    # Rebuild audit_action enum without the new values (Postgres has no DROP VALUE)
+    op.execute("ALTER TYPE audit_action RENAME TO audit_action_old")
+    new_action = sa.Enum(
+        "ADJUSTMENT",
+        "MOVE",
+        "UNLOCATE",
+        "RECEIVE",
+        "PULL_DEDUCTION",
+        "SPOT_CHECK",
+        "PUT_AWAY",
+        name="audit_action",
+    )
+    new_action.create(op.get_bind(), checkfirst=False)
+    op.execute("ALTER TABLE inventory_audit_log ALTER COLUMN action TYPE audit_action USING action::text::audit_action")
+    op.execute("DROP TYPE audit_action_old")
+
+    # Rebuild audit_entity_type enum without STOCK_ITEM
+    op.execute("ALTER TYPE audit_entity_type RENAME TO audit_entity_type_old")
+    new_entity = sa.Enum(
+        "INVENTORY_LOCATION",
+        "OPENING_ITEM",
+        name="audit_entity_type",
+    )
+    new_entity.create(op.get_bind(), checkfirst=False)
+    op.execute(
+        "ALTER TABLE inventory_audit_log "
+        "ALTER COLUMN entity_type TYPE audit_entity_type "
+        "USING entity_type::text::audit_entity_type"
+    )
+    op.execute("DROP TYPE audit_entity_type_old")

--- a/backend/alembic/versions/028_create_stock_items.py
+++ b/backend/alembic/versions/028_create_stock_items.py
@@ -1,0 +1,56 @@
+"""Phase 2: create stock_items table for non-stock (UCSH-owned) hardware
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-06-04
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "028"
+down_revision = "027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stock_items",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("hardware_category", sa.String(), nullable=False),
+        sa.Column("product_code", sa.String(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("deficient_quantity", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("aisle", sa.String(20), nullable=True),
+        sa.Column("bay", sa.String(20), nullable=True),
+        sa.Column("bin", sa.String(20), nullable=True),
+        sa.Column("received_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("quantity >= 0", name="ck_stock_items_quantity_nonneg"),
+        sa.CheckConstraint(
+            "deficient_quantity >= 0",
+            name="ck_stock_items_deficient_quantity_nonneg",
+        ),
+        sa.CheckConstraint(
+            "deficient_quantity <= quantity",
+            name="ck_stock_items_deficient_within_quantity",
+        ),
+    )
+    # Drop server_default so the Python default (0) is the canonical source
+    op.alter_column("stock_items", "deficient_quantity", server_default=None)
+
+    op.create_index(
+        "ix_stock_items_cat_code",
+        "stock_items",
+        ["hardware_category", "product_code"],
+    )
+    op.create_index("ix_stock_items_aisle", "stock_items", ["aisle"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stock_items_aisle", table_name="stock_items")
+    op.drop_index("ix_stock_items_cat_code", table_name="stock_items")
+    op.drop_table("stock_items")

--- a/backend/alembic/versions/029_inventory_location_stock_link.py
+++ b/backend/alembic/versions/029_inventory_location_stock_link.py
@@ -1,0 +1,72 @@
+"""Relax inventory_locations FK columns + add stock_item_id link for allocations from stock
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-06-04
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Make existing FK columns nullable — stock-allocated rows have no backing PO line item
+    op.alter_column(
+        "inventory_locations",
+        "po_line_item_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )
+    op.alter_column(
+        "inventory_locations",
+        "receive_line_item_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )
+
+    # 2. Add stock_item_id column linking back to the stock_items row this allocation came from
+    op.add_column(
+        "inventory_locations",
+        sa.Column(
+            "stock_item_id",
+            sa.Uuid(),
+            sa.ForeignKey("stock_items.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_inventory_locations_stock_item",
+        "inventory_locations",
+        ["stock_item_id"],
+    )
+
+    # 3. CHECK constraint: every row has either a PO origin OR a stock origin (or both, if reused)
+    op.create_check_constraint(
+        "ck_inventory_locations_has_origin",
+        "inventory_locations",
+        "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) OR stock_item_id IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_inventory_locations_has_origin", "inventory_locations", type_="check")
+    op.drop_index("ix_inventory_locations_stock_item", table_name="inventory_locations")
+    op.drop_column("inventory_locations", "stock_item_id")
+    op.alter_column(
+        "inventory_locations",
+        "receive_line_item_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )
+    op.alter_column(
+        "inventory_locations",
+        "po_line_item_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )

--- a/backend/alembic/versions/030_deficiency_reviews.py
+++ b/backend/alembic/versions/030_deficiency_reviews.py
@@ -1,0 +1,79 @@
+"""Phase 5: deficiency_reviews table + deficiency_resolution enum
+
+Revision ID: 030
+Revises: 029
+Create Date: 2026-06-04
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "030"
+down_revision = "029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    deficiency_resolution = sa.Enum(
+        "SEND_TO_STOCK",
+        "SCRAP",
+        "REPAIR",
+        "RETURN_TO_VENDOR",
+        "LEAVE_AS_DEFICIENT",
+        name="deficiency_resolution",
+    )
+    deficiency_resolution.create(op.get_bind(), checkfirst=False)
+
+    op.create_table(
+        "deficiency_reviews",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "inventory_location_id",
+            sa.Uuid(),
+            sa.ForeignKey("inventory_locations.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "stock_item_id",
+            sa.Uuid(),
+            sa.ForeignKey("stock_items.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "resolution",
+            sa.Enum(name="deficiency_resolution", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("reason_text", sa.Text(), nullable=True),
+        sa.Column("rma_reference", sa.String(100), nullable=True),
+        sa.Column("reviewed_by", sa.String(), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "resulting_stock_item_id",
+            sa.Uuid(),
+            sa.ForeignKey("stock_items.id"),
+            nullable=True,
+        ),
+        sa.CheckConstraint(
+            "(inventory_location_id IS NULL) <> (stock_item_id IS NULL)",
+            name="ck_deficiency_reviews_exactly_one_source",
+        ),
+        sa.CheckConstraint(
+            "quantity >= 1",
+            name="ck_deficiency_reviews_quantity_positive",
+        ),
+    )
+    op.create_index(
+        "ix_deficiency_reviews_reviewed_at",
+        "deficiency_reviews",
+        ["reviewed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_deficiency_reviews_reviewed_at", table_name="deficiency_reviews")
+    op.drop_table("deficiency_reviews")
+    op.execute("DROP TYPE deficiency_resolution")

--- a/backend/alembic/versions/030_deficiency_reviews.py
+++ b/backend/alembic/versions/030_deficiency_reviews.py
@@ -24,7 +24,6 @@ def upgrade() -> None:
         "LEAVE_AS_DEFICIENT",
         name="deficiency_resolution",
     )
-    deficiency_resolution.create(op.get_bind(), checkfirst=False)
 
     op.create_table(
         "deficiency_reviews",
@@ -41,11 +40,7 @@ def upgrade() -> None:
             sa.ForeignKey("stock_items.id"),
             nullable=True,
         ),
-        sa.Column(
-            "resolution",
-            sa.Enum(name="deficiency_resolution", create_type=False),
-            nullable=False,
-        ),
+        sa.Column("resolution", deficiency_resolution, nullable=False),
         sa.Column("quantity", sa.Integer(), nullable=False),
         sa.Column("reason_text", sa.Text(), nullable=True),
         sa.Column("rma_reference", sa.String(100), nullable=True),

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ class Base(DeclarativeBase):
 
 # Import all models so Alembic can detect them
 from .audit_log import InventoryAuditLog  # noqa: E402, F401
+from .deficiency_review import DeficiencyReview  # noqa: E402, F401
 from .hardware import HardwareItem  # noqa: E402, F401
 from .inventory import InventoryLocation  # noqa: E402, F401
 from .notification import Notification  # noqa: E402, F401
@@ -22,5 +23,6 @@ from .shop_assembly import (  # noqa: E402, F401
     ShopAssemblyOpeningItem,
     ShopAssemblyRequest,
 )
+from .stock_item import StockItem  # noqa: E402, F401
 from .vendor import Vendor  # noqa: E402, F401
 from .warehouse_layout import WarehouseAisle, WarehouseBay, WarehouseBin, WarehouseRow  # noqa: E402, F401

--- a/backend/app/models/deficiency_review.py
+++ b/backend/app/models/deficiency_review.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+from .enums import DeficiencyResolution
+
+
+class DeficiencyReview(Base):
+    """A reviewed outcome for a batch of deficient units (project or stock origin).
+
+    Exactly one of inventory_location_id / stock_item_id is set, enforced by CHECK.
+    """
+
+    __tablename__ = "deficiency_reviews"
+    __table_args__ = (
+        Index("ix_deficiency_reviews_reviewed_at", "reviewed_at"),
+        CheckConstraint(
+            "(inventory_location_id IS NULL) <> (stock_item_id IS NULL)",
+            name="ck_deficiency_reviews_exactly_one_source",
+        ),
+        CheckConstraint("quantity >= 1", name="ck_deficiency_reviews_quantity_positive"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    inventory_location_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("inventory_locations.id"), nullable=True)
+    stock_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("stock_items.id"), nullable=True)
+    resolution: Mapped[DeficiencyResolution] = mapped_column(
+        Enum(DeficiencyResolution, name="deficiency_resolution", create_constraint=True),
+        nullable=False,
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    reason_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    rma_reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    reviewed_by: Mapped[str] = mapped_column(String, nullable=False)
+    reviewed_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    resulting_stock_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("stock_items.id"), nullable=True)

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -76,6 +76,7 @@ class NotificationType(str, enum.Enum):
 class AuditEntityType(str, enum.Enum):
     INVENTORY_LOCATION = "INVENTORY_LOCATION"
     OPENING_ITEM = "OPENING_ITEM"
+    STOCK_ITEM = "STOCK_ITEM"
 
 
 class AuditAction(str, enum.Enum):
@@ -86,3 +87,28 @@ class AuditAction(str, enum.Enum):
     PULL_DEDUCTION = "PULL_DEDUCTION"
     SPOT_CHECK = "SPOT_CHECK"
     PUT_AWAY = "PUT_AWAY"
+    DESTOCK = "DESTOCK"
+    ALLOCATE_FROM_STOCK = "ALLOCATE_FROM_STOCK"
+    RECLASSIFY = "RECLASSIFY"
+    REPORT_DEFICIENT = "REPORT_DEFICIENT"
+    RESOLVE_DEFICIENT = "RESOLVE_DEFICIENT"
+
+
+class DestockSource(str, enum.Enum):
+    CANCELLATION = "CANCELLATION"
+    DEFICIENT_SWAP = "DEFICIENT_SWAP"
+    OVERAGE = "OVERAGE"
+    OTHER = "OTHER"
+
+
+class DeficiencyResolution(str, enum.Enum):
+    SEND_TO_STOCK = "SEND_TO_STOCK"
+    SCRAP = "SCRAP"
+    REPAIR = "REPAIR"
+    RETURN_TO_VENDOR = "RETURN_TO_VENDOR"
+    LEAVE_AS_DEFICIENT = "LEAVE_AS_DEFICIENT"
+
+
+class DeficientItemSource(str, enum.Enum):
+    PROJECT_INVENTORY = "PROJECT_INVENTORY"
+    STOCK_POOL = "STOCK_POOL"

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -17,16 +17,33 @@ class InventoryLocation(Base):
             "product_code",
         ),
         Index("ix_inventory_locations_aisle", "aisle"),
+        Index("ix_inventory_locations_stock_item", "stock_item_id"),
         CheckConstraint("quantity >= 0", name="ck_inventory_locations_quantity_nonneg"),
+        CheckConstraint(
+            "deficient_quantity >= 0",
+            name="ck_inventory_locations_deficient_quantity_nonneg",
+        ),
+        CheckConstraint(
+            "deficient_quantity <= quantity",
+            name="ck_inventory_locations_deficient_within_quantity",
+        ),
+        CheckConstraint(
+            "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) OR stock_item_id IS NOT NULL",
+            name="ck_inventory_locations_has_origin",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), nullable=False)
-    po_line_item_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("po_line_items.id"), nullable=False)
-    receive_line_item_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("receive_line_items.id"), nullable=False)
+    po_line_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("po_line_items.id"), nullable=True)
+    receive_line_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("receive_line_items.id"), nullable=True)
+    stock_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("stock_items.id", ondelete="SET NULL"), nullable=True
+    )
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    deficient_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     aisle: Mapped[str | None] = mapped_column(String(20), nullable=True)
     bay: Mapped[str | None] = mapped_column(String(20), nullable=True)
     bin: Mapped[str | None] = mapped_column(String(20), nullable=True)

--- a/backend/app/models/stock_item.py
+++ b/backend/app/models/stock_item.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class StockItem(Base):
+    """Company-owned shelf hardware not tied to any project (non-stock inventory)."""
+
+    __tablename__ = "stock_items"
+    __table_args__ = (
+        Index("ix_stock_items_cat_code", "hardware_category", "product_code"),
+        Index("ix_stock_items_aisle", "aisle"),
+        CheckConstraint("quantity >= 0", name="ck_stock_items_quantity_nonneg"),
+        CheckConstraint(
+            "deficient_quantity >= 0",
+            name="ck_stock_items_deficient_quantity_nonneg",
+        ),
+        CheckConstraint(
+            "deficient_quantity <= quantity",
+            name="ck_stock_items_deficient_within_quantity",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    hardware_category: Mapped[str] = mapped_column(String, nullable=False)
+    product_code: Mapped[str] = mapped_column(String, nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    deficient_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    aisle: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    bay: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    bin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    received_at: Mapped[datetime] = mapped_column(nullable=False)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/repositories/stock_repository.py
+++ b/backend/app/repositories/stock_repository.py
@@ -1,0 +1,1019 @@
+"""Repository for stock_items (non-stock, UCSH-owned shelf hardware)."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.errors import NotFoundError, ValidationError
+from app.models.audit_log import InventoryAuditLog
+from app.models.enums import (
+    AuditAction,
+    AuditEntityType,
+    DeficiencyResolution,
+    DeficientItemSource,
+    DestockSource,
+)
+from app.models.inventory import InventoryLocation as InventoryLocationModel
+from app.models.stock_item import StockItem
+
+
+def _log_audit_event(
+    session: Session,
+    *,
+    project_id: uuid.UUID | None,
+    entity_type: AuditEntityType,
+    entity_id: uuid.UUID,
+    action: AuditAction,
+    performed_by: str,
+    detail: dict | None = None,
+) -> None:
+    """Insert a row into inventory_audit_log. Project_id is null for pure stock-pool events."""
+    session.add(
+        InventoryAuditLog(
+            project_id=project_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action=action,
+            detail=detail,
+            performed_by=performed_by,
+        )
+    )
+
+
+def _validate_location_fields(aisle: str | None, bay: str | None, bin: str | None) -> None:
+    """Validate aisle, bay, bin lengths when provided."""
+    for field_name, value in [("aisle", aisle), ("bay", bay), ("bin", bin)]:
+        if value is not None and (len(value) < 1 or len(value) > 20):
+            raise ValidationError(f"{field_name} must be 1-20 characters", field=field_name)
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+
+
+def get_stock_items(
+    session: Session,
+    product_code_contains: str | None = None,
+    hardware_category: str | None = None,
+    aisle: str | None = None,
+    only_deficient: bool = False,
+) -> list[StockItem]:
+    """List stock_items optionally filtered by product code, category, aisle, or deficient-only."""
+    stmt = select(StockItem).order_by(
+        StockItem.hardware_category.asc(),
+        StockItem.product_code.asc(),
+        StockItem.received_at.asc(),
+    )
+    if product_code_contains:
+        stmt = stmt.where(StockItem.product_code.ilike(f"%{product_code_contains}%"))
+    if hardware_category:
+        stmt = stmt.where(StockItem.hardware_category == hardware_category)
+    if aisle:
+        stmt = stmt.where(StockItem.aisle == aisle)
+    if only_deficient:
+        stmt = stmt.where(StockItem.deficient_quantity > 0)
+    return list(session.scalars(stmt).all())
+
+
+def get_stock_item(session: Session, stock_item_id: uuid.UUID) -> StockItem:
+    si = session.get(StockItem, stock_item_id)
+    if si is None:
+        raise NotFoundError(f"Stock item {stock_item_id} not found")
+    return si
+
+
+def get_stock_matches_for_opening(
+    session: Session,
+    opening_item_id: uuid.UUID,
+) -> list[StockItem]:
+    """Return stock_items whose hardware_category matches the opening item's category.
+
+    Match is intentionally loose: same hardware_category, ranking exact product_code match first.
+    """
+    from app.models.opening_item import OpeningItem, OpeningItemHardware
+
+    oi = session.get(OpeningItem, opening_item_id)
+    if oi is None:
+        raise NotFoundError(f"Opening item {opening_item_id} not found")
+
+    # Pull installed hardware to know what categories/codes we are looking for
+    ih_stmt = select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == opening_item_id)
+    installed = list(session.scalars(ih_stmt).all())
+    if not installed:
+        return []
+
+    categories = {h.hardware_category for h in installed}
+    codes = {h.product_code for h in installed}
+
+    stmt = (
+        select(StockItem)
+        .where(StockItem.hardware_category.in_(categories))
+        .where(StockItem.quantity > 0)
+        .order_by(StockItem.product_code.asc(), StockItem.received_at.asc())
+    )
+    rows = list(session.scalars(stmt).all())
+    # Promote exact product_code matches to the front
+    rows.sort(key=lambda r: (r.product_code not in codes, r.hardware_category, r.product_code))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by destock / allocate / receive-to-stock
+# ---------------------------------------------------------------------------
+
+
+def _find_or_create_stock_row(
+    session: Session,
+    *,
+    hardware_category: str,
+    product_code: str,
+    aisle: str | None,
+    bay: str | None,
+    bin: str | None,
+    received_at: datetime,
+) -> StockItem:
+    """Find an existing stock row matching (category, code, aisle, bay, bin) or create one with qty=0.
+
+    Caller is responsible for incrementing quantity and writing audit events.
+    """
+    stmt = select(StockItem).where(
+        StockItem.hardware_category == hardware_category,
+        StockItem.product_code == product_code,
+    )
+    if aisle is None:
+        stmt = stmt.where(StockItem.aisle.is_(None))
+    else:
+        stmt = stmt.where(StockItem.aisle == aisle)
+    if bay is None:
+        stmt = stmt.where(StockItem.bay.is_(None))
+    else:
+        stmt = stmt.where(StockItem.bay == bay)
+    if bin is None:
+        stmt = stmt.where(StockItem.bin.is_(None))
+    else:
+        stmt = stmt.where(StockItem.bin == bin)
+
+    existing = session.scalars(stmt).first()
+    if existing is not None:
+        return existing
+
+    new_row = StockItem(
+        hardware_category=hardware_category,
+        product_code=product_code,
+        quantity=0,
+        deficient_quantity=0,
+        aisle=aisle,
+        bay=bay,
+        bin=bin,
+        received_at=received_at,
+    )
+    session.add(new_row)
+    session.flush()
+    return new_row
+
+
+# ---------------------------------------------------------------------------
+# Event 1: destock — InventoryLocation → StockItem
+# ---------------------------------------------------------------------------
+
+
+def destock_inventory(
+    session: Session,
+    *,
+    inventory_location_id: uuid.UUID,
+    quantity: int,
+    source: DestockSource,
+    reason_text: str | None,
+    target_aisle: str | None,
+    target_bay: str | None,
+    target_bin: str | None,
+    performed_by: str,
+) -> StockItem:
+    """Move quantity units from a project's InventoryLocation row into the stock pool."""
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if not performed_by:
+        raise ValidationError("performed_by is required", field="performed_by")
+    _validate_location_fields(target_aisle, target_bay, target_bin)
+
+    il = session.get(InventoryLocationModel, inventory_location_id)
+    if il is None:
+        raise NotFoundError(f"Inventory location {inventory_location_id} not found")
+    if quantity > il.quantity:
+        raise ValidationError("Destock quantity exceeds available quantity", field="quantity")
+
+    # If DEFICIENT_SWAP, the units being destocked are the deficient ones: tighten that flag too
+    is_deficient_swap = source == DestockSource.DEFICIENT_SWAP
+    if is_deficient_swap:
+        if quantity > (il.deficient_quantity or 0):
+            raise ValidationError(
+                "DEFICIENT_SWAP destock quantity exceeds deficient_quantity on source row",
+                field="quantity",
+            )
+
+    # Pick target bin: explicit override or fall back to source bin
+    final_aisle = target_aisle if target_aisle is not None else il.aisle
+    final_bay = target_bay if target_bay is not None else il.bay
+    final_bin = target_bin if target_bin is not None else il.bin
+
+    now = datetime.utcnow()
+    stock_row = _find_or_create_stock_row(
+        session,
+        hardware_category=il.hardware_category,
+        product_code=il.product_code,
+        aisle=final_aisle,
+        bay=final_bay,
+        bin=final_bin,
+        received_at=now,
+    )
+
+    # Apply the move
+    il.quantity -= quantity
+    if is_deficient_swap:
+        il.deficient_quantity = max(0, (il.deficient_quantity or 0) - quantity)
+    stock_row.quantity += quantity
+
+    session.flush()
+
+    detail = {
+        "fromInventoryLocationId": str(il.id),
+        "projectId": str(il.project_id),
+        "hardwareCategory": il.hardware_category,
+        "productCode": il.product_code,
+        "quantity": quantity,
+        "source": source.value,
+        "reasonText": reason_text,
+        "targetLocation": {"aisle": final_aisle, "bay": final_bay, "bin": final_bin},
+        "stockItemId": str(stock_row.id),
+    }
+    _log_audit_event(
+        session,
+        project_id=il.project_id,
+        entity_type=AuditEntityType.INVENTORY_LOCATION,
+        entity_id=il.id,
+        action=AuditAction.DESTOCK,
+        performed_by=performed_by,
+        detail=detail,
+    )
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=stock_row.id,
+        action=AuditAction.DESTOCK,
+        performed_by=performed_by,
+        detail=detail,
+    )
+    return stock_row
+
+
+# ---------------------------------------------------------------------------
+# Event 4: adjust + move stock-pool internally
+# ---------------------------------------------------------------------------
+
+
+def adjust_stock_quantity(
+    session: Session,
+    *,
+    stock_item_id: uuid.UUID,
+    new_quantity: int,
+    reason_text: str,
+    performed_by: str,
+) -> StockItem:
+    """Set stock_item.quantity to an absolute value (recount / write-off). reason required."""
+    if not reason_text or len(reason_text) > 500:
+        raise ValidationError("reason_text must be 1-500 characters", field="reason_text")
+    if new_quantity < 0:
+        raise ValidationError("new_quantity must be >= 0", field="new_quantity")
+
+    si = get_stock_item(session, stock_item_id)
+
+    # Honor the deficient_quantity <= quantity invariant by clamping if needed
+    if new_quantity < si.deficient_quantity:
+        raise ValidationError(
+            "Cannot set quantity below current deficient_quantity",
+            field="new_quantity",
+        )
+
+    old_quantity = si.quantity
+    si.quantity = new_quantity
+
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=si.id,
+        action=AuditAction.ADJUSTMENT,
+        performed_by=performed_by,
+        detail={
+            "oldQuantity": old_quantity,
+            "newQuantity": new_quantity,
+            "adjustment": new_quantity - old_quantity,
+            "reasonText": reason_text,
+        },
+    )
+    return si
+
+
+def move_stock_location(
+    session: Session,
+    *,
+    stock_item_id: uuid.UUID,
+    new_aisle: str,
+    new_bay: str,
+    new_bin: str,
+    performed_by: str,
+) -> StockItem:
+    _validate_location_fields(new_aisle, new_bay, new_bin)
+    if new_aisle is None or new_bay is None or new_bin is None:
+        raise ValidationError("new aisle/bay/bin are required", field="location")
+
+    si = get_stock_item(session, stock_item_id)
+    old = {"aisle": si.aisle, "bay": si.bay, "bin": si.bin}
+    si.aisle = new_aisle
+    si.bay = new_bay
+    si.bin = new_bin
+
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=si.id,
+        action=AuditAction.MOVE,
+        performed_by=performed_by,
+        detail={"fromLocation": old, "toLocation": {"aisle": new_aisle, "bay": new_bay, "bin": new_bin}},
+    )
+    return si
+
+
+# ---------------------------------------------------------------------------
+# Event 5: reclassify (split-capable)
+# ---------------------------------------------------------------------------
+
+
+def reclassify_stock_item(
+    session: Session,
+    *,
+    stock_item_id: uuid.UUID,
+    new_hardware_category: str,
+    new_product_code: str,
+    quantity: int,
+    reason_text: str | None,
+    performed_by: str,
+) -> tuple[StockItem, StockItem | None]:
+    """Change (category, code) on `quantity` units. If quantity < total, original keeps remainder.
+
+    Returns (reclassified_row, original_row_or_none).
+    """
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if not new_hardware_category:
+        raise ValidationError("new_hardware_category is required", field="new_hardware_category")
+    if not new_product_code:
+        raise ValidationError("new_product_code is required", field="new_product_code")
+
+    si = get_stock_item(session, stock_item_id)
+    if quantity > si.quantity:
+        raise ValidationError("Reclassify quantity exceeds stock quantity", field="quantity")
+
+    # Disallow reclassifying deficient units — those must be resolved first
+    available = si.quantity - (si.deficient_quantity or 0)
+    if quantity > available:
+        raise ValidationError(
+            "Cannot reclassify deficient units; resolve deficiency first",
+            field="quantity",
+        )
+
+    now = datetime.utcnow()
+
+    if quantity == si.quantity:
+        # Full reclassify in place
+        old_cat = si.hardware_category
+        old_code = si.product_code
+        si.hardware_category = new_hardware_category
+        si.product_code = new_product_code
+        _log_audit_event(
+            session,
+            project_id=None,
+            entity_type=AuditEntityType.STOCK_ITEM,
+            entity_id=si.id,
+            action=AuditAction.RECLASSIFY,
+            performed_by=performed_by,
+            detail={
+                "from": {"hardwareCategory": old_cat, "productCode": old_code},
+                "to": {
+                    "hardwareCategory": new_hardware_category,
+                    "productCode": new_product_code,
+                },
+                "quantity": quantity,
+                "reasonText": reason_text,
+            },
+        )
+        return (si, None)
+
+    # Split: original keeps (qty - split), new row gets `quantity` at the new (cat, code)
+    si.quantity -= quantity
+    new_row = _find_or_create_stock_row(
+        session,
+        hardware_category=new_hardware_category,
+        product_code=new_product_code,
+        aisle=si.aisle,
+        bay=si.bay,
+        bin=si.bin,
+        received_at=now,
+    )
+    new_row.quantity += quantity
+
+    session.flush()
+
+    detail = {
+        "originalStockItemId": str(si.id),
+        "newStockItemId": str(new_row.id),
+        "from": {"hardwareCategory": si.hardware_category, "productCode": si.product_code},
+        "to": {"hardwareCategory": new_hardware_category, "productCode": new_product_code},
+        "quantity": quantity,
+        "reasonText": reason_text,
+    }
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=si.id,
+        action=AuditAction.RECLASSIFY,
+        performed_by=performed_by,
+        detail=detail,
+    )
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=new_row.id,
+        action=AuditAction.RECLASSIFY,
+        performed_by=performed_by,
+        detail=detail,
+    )
+    return (new_row, si)
+
+
+# ---------------------------------------------------------------------------
+# Event 3: allocate stock → project inventory
+# ---------------------------------------------------------------------------
+
+
+def allocate_stock_to_project(
+    session: Session,
+    *,
+    stock_item_id: uuid.UUID,
+    project_id: uuid.UUID,
+    target_hardware_category: str,
+    target_product_code: str,
+    quantity: int,
+    target_aisle: str | None,
+    target_bay: str | None,
+    target_bin: str | None,
+    performed_by: str,
+) -> InventoryLocationModel:
+    """Transfer `quantity` units from a stock row into a project's inventory.
+
+    Creates an InventoryLocation whose origin is the stock_items row (stock_item_id set,
+    po_line_item_id / receive_line_item_id NULL). The CHECK constraint ck_inventory_locations_has_origin
+    enforces that every row has either a PO origin or a stock origin.
+    """
+    from app.models.project import Project as ProjectModel
+
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if not target_hardware_category:
+        raise ValidationError("target_hardware_category is required", field="target_hardware_category")
+    if not target_product_code:
+        raise ValidationError("target_product_code is required", field="target_product_code")
+    _validate_location_fields(target_aisle, target_bay, target_bin)
+
+    si = get_stock_item(session, stock_item_id)
+    available = si.quantity - (si.deficient_quantity or 0)
+    if quantity > available:
+        raise ValidationError("Allocate quantity exceeds available stock", field="quantity")
+
+    project = session.get(ProjectModel, project_id)
+    if project is None:
+        raise NotFoundError(f"Project {project_id} not found")
+
+    now = datetime.utcnow()
+
+    new_il = InventoryLocationModel(
+        project_id=project_id,
+        po_line_item_id=None,
+        receive_line_item_id=None,
+        stock_item_id=stock_item_id,
+        hardware_category=target_hardware_category,
+        product_code=target_product_code,
+        quantity=quantity,
+        deficient_quantity=0,
+        aisle=target_aisle,
+        bay=target_bay,
+        bin=target_bin,
+        received_at=now,
+    )
+    session.add(new_il)
+
+    si.quantity -= quantity
+    session.flush()
+
+    detail = {
+        "sourceStockItemId": str(stock_item_id),
+        "projectId": str(project_id),
+        "targetHardwareCategory": target_hardware_category,
+        "targetProductCode": target_product_code,
+        "quantity": quantity,
+        "targetLocation": {"aisle": target_aisle, "bay": target_bay, "bin": target_bin},
+        "newInventoryLocationId": str(new_il.id),
+    }
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=si.id,
+        action=AuditAction.ALLOCATE_FROM_STOCK,
+        performed_by=performed_by,
+        detail=detail,
+    )
+    _log_audit_event(
+        session,
+        project_id=project_id,
+        entity_type=AuditEntityType.INVENTORY_LOCATION,
+        entity_id=new_il.id,
+        action=AuditAction.ALLOCATE_FROM_STOCK,
+        performed_by=performed_by,
+        detail=detail,
+    )
+
+    # If the stock row is now empty (and not deficient), delete it
+    if si.quantity == 0 and (si.deficient_quantity or 0) == 0:
+        session.delete(si)
+        session.flush()
+
+    return new_il
+
+
+# ---------------------------------------------------------------------------
+# Events 6 + 7: deficiency report + resolve
+# ---------------------------------------------------------------------------
+
+
+def report_inventory_deficiency(
+    session: Session,
+    *,
+    inventory_location_id: uuid.UUID,
+    quantity: int,
+    reason_text: str | None,
+    performed_by: str,
+) -> InventoryLocationModel:
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+
+    il = session.get(InventoryLocationModel, inventory_location_id)
+    if il is None:
+        raise NotFoundError(f"Inventory location {inventory_location_id} not found")
+
+    new_deficient = (il.deficient_quantity or 0) + quantity
+    if new_deficient > il.quantity:
+        raise ValidationError(
+            "Reported deficient quantity exceeds total quantity on row",
+            field="quantity",
+        )
+    il.deficient_quantity = new_deficient
+
+    _log_audit_event(
+        session,
+        project_id=il.project_id,
+        entity_type=AuditEntityType.INVENTORY_LOCATION,
+        entity_id=il.id,
+        action=AuditAction.REPORT_DEFICIENT,
+        performed_by=performed_by,
+        detail={
+            "quantity": quantity,
+            "newDeficientQuantity": new_deficient,
+            "reasonText": reason_text,
+            "hardwareCategory": il.hardware_category,
+            "productCode": il.product_code,
+        },
+    )
+    return il
+
+
+def report_stock_deficiency(
+    session: Session,
+    *,
+    stock_item_id: uuid.UUID,
+    quantity: int,
+    reason_text: str | None,
+    performed_by: str,
+) -> StockItem:
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+
+    si = get_stock_item(session, stock_item_id)
+    new_deficient = (si.deficient_quantity or 0) + quantity
+    if new_deficient > si.quantity:
+        raise ValidationError(
+            "Reported deficient quantity exceeds total quantity on row",
+            field="quantity",
+        )
+    si.deficient_quantity = new_deficient
+
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=si.id,
+        action=AuditAction.REPORT_DEFICIENT,
+        performed_by=performed_by,
+        detail={
+            "quantity": quantity,
+            "newDeficientQuantity": new_deficient,
+            "reasonText": reason_text,
+            "hardwareCategory": si.hardware_category,
+            "productCode": si.product_code,
+        },
+    )
+    return si
+
+
+def report_deficiency_at_assembly(
+    session: Session,
+    *,
+    sa_opening_item_id: uuid.UUID,
+    source_inventory_location_id: uuid.UUID,
+    quantity: int,
+    reason_text: str | None,
+    performed_by: str,
+):
+    """During SA, bump source InventoryLocation deficient_quantity AND auto-create a replacement
+    pull request item against the same SAR opening.
+
+    Returns (inventory_location, replacement_pull_request_item).
+    """
+    from app.models.enums import PullRequestItemType, PullRequestSource, PullRequestStatus
+    from app.models.pull_request import PullRequest as PullRequestModel
+    from app.models.pull_request import PullRequestItem as PullRequestItemModel
+    from app.models.shop_assembly import ShopAssemblyOpening as SAOpeningModel
+    from app.models.shop_assembly import ShopAssemblyOpeningItem as SAOpeningItemModel
+
+    sa_oi = session.get(SAOpeningItemModel, sa_opening_item_id)
+    if sa_oi is None:
+        raise NotFoundError(f"Shop assembly opening item {sa_opening_item_id} not found")
+
+    il = report_inventory_deficiency(
+        session,
+        inventory_location_id=source_inventory_location_id,
+        quantity=quantity,
+        reason_text=reason_text,
+        performed_by=performed_by,
+    )
+
+    # Pull the parent SAR opening to learn opening_number for the replacement PR item
+    sa_opening = session.get(SAOpeningModel, sa_oi.shop_assembly_opening_id)
+    if sa_opening is None:
+        raise NotFoundError(f"Shop assembly opening {sa_oi.shop_assembly_opening_id} not found")
+
+    sar = sa_opening.shop_assembly_request
+
+    # Find or create an open replacement pull request for this SAR
+    replacement_request_number = f"PR-REPL-{sar.request_number}"
+    existing_pr_stmt = select(PullRequestModel).where(
+        PullRequestModel.request_number == replacement_request_number,
+        PullRequestModel.deleted_at.is_(None),
+        PullRequestModel.status.in_([PullRequestStatus.PENDING, PullRequestStatus.IN_PROGRESS]),
+    )
+    existing_pr = session.scalars(existing_pr_stmt).first()
+    if existing_pr is None:
+        replacement_pr = PullRequestModel(
+            request_number=replacement_request_number,
+            project_id=il.project_id,
+            source=PullRequestSource.SHOP_ASSEMBLY,
+            status=PullRequestStatus.PENDING,
+            requested_by=performed_by,
+        )
+        session.add(replacement_pr)
+        session.flush()
+    else:
+        replacement_pr = existing_pr
+
+    opening_number = sa_opening.opening_number or "REPLACEMENT"
+
+    pri = PullRequestItemModel(
+        pull_request_id=replacement_pr.id,
+        item_type=PullRequestItemType.LOOSE,
+        opening_number=opening_number,
+        hardware_category=il.hardware_category,
+        product_code=il.product_code,
+        requested_quantity=quantity,
+    )
+    session.add(pri)
+    session.flush()
+
+    return (il, pri)
+
+
+def resolve_deficiency(
+    session: Session,
+    *,
+    inventory_location_id: uuid.UUID | None,
+    stock_item_id: uuid.UUID | None,
+    resolution: DeficiencyResolution,
+    quantity: int,
+    reason_text: str | None,
+    rma_reference: str | None,
+    destock_source: DestockSource | None,
+    reviewed_by: str,
+):
+    """Resolve a deficient batch. Exactly one of inventory_location_id / stock_item_id is set."""
+    from app.models.deficiency_review import DeficiencyReview
+
+    if (inventory_location_id is None) == (stock_item_id is None):
+        raise ValidationError(
+            "Exactly one of inventory_location_id / stock_item_id must be provided",
+            field="source",
+        )
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if not reviewed_by:
+        raise ValidationError("reviewed_by is required", field="reviewed_by")
+    if resolution == DeficiencyResolution.RETURN_TO_VENDOR and not rma_reference:
+        raise ValidationError(
+            "rma_reference is required when resolution is RETURN_TO_VENDOR",
+            field="rma_reference",
+        )
+    if resolution == DeficiencyResolution.SEND_TO_STOCK and destock_source is None:
+        # default to DEFICIENT_SWAP for project sources if not specified
+        destock_source = DestockSource.DEFICIENT_SWAP
+
+    resulting_stock_item_id: uuid.UUID | None = None
+    project_for_audit: uuid.UUID | None = None
+    hardware_category: str
+    product_code: str
+
+    if inventory_location_id is not None:
+        il = session.get(InventoryLocationModel, inventory_location_id)
+        if il is None:
+            raise NotFoundError(f"Inventory location {inventory_location_id} not found")
+        if quantity > (il.deficient_quantity or 0):
+            raise ValidationError(
+                "Resolved quantity exceeds current deficient_quantity",
+                field="quantity",
+            )
+        project_for_audit = il.project_id
+        hardware_category = il.hardware_category
+        product_code = il.product_code
+
+        if resolution == DeficiencyResolution.SEND_TO_STOCK:
+            il.quantity -= quantity
+            il.deficient_quantity -= quantity
+            stock_row = _find_or_create_stock_row(
+                session,
+                hardware_category=il.hardware_category,
+                product_code=il.product_code,
+                aisle=il.aisle,
+                bay=il.bay,
+                bin=il.bin,
+                received_at=datetime.utcnow(),
+            )
+            stock_row.quantity += quantity
+            stock_row.deficient_quantity += quantity
+            resulting_stock_item_id = stock_row.id
+        elif resolution == DeficiencyResolution.SCRAP:
+            il.quantity -= quantity
+            il.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.REPAIR:
+            il.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.RETURN_TO_VENDOR:
+            il.quantity -= quantity
+            il.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.LEAVE_AS_DEFICIENT:
+            pass
+
+    else:
+        si = get_stock_item(session, stock_item_id)
+        if quantity > (si.deficient_quantity or 0):
+            raise ValidationError(
+                "Resolved quantity exceeds current deficient_quantity",
+                field="quantity",
+            )
+        hardware_category = si.hardware_category
+        product_code = si.product_code
+
+        if resolution == DeficiencyResolution.SEND_TO_STOCK:
+            # Already on stock — for parity record a re-routing into a (possibly new) row.
+            # Practically, leave on the same row but clear the deficient flag
+            si.deficient_quantity -= quantity
+            resulting_stock_item_id = si.id
+        elif resolution == DeficiencyResolution.SCRAP:
+            si.quantity -= quantity
+            si.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.REPAIR:
+            si.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.RETURN_TO_VENDOR:
+            si.quantity -= quantity
+            si.deficient_quantity -= quantity
+        elif resolution == DeficiencyResolution.LEAVE_AS_DEFICIENT:
+            pass
+
+        # If the row is now empty, delete it
+        if si.quantity == 0 and (si.deficient_quantity or 0) == 0:
+            session.delete(si)
+            session.flush()
+
+    review = DeficiencyReview(
+        inventory_location_id=inventory_location_id,
+        stock_item_id=stock_item_id,
+        resolution=resolution,
+        quantity=quantity,
+        reason_text=reason_text,
+        rma_reference=rma_reference,
+        reviewed_by=reviewed_by,
+        resulting_stock_item_id=resulting_stock_item_id,
+    )
+    session.add(review)
+    session.flush()
+
+    detail = {
+        "resolution": resolution.value,
+        "quantity": quantity,
+        "reasonText": reason_text,
+        "rmaReference": rma_reference,
+        "destockSource": destock_source.value if destock_source else None,
+        "resultingStockItemId": str(resulting_stock_item_id) if resulting_stock_item_id else None,
+        "hardwareCategory": hardware_category,
+        "productCode": product_code,
+    }
+    if inventory_location_id is not None:
+        _log_audit_event(
+            session,
+            project_id=project_for_audit,
+            entity_type=AuditEntityType.INVENTORY_LOCATION,
+            entity_id=inventory_location_id,
+            action=AuditAction.RESOLVE_DEFICIENT,
+            performed_by=reviewed_by,
+            detail=detail,
+        )
+    if stock_item_id is not None:
+        _log_audit_event(
+            session,
+            project_id=None,
+            entity_type=AuditEntityType.STOCK_ITEM,
+            entity_id=stock_item_id,
+            action=AuditAction.RESOLVE_DEFICIENT,
+            performed_by=reviewed_by,
+            detail=detail,
+        )
+
+    return review
+
+
+# ---------------------------------------------------------------------------
+# Deficient items review queue (union of project + stock sources)
+# ---------------------------------------------------------------------------
+
+
+def get_deficient_items(
+    session: Session,
+    project_id: uuid.UUID | None = None,
+    source: DeficientItemSource | None = None,
+) -> list[dict]:
+    rows: list[dict] = []
+
+    if source is None or source == DeficientItemSource.PROJECT_INVENTORY:
+        il_stmt = select(InventoryLocationModel).where(InventoryLocationModel.deficient_quantity > 0)
+        if project_id is not None:
+            il_stmt = il_stmt.where(InventoryLocationModel.project_id == project_id)
+        il_stmt = il_stmt.order_by(
+            InventoryLocationModel.project_id,
+            InventoryLocationModel.hardware_category,
+            InventoryLocationModel.product_code,
+        )
+        for il in session.scalars(il_stmt).all():
+            rows.append(
+                {
+                    "source": DeficientItemSource.PROJECT_INVENTORY,
+                    "inventory_location_id": il.id,
+                    "stock_item_id": None,
+                    "project_id": il.project_id,
+                    "hardware_category": il.hardware_category,
+                    "product_code": il.product_code,
+                    "deficient_quantity": il.deficient_quantity,
+                    "aisle": il.aisle,
+                    "bay": il.bay,
+                    "bin": il.bin,
+                }
+            )
+
+    if (source is None or source == DeficientItemSource.STOCK_POOL) and project_id is None:
+        si_stmt = (
+            select(StockItem)
+            .where(StockItem.deficient_quantity > 0)
+            .order_by(StockItem.hardware_category, StockItem.product_code)
+        )
+        for si in session.scalars(si_stmt).all():
+            rows.append(
+                {
+                    "source": DeficientItemSource.STOCK_POOL,
+                    "inventory_location_id": None,
+                    "stock_item_id": si.id,
+                    "project_id": None,
+                    "hardware_category": si.hardware_category,
+                    "product_code": si.product_code,
+                    "deficient_quantity": si.deficient_quantity,
+                    "aisle": si.aisle,
+                    "bay": si.bay,
+                    "bin": si.bin,
+                }
+            )
+    return rows
+
+
+def get_deficiency_reviews(
+    session: Session,
+    inventory_location_id: uuid.UUID | None = None,
+    stock_item_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> list:
+    from app.models.deficiency_review import DeficiencyReview
+
+    stmt = select(DeficiencyReview).order_by(DeficiencyReview.reviewed_at.desc())
+    if inventory_location_id is not None:
+        stmt = stmt.where(DeficiencyReview.inventory_location_id == inventory_location_id)
+    if stock_item_id is not None:
+        stmt = stmt.where(DeficiencyReview.stock_item_id == stock_item_id)
+    if project_id is not None:
+        # Project-scoped reviews join through inventory_locations
+        il_ids = select(InventoryLocationModel.id).where(InventoryLocationModel.project_id == project_id)
+        stmt = stmt.where(
+            or_(
+                DeficiencyReview.inventory_location_id.in_(il_ids),
+                # also include any review whose resulting stock item came from a project row
+                # (covered by inventory_location_id above; pure stock-side reviews don't have a project)
+            )
+        )
+    return list(session.scalars(stmt).all())
+
+
+# ---------------------------------------------------------------------------
+# Receive-to-stock helper used by receive flow when PO has no project_id
+# ---------------------------------------------------------------------------
+
+
+def receive_into_stock(
+    session: Session,
+    *,
+    hardware_category: str,
+    product_code: str,
+    quantity: int,
+    deficient_quantity: int,
+    aisle: str | None,
+    bay: str | None,
+    bin: str | None,
+    received_at: datetime,
+    received_by: str,
+    po_number: str | None,
+) -> StockItem:
+    """Receive vendor PO directly into the stock pool. Used when PO has no project_id."""
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if deficient_quantity < 0 or deficient_quantity > quantity:
+        raise ValidationError(
+            "deficient_quantity must be 0 <= deficient_quantity <= quantity",
+            field="deficient_quantity",
+        )
+
+    stock_row = _find_or_create_stock_row(
+        session,
+        hardware_category=hardware_category,
+        product_code=product_code,
+        aisle=aisle,
+        bay=bay,
+        bin=bin,
+        received_at=received_at,
+    )
+    stock_row.quantity += quantity
+    stock_row.deficient_quantity += deficient_quantity
+
+    _log_audit_event(
+        session,
+        project_id=None,
+        entity_type=AuditEntityType.STOCK_ITEM,
+        entity_id=stock_row.id,
+        action=AuditAction.RECEIVE,
+        performed_by=received_by,
+        detail={
+            "quantity": quantity,
+            "deficientQuantity": deficient_quantity,
+            "hardwareCategory": hardware_category,
+            "productCode": product_code,
+            "poNumber": po_number,
+            "location": {"aisle": aisle, "bay": bay, "bin": bin},
+        },
+    )
+    return stock_row

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -83,12 +83,15 @@ def get_warehouse_dashboard(session: Session) -> dict:
     now = datetime.utcnow()
     seven_days_ago = now - timedelta(days=7)
 
-    # Total inventory value and item count
+    # Total inventory value and item count — LEFT JOIN since stock-allocated rows have no PO line
     inv_stats = session.execute(
         select(
             func.coalesce(func.sum(InventoryLocationModel.quantity), 0),
-            func.coalesce(func.sum(InventoryLocationModel.quantity * POLineItemModel.unit_cost), 0),
-        ).join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
+            func.coalesce(
+                func.sum(InventoryLocationModel.quantity * func.coalesce(POLineItemModel.unit_cost, 0)),
+                0,
+            ),
+        ).outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
     ).one()
 
     # Unlocated count
@@ -291,8 +294,8 @@ def get_inventory_by_vendor(session: Session, project_id: uuid.UUID | None = Non
     """Group inventory by vendor name (via PO.vendor_id → Vendor), then product_code."""
     stmt = (
         select(InventoryLocationModel, POLineItemModel.unit_cost, VendorModel.name)
-        .join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
-        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
+        .outerjoin(POModel, POLineItemModel.po_id == POModel.id)
         .outerjoin(VendorModel, POModel.vendor_id == VendorModel.id)
     )
     if project_id is not None:
@@ -341,8 +344,8 @@ def get_location_contents(session: Session, aisle: str, bay: str | None = None, 
     # Inventory locations
     inv_stmt = (
         select(InventoryLocationModel, POLineItemModel.unit_cost, POModel.po_number)
-        .join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
-        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
+        .outerjoin(POModel, POLineItemModel.po_id == POModel.id)
         .where(InventoryLocationModel.aisle == aisle, InventoryLocationModel.quantity > 0)
     )
     if bay is not None:
@@ -424,7 +427,7 @@ def get_inventory_hierarchy(session: Session, project_id: uuid.UUID | None = Non
         "total_value": float
     }
     """
-    stmt = select(InventoryLocationModel, POLineItemModel.unit_cost).join(
+    stmt = select(InventoryLocationModel, POLineItemModel.unit_cost).outerjoin(
         POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id
     )
     if project_id is not None:
@@ -438,7 +441,7 @@ def get_inventory_hierarchy(session: Session, project_id: uuid.UUID | None = Non
     # Group by hardware_category -> product_code, storing (il, unit_cost) pairs
     cat_map: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
     for il, unit_cost in rows:
-        cat_map[il.hardware_category][il.product_code].append((il, unit_cost))
+        cat_map[il.hardware_category][il.product_code].append((il, unit_cost or 0))
 
     result = []
     for category in sorted(cat_map.keys()):
@@ -488,8 +491,8 @@ def get_inventory_items(
     """
     stmt = (
         select(InventoryLocationModel, POLineItemModel.classification, POModel.po_number, POLineItemModel.unit_cost)
-        .join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
-        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
+        .outerjoin(POModel, POLineItemModel.po_id == POModel.id)
         .where(
             InventoryLocationModel.hardware_category == category,
             InventoryLocationModel.product_code == product_code,
@@ -504,7 +507,7 @@ def get_inventory_items(
             "inventory_location": row[0],
             "classification": row[1],
             "po_number": row[2],
-            "unit_cost": float(row[3]),
+            "unit_cost": float(row[3]) if row[3] is not None else 0.0,
         }
         for row in rows
     ]
@@ -784,9 +787,8 @@ def create_receive(
     if po is None or po.deleted_at is not None:
         raise NotFoundError(f"Purchase order {po_id} not found")
 
-    # Validate PO has a project (required for inventory locations)
-    if po.project_id is None:
-        raise ValidationError("PO must be associated with a project before receiving", field="project_id")
+    # Project-less PO is allowed: line items route to the stock pool instead of project inventory
+    is_stock_po = po.project_id is None
 
     # Validate PO status
     if po.status not in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED):
@@ -828,6 +830,12 @@ def create_receive(
             for loc in locations:
                 if loc["quantity"] < 1:
                     raise ValidationError("Location quantity must be >= 1", field="quantity")
+                deficient_q = loc.get("deficient_quantity", 0) or 0
+                if deficient_q < 0 or deficient_q > loc["quantity"]:
+                    raise ValidationError(
+                        "deficient_quantity must satisfy 0 <= deficient_quantity <= quantity",
+                        field="deficient_quantity",
+                    )
                 _validate_location_fields(loc["aisle"], loc["bay"], loc["bin"])
 
     # 5. Execute in single transaction
@@ -856,7 +864,40 @@ def create_receive(
 
         locations = li_input["locations"]
         created_inv_locs: list[InventoryLocationModel] = []
-        if locations:
+        if is_stock_po:
+            # Route into the stock pool. Each location becomes (or merges into) a stock_items row.
+            from app.repositories import stock_repository
+
+            if locations:
+                for loc in locations:
+                    stock_repository.receive_into_stock(
+                        session,
+                        hardware_category=poli.hardware_category,
+                        product_code=poli.product_code,
+                        quantity=loc["quantity"],
+                        deficient_quantity=loc.get("deficient_quantity", 0) or 0,
+                        aisle=loc["aisle"],
+                        bay=loc["bay"],
+                        bin=loc["bin"],
+                        received_at=receive_record.received_at,
+                        received_by=received_by,
+                        po_number=po.po_number,
+                    )
+            else:
+                stock_repository.receive_into_stock(
+                    session,
+                    hardware_category=poli.hardware_category,
+                    product_code=poli.product_code,
+                    quantity=li_input["quantity_received"],
+                    deficient_quantity=0,
+                    aisle=None,
+                    bay=None,
+                    bin=None,
+                    received_at=receive_record.received_at,
+                    received_by=received_by,
+                    po_number=po.po_number,
+                )
+        elif locations:
             for loc in locations:
                 inv_loc = InventoryLocationModel(
                     project_id=po.project_id,
@@ -865,6 +906,7 @@ def create_receive(
                     hardware_category=poli.hardware_category,
                     product_code=poli.product_code,
                     quantity=loc["quantity"],
+                    deficient_quantity=loc.get("deficient_quantity", 0) or 0,
                     aisle=loc["aisle"],
                     bay=loc["bay"],
                     bin=loc["bin"],
@@ -1062,7 +1104,7 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
     else:
         locked_inventory = []
 
-    # 4. Check sufficiency
+    # 4. Check sufficiency — only non-deficient (available) units can satisfy a pull
     insufficient = False
     if needed_combos:
         # Group locked inventory by (cat, code)
@@ -1072,7 +1114,7 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
             inv_by_combo[key].append(il)
 
         for (cat, code), requested in needed_combos.items():
-            available = sum(il.quantity for il in inv_by_combo.get((cat, code), []))
+            available = sum(il.quantity - (il.deficient_quantity or 0) for il in inv_by_combo.get((cat, code), []))
             if available < requested:
                 insufficient = True
                 break
@@ -1110,7 +1152,11 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
             for row in rows:
                 if remaining <= 0:
                     break
-                deduct = min(remaining, row.quantity)
+                # Deficient units must stay on the row — only available units can be pulled
+                row_available = row.quantity - (row.deficient_quantity or 0)
+                if row_available <= 0:
+                    continue
+                deduct = min(remaining, row_available)
                 old_qty = row.quantity
                 row.quantity -= deduct
                 remaining -= deduct
@@ -1205,8 +1251,8 @@ def get_unlocated_inventory(session: Session, project_id: uuid.UUID | None = Non
     """
     stmt = (
         select(InventoryLocationModel, POLineItemModel.classification, POModel.po_number, POLineItemModel.unit_cost)
-        .join(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
-        .join(POModel, POLineItemModel.po_id == POModel.id)
+        .outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
+        .outerjoin(POModel, POLineItemModel.po_id == POModel.id)
         .where(
             InventoryLocationModel.aisle.is_(None),
             InventoryLocationModel.bay.is_(None),
@@ -1228,7 +1274,7 @@ def get_unlocated_inventory(session: Session, project_id: uuid.UUID | None = Non
             "inventory_location": row[0],
             "classification": row[1],
             "po_number": row[2],
-            "unit_cost": float(row[3]),
+            "unit_cost": float(row[3]) if row[3] is not None else 0.0,
         }
         for row in rows
     ]

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -15,6 +15,15 @@ from app.models.enums import (
     Classification as ClassificationDB,
 )
 from app.models.enums import (
+    DeficiencyResolution as DeficiencyResolutionDB,
+)
+from app.models.enums import (
+    DeficientItemSource as DeficientItemSourceDB,
+)
+from app.models.enums import (
+    DestockSource as DestockSourceDB,
+)
+from app.models.enums import (
     HardwareItemState as HardwareItemStateDB,
 )
 from app.models.enums import (
@@ -60,6 +69,9 @@ PullStatus = strawberry.enum(PullStatusDB)
 AssemblyStatus = strawberry.enum(AssemblyStatusDB)
 NotificationType = strawberry.enum(NotificationTypeDB)
 PODocumentType = strawberry.enum(PODocumentTypeDB)
+DestockSource = strawberry.enum(DestockSourceDB)
+DeficiencyResolution = strawberry.enum(DeficiencyResolutionDB)
+DeficientItemSource = strawberry.enum(DeficientItemSourceDB)
 
 
 # GraphQL-only enums (not stored in database)

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -1,6 +1,6 @@
 import strawberry
 
-from .enums import Classification, PullRequestItemType
+from .enums import Classification, DeficiencyResolution, DestockSource, PullRequestItemType
 
 
 @strawberry.input
@@ -192,6 +192,7 @@ class LocationInput:
     bay: str
     bin: str
     quantity: int
+    deficient_quantity: int = 0
 
 
 @strawberry.input
@@ -231,3 +232,98 @@ class CompleteOpeningInput:
     aisle: str | None = None
     bay: str | None = None
     bin: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Stock pool + deficiency inputs
+# ---------------------------------------------------------------------------
+
+
+@strawberry.input
+class DestockInventoryInput:
+    inventory_location_id: strawberry.ID
+    quantity: int
+    source: DestockSource
+    reason_text: str | None = None
+    target_aisle: str | None = None
+    target_bay: str | None = None
+    target_bin: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class AllocateStockToProjectInput:
+    stock_item_id: strawberry.ID
+    project_id: strawberry.ID
+    target_hardware_category: str
+    target_product_code: str
+    quantity: int
+    target_aisle: str | None = None
+    target_bay: str | None = None
+    target_bin: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class AdjustStockQuantityInput:
+    stock_item_id: strawberry.ID
+    new_quantity: int
+    reason_text: str
+    performed_by: str = ""
+
+
+@strawberry.input
+class MoveStockLocationInput:
+    stock_item_id: strawberry.ID
+    new_aisle: str
+    new_bay: str
+    new_bin: str
+    performed_by: str = ""
+
+
+@strawberry.input
+class ReclassifyStockItemInput:
+    stock_item_id: strawberry.ID
+    new_hardware_category: str
+    new_product_code: str
+    quantity: int
+    reason_text: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class ReportInventoryDeficiencyInput:
+    inventory_location_id: strawberry.ID
+    quantity: int
+    reason_text: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class ReportStockDeficiencyInput:
+    stock_item_id: strawberry.ID
+    quantity: int
+    reason_text: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class ReportDeficiencyAtAssemblyInput:
+    shop_assembly_opening_item_id: strawberry.ID
+    source_inventory_location_id: strawberry.ID
+    quantity: int
+    reason_text: str | None = None
+    performed_by: str = ""
+
+
+@strawberry.input
+class ResolveDeficiencyInput:
+    # exactly one of inventory_location_id / stock_item_id must be set
+    inventory_location_id: strawberry.ID | None = None
+    stock_item_id: strawberry.ID | None = None
+    resolution: DeficiencyResolution = DeficiencyResolution.LEAVE_AS_DEFICIENT
+    quantity: int = 1
+    reason_text: str | None = None
+    rma_reference: str | None = None
+    destock_source: DestockSource | None = None
+    reviewed_by: str = ""

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -11,6 +11,7 @@ from app.repositories import (
     project_repository,
     shipping_repository,
     shop_assembly_repository,
+    stock_repository,
     user_repository,
     vendor_repository,
     warehouse_layout_repository,
@@ -19,6 +20,8 @@ from app.repositories import (
 
 from .enums import ApproveOutcome, PODocumentType
 from .inputs import (
+    AdjustStockQuantityInput,
+    AllocateStockToProjectInput,
     AssignOpeningsInput,
     CompleteOpeningInput,
     ConfirmShipmentInput,
@@ -26,13 +29,21 @@ from .inputs import (
     CreateProjectInput,
     CreateReceiveInput,
     CreateVendorInput,
+    DestockInventoryInput,
     FinalizeImportSessionInput,
+    MoveStockLocationInput,
+    ReclassifyStockItemInput,
+    ReportDeficiencyAtAssemblyInput,
+    ReportInventoryDeficiencyInput,
+    ReportStockDeficiencyInput,
+    ResolveDeficiencyInput,
     UpdateVendorInput,
 )
 from .queries import (
     _aisle_to_type,
     _bay_to_type,
     _bin_to_type,
+    _deficiency_review_to_type,
     _inventory_location_to_type,
     _notification_to_type,
     _opening_item_to_type,
@@ -41,17 +52,20 @@ from .queries import (
     _po_line_item_to_type,
     _po_to_type,
     _project_to_type,
+    _pull_request_item_to_type,
     _pull_request_to_type,
     _receive_record_to_type,
     _row_to_type,
     _shop_assembly_opening_to_type,
     _shop_assembly_request_to_type,
+    _stock_item_to_type,
     _vendor_to_type,
 )
 from .types import (
     ApproveResult,
     ApproveShopAssemblyResult,
     ClerkUser,
+    DeficiencyReview,
     FinalizeImportResult,
     InventoryLocation,
     Notification,
@@ -62,8 +76,11 @@ from .types import (
     PullRequest,
     PurchaseOrder,
     ReceiveRecord,
+    ReclassifyStockResult,
+    SAReplacementResult,
     ShopAssemblyOpening,
     ShopAssemblyRequest,
+    StockItem,
     Vendor,
     WarehouseAisleType,
     WarehouseBayType,
@@ -476,6 +493,7 @@ class Mutation:
                         "bay": loc.bay,
                         "bin": loc.bin,
                         "quantity": loc.quantity,
+                        "deficient_quantity": loc.deficient_quantity,
                     }
                     for loc in li.locations
                 ],
@@ -1019,3 +1037,161 @@ class Mutation:
             session.commit()
             session.refresh(aisle)
             return _aisle_to_type(aisle)
+
+    # ---------------------------------------------------------------------------
+    # Stock pool + deficiency mutations
+    # ---------------------------------------------------------------------------
+
+    @strawberry.mutation
+    def destock_inventory(self, input: DestockInventoryInput) -> StockItem:
+        with SessionLocal() as session:
+            result = stock_repository.destock_inventory(
+                session,
+                inventory_location_id=uuid.UUID(str(input.inventory_location_id)),
+                quantity=input.quantity,
+                source=input.source,
+                reason_text=input.reason_text,
+                target_aisle=input.target_aisle,
+                target_bay=input.target_bay,
+                target_bin=input.target_bin,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(result)
+            return _stock_item_to_type(result)
+
+    @strawberry.mutation
+    def allocate_stock_to_project(self, input: AllocateStockToProjectInput) -> InventoryLocation:
+        with SessionLocal() as session:
+            result = stock_repository.allocate_stock_to_project(
+                session,
+                stock_item_id=uuid.UUID(str(input.stock_item_id)),
+                project_id=uuid.UUID(str(input.project_id)),
+                target_hardware_category=input.target_hardware_category,
+                target_product_code=input.target_product_code,
+                quantity=input.quantity,
+                target_aisle=input.target_aisle,
+                target_bay=input.target_bay,
+                target_bin=input.target_bin,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(result)
+            return _inventory_location_to_type(result)
+
+    @strawberry.mutation
+    def adjust_stock_quantity(self, input: AdjustStockQuantityInput) -> StockItem:
+        with SessionLocal() as session:
+            result = stock_repository.adjust_stock_quantity(
+                session,
+                stock_item_id=uuid.UUID(str(input.stock_item_id)),
+                new_quantity=input.new_quantity,
+                reason_text=input.reason_text,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(result)
+            return _stock_item_to_type(result)
+
+    @strawberry.mutation
+    def move_stock_location(self, input: MoveStockLocationInput) -> StockItem:
+        with SessionLocal() as session:
+            result = stock_repository.move_stock_location(
+                session,
+                stock_item_id=uuid.UUID(str(input.stock_item_id)),
+                new_aisle=input.new_aisle,
+                new_bay=input.new_bay,
+                new_bin=input.new_bin,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(result)
+            return _stock_item_to_type(result)
+
+    @strawberry.mutation
+    def reclassify_stock_item(self, input: ReclassifyStockItemInput) -> ReclassifyStockResult:
+        with SessionLocal() as session:
+            new_row, original = stock_repository.reclassify_stock_item(
+                session,
+                stock_item_id=uuid.UUID(str(input.stock_item_id)),
+                new_hardware_category=input.new_hardware_category,
+                new_product_code=input.new_product_code,
+                quantity=input.quantity,
+                reason_text=input.reason_text,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(new_row)
+            if original is not None:
+                session.refresh(original)
+            return ReclassifyStockResult(
+                reclassified_stock_item=_stock_item_to_type(new_row),
+                original_stock_item=_stock_item_to_type(original) if original else None,
+            )
+
+    @strawberry.mutation
+    def report_inventory_deficiency(self, input: ReportInventoryDeficiencyInput) -> InventoryLocation:
+        with SessionLocal() as session:
+            il = stock_repository.report_inventory_deficiency(
+                session,
+                inventory_location_id=uuid.UUID(str(input.inventory_location_id)),
+                quantity=input.quantity,
+                reason_text=input.reason_text,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(il)
+            return _inventory_location_to_type(il)
+
+    @strawberry.mutation
+    def report_stock_deficiency(self, input: ReportStockDeficiencyInput) -> StockItem:
+        with SessionLocal() as session:
+            si = stock_repository.report_stock_deficiency(
+                session,
+                stock_item_id=uuid.UUID(str(input.stock_item_id)),
+                quantity=input.quantity,
+                reason_text=input.reason_text,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(si)
+            return _stock_item_to_type(si)
+
+    @strawberry.mutation
+    def report_deficiency_at_assembly(self, input: ReportDeficiencyAtAssemblyInput) -> SAReplacementResult:
+        with SessionLocal() as session:
+            il, pri = stock_repository.report_deficiency_at_assembly(
+                session,
+                sa_opening_item_id=uuid.UUID(str(input.shop_assembly_opening_item_id)),
+                source_inventory_location_id=uuid.UUID(str(input.source_inventory_location_id)),
+                quantity=input.quantity,
+                reason_text=input.reason_text,
+                performed_by=input.performed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(il)
+            session.refresh(pri)
+            return SAReplacementResult(
+                inventory_location=_inventory_location_to_type(il),
+                replacement_pull_request_item=_pull_request_item_to_type(pri),
+            )
+
+    @strawberry.mutation
+    def resolve_deficiency(self, input: ResolveDeficiencyInput) -> DeficiencyReview:
+        with SessionLocal() as session:
+            review = stock_repository.resolve_deficiency(
+                session,
+                inventory_location_id=(
+                    uuid.UUID(str(input.inventory_location_id)) if input.inventory_location_id else None
+                ),
+                stock_item_id=(uuid.UUID(str(input.stock_item_id)) if input.stock_item_id else None),
+                resolution=input.resolution,
+                quantity=input.quantity,
+                reason_text=input.reason_text,
+                rma_reference=input.rma_reference,
+                destock_source=input.destock_source,
+                reviewed_by=input.reviewed_by or "Admin/Manager",
+            )
+            session.commit()
+            session.refresh(review)
+            return _deficiency_review_to_type(review)

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -15,6 +15,7 @@ from app.repositories import (
     po_repository,
     shipping_repository,
     shop_assembly_repository,
+    stock_repository,
     user_repository,
     vendor_repository,
     warehouse_layout_repository,
@@ -23,6 +24,7 @@ from app.repositories import (
 
 from .enums import (
     AuditEntityType,
+    DeficientItemSource,
     POStatus,
     PullRequestSource,
     PullRequestStatus,
@@ -34,6 +36,7 @@ from .types import (
     AuditLogEntry,
     BackOrderedItem,
     ClerkUser,
+    DeficientItemRow,
     HardwareSummaryRow,
     HomeDashboardStats,
     InventoryHierarchyNode,
@@ -79,6 +82,9 @@ from .types import (
     WarehouseRowType,
 )
 from .types import (
+    DeficiencyReview as DeficiencyReviewType,
+)
+from .types import (
     InventoryLocation as InventoryLocationType,
 )
 from .types import (
@@ -89,6 +95,9 @@ from .types import (
 )
 from .types import (
     PackingSlipItem as PackingSlipItemType,
+)
+from .types import (
+    StockItem as StockItemType,
 )
 
 
@@ -277,14 +286,19 @@ def _project_hardware_schedule_to_type(data: dict) -> ProjectHardwareSchedule:
 
 
 def _inventory_location_to_type(il) -> InventoryLocationType:
+    deficient_qty = getattr(il, "deficient_quantity", 0) or 0
+    stock_item_id = getattr(il, "stock_item_id", None)
     return InventoryLocationType(
         id=strawberry.ID(str(il.id)),
         project_id=strawberry.ID(str(il.project_id)),
-        po_line_item_id=strawberry.ID(str(il.po_line_item_id)),
-        receive_line_item_id=strawberry.ID(str(il.receive_line_item_id)),
+        po_line_item_id=strawberry.ID(str(il.po_line_item_id)) if il.po_line_item_id else None,
+        receive_line_item_id=(strawberry.ID(str(il.receive_line_item_id)) if il.receive_line_item_id else None),
+        stock_item_id=strawberry.ID(str(stock_item_id)) if stock_item_id else None,
         hardware_category=il.hardware_category,
         product_code=il.product_code,
         quantity=il.quantity,
+        deficient_quantity=deficient_qty,
+        available=il.quantity - deficient_qty,
         aisle=il.aisle,
         row=il.row,
         bay=il.bay,
@@ -470,6 +484,58 @@ def _bay_to_type(bay) -> WarehouseBayType:
         col_position=bay.col_position,
         is_active=bay.is_active,
         bins=[_bin_to_type(b) for b in getattr(bay, "bins", [])],
+    )
+
+
+def _stock_item_to_type(si) -> StockItemType:
+    deficient_qty = getattr(si, "deficient_quantity", 0) or 0
+    return StockItemType(
+        id=strawberry.ID(str(si.id)),
+        hardware_category=si.hardware_category,
+        product_code=si.product_code,
+        quantity=si.quantity,
+        deficient_quantity=deficient_qty,
+        available=si.quantity - deficient_qty,
+        aisle=si.aisle,
+        bay=si.bay,
+        bin=si.bin,
+        received_at=si.received_at,
+        created_at=si.created_at,
+        updated_at=si.updated_at,
+    )
+
+
+def _deficiency_review_to_type(dr) -> DeficiencyReviewType:
+    return DeficiencyReviewType(
+        id=strawberry.ID(str(dr.id)),
+        inventory_location_id=(strawberry.ID(str(dr.inventory_location_id)) if dr.inventory_location_id else None),
+        stock_item_id=strawberry.ID(str(dr.stock_item_id)) if dr.stock_item_id else None,
+        resolution=dr.resolution,
+        quantity=dr.quantity,
+        reason_text=dr.reason_text,
+        rma_reference=dr.rma_reference,
+        reviewed_by=dr.reviewed_by,
+        reviewed_at=dr.reviewed_at,
+        resulting_stock_item_id=(
+            strawberry.ID(str(dr.resulting_stock_item_id)) if dr.resulting_stock_item_id else None
+        ),
+    )
+
+
+def _deficient_item_row_to_type(row: dict) -> DeficientItemRow:
+    return DeficientItemRow(
+        source=row["source"],
+        inventory_location_id=(
+            strawberry.ID(str(row["inventory_location_id"])) if row["inventory_location_id"] else None
+        ),
+        stock_item_id=strawberry.ID(str(row["stock_item_id"])) if row["stock_item_id"] else None,
+        project_id=strawberry.ID(str(row["project_id"])) if row["project_id"] else None,
+        hardware_category=row["hardware_category"],
+        product_code=row["product_code"],
+        deficient_quantity=row["deficient_quantity"],
+        aisle=row["aisle"],
+        bay=row["bay"],
+        bin=row["bin"],
     )
 
 
@@ -1143,3 +1209,70 @@ class Query:
                 )
                 for s in suggestions
             ]
+
+    # ---------------------------------------------------------------------------
+    # Stock pool + deficiency queries
+    # ---------------------------------------------------------------------------
+
+    @strawberry.field
+    def stock_items(
+        self,
+        product_code_contains: str | None = None,
+        hardware_category: str | None = None,
+        aisle: str | None = None,
+        only_deficient: bool = False,
+    ) -> list[StockItemType]:
+        with SessionLocal() as session:
+            rows = stock_repository.get_stock_items(
+                session,
+                product_code_contains=product_code_contains,
+                hardware_category=hardware_category,
+                aisle=aisle,
+                only_deficient=only_deficient,
+            )
+            return [_stock_item_to_type(r) for r in rows]
+
+    @strawberry.field
+    def stock_item(self, id: strawberry.ID) -> StockItemType | None:
+        with SessionLocal() as session:
+            try:
+                row = stock_repository.get_stock_item(session, uuid.UUID(str(id)))
+            except Exception:
+                return None
+            return _stock_item_to_type(row)
+
+    @strawberry.field
+    def deficient_items(
+        self,
+        project_id: strawberry.ID | None = None,
+        source: DeficientItemSource | None = None,
+    ) -> list[DeficientItemRow]:
+        with SessionLocal() as session:
+            rows = stock_repository.get_deficient_items(
+                session,
+                project_id=uuid.UUID(str(project_id)) if project_id else None,
+                source=source,
+            )
+            return [_deficient_item_row_to_type(r) for r in rows]
+
+    @strawberry.field
+    def deficiency_reviews(
+        self,
+        inventory_location_id: strawberry.ID | None = None,
+        stock_item_id: strawberry.ID | None = None,
+        project_id: strawberry.ID | None = None,
+    ) -> list[DeficiencyReviewType]:
+        with SessionLocal() as session:
+            rows = stock_repository.get_deficiency_reviews(
+                session,
+                inventory_location_id=(uuid.UUID(str(inventory_location_id)) if inventory_location_id else None),
+                stock_item_id=uuid.UUID(str(stock_item_id)) if stock_item_id else None,
+                project_id=uuid.UUID(str(project_id)) if project_id else None,
+            )
+            return [_deficiency_review_to_type(r) for r in rows]
+
+    @strawberry.field
+    def stock_matches_for_opening(self, opening_item_id: strawberry.ID) -> list[StockItemType]:
+        with SessionLocal() as session:
+            rows = stock_repository.get_stock_matches_for_opening(session, uuid.UUID(str(opening_item_id)))
+            return [_stock_item_to_type(r) for r in rows]

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -8,6 +8,8 @@ from .enums import (
     AuditAction,
     AuditEntityType,
     Classification,
+    DeficiencyResolution,
+    DeficientItemSource,
     HardwareItemState,
     NotificationType,
     OpeningItemState,
@@ -227,11 +229,14 @@ class ProjectHardwareSchedule:
 class InventoryLocation:
     id: strawberry.ID
     project_id: strawberry.ID
-    po_line_item_id: strawberry.ID
-    receive_line_item_id: strawberry.ID
+    po_line_item_id: strawberry.ID | None
+    receive_line_item_id: strawberry.ID | None
+    stock_item_id: strawberry.ID | None
     hardware_category: str
     product_code: str
     quantity: int
+    deficient_quantity: int
+    available: int
     aisle: str | None
     row: str | None
     bay: str | None
@@ -619,6 +624,62 @@ class AuditLogEntry:
     detail: strawberry.scalars.JSON | None
     performed_by: str
     created_at: datetime
+
+
+@strawberry.type
+class StockItem:
+    id: strawberry.ID
+    hardware_category: str
+    product_code: str
+    quantity: int
+    deficient_quantity: int
+    available: int
+    aisle: str | None
+    bay: str | None
+    bin: str | None
+    received_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+@strawberry.type
+class DeficiencyReview:
+    id: strawberry.ID
+    inventory_location_id: strawberry.ID | None
+    stock_item_id: strawberry.ID | None
+    resolution: DeficiencyResolution
+    quantity: int
+    reason_text: str | None
+    rma_reference: str | None
+    reviewed_by: str
+    reviewed_at: datetime
+    resulting_stock_item_id: strawberry.ID | None
+
+
+@strawberry.type
+class DeficientItemRow:
+    source: DeficientItemSource
+    inventory_location_id: strawberry.ID | None
+    stock_item_id: strawberry.ID | None
+    project_id: strawberry.ID | None
+    hardware_category: str
+    product_code: str
+    deficient_quantity: int
+    aisle: str | None
+    bay: str | None
+    bin: str | None
+
+
+@strawberry.type
+class ReclassifyStockResult:
+    reclassified_stock_item: "StockItem"
+    original_stock_item: "StockItem | None"
+
+
+@strawberry.type
+class SAReplacementResult:
+    inventory_location: "InventoryLocation"
+    replacement_pull_request_item: "PullRequestItem"
 
 
 @strawberry.type

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -667,3 +667,92 @@ export const CLONE_AISLE = gql`
     }
   }
 `;
+
+// ---------------------------------------------------------------------------
+// Stock pool + deficiency mutations
+// ---------------------------------------------------------------------------
+
+export const DESTOCK_INVENTORY = gql`
+  mutation DestockInventory($input: DestockInventoryInput!) {
+    destockInventory(input: $input) {
+      id hardwareCategory productCode quantity deficientQuantity available
+      aisle bay bin receivedAt
+    }
+  }
+`;
+
+export const ALLOCATE_STOCK_TO_PROJECT = gql`
+  mutation AllocateStockToProject($input: AllocateStockToProjectInput!) {
+    allocateStockToProject(input: $input) {
+      id projectId hardwareCategory productCode quantity deficientQuantity available
+      aisle bay bin receivedAt
+    }
+  }
+`;
+
+export const ADJUST_STOCK_QUANTITY = gql`
+  mutation AdjustStockQuantity($input: AdjustStockQuantityInput!) {
+    adjustStockQuantity(input: $input) {
+      id hardwareCategory productCode quantity deficientQuantity available
+    }
+  }
+`;
+
+export const MOVE_STOCK_LOCATION = gql`
+  mutation MoveStockLocation($input: MoveStockLocationInput!) {
+    moveStockLocation(input: $input) {
+      id aisle bay bin
+    }
+  }
+`;
+
+export const RECLASSIFY_STOCK_ITEM = gql`
+  mutation ReclassifyStockItem($input: ReclassifyStockItemInput!) {
+    reclassifyStockItem(input: $input) {
+      reclassifiedStockItem {
+        id hardwareCategory productCode quantity deficientQuantity available
+        aisle bay bin
+      }
+      originalStockItem {
+        id hardwareCategory productCode quantity deficientQuantity available
+        aisle bay bin
+      }
+    }
+  }
+`;
+
+export const REPORT_INVENTORY_DEFICIENCY = gql`
+  mutation ReportInventoryDeficiency($input: ReportInventoryDeficiencyInput!) {
+    reportInventoryDeficiency(input: $input) {
+      id quantity deficientQuantity available
+    }
+  }
+`;
+
+export const REPORT_STOCK_DEFICIENCY = gql`
+  mutation ReportStockDeficiency($input: ReportStockDeficiencyInput!) {
+    reportStockDeficiency(input: $input) {
+      id quantity deficientQuantity available
+    }
+  }
+`;
+
+export const REPORT_DEFICIENCY_AT_ASSEMBLY = gql`
+  mutation ReportDeficiencyAtAssembly($input: ReportDeficiencyAtAssemblyInput!) {
+    reportDeficiencyAtAssembly(input: $input) {
+      inventoryLocation { id quantity deficientQuantity available }
+      replacementPullRequestItem {
+        id pullRequestId itemType openingNumber hardwareCategory productCode requestedQuantity
+      }
+    }
+  }
+`;
+
+export const RESOLVE_DEFICIENCY = gql`
+  mutation ResolveDeficiency($input: ResolveDeficiencyInput!) {
+    resolveDeficiency(input: $input) {
+      id inventoryLocationId stockItemId resolution quantity reasonText
+      rmaReference reviewedBy reviewedAt resultingStockItemId
+    }
+  }
+`;

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -134,8 +134,8 @@ export const GET_INVENTORY_ITEMS = gql`
   query GetInventoryItems($projectId: ID, $category: String!, $productCode: String!) {
     inventoryItems(projectId: $projectId, category: $category, productCode: $productCode) {
       inventoryLocation {
-        id projectId poLineItemId receiveLineItemId
-        hardwareCategory productCode quantity
+        id projectId poLineItemId receiveLineItemId stockItemId
+        hardwareCategory productCode quantity deficientQuantity available
         aisle row bay bin receivedAt createdAt updatedAt
       }
       poNumber
@@ -780,6 +780,112 @@ export const GET_ADMIN_STATS = gql`
       userCount
       hardwareItemCount
       openingCount
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Stock pool + deficiency
+// ---------------------------------------------------------------------------
+
+export const GET_STOCK_ITEMS = gql`
+  query GetStockItems(
+    $productCodeContains: String
+    $hardwareCategory: String
+    $aisle: String
+    $onlyDeficient: Boolean
+  ) {
+    stockItems(
+      productCodeContains: $productCodeContains
+      hardwareCategory: $hardwareCategory
+      aisle: $aisle
+      onlyDeficient: $onlyDeficient
+    ) {
+      id
+      hardwareCategory
+      productCode
+      quantity
+      deficientQuantity
+      available
+      aisle
+      bay
+      bin
+      receivedAt
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const GET_STOCK_ITEM = gql`
+  query GetStockItem($id: ID!) {
+    stockItem(id: $id) {
+      id
+      hardwareCategory
+      productCode
+      quantity
+      deficientQuantity
+      available
+      aisle
+      bay
+      bin
+      receivedAt
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const GET_DEFICIENT_ITEMS = gql`
+  query GetDeficientItems($projectId: ID, $source: DeficientItemSource) {
+    deficientItems(projectId: $projectId, source: $source) {
+      source
+      inventoryLocationId
+      stockItemId
+      projectId
+      hardwareCategory
+      productCode
+      deficientQuantity
+      aisle
+      bay
+      bin
+    }
+  }
+`;
+
+export const GET_DEFICIENCY_REVIEWS = gql`
+  query GetDeficiencyReviews($inventoryLocationId: ID, $stockItemId: ID, $projectId: ID) {
+    deficiencyReviews(
+      inventoryLocationId: $inventoryLocationId
+      stockItemId: $stockItemId
+      projectId: $projectId
+    ) {
+      id
+      inventoryLocationId
+      stockItemId
+      resolution
+      quantity
+      reasonText
+      rmaReference
+      reviewedBy
+      reviewedAt
+      resultingStockItemId
+    }
+  }
+`;
+
+export const GET_STOCK_MATCHES_FOR_OPENING = gql`
+  query GetStockMatchesForOpening($openingItemId: ID!) {
+    stockMatchesForOpening(openingItemId: $openingItemId) {
+      id
+      hardwareCategory
+      productCode
+      quantity
+      deficientQuantity
+      available
+      aisle
+      bay
+      bin
     }
   }
 `;

--- a/frontend/src/modules/admin/InventoryCorrectionModal.tsx
+++ b/frontend/src/modules/admin/InventoryCorrectionModal.tsx
@@ -26,11 +26,14 @@ import {
 interface InventoryItem {
   id: string;
   projectId: string;
-  poLineItemId: string;
-  receiveLineItemId: string;
+  poLineItemId: string | null;
+  receiveLineItemId: string | null;
+  stockItemId?: string | null;
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  deficientQuantity?: number;
+  available?: number;
   aisle: string | null;
   bay: string | null;
   bin: string | null;

--- a/frontend/src/modules/warehouse/DeficientItemsReview.tsx
+++ b/frontend/src/modules/warehouse/DeficientItemsReview.tsx
@@ -1,0 +1,142 @@
+import { useState, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Chip,
+  Stack,
+  Button,
+  Alert,
+  Card,
+  CardContent,
+  ToggleButtonGroup,
+  ToggleButton,
+} from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery } from '@apollo/client/react';
+import GavelIcon from '@mui/icons-material/Gavel';
+import { GET_DEFICIENT_ITEMS } from '../../graphql/queries';
+import ResolveDeficiencyModal, { type DeficientRow } from './stock/ResolveDeficiencyModal';
+
+type SourceFilter = 'ALL' | 'PROJECT_INVENTORY' | 'STOCK_POOL';
+
+export default function DeficientItemsReview() {
+  const [filter, setFilter] = useState<SourceFilter>('ALL');
+  const [selected, setSelected] = useState<DeficientRow | null>(null);
+
+  const { data, loading, error, refetch } = useQuery<{
+    deficientItems: (DeficientRow & {
+      projectId: string | null;
+      aisle: string | null;
+      bay: string | null;
+      bin: string | null;
+    })[];
+  }>(GET_DEFICIENT_ITEMS, {
+    variables: { source: filter === 'ALL' ? null : filter },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const rows = useMemo(() => data?.deficientItems ?? [], [data]);
+
+  const columns: GridColDef[] = [
+    {
+      field: 'source',
+      headerName: 'Source',
+      width: 160,
+      renderCell: ({ row }) => (
+        <Chip
+          size="small"
+          label={row.source === 'PROJECT_INVENTORY' ? 'project' : 'stock pool'}
+          color={row.source === 'PROJECT_INVENTORY' ? 'primary' : 'default'}
+        />
+      ),
+    },
+    { field: 'hardwareCategory', headerName: 'Category', flex: 1, minWidth: 140 },
+    { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 140 },
+    {
+      field: 'deficientQuantity',
+      headerName: 'Deficient',
+      width: 110,
+      type: 'number',
+      renderCell: ({ row }) => <Chip label={row.deficientQuantity} color="warning" size="small" />,
+    },
+    {
+      field: 'location',
+      headerName: 'Location',
+      flex: 1,
+      minWidth: 160,
+      valueGetter: (_v, row) =>
+        [row.aisle, row.bay, row.bin].filter(Boolean).join(' / ') || '— Unlocated —',
+    },
+    {
+      field: 'actions',
+      headerName: 'Resolve',
+      width: 130,
+      sortable: false,
+      filterable: false,
+      renderCell: ({ row }) => (
+        <Button
+          size="small"
+          startIcon={<GavelIcon />}
+          variant="outlined"
+          onClick={() => setSelected(row as DeficientRow)}
+        >
+          Resolve
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Typography variant="h5">Deficient Items Review</Typography>
+        <ToggleButtonGroup
+          value={filter}
+          exclusive
+          onChange={(_, v) => v && setFilter(v)}
+          size="small"
+        >
+          <ToggleButton value="ALL">All</ToggleButton>
+          <ToggleButton value="PROJECT_INVENTORY">Project</ToggleButton>
+          <ToggleButton value="STOCK_POOL">Stock</ToggleButton>
+        </ToggleButtonGroup>
+      </Stack>
+
+      {error && <Alert severity="error">{error.message}</Alert>}
+
+      {rows.length === 0 && !loading ? (
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="h6">No deficient items pending review</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Deficient items appear here when they're flagged during receiving, shop assembly, or
+              directly from the stock pool. Resolving moves them out of this queue.
+            </Typography>
+          </CardContent>
+        </Card>
+      ) : (
+        <Box sx={{ height: 'calc(100vh - 320px)' }}>
+          <DataGrid
+            rows={rows.map((r, i) => ({ ...r, id: `${r.inventoryLocationId ?? r.stockItemId ?? i}` }))}
+            columns={columns}
+            loading={loading}
+            disableRowSelectionOnClick
+            pageSizeOptions={[25, 50, 100]}
+            initialState={{ pagination: { paginationModel: { pageSize: 50 } } }}
+          />
+        </Box>
+      )}
+
+      {selected && (
+        <ResolveDeficiencyModal
+          row={selected}
+          onClose={() => setSelected(null)}
+          onSuccess={() => {
+            setSelected(null);
+            refetch();
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -13,27 +13,34 @@ import {
   CircularProgress,
   Alert,
   Button,
+  Chip,
   ToggleButton,
   ToggleButtonGroup,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
-import { useQuery, useLazyQuery } from '@apollo/client/react';
+import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
 import { GET_INVENTORY_HIERARCHY, GET_INVENTORY_ITEMS, GET_INVENTORY_BY_VENDOR } from '../../graphql/queries';
+import { REPORT_INVENTORY_DEFICIENCY } from '../../graphql/mutations';
 import { useIdentity } from '../../hooks/useIdentity';
+import { useToast } from '../../components/Toast';
 import InventoryCorrectionModal from '../admin/InventoryCorrectionModal';
 import AuditHistoryDrawer from './AuditHistoryDrawer';
 import ProjectProgressDashboard from './ProjectProgressDashboard';
 import SpotCheckModal from './SpotCheckModal';
+import DestockInventoryModal from './stock/DestockInventoryModal';
 
 interface InventoryItem {
   id: string;
   projectId: string;
-  poLineItemId: string;
-  receiveLineItemId: string;
+  poLineItemId: string | null;
+  receiveLineItemId: string | null;
+  stockItemId: string | null;
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  deficientQuantity: number;
+  available: number;
   aisle: string | null;
   bay: string | null;
   bin: string | null;
@@ -97,6 +104,18 @@ const baseDetailColumns: GridColDef[] = [
   { field: 'productCode', headerName: 'Product Code', flex: 1 },
   { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
   { field: 'quantity', headerName: 'Quantity', flex: 0.5, type: 'number' },
+  {
+    field: 'deficient',
+    headerName: 'Deficient',
+    flex: 0.5,
+    type: 'number',
+    valueGetter: (_v: unknown, row: InventoryItemDetail) =>
+      row.inventoryLocation.deficientQuantity ?? 0,
+    renderCell: (params: { row: InventoryItemDetail }) => {
+      const dq = params.row.inventoryLocation.deficientQuantity ?? 0;
+      return dq > 0 ? <Chip label={dq} color="warning" size="small" /> : <span>0</span>;
+    },
+  },
   {
     field: 'unitCost',
     headerName: 'Unit Cost',
@@ -169,6 +188,19 @@ function ProductCodeDetail({
   const [spotCheckItem, setSpotCheckItem] = useState<InventoryItem | null>(null);
   const [spotCheckOpen, setSpotCheckOpen] = useState(false);
 
+  // Destock modal
+  const [destockItem, setDestockItem] = useState<InventoryItem | null>(null);
+
+  // Report deficient — uses prompt for the qty (lightweight; can be upgraded later)
+  const { showToast } = useToast();
+  const [reportDeficient] = useMutation(REPORT_INVENTORY_DEFICIENCY, {
+    onCompleted: () => {
+      showToast('Deficient quantity flagged on row', 'success');
+      fetchItems({ variables: { projectId, category, productCode } });
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
   const handleExpand = useCallback(
     (_event: React.SyntheticEvent, isExpanded: boolean) => {
       setExpanded(isExpanded);
@@ -232,7 +264,71 @@ function ProductCodeDetail({
         </Button>
       ),
     };
-    if (!isAdmin) return [...baseDetailColumns, spotCheckCol, historyCol];
+    const destockCol: GridColDef = {
+      field: 'destock',
+      headerName: '',
+      width: 100,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: { row: InventoryItemDetail }) => (
+        <Button
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation();
+            setDestockItem(params.row.inventoryLocation);
+          }}
+          disabled={params.row.inventoryLocation.quantity <= 0}
+        >
+          Destock
+        </Button>
+      ),
+    };
+    const reportDefCol: GridColDef = {
+      field: 'reportDeficient',
+      headerName: '',
+      width: 110,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: { row: InventoryItemDetail }) => (
+        <Button
+          size="small"
+          color="warning"
+          onClick={(e) => {
+            e.stopPropagation();
+            const il = params.row.inventoryLocation;
+            const avail = il.available ?? il.quantity - (il.deficientQuantity ?? 0);
+            if (avail <= 0) {
+              showToast('Nothing left to flag — all units already deficient', 'info');
+              return;
+            }
+            const input = window.prompt(`Flag how many of ${il.productCode} as deficient? (max ${avail})`, '1');
+            if (!input) return;
+            const q = Number(input);
+            if (!Number.isInteger(q) || q < 1 || q > avail) {
+              showToast('Invalid quantity', 'error');
+              return;
+            }
+            const reason = window.prompt('Reason (optional)', '') || null;
+            reportDeficient({
+              variables: {
+                input: {
+                  inventoryLocationId: il.id,
+                  quantity: q,
+                  reasonText: reason,
+                  performedBy: 'Warehouse',
+                },
+              },
+            });
+          }}
+          disabled={
+            (params.row.inventoryLocation.available ?? params.row.inventoryLocation.quantity) <= 0
+          }
+        >
+          Flag Deficient
+        </Button>
+      ),
+    };
+    if (!isAdmin) return [...baseDetailColumns, destockCol, reportDefCol, spotCheckCol, historyCol];
     return [
       ...baseDetailColumns,
       {
@@ -255,10 +351,12 @@ function ProductCodeDetail({
           </Button>
         ),
       } satisfies GridColDef,
+      destockCol,
+      reportDefCol,
       spotCheckCol,
       historyCol,
     ];
-  }, [isAdmin]);
+  }, [isAdmin, reportDeficient, showToast]);
 
   const handleCorrectionSuccess = useCallback(() => {
     fetchItems({
@@ -339,6 +437,17 @@ function ProductCodeDetail({
           }}
           item={spotCheckItem}
           onSuccess={handleCorrectionSuccess}
+        />
+      )}
+
+      {destockItem && (
+        <DestockInventoryModal
+          inventoryLocation={destockItem}
+          onClose={() => setDestockItem(null)}
+          onSuccess={() => {
+            setDestockItem(null);
+            handleCorrectionSuccess();
+          }}
         />
       )}
     </>

--- a/frontend/src/modules/warehouse/OpeningItemsTab.tsx
+++ b/frontend/src/modules/warehouse/OpeningItemsTab.tsx
@@ -20,6 +20,7 @@ import { GET_OPENING_ITEMS, GET_OPENING_ITEM_DETAILS } from '../../graphql/queri
 import Modal from '../../components/Modal';
 import { useIdentity } from '../../hooks/useIdentity';
 import InventoryCorrectionModal from '../admin/InventoryCorrectionModal';
+import FindInStockButton from './stock/FindInStockButton';
 
 interface InstalledHardware {
   id: string;
@@ -204,8 +205,8 @@ function OpeningItemDetailModal({
               </Box>
             </Box>
 
-            {isAdmin && (
-              <Box sx={{ mb: 3 }}>
+            <Box sx={{ mb: 3, display: 'flex', gap: 1 }}>
+              {isAdmin && (
                 <Button
                   variant="outlined"
                   size="small"
@@ -213,8 +214,15 @@ function OpeningItemDetailModal({
                 >
                   Correction
                 </Button>
-              </Box>
-            )}
+              )}
+              <FindInStockButton
+                openingItemId={openingItem.id}
+                projectId={openingItem.projectId}
+                defaultCategory={hardware[0]?.hardwareCategory}
+                defaultProductCode={hardware[0]?.productCode}
+                onAllocated={handleCorrectionSuccess}
+              />
+            </Box>
 
             <Typography variant="h6" sx={{ mb: 1 }}>
               Installed Hardware

--- a/frontend/src/modules/warehouse/ReceivingPage.tsx
+++ b/frontend/src/modules/warehouse/ReceivingPage.tsx
@@ -35,7 +35,7 @@ interface OpenPOLineItem {
 interface OpenPO {
   id: string;
   poNumber: string | null;
-  projectId: string;
+  projectId: string | null;
   status: string;
   vendor: { id: string; name: string } | null;
   orderedAt: string | null;
@@ -176,7 +176,7 @@ export default function ReceivingPage() {
           id: po.id,
           poNumber: po.poNumber ?? '\u2014',
           vendorName: po.vendor?.name ?? '\u2014',
-          projectName: projectMap.get(po.projectId) ?? '\u2014',
+          projectName: po.projectId ? (projectMap.get(po.projectId) ?? '\u2014') : 'Stock PO',
           expectedDeliveryDate: po.expectedDeliveryDate,
           pendingLines,
           pendingQty,

--- a/frontend/src/modules/warehouse/StockPoolView.tsx
+++ b/frontend/src/modules/warehouse/StockPoolView.tsx
@@ -1,0 +1,261 @@
+import { useState, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  Chip,
+  IconButton,
+  Tooltip,
+  Stack,
+  Button,
+  Alert,
+  Card,
+  CardContent,
+} from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery } from '@apollo/client/react';
+import EditIcon from '@mui/icons-material/Edit';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import { GET_STOCK_ITEMS } from '../../graphql/queries';
+import AdjustStockModal from './stock/AdjustStockModal';
+import MoveStockLocationModal from './stock/MoveStockLocationModal';
+import ReclassifyStockModal from './stock/ReclassifyStockModal';
+import AllocateStockModal from './stock/AllocateStockModal';
+import ReportStockDeficiencyModal from './stock/ReportStockDeficiencyModal';
+
+export interface StockItem {
+  id: string;
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+  deficientQuantity: number;
+  available: number;
+  aisle: string | null;
+  bay: string | null;
+  bin: string | null;
+  receivedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function StockPoolView() {
+  const [productCodeFilter, setProductCodeFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [onlyDeficient, setOnlyDeficient] = useState(false);
+  const [selected, setSelected] = useState<StockItem | null>(null);
+  const [modal, setModal] = useState<
+    'adjust' | 'move' | 'reclassify' | 'allocate' | 'report-deficient' | null
+  >(null);
+
+  const { data, loading, error, refetch } = useQuery<{ stockItems: StockItem[] }>(
+    GET_STOCK_ITEMS,
+    {
+      variables: {
+        productCodeContains: productCodeFilter || null,
+        hardwareCategory: categoryFilter || null,
+        onlyDeficient,
+      },
+      fetchPolicy: 'cache-and-network',
+    },
+  );
+
+  const rows = useMemo(() => data?.stockItems ?? [], [data]);
+
+  const closeModal = () => {
+    setModal(null);
+    setSelected(null);
+  };
+
+  const onSuccess = () => {
+    closeModal();
+    refetch();
+  };
+
+  const columns: GridColDef<StockItem>[] = [
+    { field: 'hardwareCategory', headerName: 'Category', flex: 1, minWidth: 140 },
+    { field: 'productCode', headerName: 'Product Code', flex: 1, minWidth: 140 },
+    {
+      field: 'quantity',
+      headerName: 'Qty',
+      width: 80,
+      type: 'number',
+    },
+    {
+      field: 'deficientQuantity',
+      headerName: 'Deficient',
+      width: 100,
+      type: 'number',
+      renderCell: ({ row }) =>
+        row.deficientQuantity > 0 ? (
+          <Chip label={row.deficientQuantity} color="warning" size="small" />
+        ) : (
+          <span>0</span>
+        ),
+    },
+    {
+      field: 'available',
+      headerName: 'Available',
+      width: 100,
+      type: 'number',
+    },
+    {
+      field: 'location',
+      headerName: 'Location',
+      flex: 1,
+      minWidth: 160,
+      valueGetter: (_value, row) =>
+        [row.aisle, row.bay, row.bin].filter(Boolean).join(' / ') || '— Unlocated —',
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 280,
+      sortable: false,
+      filterable: false,
+      renderCell: ({ row }) => (
+        <Stack direction="row" spacing={0.5}>
+          <Tooltip title="Allocate to project">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('allocate');
+              }}
+              disabled={row.available <= 0}
+            >
+              <OpenInFullIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Adjust quantity">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('adjust');
+              }}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Move location">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('move');
+              }}
+            >
+              <LocationOnIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Reclassify (split-capable)">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('reclassify');
+              }}
+            >
+              <CallSplitIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Report deficient">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('report-deficient');
+              }}
+              disabled={row.available <= 0}
+            >
+              <ReportProblemIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      ),
+    },
+  ];
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Typography variant="h5">Stock Pool</Typography>
+        <Button
+          variant={onlyDeficient ? 'contained' : 'outlined'}
+          color="warning"
+          startIcon={<ReportProblemIcon />}
+          onClick={() => setOnlyDeficient((v) => !v)}
+        >
+          {onlyDeficient ? 'Showing deficient only' : 'Show deficient only'}
+        </Button>
+      </Stack>
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <TextField
+          label="Product code contains"
+          size="small"
+          value={productCodeFilter}
+          onChange={(e) => setProductCodeFilter(e.target.value)}
+        />
+        <TextField
+          label="Hardware category"
+          size="small"
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+        />
+      </Stack>
+
+      {error && <Alert severity="error">{error.message}</Alert>}
+
+      {rows.length === 0 && !loading ? (
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="h6">Nothing in the stock pool yet</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Items arrive in stock by being destocked from a project's inventory, by being received
+              from a PO that has no project assignment, or as the outcome of a deficiency review
+              that sent items here.
+            </Typography>
+            <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+              <Chip size="small" label="destock from project" />
+              <Chip size="small" label="receive stock PO" />
+              <Chip size="small" label="resolve deficient → stock" />
+            </Stack>
+          </CardContent>
+        </Card>
+      ) : (
+        <Box sx={{ height: 'calc(100vh - 320px)' }}>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            getRowId={(r) => r.id}
+            loading={loading}
+            disableRowSelectionOnClick
+            pageSizeOptions={[25, 50, 100]}
+            initialState={{ pagination: { paginationModel: { pageSize: 50 } } }}
+          />
+        </Box>
+      )}
+
+      {selected && modal === 'adjust' && (
+        <AdjustStockModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+      {selected && modal === 'move' && (
+        <MoveStockLocationModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+      {selected && modal === 'reclassify' && (
+        <ReclassifyStockModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+      {selected && modal === 'allocate' && (
+        <AllocateStockModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+      {selected && modal === 'report-deficient' && (
+        <ReportStockDeficiencyModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+    </Box>
+  );
+}
+

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -7,6 +7,8 @@ import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import DownloadIcon from '@mui/icons-material/Download';
 import MoveToInboxIcon from '@mui/icons-material/MoveToInbox';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import WarehouseIcon from '@mui/icons-material/Warehouse';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import { useNavigate } from 'react-router-dom';
 import DashboardCards from './DashboardCards';
 import WarehouseMap from './WarehouseMap';
@@ -37,6 +39,8 @@ const SUB_ROUTES = [
   { label: 'Receiving', path: '/app/warehouse/receiving', icon: <DownloadIcon fontSize="large" /> },
   { label: 'Put Away', path: '/app/warehouse/put-away', icon: <MoveToInboxIcon fontSize="large" /> },
   { label: 'Pull Requests', path: '/app/warehouse/pull-requests', icon: <AssignmentIcon fontSize="large" /> },
+  { label: 'Stock Pool', path: '/app/warehouse/stock-pool', icon: <WarehouseIcon fontSize="large" /> },
+  { label: 'Deficient Items', path: '/app/warehouse/deficient-items', icon: <ReportProblemIcon fontSize="large" /> },
 ];
 
 export default function WarehouseLanding() {

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -8,6 +8,8 @@ import LocationsTab from './LocationsTab';
 import ReceivingPage from './ReceivingPage';
 import PullRequestQueue from './PullRequestQueue';
 import PutAwayTab from './PutAwayTab';
+import StockPoolView from './StockPoolView';
+import DeficientItemsReview from './DeficientItemsReview';
 import BackToModule from '../../components/BackToModule';
 
 function WarehouseSubLayout({ children }: { children: ReactNode }) {
@@ -29,6 +31,8 @@ export default function WarehouseModule() {
       <Route path="receiving" element={<WarehouseSubLayout><ReceivingPage /></WarehouseSubLayout>} />
       <Route path="put-away" element={<WarehouseSubLayout><PutAwayTab /></WarehouseSubLayout>} />
       <Route path="pull-requests" element={<WarehouseSubLayout><PullRequestQueue /></WarehouseSubLayout>} />
+      <Route path="stock-pool" element={<WarehouseSubLayout><StockPoolView /></WarehouseSubLayout>} />
+      <Route path="deficient-items" element={<WarehouseSubLayout><DeficientItemsReview /></WarehouseSubLayout>} />
       <Route path="*" element={<Navigate to="" replace />} />
     </Routes>
   );

--- a/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Button, Stack, TextField, Alert } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { ADJUST_STOCK_QUANTITY } from '../../../graphql/mutations';
+import type { StockItem } from '../StockPoolView';
+
+interface Props {
+  item: StockItem;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function AdjustStockModal({ item, onClose, onSuccess }: Props) {
+  const [newQuantity, setNewQuantity] = useState<string>(String(item.quantity));
+  const [reason, setReason] = useState('');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(ADJUST_STOCK_QUANTITY, {
+    onCompleted: () => {
+      showToast('Stock quantity adjusted', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const newQ = Number(newQuantity);
+  const valid =
+    Number.isInteger(newQ) && newQ >= 0 && reason.trim().length > 0 && newQ !== item.quantity;
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          stockItemId: item.id,
+          newQuantity: newQ,
+          reasonText: reason.trim(),
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Adjust stock — ${item.hardwareCategory} / ${item.productCode}`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Apply
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <TextField
+          label="Current quantity"
+          value={item.quantity}
+          InputProps={{ readOnly: true }}
+          size="small"
+        />
+        <TextField
+          label="New quantity (absolute)"
+          type="number"
+          value={newQuantity}
+          onChange={(e) => setNewQuantity(e.target.value)}
+          size="small"
+          inputProps={{ min: item.deficientQuantity }}
+          helperText={
+            item.deficientQuantity > 0
+              ? `Cannot drop below current deficient (${item.deficientQuantity})`
+              : null
+          }
+        />
+        <TextField
+          label="Reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          multiline
+          minRows={2}
+          required
+          placeholder="e.g. cycle count, write-off, found extras"
+        />
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import {
+  Button,
+  Stack,
+  TextField,
+  Alert,
+  Typography,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@mui/material';
+import { useMutation, useQuery } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { ALLOCATE_STOCK_TO_PROJECT } from '../../../graphql/mutations';
+import { GET_PROJECTS } from '../../../graphql/queries';
+import type { StockItem } from '../StockPoolView';
+
+interface Project {
+  id: string;
+  projectId: string;
+  description: string | null;
+}
+
+interface Props {
+  item: StockItem;
+  onClose: () => void;
+  onSuccess: () => void;
+  prefillProjectId?: string;
+  prefillCategory?: string;
+  prefillProductCode?: string;
+}
+
+export default function AllocateStockModal({
+  item,
+  onClose,
+  onSuccess,
+  prefillProjectId,
+  prefillCategory,
+  prefillProductCode,
+}: Props) {
+  const [projectId, setProjectId] = useState(prefillProjectId ?? '');
+  const [category, setCategory] = useState(prefillCategory ?? item.hardwareCategory);
+  const [productCode, setProductCode] = useState(prefillProductCode ?? item.productCode);
+  const [quantity, setQuantity] = useState<string>('1');
+  const [aisle, setAisle] = useState('');
+  const [bay, setBay] = useState('');
+  const [bin, setBin] = useState('');
+  const { showToast } = useToast();
+
+  const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
+  const [mutate, { loading, error }] = useMutation(ALLOCATE_STOCK_TO_PROJECT, {
+    onCompleted: () => {
+      showToast('Stock allocated to project inventory', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const valid =
+    projectId &&
+    category.trim() &&
+    productCode.trim() &&
+    Number.isInteger(q) &&
+    q >= 1 &&
+    q <= item.available;
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          stockItemId: item.id,
+          projectId,
+          targetHardwareCategory: category.trim(),
+          targetProductCode: productCode.trim(),
+          quantity: q,
+          targetAisle: aisle.trim() || null,
+          targetBay: bay.trim() || null,
+          targetBin: bin.trim() || null,
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Allocate ${item.productCode} to a project`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Allocate
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          Source: <b>{item.hardwareCategory}</b> / <b>{item.productCode}</b> (available{' '}
+          {item.available})
+        </Typography>
+        <FormControl size="small" required>
+          <InputLabel>Target project</InputLabel>
+          <Select
+            label="Target project"
+            value={projectId}
+            onChange={(e) => setProjectId(e.target.value)}
+          >
+            {(projectsData?.projects ?? []).map((p) => (
+              <MenuItem key={p.id} value={p.id}>
+                {p.description || p.projectId}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Target hardware category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            fullWidth
+            required
+          />
+          <TextField
+            label="Target product code"
+            value={productCode}
+            onChange={(e) => setProductCode(e.target.value)}
+            fullWidth
+            required
+          />
+        </Stack>
+        <TextField
+          label={`Quantity (max ${item.available})`}
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          required
+          inputProps={{ min: 1, max: item.available }}
+        />
+        <Typography variant="body2" color="text.secondary">
+          Optional: pre-locate the new inventory row at a specific bin (leave blank for unlocated).
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <TextField label="Aisle" value={aisle} onChange={(e) => setAisle(e.target.value)} />
+          <TextField label="Bay" value={bay} onChange={(e) => setBay(e.target.value)} />
+          <TextField label="Bin" value={bin} onChange={(e) => setBin(e.target.value)} />
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
+++ b/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import {
+  Button,
+  Stack,
+  TextField,
+  Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { DESTOCK_INVENTORY } from '../../../graphql/mutations';
+
+export interface DestockSource {
+  id: string;
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+  deficientQuantity?: number;
+  aisle: string | null;
+  bay: string | null;
+  bin: string | null;
+}
+
+interface Props {
+  inventoryLocation: DestockSource;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const SOURCES = [
+  { value: 'CANCELLATION', label: 'Cancellation / schedule change' },
+  { value: 'DEFICIENT_SWAP', label: 'Deficient swap' },
+  { value: 'OVERAGE', label: 'Overage' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+export default function DestockInventoryModal({ inventoryLocation, onClose, onSuccess }: Props) {
+  const [quantity, setQuantity] = useState<string>('1');
+  const [source, setSource] = useState<string>('OVERAGE');
+  const [reason, setReason] = useState('');
+  const [overrideLoc, setOverrideLoc] = useState(false);
+  const [aisle, setAisle] = useState('');
+  const [bay, setBay] = useState('');
+  const [bin, setBin] = useState('');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(DESTOCK_INVENTORY, {
+    onCompleted: () => {
+      showToast('Inventory destocked to the stock pool', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const valid =
+    Number.isInteger(q) &&
+    q >= 1 &&
+    q <= inventoryLocation.quantity &&
+    (source !== 'DEFICIENT_SWAP' || q <= (inventoryLocation.deficientQuantity ?? 0));
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          inventoryLocationId: inventoryLocation.id,
+          quantity: q,
+          source,
+          reasonText: reason.trim() || null,
+          targetAisle: overrideLoc ? aisle.trim() || null : null,
+          targetBay: overrideLoc ? bay.trim() || null : null,
+          targetBin: overrideLoc ? bin.trim() || null : null,
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Destock ${inventoryLocation.productCode} to stock pool`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Destock
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          Source row: {inventoryLocation.hardwareCategory} / {inventoryLocation.productCode} at{' '}
+          {[inventoryLocation.aisle, inventoryLocation.bay, inventoryLocation.bin]
+            .filter(Boolean)
+            .join(' / ') || 'unlocated'}{' '}
+          (qty {inventoryLocation.quantity})
+        </Typography>
+        <TextField
+          label={`Quantity (max ${inventoryLocation.quantity})`}
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          required
+          inputProps={{ min: 1, max: inventoryLocation.quantity }}
+        />
+        <FormControl size="small" required>
+          <InputLabel>Source</InputLabel>
+          <Select label="Source" value={source} onChange={(e) => setSource(e.target.value)}>
+            {SOURCES.map((s) => (
+              <MenuItem key={s.value} value={s.value}>
+                {s.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          label="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        <Button size="small" onClick={() => setOverrideLoc((v) => !v)}>
+          {overrideLoc ? 'Use source bin' : 'Override target bin'}
+        </Button>
+        {overrideLoc && (
+          <Stack direction="row" spacing={2}>
+            <TextField label="Aisle" value={aisle} onChange={(e) => setAisle(e.target.value)} />
+            <TextField label="Bay" value={bay} onChange={(e) => setBay(e.target.value)} />
+            <TextField label="Bin" value={bin} onChange={(e) => setBin(e.target.value)} />
+          </Stack>
+        )}
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/FindInStockButton.tsx
+++ b/frontend/src/modules/warehouse/stock/FindInStockButton.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import {
+  Button,
+  Stack,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Alert,
+  CircularProgress,
+  Box,
+} from '@mui/material';
+import { useLazyQuery } from '@apollo/client/react';
+import SearchIcon from '@mui/icons-material/Search';
+import Modal from '../../../components/Modal';
+import { GET_STOCK_MATCHES_FOR_OPENING } from '../../../graphql/queries';
+import AllocateStockModal from './AllocateStockModal';
+import type { StockItem } from '../StockPoolView';
+
+interface Props {
+  openingItemId: string;
+  projectId: string;
+  defaultCategory?: string;
+  defaultProductCode?: string;
+  onAllocated?: () => void;
+}
+
+export default function FindInStockButton({
+  openingItemId,
+  projectId,
+  defaultCategory,
+  defaultProductCode,
+  onAllocated,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [allocateItem, setAllocateItem] = useState<StockItem | null>(null);
+
+  const [fetchMatches, { data, loading, error }] = useLazyQuery<{
+    stockMatchesForOpening: StockItem[];
+  }>(GET_STOCK_MATCHES_FOR_OPENING, {
+    fetchPolicy: 'network-only',
+  });
+
+  const handleOpen = () => {
+    setOpen(true);
+    fetchMatches({ variables: { openingItemId } });
+  };
+
+  const matches = data?.stockMatchesForOpening ?? [];
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<SearchIcon />}
+        onClick={handleOpen}
+      >
+        Find in Stock
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Stock pool matches for this opening"
+      >
+        <Stack spacing={2}>
+          {loading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
+          {error && <Alert severity="error">{error.message}</Alert>}
+          {!loading && matches.length === 0 && (
+            <Typography color="text.secondary">
+              No matching stock-pool items found for this opening.
+            </Typography>
+          )}
+          {matches.length > 0 && (
+            <TableContainer component={Paper} variant="outlined">
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Category</TableCell>
+                    <TableCell>Product Code</TableCell>
+                    <TableCell align="right">Available</TableCell>
+                    <TableCell>Location</TableCell>
+                    <TableCell />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {matches.map((m) => (
+                    <TableRow key={m.id}>
+                      <TableCell>{m.hardwareCategory}</TableCell>
+                      <TableCell>{m.productCode}</TableCell>
+                      <TableCell align="right">{m.available}</TableCell>
+                      <TableCell>
+                        {[m.aisle, m.bay, m.bin].filter(Boolean).join(' / ') || '— unlocated —'}
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          disabled={m.available <= 0}
+                          onClick={() => {
+                            setAllocateItem(m);
+                            setOpen(false);
+                          }}
+                        >
+                          Allocate
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Stack>
+      </Modal>
+
+      {allocateItem && (
+        <AllocateStockModal
+          item={allocateItem}
+          onClose={() => setAllocateItem(null)}
+          onSuccess={() => {
+            setAllocateItem(null);
+            onAllocated?.();
+          }}
+          prefillProjectId={projectId}
+          prefillCategory={defaultCategory}
+          prefillProductCode={defaultProductCode}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
+++ b/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Button, Stack, TextField, Alert } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { MOVE_STOCK_LOCATION } from '../../../graphql/mutations';
+import type { StockItem } from '../StockPoolView';
+
+interface Props {
+  item: StockItem;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function MoveStockLocationModal({ item, onClose, onSuccess }: Props) {
+  const [aisle, setAisle] = useState(item.aisle ?? '');
+  const [bay, setBay] = useState(item.bay ?? '');
+  const [bin, setBin] = useState(item.bin ?? '');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(MOVE_STOCK_LOCATION, {
+    onCompleted: () => {
+      showToast('Stock location updated', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const valid = aisle.trim() && bay.trim() && bin.trim();
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          stockItemId: item.id,
+          newAisle: aisle.trim(),
+          newBay: bay.trim(),
+          newBin: bin.trim(),
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Move ${item.productCode} to new bin`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Move
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Stack direction="row" spacing={2}>
+          <TextField label="Aisle" value={aisle} onChange={(e) => setAisle(e.target.value)} required />
+          <TextField label="Bay" value={bay} onChange={(e) => setBay(e.target.value)} required />
+          <TextField label="Bin" value={bin} onChange={(e) => setBin(e.target.value)} required />
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Button, Stack, TextField, Alert, Typography } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { RECLASSIFY_STOCK_ITEM } from '../../../graphql/mutations';
+import type { StockItem } from '../StockPoolView';
+
+interface Props {
+  item: StockItem;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function ReclassifyStockModal({ item, onClose, onSuccess }: Props) {
+  const [newCategory, setNewCategory] = useState(item.hardwareCategory);
+  const [newCode, setNewCode] = useState(item.productCode);
+  const [quantity, setQuantity] = useState<string>(String(item.available));
+  const [reason, setReason] = useState('');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(RECLASSIFY_STOCK_ITEM, {
+    onCompleted: () => {
+      showToast('Stock reclassified', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const isSplit = q > 0 && q < item.available;
+  const valid =
+    Number.isInteger(q) &&
+    q >= 1 &&
+    q <= item.available &&
+    newCategory.trim() &&
+    newCode.trim() &&
+    (newCategory.trim() !== item.hardwareCategory || newCode.trim() !== item.productCode);
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          stockItemId: item.id,
+          newHardwareCategory: newCategory.trim(),
+          newProductCode: newCode.trim(),
+          quantity: q,
+          reasonText: reason.trim() || null,
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Reclassify ${item.productCode}`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Reclassify {isSplit ? '(split)' : ''}
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          Currently: <b>{item.hardwareCategory}</b> / <b>{item.productCode}</b> (qty {item.quantity},
+          available {item.available})
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="New category"
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            fullWidth
+            required
+          />
+          <TextField
+            label="New product code"
+            value={newCode}
+            onChange={(e) => setNewCode(e.target.value)}
+            fullWidth
+            required
+          />
+        </Stack>
+        <TextField
+          label={`Quantity to reclassify (max ${item.available})`}
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          required
+          inputProps={{ min: 1, max: item.available }}
+          helperText={
+            isSplit
+              ? `Will leave ${item.available - q} of the original (category, code) on this row`
+              : 'Reclassifies the entire row in place'
+          }
+        />
+        <TextField
+          label="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          multiline
+          minRows={2}
+        />
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Button, Stack, TextField, Alert, Typography } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { REPORT_STOCK_DEFICIENCY } from '../../../graphql/mutations';
+import type { StockItem } from '../StockPoolView';
+
+interface Props {
+  item: StockItem;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function ReportStockDeficiencyModal({ item, onClose, onSuccess }: Props) {
+  const [quantity, setQuantity] = useState<string>('1');
+  const [reason, setReason] = useState('');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(REPORT_STOCK_DEFICIENCY, {
+    onCompleted: () => {
+      showToast('Deficient quantity flagged on stock row', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const valid = Number.isInteger(q) && q >= 1 && q <= item.available;
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          stockItemId: item.id,
+          quantity: q,
+          reasonText: reason.trim() || null,
+          performedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Report deficient on ${item.productCode}`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" color="warning" onClick={handleSubmit} disabled={!valid || loading}>
+            Flag deficient
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          Currently available: {item.available} of {item.quantity}. Flagged units stay on the row but
+          are excluded from pulls until resolved.
+        </Typography>
+        <TextField
+          label={`Quantity to flag (max ${item.available})`}
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          required
+          inputProps={{ min: 1, max: item.available }}
+        />
+        <TextField
+          label="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          multiline
+          minRows={2}
+          placeholder="e.g. visible damage, wrong finish"
+        />
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import {
+  Button,
+  Stack,
+  TextField,
+  Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../../components/Modal';
+import { useToast } from '../../../components/Toast';
+import { RESOLVE_DEFICIENCY } from '../../../graphql/mutations';
+
+export interface DeficientRow {
+  source: 'PROJECT_INVENTORY' | 'STOCK_POOL';
+  inventoryLocationId: string | null;
+  stockItemId: string | null;
+  hardwareCategory: string;
+  productCode: string;
+  deficientQuantity: number;
+}
+
+interface Props {
+  row: DeficientRow;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const RESOLUTIONS = [
+  { value: 'SEND_TO_STOCK', label: 'Send to stock pool' },
+  { value: 'SCRAP', label: 'Scrap / write off' },
+  { value: 'REPAIR', label: 'Repair (clear flag, keep on row)' },
+  { value: 'RETURN_TO_VENDOR', label: 'Return to vendor' },
+  { value: 'LEAVE_AS_DEFICIENT', label: 'Leave as deficient (just log)' },
+];
+
+export default function ResolveDeficiencyModal({ row, onClose, onSuccess }: Props) {
+  const [resolution, setResolution] = useState('SEND_TO_STOCK');
+  const [quantity, setQuantity] = useState<string>(String(row.deficientQuantity));
+  const [reason, setReason] = useState('');
+  const [rma, setRma] = useState('');
+  const { showToast } = useToast();
+
+  const [mutate, { loading, error }] = useMutation(RESOLVE_DEFICIENCY, {
+    onCompleted: () => {
+      showToast('Deficiency resolved', 'success');
+      onSuccess();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const needsRma = resolution === 'RETURN_TO_VENDOR';
+  const valid =
+    Number.isInteger(q) &&
+    q >= 1 &&
+    q <= row.deficientQuantity &&
+    (!needsRma || rma.trim().length > 0);
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    mutate({
+      variables: {
+        input: {
+          inventoryLocationId: row.inventoryLocationId,
+          stockItemId: row.stockItemId,
+          resolution,
+          quantity: q,
+          reasonText: reason.trim() || null,
+          rmaReference: needsRma ? rma.trim() : null,
+          destockSource: resolution === 'SEND_TO_STOCK' ? 'DEFICIENT_SWAP' : null,
+          reviewedBy: 'Warehouse',
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Resolve deficient ${row.productCode}`}
+      actions={
+        <>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            Resolve
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          {row.source === 'PROJECT_INVENTORY' ? 'Project inventory' : 'Stock pool'} ·{' '}
+          {row.hardwareCategory} · {row.deficientQuantity} deficient
+        </Typography>
+        <FormControl size="small" required>
+          <InputLabel>Resolution</InputLabel>
+          <Select
+            label="Resolution"
+            value={resolution}
+            onChange={(e) => setResolution(e.target.value)}
+          >
+            {RESOLUTIONS.map((r) => (
+              <MenuItem key={r.value} value={r.value}>
+                {r.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          label={`Quantity (max ${row.deficientQuantity})`}
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          required
+          inputProps={{ min: 1, max: row.deficientQuantity }}
+        />
+        <TextField
+          label="Notes (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        {needsRma && (
+          <TextField
+            label="RMA reference"
+            value={rma}
+            onChange={(e) => setRma(e.target.value)}
+            required
+            helperText="Required for return-to-vendor"
+          />
+        )}
+      </Stack>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the full proposal from #131. Adds a sibling `stock_items` table for company-owned shelf hardware (no project_id), the seven lifecycle events (destock, stock PO receipt, allocate, adjust, move, reclassify-with-split, report/resolve deficient), and the unified deficient-items review queue.

Closes #131.

## What ships

backend
- migrations 027–030 (deficient_quantity column, stock_items table, nullable PO FKs + stock_item_id link, deficiency_reviews table)
- `stock_repository` covers all 7 lifecycle events end-to-end
- `pull_request` validation + deduction subtracts `deficient_quantity` so flagged units never satisfy a pull
- `create_receive` now accepts POs with null project_id and routes line items into the stock pool; also accepts per-location `deficient_quantity`
- new GraphQL types (`StockItem`, `DeficiencyReview`, `DeficientItemRow`), queries (`stockItems`, `deficientItems`, `deficiencyReviews`, `stockMatchesForOpening`), and mutations for every event

frontend
- new warehouse sub-views: **Stock Pool** (browse + allocate + adjust + move + reclassify + flag-deficient) and **Deficient Items Review** (unified project + stock queue with 5 resolutions)
- every project inventory row gains a `Destock` action and a `Flag Deficient` action
- opening detail gains a `Find in Stock` button that surfaces matching stock items and opens the allocation modal with the opening's target pre-filled
- `Receiving` page handles null-project POs (labelled "Stock PO")

## Notes / deviations from the proposal

- the proposal didn't specify how stock-to-project allocation creates an `InventoryLocation` row. went with relaxing the `po_line_item_id` / `receive_line_item_id` FKs to nullable and adding a `stock_item_id` FK, enforced by a CHECK that requires either a PO origin or a stock origin. cleaner than synthesizing fake POs, but cascades into every read path that joined `inventory_locations → po_line_items` — those joins are now `outerjoin` with `coalesce` on unit_cost.
- receive-time deficient marking is backend-complete but the UI doesn't yet expose a per-location deficient input (current ReceiveModal doesn't collect locations either). The post-receive `Flag Deficient` button on every inventory row covers this for now.
- no automated tests added for the new mutations / repository functions — relying on CI's migration upgrade/downgrade cycle and the existing pull/ship-ready suite for regression. follow-up issue is a good idea before scaling usage.