### PR TITLE
locations tab: sync queries on mutation so panel reflects new state immediately

### DIFF
--- a/frontend/src/modules/warehouse/LocationActionDialog.tsx
+++ b/frontend/src/modules/warehouse/LocationActionDialog.tsx
@@ -90,15 +90,21 @@ export default function LocationActionDialog({
     }
   }, [open, mode, single]);
 
-  // Mutations — one of each. We dispatch by kind/mode in handleConfirm.
-  const [moveInv] = useMutation(MOVE_INVENTORY_LOCATION);
-  const [moveOpen] = useMutation(MOVE_OPENING_ITEM_LOCATION);
-  const [moveStock] = useMutation(MOVE_STOCK_LOCATION);
-  const [unlocateInv] = useMutation(MARK_INVENTORY_UNLOCATED);
-  const [unlocateOpen] = useMutation(MARK_OPENING_ITEM_UNLOCATED);
-  const [unlocateStock] = useMutation(MARK_STOCK_ITEM_UNLOCATED);
-  const [adjustInv] = useMutation(ADJUST_INVENTORY_QUANTITY);
-  const [adjustStock] = useMutation(ADJUST_STOCK_QUANTITY);
+  // Mutations dispatch by kind/mode in handleConfirm. Each one syncs the queries the
+  // LocationsTab + side panel depend on so the UI reflects the new server state when
+  // the success toast appears (no stale render until full reload).
+  const syncQueries = {
+    refetchQueries: ['GetLocationUtilization', 'GetLocationContents', 'GetLocationAuditHistory'],
+    awaitRefetchQueries: true,
+  };
+  const [moveInv] = useMutation(MOVE_INVENTORY_LOCATION, syncQueries);
+  const [moveOpen] = useMutation(MOVE_OPENING_ITEM_LOCATION, syncQueries);
+  const [moveStock] = useMutation(MOVE_STOCK_LOCATION, syncQueries);
+  const [unlocateInv] = useMutation(MARK_INVENTORY_UNLOCATED, syncQueries);
+  const [unlocateOpen] = useMutation(MARK_OPENING_ITEM_UNLOCATED, syncQueries);
+  const [unlocateStock] = useMutation(MARK_STOCK_ITEM_UNLOCATED, syncQueries);
+  const [adjustInv] = useMutation(ADJUST_INVENTORY_QUANTITY, syncQueries);
+  const [adjustStock] = useMutation(ADJUST_STOCK_QUANTITY, syncQueries);
 
   const [submitting, setSubmitting] = useState(false);
 

--- a/frontend/src/modules/warehouse/LocationsTab.tsx
+++ b/frontend/src/modules/warehouse/LocationsTab.tsx
@@ -146,7 +146,6 @@ const utilColumns: GridColDef<LocationEntry & { id: string }>[] = [
 interface ContentsPanelProps {
   selected: LocationEntry;
   onClose: () => void;
-  onRefetch: () => void;
   aisleOptions: string[];
   bayOptions: string[];
   binOptions: string[];
@@ -204,18 +203,14 @@ function RowActionMenu({
 function ContentsPanel({
   selected,
   onClose,
-  onRefetch,
   aisleOptions,
   bayOptions,
   binOptions,
 }: ContentsPanelProps) {
-  const { data, loading, error, refetch: refetchContents } = useQuery<LocationContentsData>(
-    GET_LOCATION_CONTENTS,
-    {
-      variables: { aisle: selected.aisle, bay: selected.bay, bin: selected.bin },
-      fetchPolicy: 'cache-and-network',
-    },
-  );
+  const { data, loading, error } = useQuery<LocationContentsData>(GET_LOCATION_CONTENTS, {
+    variables: { aisle: selected.aisle, bay: selected.bay, bin: selected.bin },
+    fetchPolicy: 'cache-and-network',
+  });
 
   const invItems = data?.locationContents?.inventoryItems ?? [];
   const oiItems = data?.locationContents?.openingItems ?? [];
@@ -237,10 +232,10 @@ function ContentsPanel({
   }, []);
 
   const handleSuccess = useCallback(() => {
+    // Mutations declare refetchQueries with awaitRefetchQueries: true, so locationUtilization,
+    // locationContents, and locationAuditHistory are already fresh by the time this fires.
     setSelectedIds(new Set());
-    refetchContents();
-    onRefetch();
-  }, [refetchContents, onRefetch]);
+  }, []);
 
   const allTargetsById = useMemo(() => {
     const map = new Map<string, LocationActionTarget>();
@@ -507,7 +502,7 @@ export default function LocationsTab() {
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<LocationEntry | null>(null);
 
-  const { data: utilData, loading: utilLoading, error: utilError, refetch: refetchUtil } = useQuery<{
+  const { data: utilData, loading: utilLoading, error: utilError } = useQuery<{
     locationUtilization: LocationEntry[];
   }>(GET_LOCATION_UTILIZATION, { fetchPolicy: 'cache-and-network' });
 
@@ -609,7 +604,6 @@ export default function LocationsTab() {
             <ContentsPanel
               selected={selected}
               onClose={() => setSelected(null)}
-              onRefetch={refetchUtil}
               aisleOptions={aisles}
               bayOptions={bays}
               binOptions={bins}


### PR DESCRIPTION
follow-up to #149 (issue #133).

the contents panel in the redesigned Locations tab could show the just-mutated item until full page reload. the mutation hook resolved before the cache-and-network refetch returned, so the success toast and post-mutation render landed first and the panel briefly carried stale data. surfaced during the simulated user testing on #149.

each mutation in LocationActionDialog now passes refetchQueries (GetLocationUtilization / GetLocationContents / GetLocationAuditHistory) with awaitRefetchQueries: true. Apollo waits for the three queries to refetch before resolving the mutation; by the time onCompleted fires the panel is rendering the new server state. the manual refetchContents() + onRefetch() in handleSuccess is dropped along with the now-unused onRefetch prop and refetchUtil destructure — they were the same refetch fired a second time after Apollo already handled it.