### PR TITLE
inventory quantity override per row (#138): absolute new qty, destination bins on increase, reason required, all users

### DIFF
--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -935,6 +935,127 @@ def adjust_inventory_quantity(
     return il
 
 
+def override_inventory_quantity(
+    session: Session,
+    *,
+    inv_id: uuid.UUID,
+    new_quantity: int,
+    reason: str,
+    destinations: list[dict],
+    performed_by: str,
+) -> InventoryLocationModel:
+    """Set an InventoryLocation row to an absolute new_quantity. Reason always required, audit-logged.
+
+    Decrease: the row shrinks to new_quantity (lost units written off with the reason); it cannot drop
+    below the row's own deficient_quantity.
+
+    Increase: the added (new_quantity - current) units must be placed via `destinations`, whose
+    quantities sum to the delta. A destination at the row's own aisle/bay/bin bumps this row; any other
+    destination becomes a new InventoryLocation that inherits this row's origin, so the has-origin CHECK
+    holds and valuations keep the same unit_cost.
+    """
+    il = session.get(InventoryLocationModel, inv_id)
+    if il is None:
+        raise NotFoundError(f"Inventory location {inv_id} not found")
+    if not reason or len(reason) > 500:
+        raise ValidationError("reason_text must be 1-500 characters", field="reason_text")
+    if new_quantity < 0:
+        raise ValidationError("new_quantity must be >= 0", field="new_quantity")
+
+    old_quantity = il.quantity
+    delta = new_quantity - old_quantity
+    if delta == 0:
+        raise ValidationError("new_quantity must differ from the current quantity", field="new_quantity")
+
+    created: list[InventoryLocationModel] = []
+    audit_destinations: list[dict] = []
+
+    if delta < 0:
+        if new_quantity < il.deficient_quantity:
+            raise ValidationError(
+                "Cannot set quantity below this row's deficient quantity",
+                field="new_quantity",
+            )
+        il.quantity = new_quantity
+    else:
+        if not destinations:
+            raise ValidationError(
+                "destination location(s) are required when increasing quantity",
+                field="destinations",
+            )
+        normalized: list[dict] = []
+        for dest in destinations:
+            qty = dest["quantity"]
+            if qty < 1:
+                raise ValidationError("destination quantity must be >= 1", field="destinations")
+            a, b, c = _normalize_and_validate_location_fields(dest["aisle"], dest["bay"], dest["bin"])
+            normalized.append({"aisle": a, "bay": b, "bin": c, "quantity": qty})
+        if sum(d["quantity"] for d in normalized) != delta:
+            raise ValidationError(
+                "destination quantities must sum to the added quantity",
+                field="destinations",
+            )
+
+        now = datetime.utcnow()
+        for dest in normalized:
+            audit_destinations.append(dest)
+            if (dest["aisle"], dest["bay"], dest["bin"]) == (il.aisle, il.bay, il.bin):
+                il.quantity += dest["quantity"]
+            else:
+                new_il = InventoryLocationModel(
+                    project_id=il.project_id,
+                    po_line_item_id=il.po_line_item_id,
+                    receive_line_item_id=il.receive_line_item_id,
+                    stock_item_id=il.stock_item_id,
+                    hardware_category=il.hardware_category,
+                    product_code=il.product_code,
+                    quantity=dest["quantity"],
+                    deficient_quantity=0,
+                    aisle=dest["aisle"],
+                    bay=dest["bay"],
+                    bin=dest["bin"],
+                    received_at=now,
+                )
+                session.add(new_il)
+                created.append(new_il)
+
+    _log_audit_event(
+        session,
+        project_id=il.project_id,
+        entity_type=AuditEntityType.INVENTORY_LOCATION,
+        entity_id=il.id,
+        action=AuditAction.ADJUSTMENT,
+        performed_by=performed_by,
+        detail={
+            "oldQuantity": old_quantity,
+            "newQuantity": new_quantity,
+            "delta": delta,
+            "reason": reason,
+            "override": True,
+            "destinations": audit_destinations,
+        },
+    )
+
+    session.flush()
+    for new_il in created:
+        _log_audit_event(
+            session,
+            project_id=new_il.project_id,
+            entity_type=AuditEntityType.INVENTORY_LOCATION,
+            entity_id=new_il.id,
+            action=AuditAction.ADJUSTMENT,
+            performed_by=performed_by,
+            detail={
+                "createdByOverrideOf": str(il.id),
+                "quantity": new_il.quantity,
+                "location": {"aisle": new_il.aisle, "bay": new_il.bay, "bin": new_il.bin},
+                "reason": reason,
+            },
+        )
+
+    return il
+
+
 def move_inventory_location(
     session: Session, inv_id: uuid.UUID, new_aisle: str, new_bay: str, new_bin: str
 ) -> InventoryLocationModel:

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -300,6 +300,26 @@ class ReportInventoryDeficiencyInput:
 
 
 @strawberry.input
+class OverrideDestinationInput:
+    """A bin and how many of the added units land there (used by an inventory quantity override)."""
+
+    aisle: str
+    bay: str
+    bin: str
+    quantity: int
+
+
+@strawberry.input
+class OverrideInventoryQuantityInput:
+    inventory_location_id: strawberry.ID
+    new_quantity: int
+    reason_text: str
+    # required when new_quantity increases the row; ignored on a decrease. quantities must sum to the delta.
+    destinations: list[OverrideDestinationInput] = strawberry.field(default_factory=list)
+    performed_by: str = ""
+
+
+@strawberry.input
 class ReportStockDeficiencyInput:
     stock_item_id: strawberry.ID
     quantity: int

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -31,6 +31,7 @@ from .inputs import (
     DestockInventoryInput,
     FinalizeImportSessionInput,
     MoveStockLocationInput,
+    OverrideInventoryQuantityInput,
     ReclassifyStockItemInput,
     ReportDeficiencyAtAssemblyInput,
     ReportInventoryDeficiencyInput,
@@ -597,6 +598,23 @@ class Mutation:
         with SessionLocal() as session:
             result = warehouse_repository.adjust_inventory_quantity(
                 session, uuid.UUID(str(inventory_location_id)), adjustment, reason
+            )
+            session.commit()
+            session.refresh(result)
+            return _inventory_location_to_type(result)
+
+    @strawberry.mutation
+    def override_inventory_quantity(self, input: OverrideInventoryQuantityInput) -> InventoryLocation:
+        with SessionLocal() as session:
+            result = warehouse_repository.override_inventory_quantity(
+                session,
+                inv_id=uuid.UUID(str(input.inventory_location_id)),
+                new_quantity=input.new_quantity,
+                reason=input.reason_text,
+                destinations=[
+                    {"aisle": d.aisle, "bay": d.bay, "bin": d.bin, "quantity": d.quantity} for d in input.destinations
+                ],
+                performed_by=input.performed_by or "Warehouse",
             )
             session.commit()
             session.refresh(result)

--- a/backend/tests/test_warehouse_repository_override_quantity.py
+++ b/backend/tests/test_warehouse_repository_override_quantity.py
@@ -1,0 +1,171 @@
+"""Tests for warehouse_repository.override_inventory_quantity (issue #138)."""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import ValidationError
+from app.models.inventory import InventoryLocation
+from app.models.project import Project
+from app.models.stock_item import StockItem
+from app.repositories import warehouse_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_stock_item(session) -> StockItem:
+    si = StockItem(
+        id=uuid.uuid4(),
+        hardware_category="HINGE",
+        product_code="HG-100",
+        quantity=10,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    return si
+
+
+def _make_il(session, project_id, stock_item_id, *, quantity, deficient=0, aisle="A", bay="1", bin="1"):
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=stock_item_id,
+        hardware_category="HINGE",
+        product_code="HG-100",
+        quantity=quantity,
+        deficient_quantity=deficient,
+        aisle=aisle,
+        bay=bay,
+        bin=bin,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _rows(session, project_id):
+    return list(session.scalars(select(InventoryLocation).where(InventoryLocation.project_id == project_id)).all())
+
+
+def test_override_decrease_shrinks_row(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=10)
+
+    warehouse_repository.override_inventory_quantity(
+        db_session, inv_id=il.id, new_quantity=4, reason="recount", destinations=[], performed_by="tester"
+    )
+
+    assert il.quantity == 4
+    assert len(_rows(db_session, project.id)) == 1
+
+
+def test_override_decrease_below_deficient_rejected(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=10, deficient=5)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.override_inventory_quantity(
+            db_session, inv_id=il.id, new_quantity=3, reason="recount", destinations=[], performed_by="tester"
+        )
+
+
+def test_override_increase_same_location_bumps_row(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5, aisle="A", bay="1", bin="1")
+
+    warehouse_repository.override_inventory_quantity(
+        db_session,
+        inv_id=il.id,
+        new_quantity=8,
+        reason="found extra",
+        destinations=[{"aisle": "A", "bay": "1", "bin": "1", "quantity": 3}],
+        performed_by="tester",
+    )
+
+    assert il.quantity == 8
+    assert len(_rows(db_session, project.id)) == 1  # no new row created
+
+
+def test_override_increase_new_location_creates_row(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5, aisle="A", bay="1", bin="1")
+
+    warehouse_repository.override_inventory_quantity(
+        db_session,
+        inv_id=il.id,
+        new_quantity=8,
+        reason="found extra in another bin",
+        destinations=[{"aisle": "B", "bay": "2", "bin": "2", "quantity": 3}],
+        performed_by="tester",
+    )
+
+    rows = _rows(db_session, project.id)
+    assert il.quantity == 5  # source row unchanged; added units landed elsewhere
+    assert len(rows) == 2
+    new_row = next(r for r in rows if r.id != il.id)
+    assert (new_row.aisle, new_row.bay, new_row.bin) == ("B", "2", "2")
+    assert new_row.quantity == 3
+    assert new_row.stock_item_id == origin.id  # inherits the source row's origin
+
+
+def test_override_increase_requires_destinations(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.override_inventory_quantity(
+            db_session, inv_id=il.id, new_quantity=8, reason="extra", destinations=[], performed_by="tester"
+        )
+
+
+def test_override_increase_destinations_must_sum_to_delta(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.override_inventory_quantity(
+            db_session,
+            inv_id=il.id,
+            new_quantity=8,  # delta = 3
+            reason="extra",
+            destinations=[{"aisle": "B", "bay": "2", "bin": "2", "quantity": 2}],  # sums to 2, not 3
+            performed_by="tester",
+        )
+
+
+def test_override_requires_reason(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.override_inventory_quantity(
+            db_session, inv_id=il.id, new_quantity=3, reason="", destinations=[], performed_by="tester"
+        )
+
+
+def test_override_no_change_rejected(db_session):
+    project = _make_project(db_session)
+    origin = _make_stock_item(db_session)
+    il = _make_il(db_session, project.id, origin.id, quantity=5)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.override_inventory_quantity(
+            db_session, inv_id=il.id, new_quantity=5, reason="no change", destinations=[], performed_by="tester"
+        )

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -163,6 +163,29 @@ export const ADJUST_INVENTORY_QUANTITY = gql`
   }
 `;
 
+export const OVERRIDE_INVENTORY_QUANTITY = gql`
+  mutation OverrideInventoryQuantity($input: OverrideInventoryQuantityInput!) {
+    overrideInventoryQuantity(input: $input) {
+      id
+      projectId
+      poLineItemId
+      receiveLineItemId
+      stockItemId
+      hardwareCategory
+      productCode
+      quantity
+      deficientQuantity
+      available
+      aisle
+      bay
+      bin
+      receivedAt
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
 export const MOVE_INVENTORY_LOCATION = gql`
   mutation MoveInventoryLocation($inventoryLocationId: ID!, $newAisle: String!, $newBay: String!, $newBin: String!) {
     moveInventoryLocation(inventoryLocationId: $inventoryLocationId, newAisle: $newAisle, newBay: $newBay, newBin: $newBin) {

--- a/frontend/src/modules/admin/InventoryCorrectionModal.tsx
+++ b/frontend/src/modules/admin/InventoryCorrectionModal.tsx
@@ -6,13 +6,17 @@ import {
   Button,
   Chip,
   Stack,
+  IconButton,
 } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useMutation } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
 import {
-  ADJUST_INVENTORY_QUANTITY,
+  OVERRIDE_INVENTORY_QUANTITY,
   MOVE_INVENTORY_LOCATION,
   MARK_INVENTORY_UNLOCATED,
   ASSIGN_INVENTORY_LOCATION,
@@ -70,7 +74,15 @@ interface OpeningItem {
   installedHardware: InstalledHardware[];
 }
 
-type CorrectionType = 'adjustQuantity' | 'moveLocation' | 'markUnlocated' | 'assignLocation';
+type CorrectionType = 'overrideQuantity' | 'moveLocation' | 'markUnlocated' | 'assignLocation';
+
+// A destination bin for the units ADDED by a quantity increase. Strings bind to text inputs.
+interface DestinationDraft {
+  aisle: string;
+  bay: string;
+  bin: string;
+  quantity: string;
+}
 
 interface InventoryCorrectionModalProps {
   open: boolean;
@@ -101,6 +113,7 @@ export default function InventoryCorrectionModal({
   onSuccess,
 }: InventoryCorrectionModalProps) {
   const { showToast } = useToast();
+  const { displayName } = useIdentity();
 
   // Determine smart default correction type
   const defaultCorrectionType: CorrectionType = hasLocation(item) ? 'moveLocation' : 'assignLocation';
@@ -108,9 +121,11 @@ export default function InventoryCorrectionModal({
   const [correctionType, setCorrectionType] = useState<CorrectionType>(defaultCorrectionType);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  // Adjust Quantity state
-  const [adjustment, setAdjustment] = useState<string>('');
+  // Override Quantity state: an absolute new quantity for this row plus a required reason.
+  const [newQty, setNewQty] = useState<string>('');
   const [reason, setReason] = useState('');
+  // Where the ADDED units land when increasing. Empty falls back to one bin = this row's location.
+  const [destinations, setDestinations] = useState<DestinationDraft[]>([]);
 
   // Move / Assign Location state
   const [aisle, setAisle] = useState(item.aisle ?? '');
@@ -121,7 +136,7 @@ export default function InventoryCorrectionModal({
   const correctionOptions = useMemo(() => {
     const options: { key: CorrectionType; label: string }[] = [];
     if (itemType === 'inventory') {
-      options.push({ key: 'adjustQuantity', label: 'Adjust Quantity' });
+      options.push({ key: 'overrideQuantity', label: 'Override Quantity' });
     }
     options.push({ key: 'moveLocation', label: 'Move Location' });
     options.push({ key: 'markUnlocated', label: 'Mark Unlocated' });
@@ -132,8 +147,9 @@ export default function InventoryCorrectionModal({
   // Reset fields when correction type changes
   const handleCorrectionTypeChange = (type: CorrectionType) => {
     setCorrectionType(type);
-    setAdjustment('');
+    setNewQty('');
     setReason('');
+    setDestinations([]);
     if (type === 'moveLocation') {
       setAisle(item.aisle ?? '');
       setBay(item.bay ?? '');
@@ -147,19 +163,56 @@ export default function InventoryCorrectionModal({
 
   // --- Computed values ---
 
-  const adjustmentNum = parseInt(adjustment, 10);
-  const newQuantity = isNaN(adjustmentNum) ? item.quantity : item.quantity + adjustmentNum;
+  const newQtyNum = parseInt(newQty, 10);
+  const delta = Number.isNaN(newQtyNum) ? 0 : newQtyNum - item.quantity;
+  const itemDeficient = (item as InventoryItem).deficientQuantity ?? 0;
+
+  // Destination rows for the added units, defaulting to one bin = this row's current location with
+  // the whole delta. The default tracks delta until the user edits, then their edits stick.
+  const destRows = useMemo<DestinationDraft[]>(
+    () =>
+      destinations.length
+        ? destinations
+        : [
+            {
+              aisle: item.aisle ?? '',
+              bay: item.bay ?? '',
+              bin: item.bin ?? '',
+              quantity: delta > 0 ? String(delta) : '',
+            },
+          ],
+    [destinations, item.aisle, item.bay, item.bin, delta],
+  );
+
+  const placedTotal = destRows.reduce((s, d) => s + (Number(d.quantity) || 0), 0);
+
+  const updateDest = (idx: number, field: keyof DestinationDraft, value: string) => {
+    const v = field === 'quantity' ? value : value.slice(0, 20);
+    setDestinations(destRows.map((d, i) => (i === idx ? { ...d, [field]: v } : d)));
+  };
+  const addDest = () => setDestinations([...destRows, { aisle: '', bay: '', bin: '', quantity: '' }]);
+  const removeDest = (idx: number) => setDestinations(destRows.filter((_, i) => i !== idx));
 
   // --- Validation ---
 
   const isValid = useMemo(() => {
     switch (correctionType) {
-      case 'adjustQuantity': {
-        if (isNaN(adjustmentNum) || adjustmentNum === 0) return false;
-        if (newQuantity < 0) return false;
-        if (!reason.trim()) return false;
-        if (reason.length > REASON_MAX_LENGTH) return false;
-        return true;
+      case 'overrideQuantity': {
+        if (!reason.trim() || reason.length > REASON_MAX_LENGTH) return false;
+        if (Number.isNaN(newQtyNum) || newQtyNum < 0) return false;
+        if (delta === 0) return false;
+        if (delta < 0) return newQtyNum >= itemDeficient;
+        // increase: every added unit must be placed in a valid bin, summing to the delta
+        let sum = 0;
+        for (const d of destRows) {
+          const q = Number(d.quantity);
+          if (!d.aisle.trim() || d.aisle.length > 20) return false;
+          if (!d.bay.trim() || d.bay.length > 20) return false;
+          if (!d.bin.trim() || d.bin.length > 20) return false;
+          if (!Number.isInteger(q) || q < 1) return false;
+          sum += q;
+        }
+        return sum === delta;
       }
       case 'moveLocation':
       case 'assignLocation': {
@@ -173,14 +226,16 @@ export default function InventoryCorrectionModal({
       default:
         return false;
     }
-  }, [correctionType, adjustmentNum, newQuantity, reason, aisle, bay, bin]);
+  }, [correctionType, newQtyNum, delta, itemDeficient, destRows, reason, aisle, bay, bin]);
 
   // --- Confirmation message ---
 
   const confirmMessage = useMemo(() => {
     switch (correctionType) {
-      case 'adjustQuantity':
-        return `Adjust quantity by ${adjustmentNum > 0 ? '+' : ''}${adjustmentNum} (${item.quantity} -> ${newQuantity}). Reason: "${reason.trim()}"`;
+      case 'overrideQuantity':
+        return delta < 0
+          ? `Override quantity ${item.quantity} -> ${newQtyNum} (remove ${-delta}). Reason: "${reason.trim()}"`
+          : `Override quantity ${item.quantity} -> ${newQtyNum} (add ${delta} across ${destRows.length} location(s)). Reason: "${reason.trim()}"`;
       case 'moveLocation':
         return `Move item from ${formatLocation(item.aisle, item.bay, item.bin)} to ${formatLocation(aisle, bay, bin)}`;
       case 'markUnlocated':
@@ -190,15 +245,15 @@ export default function InventoryCorrectionModal({
       default:
         return '';
     }
-  }, [correctionType, adjustmentNum, newQuantity, item, reason, aisle, bay, bin]);
+  }, [correctionType, delta, newQtyNum, destRows, item, reason, aisle, bay, bin]);
 
   // --- Mutations ---
 
-  const [adjustInventoryQuantity, { loading: adjustLoading }] = useMutation(ADJUST_INVENTORY_QUANTITY, {
+  const [overrideInventoryQuantity, { loading: overrideLoading }] = useMutation(OVERRIDE_INVENTORY_QUANTITY, {
     refetchQueries: WAREHOUSE_REFETCH_QUERIES,
     awaitRefetchQueries: true,
     onCompleted: () => {
-      showToast('Correction applied successfully', 'success');
+      showToast('Quantity override applied', 'success');
       onSuccess();
       onClose();
     },
@@ -286,7 +341,7 @@ export default function InventoryCorrectionModal({
   });
 
   const mutationLoading =
-    adjustLoading ||
+    overrideLoading ||
     moveInvLoading ||
     unlocateInvLoading ||
     assignInvLoading ||
@@ -301,12 +356,24 @@ export default function InventoryCorrectionModal({
 
     if (itemType === 'inventory') {
       switch (correctionType) {
-        case 'adjustQuantity':
-          adjustInventoryQuantity({
+        case 'overrideQuantity':
+          overrideInventoryQuantity({
             variables: {
-              inventoryLocationId: item.id,
-              adjustment: adjustmentNum,
-              reason: reason.trim(),
+              input: {
+                inventoryLocationId: item.id,
+                newQuantity: newQtyNum,
+                reasonText: reason.trim(),
+                destinations:
+                  delta > 0
+                    ? destRows.map((d) => ({
+                        aisle: d.aisle.trim(),
+                        bay: d.bay.trim(),
+                        bin: d.bin.trim(),
+                        quantity: Number(d.quantity),
+                      }))
+                    : [],
+                performedBy: displayName,
+              },
             },
           });
           break;
@@ -429,28 +496,30 @@ export default function InventoryCorrectionModal({
 
   const renderForm = () => {
     switch (correctionType) {
-      case 'adjustQuantity':
+      case 'overrideQuantity': {
+        const remaining = delta - placedTotal;
         return (
           <Stack spacing={2}>
             <TextField
-              label="Adjustment (+/-)"
+              label="New quantity"
               type="number"
-              value={adjustment}
-              onChange={(e) => setAdjustment(e.target.value)}
+              value={newQty}
+              onChange={(e) => setNewQty(e.target.value)}
               size="small"
               fullWidth
+              error={!Number.isNaN(newQtyNum) && (newQtyNum < 0 || (delta < 0 && newQtyNum < itemDeficient))}
               helperText={
-                !isNaN(adjustmentNum)
-                  ? newQuantity < 0
-                    ? `New qty: ${newQuantity} — Cannot reduce below 0`
-                    : `New qty: ${newQuantity}`
-                  : 'Enter a positive or negative number'
+                Number.isNaN(newQtyNum)
+                  ? `Current quantity: ${item.quantity}`
+                  : delta === 0
+                    ? 'Enter a quantity different from the current one'
+                    : delta < 0
+                      ? newQtyNum < itemDeficient
+                        ? `Cannot go below ${itemDeficient} deficient unit(s) on this row`
+                        : `Removing ${-delta} (current ${item.quantity})`
+                      : `Adding ${delta} (current ${item.quantity}) - place the added units below`
               }
-              slotProps={{
-                formHelperText: {
-                  sx: { color: newQuantity < 0 ? 'error.main' : 'text.secondary' },
-                },
-              }}
+              slotProps={{ htmlInput: { min: 0 } }}
             />
             <TextField
               label="Reason"
@@ -467,8 +536,66 @@ export default function InventoryCorrectionModal({
               maxRows={4}
               helperText={`${reason.length}/${REASON_MAX_LENGTH}`}
             />
+            {delta > 0 && (
+              <Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 1, gap: 1 }}>
+                  <Typography variant="subtitle2">Where do the {delta} added unit(s) go?</Typography>
+                  <Typography variant="caption" color={remaining === 0 ? 'success.main' : 'error.main'}>
+                    {remaining === 0 ? 'all placed' : `${remaining} unplaced`}
+                  </Typography>
+                </Box>
+                <Stack spacing={1}>
+                  {destRows.map((d, idx) => (
+                    <Stack key={idx} direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'wrap' }}>
+                      <TextField
+                        label="Aisle"
+                        size="small"
+                        value={d.aisle}
+                        onChange={(e) => updateDest(idx, 'aisle', e.target.value)}
+                        sx={{ width: 90 }}
+                      />
+                      <TextField
+                        label="Bay"
+                        size="small"
+                        value={d.bay}
+                        onChange={(e) => updateDest(idx, 'bay', e.target.value)}
+                        sx={{ width: 90 }}
+                      />
+                      <TextField
+                        label="Bin"
+                        size="small"
+                        value={d.bin}
+                        onChange={(e) => updateDest(idx, 'bin', e.target.value)}
+                        sx={{ width: 90 }}
+                      />
+                      <TextField
+                        label="Qty"
+                        type="number"
+                        size="small"
+                        value={d.quantity}
+                        onChange={(e) => updateDest(idx, 'quantity', e.target.value)}
+                        slotProps={{ htmlInput: { min: 1 } }}
+                        sx={{ width: 80 }}
+                      />
+                      <IconButton
+                        size="small"
+                        aria-label="Remove location"
+                        disabled={destRows.length <= 1}
+                        onClick={() => removeDest(idx)}
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Stack>
+                  ))}
+                  <Button size="small" startIcon={<AddIcon />} onClick={addDest} sx={{ alignSelf: 'flex-start' }}>
+                    Add location
+                  </Button>
+                </Stack>
+              </Box>
+            )}
           </Stack>
         );
+      }
 
       case 'moveLocation':
         return (

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -23,7 +23,6 @@ import { useQuery, useLazyQuery, useMutation } from '@apollo/client/react';
 import { GET_INVENTORY_HIERARCHY, GET_INVENTORY_ITEMS, GET_INVENTORY_BY_VENDOR } from '../../graphql/queries';
 import { REPORT_INVENTORY_DEFICIENCY } from '../../graphql/mutations';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
-import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import InventoryCorrectionModal from '../admin/InventoryCorrectionModal';
 import AuditHistoryDrawer from './AuditHistoryDrawer';
@@ -167,8 +166,6 @@ function ProductCodeDetail({
   totalQuantity: number;
   totalValue: number;
 }) {
-  const { isAdmin } = useIdentity();
-
   const [expanded, setExpanded] = useState(false);
   const hasFetched = useRef(false);
   const [fetchItems, { data, loading, error }] = useLazyQuery<{
@@ -330,35 +327,29 @@ function ProductCodeDetail({
         </Button>
       ),
     };
-    if (!isAdmin) return [...baseDetailColumns, destockCol, reportDefCol, spotCheckCol, historyCol];
-    return [
-      ...baseDetailColumns,
-      {
-        field: 'actions',
-        headerName: 'Actions',
-        flex: 0.7,
-        sortable: false,
-        filterable: false,
-        renderCell: (params: { row: InventoryItemDetail }) => (
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={(e) => {
-              e.stopPropagation();
-              setCorrectionItem(params.row.inventoryLocation);
-              setCorrectionOpen(true);
-            }}
-          >
-            Correction
-          </Button>
-        ),
-      } satisfies GridColDef,
-      destockCol,
-      reportDefCol,
-      spotCheckCol,
-      historyCol,
-    ];
-  }, [isAdmin, reportDeficient, showToast]);
+    const correctionCol: GridColDef = {
+      field: 'actions',
+      headerName: 'Actions',
+      flex: 0.7,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: { row: InventoryItemDetail }) => (
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={(e) => {
+            e.stopPropagation();
+            setCorrectionItem(params.row.inventoryLocation);
+            setCorrectionOpen(true);
+          }}
+        >
+          Correction
+        </Button>
+      ),
+    };
+    // Correction (quantity override + location fixes) is available to all users, not just admins.
+    return [...baseDetailColumns, correctionCol, destockCol, reportDefCol, spotCheckCol, historyCol];
+  }, [reportDeficient, showToast]);
 
   const handleCorrectionSuccess = useCallback(() => {
     fetchItems({


### PR DESCRIPTION
closes #138. split from #127. lets a user override the on-hand quantity of a hardware item per project from the inventory view, with a required reason on every change and full audit logging.

this enhances the existing per-row Correction: the Adjust Quantity tab becomes Override Quantity and no longer takes a +/- delta, it takes the absolute new quantity for that InventoryLocation row. direction drives the rest:
- decrease: the row shrinks to the new quantity (lost units written off with the reason); it can't drop below the units already flagged deficient on that row.
- increase: the added units have to go somewhere, so the modal asks for destination bin(s) whose quantities must sum to the increase. a destination at the row's own aisle/bay/bin just bumps that row; a different bin becomes a new InventoryLocation that inherits the row's origin (PO receipt or stock allocation), keeping the has-origin CHECK satisfied and the unit_cost intact for valuations.
- a reason is required either way and lands in the audit log alongside the user, timestamp, before/after quantity, and the destination bins.

the backend adds an override_inventory_quantity repository function and an overrideInventoryQuantity mutation taking OverrideInventoryQuantityInput { inventoryLocationId, newQuantity, reasonText, destinations[], performedBy }. the old adjustInventoryQuantity mutation stays put, since SpotCheckModal and the Locations tab still use it for delta tweaks. a new test file covers decrease, increase-into-the-same-bin, increase-into-a-new-bin, and the validation paths.

per the decision recorded on the issue, the override is available to ALL users, not just admins. the Correction action used to be admin-only and is now shown to everyone in the inventory grid, which also surfaces the modal's existing location corrections (move / unlocate / assign) to non-admins - say the word if you'd rather keep those admin-gated and i'll split the gate so only the quantity override opens up.

an increase that places units in a different bin leaves the source row at its old quantity and creates a separate row for the added units, so the row you edited may still read its original number while a new row appears. the modal defaults the destination to the source row's own bin, so the simple "just make it N here" case stays one row.