### PR TITLE
inventory follow-ups (#145): stale-counter refetch, hide zero-qty rows, receive-time locations + deficient

### DIFF
--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -381,7 +381,9 @@ def get_inventory_by_vendor(session: Session, project_id: uuid.UUID | None = Non
     vendor_map: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
     for il, unit_cost, vendor_name in rows:
         vname = vendor_name or "No Vendor"
-        vendor_map[vname][il.product_code].append((il, unit_cost))
+        # Stock-allocated rows (stock_item origin) have no PO unit_cost; coerce to 0 like the
+        # category hierarchy does, otherwise the float() in the value sum below blows up.
+        vendor_map[vname][il.product_code].append((il, unit_cost or 0))
 
     result = []
     for vendor in sorted(vendor_map.keys()):

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -370,6 +370,8 @@ def get_inventory_by_vendor(session: Session, project_id: uuid.UUID | None = Non
         .outerjoin(POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id)
         .outerjoin(POModel, POLineItemModel.po_id == POModel.id)
         .outerjoin(VendorModel, POModel.vendor_id == VendorModel.id)
+        # Hide rows fully emptied by destock/allocation (kept in DB for FK integrity).
+        .where(InventoryLocationModel.quantity > 0)
     )
     if project_id is not None:
         stmt = stmt.where(InventoryLocationModel.project_id == project_id)
@@ -759,6 +761,9 @@ def get_inventory_hierarchy(session: Session, project_id: uuid.UUID | None = Non
     stmt = select(InventoryLocationModel, POLineItemModel.unit_cost).outerjoin(
         POLineItemModel, InventoryLocationModel.po_line_item_id == POLineItemModel.id
     )
+    # Hide rows fully emptied by destock/allocation (quantity = 0). They are kept in the DB
+    # for FK integrity (origin of stock allocations) but should not clutter the inventory view.
+    stmt = stmt.where(InventoryLocationModel.quantity > 0)
     if project_id is not None:
         stmt = stmt.where(InventoryLocationModel.project_id == project_id)
     stmt = stmt.order_by(
@@ -825,6 +830,8 @@ def get_inventory_items(
         .where(
             InventoryLocationModel.hardware_category == category,
             InventoryLocationModel.product_code == product_code,
+            # Hide rows fully emptied by destock/allocation (kept in DB for FK integrity).
+            InventoryLocationModel.quantity > 0,
         )
     )
     if project_id is not None:

--- a/backend/tests/test_warehouse_repository_inventory_hierarchy.py
+++ b/backend/tests/test_warehouse_repository_inventory_hierarchy.py
@@ -1,0 +1,104 @@
+"""Tests for the quantity > 0 filter on inventory list queries (issue #145).
+
+Rows fully emptied by destock/allocation are kept in the DB for FK integrity (they remain
+the origin of stock allocations) but must not show up in the project inventory view.
+"""
+
+import uuid
+from datetime import datetime
+
+from app.models.inventory import InventoryLocation
+from app.models.project import Project
+from app.models.stock_item import StockItem
+from app.repositories import warehouse_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_stock_item(session) -> StockItem:
+    """A stock row used purely as a valid origin for InventoryLocation rows."""
+    si = StockItem(
+        id=uuid.uuid4(),
+        hardware_category="HINGE",
+        product_code="HG-100",
+        quantity=10,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    return si
+
+
+def _make_il(session, project_id, stock_item_id, *, quantity, product_code="HG-100", hardware_category="HINGE"):
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=stock_item_id,
+        hardware_category=hardware_category,
+        product_code=product_code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def test_inventory_hierarchy_hides_zero_quantity_rows(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    _make_il(db_session, project.id, origin.id, quantity=3)
+    _make_il(db_session, project.id, origin.id, quantity=0)
+
+    hierarchy = warehouse_repository.get_inventory_hierarchy(db_session, project.id)
+
+    assert len(hierarchy) == 1
+    cat = hierarchy[0]
+    assert cat["total_quantity"] == 3
+    pcs = cat["product_codes"]
+    assert len(pcs) == 1
+    assert pcs[0]["product_code"] == "HG-100"
+    assert pcs[0]["total_quantity"] == 3
+    # only the qty=3 row survives; the destocked-to-zero row is filtered out
+    assert len(pcs[0]["items"]) == 1
+    assert pcs[0]["items"][0].quantity == 3
+
+
+def test_inventory_hierarchy_drops_category_when_all_rows_zero(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    _make_il(db_session, project.id, origin.id, quantity=0, product_code="HG-200")
+
+    hierarchy = warehouse_repository.get_inventory_hierarchy(db_session, project.id)
+    assert hierarchy == []
+
+
+def test_inventory_items_hides_zero_quantity_rows(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    _make_il(db_session, project.id, origin.id, quantity=5)
+    _make_il(db_session, project.id, origin.id, quantity=0)
+
+    items = warehouse_repository.get_inventory_items(db_session, project.id, "HINGE", "HG-100")
+    assert len(items) == 1
+    assert items[0]["inventory_location"].quantity == 5
+
+
+def test_inventory_by_vendor_hides_zero_quantity_rows(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    _make_il(db_session, project.id, origin.id, quantity=4)
+    _make_il(db_session, project.id, origin.id, quantity=0)
+
+    groups = warehouse_repository.get_inventory_by_vendor(db_session, project.id)
+    total_qty = sum(g["total_quantity"] for g in groups)
+    total_items = sum(len(pc["items"]) for g in groups for pc in g["product_codes"])
+    assert total_qty == 4
+    assert total_items == 1

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -1,0 +1,18 @@
+// Operation names of the warehouse list/summary queries that go stale after an inventory or
+// stock mutation (destock, allocate, flag/resolve deficient, adjust/move/reclassify, correction).
+// Passed to useMutation's `refetchQueries` by operation name: Apollo refetches only the query
+// instances currently mounted, so applying this superset uniformly is safe and self-scoping.
+//
+// GetInventoryItems (the lazy per-product-code detail grid) is intentionally NOT here - each
+// caller already refetches that grid in its own onCompleted/onSuccess callback, so listing it
+// would double-fetch. This list is what fixes the stale summary header and accordion counts.
+export const WAREHOUSE_REFETCH_QUERIES = [
+  'GetInventoryHierarchy',
+  'GetInventoryByVendor',
+  'GetUnlocatedInventory',
+  'GetStockItems',
+  'GetDeficientItems',
+  'GetDeficiencyReviews',
+  'GetWarehouseDashboard',
+  'GetProjectProgressByProduct',
+];

--- a/frontend/src/modules/admin/InventoryCorrectionModal.tsx
+++ b/frontend/src/modules/admin/InventoryCorrectionModal.tsx
@@ -20,6 +20,7 @@ import {
   MARK_OPENING_ITEM_UNLOCATED,
   ASSIGN_OPENING_ITEM_LOCATION,
 } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 
 // --- Item types ---
 
@@ -194,6 +195,8 @@ export default function InventoryCorrectionModal({
   // --- Mutations ---
 
   const [adjustInventoryQuantity, { loading: adjustLoading }] = useMutation(ADJUST_INVENTORY_QUANTITY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -205,6 +208,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [moveInventoryLocation, { loading: moveInvLoading }] = useMutation(MOVE_INVENTORY_LOCATION, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -216,6 +221,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [markInventoryUnlocated, { loading: unlocateInvLoading }] = useMutation(MARK_INVENTORY_UNLOCATED, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -227,6 +234,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [assignInventoryLocation, { loading: assignInvLoading }] = useMutation(ASSIGN_INVENTORY_LOCATION, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -238,6 +247,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [moveOpeningItemLocation, { loading: moveOpenLoading }] = useMutation(MOVE_OPENING_ITEM_LOCATION, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -249,6 +260,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [markOpeningItemUnlocated, { loading: unlocateOpenLoading }] = useMutation(MARK_OPENING_ITEM_UNLOCATED, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();
@@ -260,6 +273,8 @@ export default function InventoryCorrectionModal({
   });
 
   const [assignOpeningItemLocation, { loading: assignOpenLoading }] = useMutation(ASSIGN_OPENING_ITEM_LOCATION, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Correction applied successfully', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -22,6 +22,7 @@ import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
 import { GET_INVENTORY_HIERARCHY, GET_INVENTORY_ITEMS, GET_INVENTORY_BY_VENDOR } from '../../graphql/queries';
 import { REPORT_INVENTORY_DEFICIENCY } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import InventoryCorrectionModal from '../admin/InventoryCorrectionModal';
@@ -193,6 +194,8 @@ function ProductCodeDetail({
   // Report deficient — uses prompt for the qty (lightweight; can be upgraded later)
   const { showToast } = useToast();
   const [reportDeficient] = useMutation(REPORT_INVENTORY_DEFICIENCY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Deficient quantity flagged on row', 'success');
       fetchItems({ variables: { projectId, category, productCode } });

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -7,7 +7,13 @@ import {
   Alert,
   CircularProgress,
   Paper,
+  Switch,
+  FormControlLabel,
+  Stack,
+  IconButton,
 } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useMutation } from '@apollo/client/react';
 import { useApolloClient } from '@apollo/client/react';
@@ -18,6 +24,7 @@ import ConfirmDialog from '../../components/ConfirmDialog';
 import { useNavigate } from 'react-router-dom';
 import { GET_PO_RECEIVING_DETAILS } from '../../graphql/queries';
 import { CREATE_RECEIVE } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 
 // ---- Types ----
 
@@ -42,12 +49,28 @@ interface PODetails {
   lineItems: PODetailLineItem[];
 }
 
+// One destination bin for a received line, plus how many of those units arrived deficient.
+// Fields are strings because they are bound to text inputs; parsed at validate/submit time.
+interface LocationDraft {
+  aisle: string;
+  bay: string;
+  bin: string;
+  quantity: string;
+  deficient: string;
+}
+
 // ---- Props ----
 
 interface ReceiveModalProps {
   open: boolean;
   onClose: () => void;
   poIds: string[];
+}
+
+const MAX_LOC_LEN = 20;
+
+function emptyDraft(quantity: number): LocationDraft {
+  return { aisle: '', bay: '', bin: '', quantity: String(quantity), deficient: '0' };
 }
 
 export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps) {
@@ -63,6 +86,10 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   const [poDetailsMap, setPoDetailsMap] = useState<Record<string, PODetails>>({});
   const [poDetailsLoading, setPoDetailsLoading] = useState(false);
   const [poDetailsError, setPoDetailsError] = useState<string | null>(null);
+  // Optional put-away: when on, the user assigns destination bin(s) for each received line and
+  // may flag how many units arrived deficient. Off by default → receive as unlocated (locations: []).
+  const [putAwayMode, setPutAwayMode] = useState(false);
+  const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
 
   const [createReceive, { loading: submitLoading }] = useMutation(CREATE_RECEIVE);
 
@@ -104,6 +131,8 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       setReceiveQuantities({});
       setMutationError(null);
       setSucceeded(false);
+      setPutAwayMode(false);
+      setLineLocations({});
       fetchPODetails(poIds);
     }
   }, [open, poIds, fetchPODetails]);
@@ -131,6 +160,48 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     [lineItemsToReceive, receiveQuantities],
   );
 
+  // ---- Put-away helpers ----
+
+  // Drafts for a line, defaulting to a single bin holding the whole received quantity. The default
+  // is materialized on first edit, so an untouched line carries one row whose location is still blank
+  // (which keeps the line invalid until the user fills it in put-away mode).
+  const draftsFor = useCallback(
+    (lineId: string, receiveNow: number): LocationDraft[] => lineLocations[lineId] ?? [emptyDraft(receiveNow)],
+    [lineLocations],
+  );
+
+  const setDrafts = useCallback((lineId: string, drafts: LocationDraft[]) => {
+    setLineLocations((prev) => ({ ...prev, [lineId]: drafts }));
+  }, []);
+
+  const updateLocation = useCallback(
+    (lineId: string, receiveNow: number, idx: number, field: keyof LocationDraft, value: string) => {
+      const v = field === 'aisle' || field === 'bay' || field === 'bin' ? value.slice(0, MAX_LOC_LEN) : value;
+      setDrafts(
+        lineId,
+        draftsFor(lineId, receiveNow).map((d, i) => (i === idx ? { ...d, [field]: v } : d)),
+      );
+    },
+    [draftsFor, setDrafts],
+  );
+
+  const addLocation = useCallback(
+    (lineId: string, receiveNow: number) => {
+      setDrafts(lineId, [...draftsFor(lineId, receiveNow), emptyDraft(0)]);
+    },
+    [draftsFor, setDrafts],
+  );
+
+  const removeLocation = useCallback(
+    (lineId: string, receiveNow: number, idx: number) => {
+      setDrafts(
+        lineId,
+        draftsFor(lineId, receiveNow).filter((_, i) => i !== idx),
+      );
+    },
+    [draftsFor, setDrafts],
+  );
+
   // ---- Validation ----
 
   const hasQuantityErrors = useMemo(() => {
@@ -151,6 +222,26 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     [receiveQuantities],
   );
 
+  // In put-away mode every received unit must land in a valid bin and each bin's deficient count must
+  // be within its quantity. Mirrors the backend contract in warehouse_repository.create_receive.
+  const putAwayValid = useMemo(() => {
+    if (!putAwayMode) return true;
+    for (const li of lineItemsToReceive) {
+      const receiveNow = receiveQuantities[li.id] ?? 0;
+      let placed = 0;
+      for (const d of draftsFor(li.id, receiveNow)) {
+        const q = Number(d.quantity);
+        const def = Number(d.deficient || '0');
+        if (!d.aisle.trim() || !d.bay.trim() || !d.bin.trim()) return false;
+        if (!Number.isInteger(q) || q < 1) return false;
+        if (!Number.isInteger(def) || def < 0 || def > q) return false;
+        placed += q;
+      }
+      if (placed !== receiveNow) return false;
+    }
+    return true;
+  }, [putAwayMode, lineItemsToReceive, receiveQuantities, draftsFor]);
+
   // ---- Columns ----
 
   const quantityColumns: GridColDef[] = useMemo(
@@ -160,7 +251,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         field: 'orderAs',
         headerName: 'Ordered As',
         flex: 0.8,
-        renderCell: (params) => params.value || '\u2014',
+        renderCell: (params) => params.value || '—',
       },
       { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1 },
       { field: 'orderedQuantity', headerName: 'Ordered Qty', flex: 0.7, type: 'number' },
@@ -220,11 +311,21 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       const input = {
         poId,
         receivedBy: displayName,
-        lineItems: poLineItems.map((li) => ({
-          poLineItemId: li.id,
-          quantityReceived: receiveQuantities[li.id] ?? 0,
-          locations: [],
-        })),
+        lineItems: poLineItems.map((li) => {
+          const receiveNow = receiveQuantities[li.id] ?? 0;
+          const drafts = putAwayMode ? draftsFor(li.id, receiveNow) : [];
+          return {
+            poLineItemId: li.id,
+            quantityReceived: receiveNow,
+            locations: drafts.map((d) => ({
+              aisle: d.aisle.trim(),
+              bay: d.bay.trim(),
+              bin: d.bin.trim(),
+              quantity: Number(d.quantity),
+              deficientQuantity: Number(d.deficient || '0'),
+            })),
+          };
+        }),
       };
 
       try {
@@ -238,6 +339,13 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       }
     }
 
+    // Refresh inventory/stock/dashboard counts once after all POs are received.
+    try {
+      await client.refetchQueries({ include: WAREHOUSE_REFETCH_QUERIES });
+    } catch {
+      // a failed background refetch should not mask a successful receive
+    }
+
     showToast(
       `Receive completed successfully. ${totalItemsToReceive} items added to inventory.`,
       'success',
@@ -248,7 +356,10 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     displayName,
     lineItemsToReceive,
     receiveQuantities,
+    putAwayMode,
+    draftsFor,
     createReceive,
+    client,
     showToast,
     totalItemsToReceive,
     poDetailsMap,
@@ -261,6 +372,8 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     setMutationError(null);
     setSucceeded(false);
     setConfirmOpen(false);
+    setPutAwayMode(false);
+    setLineLocations({});
     onClose();
   }, [onClose]);
 
@@ -270,9 +383,9 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     if (poIds.length === 1) {
       const details = poDetailsMap[poIds[0]];
       const label = details?.poNumber ?? 'Purchase Order';
-      return `Receive \u2014 ${label}`;
+      return `Receive — ${label}`;
     }
-    return `Receive \u2014 ${poIds.length} Purchase Orders`;
+    return `Receive — ${poIds.length} Purchase Orders`;
   }, [poIds, poDetailsMap]);
 
   // ---- Render PO sections ----
@@ -297,7 +410,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         {showHeader && (
           <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: details.notes ? 0.5 : 1 }}>
             {details.poNumber ?? 'Unknown PO'}
-            {details.vendor ? ` \u2014 ${details.vendor.name}` : ''}
+            {details.vendor ? ` — ${details.vendor.name}` : ''}
           </Typography>
         )}
         {details.notes && (
@@ -330,6 +443,95 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     );
   };
 
+  // ---- Render put-away editor ----
+
+  const renderLineLocations = (li: PODetailLineItem) => {
+    const receiveNow = receiveQuantities[li.id] ?? 0;
+    const drafts = draftsFor(li.id, receiveNow);
+    const placed = drafts.reduce((s, d) => s + (Number(d.quantity) || 0), 0);
+    const remaining = receiveNow - placed;
+    return (
+      <Paper key={li.id} variant="outlined" sx={{ p: 1.5 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 1, gap: 1 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {li.productCode} · {li.hardwareCategory} (placing {receiveNow})
+          </Typography>
+          <Typography variant="caption" color={remaining === 0 ? 'success.main' : 'error.main'}>
+            {remaining === 0 ? 'all placed' : `${remaining} unplaced`}
+          </Typography>
+        </Box>
+        <Stack spacing={1}>
+          {drafts.map((d, idx) => {
+            const q = Number(d.quantity);
+            const def = Number(d.deficient || '0');
+            const defError = !Number.isInteger(def) || def < 0 || def > (Number.isInteger(q) ? q : 0);
+            return (
+              <Stack key={idx} direction="row" spacing={1} alignItems="flex-start" sx={{ flexWrap: 'wrap' }}>
+                <TextField
+                  label="Aisle"
+                  size="small"
+                  value={d.aisle}
+                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'aisle', e.target.value)}
+                  sx={{ width: 90 }}
+                />
+                <TextField
+                  label="Bay"
+                  size="small"
+                  value={d.bay}
+                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'bay', e.target.value)}
+                  sx={{ width: 90 }}
+                />
+                <TextField
+                  label="Bin"
+                  size="small"
+                  value={d.bin}
+                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'bin', e.target.value)}
+                  sx={{ width: 90 }}
+                />
+                <TextField
+                  label="Qty"
+                  type="number"
+                  size="small"
+                  value={d.quantity}
+                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'quantity', e.target.value)}
+                  slotProps={{ htmlInput: { min: 1 } }}
+                  sx={{ width: 80 }}
+                />
+                <TextField
+                  label="Deficient"
+                  type="number"
+                  size="small"
+                  value={d.deficient}
+                  error={defError}
+                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'deficient', e.target.value)}
+                  slotProps={{ htmlInput: { min: 0, max: Number.isInteger(q) ? q : undefined } }}
+                  sx={{ width: 100 }}
+                />
+                <IconButton
+                  size="small"
+                  aria-label="Remove location"
+                  disabled={drafts.length <= 1}
+                  onClick={() => removeLocation(li.id, receiveNow, idx)}
+                  sx={{ mt: 0.5 }}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            );
+          })}
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={() => addLocation(li.id, receiveNow)}
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            Add location
+          </Button>
+        </Stack>
+      </Paper>
+    );
+  };
+
   // ---- Render ----
 
   const actions = succeeded ? (
@@ -344,7 +546,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       <Button onClick={handleClose}>Cancel</Button>
       <Button
         variant="contained"
-        disabled={!hasAnyReceiveQuantity || hasQuantityErrors || submitLoading}
+        disabled={!hasAnyReceiveQuantity || hasQuantityErrors || !putAwayValid || submitLoading}
         onClick={() => setConfirmOpen(true)}
       >
         {submitLoading ? <CircularProgress size={24} /> : 'Complete Receive'}
@@ -376,6 +578,20 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
           </Alert>
         )}
         {!poDetailsLoading && !poDetailsError && !succeeded && poIds.map(renderPOSection)}
+
+        {!poDetailsLoading && !poDetailsError && !succeeded && hasAnyReceiveQuantity && (
+          <Box sx={{ mt: 1 }}>
+            <FormControlLabel
+              control={<Switch checked={putAwayMode} onChange={(e) => setPutAwayMode(e.target.checked)} />}
+              label="Assign locations & flag deficient units now"
+            />
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+              Leave off to receive as unlocated and put away later. When on, place every received unit
+              and optionally record how many of each arrived deficient.
+            </Typography>
+            {putAwayMode && <Stack spacing={2}>{lineItemsToReceive.map(renderLineLocations)}</Stack>}
+          </Box>
+        )}
       </Modal>
 
       <ConfirmDialog

--- a/frontend/src/modules/warehouse/SpotCheckModal.tsx
+++ b/frontend/src/modules/warehouse/SpotCheckModal.tsx
@@ -5,6 +5,7 @@ import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
 import { ADJUST_INVENTORY_QUANTITY } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 
 interface SpotCheckItem {
   id: string;
@@ -43,6 +44,8 @@ export default function SpotCheckModal({ open, onClose, item, onSuccess }: SpotC
   }, [physicalNum]);
 
   const [adjustQuantity, { loading }] = useMutation(ADJUST_INVENTORY_QUANTITY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Spot check adjustment applied', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { ADJUST_STOCK_QUANTITY } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 import type { StockItem } from '../StockPoolView';
 
 interface Props {
@@ -18,6 +19,8 @@ export default function AdjustStockModal({ item, onClose, onSuccess }: Props) {
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(ADJUST_STOCK_QUANTITY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Stock quantity adjusted', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
@@ -14,6 +14,7 @@ import { useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { ALLOCATE_STOCK_TO_PROJECT } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 import { GET_PROJECTS } from '../../../graphql/queries';
 import type { StockItem } from '../StockPoolView';
 
@@ -51,6 +52,8 @@ export default function AllocateStockModal({
 
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
   const [mutate, { loading, error }] = useMutation(ALLOCATE_STOCK_TO_PROJECT, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Stock allocated to project inventory', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
+++ b/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
@@ -14,6 +14,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { DESTOCK_INVENTORY } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 
 export interface DestockSource {
   id: string;
@@ -50,6 +51,8 @@ export default function DestockInventoryModal({ inventoryLocation, onClose, onSu
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(DESTOCK_INVENTORY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Inventory destocked to the stock pool', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
+++ b/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { MOVE_STOCK_LOCATION } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 import type { StockItem } from '../StockPoolView';
 
 interface Props {
@@ -19,6 +20,8 @@ export default function MoveStockLocationModal({ item, onClose, onSuccess }: Pro
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(MOVE_STOCK_LOCATION, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Stock location updated', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { RECLASSIFY_STOCK_ITEM } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 import type { StockItem } from '../StockPoolView';
 
 interface Props {
@@ -20,6 +21,8 @@ export default function ReclassifyStockModal({ item, onClose, onSuccess }: Props
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(RECLASSIFY_STOCK_ITEM, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Stock reclassified', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { REPORT_STOCK_DEFICIENCY } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 import type { StockItem } from '../StockPoolView';
 
 interface Props {
@@ -18,6 +19,8 @@ export default function ReportStockDeficiencyModal({ item, onClose, onSuccess }:
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(REPORT_STOCK_DEFICIENCY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Deficient quantity flagged on stock row', 'success');
       onSuccess();

--- a/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
@@ -14,6 +14,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../../components/Modal';
 import { useToast } from '../../../components/Toast';
 import { RESOLVE_DEFICIENCY } from '../../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../../graphql/refetch';
 
 export interface DeficientRow {
   source: 'PROJECT_INVENTORY' | 'STOCK_POOL';
@@ -46,6 +47,8 @@ export default function ResolveDeficiencyModal({ row, onClose, onSuccess }: Prop
   const { showToast } = useToast();
 
   const [mutate, { loading, error }] = useMutation(RESOLVE_DEFICIENCY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
     onCompleted: () => {
       showToast('Deficiency resolved', 'success');
       onSuccess();


### PR DESCRIPTION
closes #145. these are the rough edges surfaced during simulated user testing of #131 (PR #143 + #144) - four of them, bundled into one PR.

destock / allocate / flag-deficient on a row in /app/warehouse/inventory used to refetch only the detail grid, so the row updated but the Inventory Summary header, the per-category and per-product-code accordion totals, and other warehouse counts stayed frozen until a manual reload. there's now a shared WAREHOUSE_REFETCH_QUERIES operation-name list in frontend/src/graphql/refetch.ts, wired as refetchQueries + awaitRefetchQueries onto every inventory and stock mutation hook (destock, allocate, report/resolve deficiency, adjust/move/reclassify stock, inventory correction, spot check). refetch-by-name only re-runs the query instances currently mounted, so applying the same list everywhere is safe and self-scoping. the separate "accordion header shows the pre-mutation quantity" bug shares this root cause and is fixed by the same change.

after destocking a row's entire quantity it used to linger in the inventory view with qty 0 and its action buttons disabled. those rows are deliberately kept in the DB for FK integrity (they remain the origin of any stock allocation), so rather than delete them they're now hidden at read time, with `quantity > 0` applied in get_inventory_hierarchy, get_inventory_items, and get_inventory_by_vendor, mirroring the filter already in get_location_contents and get_stock_items. a new backend test covers all three list queries.

the backend already accepted a per-location deficient_quantity at receive, but ReceiveModal always sent locations: [], so there was nowhere to set it. receiving now has an optional, off-by-default "assign locations & flag deficient units now" toggle. left off, the receive stays unlocated exactly as before. switched on, each received line gets a bin editor (aisle / bay / bin / qty / deficient, multiple bins allowed); the bin quantities must sum to the received amount and each bin's deficient count is bounded by its quantity, matching the validation in create_receive. on success the modal refetches the warehouse queries so counts land fresh.

the issue also listed the Project Progress by Product table going stale in this view; that one is already resolved, since the table moved out to Admin in #146 and fetches on its own there. GetProjectProgressByProduct is still in the shared refetch list so it stays current wherever it's mounted.