### PR TITLE
Fix: old admin URLs land blank because <Navigate to=""> is a no-op

### DIFF
--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -25,7 +25,7 @@ export default function AdminModule() {
       <Route path="opening-status" element={<AdminSubLayout><OpeningStatusTab /></AdminSubLayout>} />
       <Route path="vendors" element={<AdminSubLayout><VendorsPage /></AdminSubLayout>} />
       <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />
-      <Route path="*" element={<Navigate to="" replace />} />
+      <Route path="*" element={<Navigate to="/app/admin" replace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
@
## Summary
- visiting `/app/admin/hardware-summary` (the old URL of what is now `/app/admin/project-purchasing-progress` after #146) rendered a blank `<main>` instead of bouncing to AdminLanding. surfaced during simulated user testing of #134.
- root cause: `<Navigate to="" replace />` in `frontend/src/modules/admin/index.tsx` is a no-op under react-router v6. change to an absolute `/app/admin` so the redirect actually fires.

## Notes
- the same pattern lives in warehouse / shipping / po / shop-assembly / import modules; their unknown-subroute URLs also dead-end. only fixing admin's here since the URL rename in #134 is what surfaced it. broader fix can be a follow-up if you want it.
@