### PR TITLE
warehouses: model + admin CRUD + receive picks warehouse (#88)

### DIFF
--- a/backend/alembic/versions/033_add_warehouses.py
+++ b/backend/alembic/versions/033_add_warehouses.py
@@ -1,0 +1,79 @@
+"""Add warehouses table and warehouse_id FK on inventory_locations / stock_items / opening_items
+
+Revision ID: 033
+Revises: 032
+Create Date: 2026-06-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "033"
+down_revision = "032"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("inventory_locations", "stock_items", "opening_items")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "warehouses",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("code", sa.String(20), nullable=False),
+        sa.Column("address", sa.String(), nullable=True),
+        sa.Column("city", sa.String(), nullable=True),
+        sa.Column("province", sa.String(), nullable=True),
+        sa.Column("postal_code", sa.String(), nullable=True),
+        sa.Column("is_primary", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("name", name="uq_warehouses_name"),
+        sa.UniqueConstraint("code", name="uq_warehouses_code"),
+    )
+
+    # Seed the two physical warehouses (Warden is primary / default for backfill)
+    op.execute(
+        """
+        INSERT INTO warehouses (id, name, code, is_primary, is_active, created_at, updated_at)
+        VALUES
+            (gen_random_uuid(), 'Warden', 'WRD', true, true, now(), now()),
+            (gen_random_uuid(), 'VP', 'VP', false, true, now(), now())
+        """
+    )
+
+    for table in _TABLES:
+        op.add_column(table, sa.Column("warehouse_id", sa.Uuid(), nullable=True))
+        op.create_foreign_key(
+            f"fk_{table}_warehouse_id",
+            table,
+            "warehouses",
+            ["warehouse_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        # Backfill every existing row to the primary warehouse
+        op.execute(
+            f"""
+            UPDATE {table}
+            SET warehouse_id = (SELECT id FROM warehouses WHERE is_primary = true LIMIT 1)
+            WHERE warehouse_id IS NULL
+            """
+        )
+        op.alter_column(table, "warehouse_id", nullable=False)
+        op.create_index(
+            f"ix_{table}_warehouse",
+            table,
+            ["warehouse_id", "aisle", "bay", "bin"],
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.drop_index(f"ix_{table}_warehouse", table_name=table)
+        op.drop_constraint(f"fk_{table}_warehouse_id", table, type_="foreignkey")
+        op.drop_column(table, "warehouse_id")
+    op.drop_table("warehouses")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -25,3 +25,4 @@ from .shop_assembly import (  # noqa: E402, F401
 )
 from .stock_item import StockItem  # noqa: E402, F401
 from .vendor import Vendor  # noqa: E402, F401
+from .warehouse import Warehouse  # noqa: E402, F401

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -18,6 +18,7 @@ class InventoryLocation(Base):
         ),
         Index("ix_inventory_locations_aisle", "aisle"),
         Index("ix_inventory_locations_stock_item", "stock_item_id"),
+        Index("ix_inventory_locations_warehouse", "warehouse_id", "aisle", "bay", "bin"),
         CheckConstraint("quantity >= 0", name="ck_inventory_locations_quantity_nonneg"),
         CheckConstraint(
             "deficient_quantity >= 0",
@@ -40,6 +41,7 @@ class InventoryLocation(Base):
     stock_item_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("stock_items.id", ondelete="SET NULL"), nullable=True
     )
+    warehouse_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/models/opening_item.py
+++ b/backend/app/models/opening_item.py
@@ -13,6 +13,7 @@ class OpeningItem(Base):
     __table_args__ = (
         Index("ix_opening_items_project_state", "project_id", "state"),
         Index("ix_opening_items_opening_id", "opening_id"),
+        Index("ix_opening_items_warehouse", "warehouse_id", "aisle", "bay", "bin"),
         CheckConstraint("quantity >= 1", name="ck_opening_items_quantity_positive"),
     )
 
@@ -21,6 +22,7 @@ class OpeningItem(Base):
     # Historical UUID of the source opening at assembly time. Not FK-enforced; the source
     # Opening row may be deleted in a later re-upload, but this stamp is preserved.
     opening_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    warehouse_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
     opening_number: Mapped[str] = mapped_column(String, nullable=False)
     building: Mapped[str | None] = mapped_column(String, nullable=True)
     floor: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/models/stock_item.py
+++ b/backend/app/models/stock_item.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Index, Integer, String
+from sqlalchemy import CheckConstraint, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from . import Base
@@ -14,6 +14,7 @@ class StockItem(Base):
     __table_args__ = (
         Index("ix_stock_items_cat_code", "hardware_category", "product_code"),
         Index("ix_stock_items_aisle", "aisle"),
+        Index("ix_stock_items_warehouse", "warehouse_id", "aisle", "bay", "bin"),
         CheckConstraint("quantity >= 0", name="ck_stock_items_quantity_nonneg"),
         CheckConstraint(
             "deficient_quantity >= 0",
@@ -26,6 +27,7 @@ class StockItem(Base):
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    warehouse_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/models/warehouse.py
+++ b/backend/app/models/warehouse.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class Warehouse(Base):
+    """A physical warehouse building. Bins (aisle/bay/bin) are scoped to one warehouse."""
+
+    __tablename__ = "warehouses"
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_warehouses_name"),
+        UniqueConstraint("code", name="uq_warehouses_code"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    code: Mapped[str] = mapped_column(String(20), nullable=False)
+    address: Mapped[str | None] = mapped_column(String, nullable=True)
+    city: Mapped[str | None] = mapped_column(String, nullable=True)
+    province: Mapped[str | None] = mapped_column(String, nullable=True)
+    postal_code: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_primary: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -308,10 +308,13 @@ def complete_opening(
 
     # 5. Create OpeningItem (snapshot opening identity from SAR row)
     now = datetime.utcnow()
+    from app.repositories import warehouse_admin_repository
+
     opening_item = OpeningItemModel(
         id=uuid.uuid4(),
         project_id=sar.project_id,
         opening_id=sa_opening.opening_id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
         opening_number=sa_opening.opening_number,
         building=sa_opening.building,
         floor=sa_opening.floor,

--- a/backend/app/repositories/stock_repository.py
+++ b/backend/app/repositories/stock_repository.py
@@ -72,6 +72,7 @@ def get_stock_items(
     hardware_category: str | None = None,
     aisle: str | None = None,
     only_deficient: bool = False,
+    warehouse_id: uuid.UUID | None = None,
 ) -> list[StockItem]:
     """List stock_items optionally filtered by product code, category, aisle, or deficient-only.
 
@@ -96,6 +97,8 @@ def get_stock_items(
         stmt = stmt.where(StockItem.aisle == aisle)
     if only_deficient:
         stmt = stmt.where(StockItem.deficient_quantity > 0)
+    if warehouse_id is not None:
+        stmt = stmt.where(StockItem.warehouse_id == warehouse_id)
     return list(session.scalars(stmt).all())
 
 
@@ -149,6 +152,7 @@ def get_stock_matches_for_opening(
 def _find_or_create_stock_row(
     session: Session,
     *,
+    warehouse_id: uuid.UUID,
     hardware_category: str,
     product_code: str,
     aisle: str | None,
@@ -156,7 +160,7 @@ def _find_or_create_stock_row(
     bin: str | None,
     received_at: datetime,
 ) -> StockItem:
-    """Find an existing stock row matching (category, code, aisle, bay, bin) or create one with qty=0.
+    """Find an existing stock row matching (warehouse, category, code, aisle, bay, bin) or create one with qty=0.
 
     Caller is responsible for incrementing quantity and writing audit events. Location fields are
     normalized here so writes from any entry path (destock, allocate, receive) match canonical form.
@@ -166,6 +170,7 @@ def _find_or_create_stock_row(
     bin = normalize_location_value(bin)
 
     stmt = select(StockItem).where(
+        StockItem.warehouse_id == warehouse_id,
         StockItem.hardware_category == hardware_category,
         StockItem.product_code == product_code,
     )
@@ -187,6 +192,7 @@ def _find_or_create_stock_row(
         return existing
 
     new_row = StockItem(
+        warehouse_id=warehouse_id,
         hardware_category=hardware_category,
         product_code=product_code,
         quantity=0,
@@ -248,6 +254,7 @@ def destock_inventory(
     now = datetime.utcnow()
     stock_row = _find_or_create_stock_row(
         session,
+        warehouse_id=il.warehouse_id,
         hardware_category=il.hardware_category,
         product_code=il.product_code,
         aisle=final_aisle,
@@ -590,6 +597,7 @@ def allocate_stock_to_project(
         po_line_item_id=None,
         receive_line_item_id=None,
         stock_item_id=stock_item_id,
+        warehouse_id=si.warehouse_id,
         hardware_category=target_hardware_category,
         product_code=target_product_code,
         quantity=quantity,
@@ -1047,6 +1055,7 @@ def get_deficiency_reviews(
 def receive_into_stock(
     session: Session,
     *,
+    warehouse_id: uuid.UUID | None = None,
     hardware_category: str,
     product_code: str,
     quantity: int,
@@ -1067,8 +1076,14 @@ def receive_into_stock(
             field="deficient_quantity",
         )
 
+    if warehouse_id is None:
+        from app.repositories import warehouse_admin_repository
+
+        warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+
     stock_row = _find_or_create_stock_row(
         session,
+        warehouse_id=warehouse_id,
         hardware_category=hardware_category,
         product_code=product_code,
         aisle=aisle,

--- a/backend/app/repositories/warehouse_admin_repository.py
+++ b/backend/app/repositories/warehouse_admin_repository.py
@@ -1,0 +1,180 @@
+"""Repository for Warehouse entity CRUD (the physical buildings, not inventory ops)."""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.errors import ConflictError, NotFoundError, ValidationError
+from app.models.inventory import InventoryLocation as InventoryLocationModel
+from app.models.opening_item import OpeningItem as OpeningItemModel
+from app.models.stock_item import StockItem as StockItemModel
+from app.models.warehouse import Warehouse
+
+
+def list_warehouses(session: Session, *, include_inactive: bool = True) -> list[Warehouse]:
+    stmt = select(Warehouse).order_by(Warehouse.is_primary.desc(), Warehouse.name)
+    if not include_inactive:
+        stmt = stmt.where(Warehouse.is_active.is_(True))
+    return list(session.scalars(stmt).all())
+
+
+def get_warehouse(session: Session, warehouse_id: uuid.UUID) -> Warehouse:
+    wh = session.get(Warehouse, warehouse_id)
+    if wh is None:
+        raise NotFoundError(f"Warehouse {warehouse_id} not found")
+    return wh
+
+
+def get_primary_warehouse_id(session: Session) -> uuid.UUID:
+    """The default warehouse new rows fall back to when none is otherwise determined."""
+    wh_id = session.scalar(
+        select(Warehouse.id).where(Warehouse.is_primary.is_(True)).order_by(Warehouse.created_at).limit(1)
+    )
+    if wh_id is None:
+        # No primary flagged: fall back to the oldest warehouse so creates never fail.
+        wh_id = session.scalar(select(Warehouse.id).order_by(Warehouse.created_at).limit(1))
+    if wh_id is None:
+        raise ConflictError("No warehouse exists; cannot place inventory")
+    return wh_id
+
+
+def _norm(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _check_name_unique(session: Session, name: str, exclude_id: uuid.UUID | None = None) -> None:
+    stmt = select(func.count()).select_from(Warehouse).where(func.lower(Warehouse.name) == name.lower())
+    if exclude_id is not None:
+        stmt = stmt.where(Warehouse.id != exclude_id)
+    if session.scalar(stmt):
+        raise ConflictError(f"A warehouse named '{name}' already exists")
+
+
+def _check_code_unique(session: Session, code: str, exclude_id: uuid.UUID | None = None) -> None:
+    stmt = select(func.count()).select_from(Warehouse).where(func.lower(Warehouse.code) == code.lower())
+    if exclude_id is not None:
+        stmt = stmt.where(Warehouse.id != exclude_id)
+    if session.scalar(stmt):
+        raise ConflictError(f"A warehouse with code '{code}' already exists")
+
+
+def create_warehouse(
+    session: Session,
+    *,
+    name: str,
+    code: str,
+    address: str | None = None,
+    city: str | None = None,
+    province: str | None = None,
+    postal_code: str | None = None,
+    is_primary: bool = False,
+    is_active: bool = True,
+) -> Warehouse:
+    name = (name or "").strip()
+    code = (code or "").strip()
+    if not name:
+        raise ValidationError("Warehouse name is required", field="name")
+    if not code:
+        raise ValidationError("Warehouse code is required", field="code")
+    if len(code) > 20:
+        raise ValidationError("Warehouse code must be 20 characters or fewer", field="code")
+    _check_name_unique(session, name)
+    _check_code_unique(session, code)
+
+    if is_primary:
+        _clear_primary(session)
+
+    wh = Warehouse(
+        id=uuid.uuid4(),
+        name=name,
+        code=code,
+        address=_norm(address),
+        city=_norm(city),
+        province=_norm(province),
+        postal_code=_norm(postal_code),
+        is_primary=is_primary,
+        is_active=is_active,
+    )
+    session.add(wh)
+    session.flush()
+    return wh
+
+
+def update_warehouse(
+    session: Session,
+    warehouse_id: uuid.UUID,
+    *,
+    name: str | None = None,
+    code: str | None = None,
+    address: str | None = None,
+    city: str | None = None,
+    province: str | None = None,
+    postal_code: str | None = None,
+    is_primary: bool | None = None,
+    is_active: bool | None = None,
+) -> Warehouse:
+    wh = get_warehouse(session, warehouse_id)
+
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValidationError("Warehouse name is required", field="name")
+        _check_name_unique(session, name, exclude_id=warehouse_id)
+        wh.name = name
+    if code is not None:
+        code = code.strip()
+        if not code:
+            raise ValidationError("Warehouse code is required", field="code")
+        if len(code) > 20:
+            raise ValidationError("Warehouse code must be 20 characters or fewer", field="code")
+        _check_code_unique(session, code, exclude_id=warehouse_id)
+        wh.code = code
+    if address is not None:
+        wh.address = _norm(address)
+    if city is not None:
+        wh.city = _norm(city)
+    if province is not None:
+        wh.province = _norm(province)
+    if postal_code is not None:
+        wh.postal_code = _norm(postal_code)
+    if is_active is not None:
+        wh.is_active = is_active
+    if is_primary is not None:
+        if is_primary:
+            _clear_primary(session, exclude_id=warehouse_id)
+            wh.is_primary = True
+        else:
+            wh.is_primary = False
+
+    session.flush()
+    return wh
+
+
+def delete_warehouse(session: Session, warehouse_id: uuid.UUID) -> None:
+    wh = get_warehouse(session, warehouse_id)
+    if wh.is_primary:
+        raise ConflictError("Cannot delete the primary warehouse")
+
+    for model, label in (
+        (InventoryLocationModel, "inventory location"),
+        (StockItemModel, "stock"),
+        (OpeningItemModel, "opening item"),
+    ):
+        count = session.scalar(select(func.count()).select_from(model).where(model.warehouse_id == warehouse_id))
+        if count and count > 0:
+            raise ConflictError(f"Cannot delete warehouse: {count} {label} row(s) still reference it")
+
+    session.delete(wh)
+    session.flush()
+
+
+def _clear_primary(session: Session, exclude_id: uuid.UUID | None = None) -> None:
+    stmt = select(Warehouse).where(Warehouse.is_primary.is_(True))
+    if exclude_id is not None:
+        stmt = stmt.where(Warehouse.id != exclude_id)
+    for wh in session.scalars(stmt).all():
+        wh.is_primary = False

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -1007,6 +1007,7 @@ def override_inventory_quantity(
                     po_line_item_id=il.po_line_item_id,
                     receive_line_item_id=il.receive_line_item_id,
                     stock_item_id=il.stock_item_id,
+                    warehouse_id=il.warehouse_id,
                     hardware_category=il.hardware_category,
                     product_code=il.product_code,
                     quantity=dest["quantity"],
@@ -1228,6 +1229,7 @@ def create_receive(
     po_id: uuid.UUID,
     received_by: str,
     line_items_input: list[dict],
+    warehouse_id: uuid.UUID | None = None,
 ) -> ReceiveRecordModel:
     """
     Create a ReceiveRecord with ReceiveLineItems and InventoryLocations.
@@ -1252,6 +1254,11 @@ def create_receive(
 
     # Project-less PO is allowed: line items route to the stock pool instead of project inventory
     is_stock_po = po.project_id is None
+
+    if warehouse_id is None:
+        from app.repositories import warehouse_admin_repository
+
+        warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
 
     # Validate PO status
     if po.status not in (POStatus.ORDERED, POStatus.VENDOR_CONFIRMED, POStatus.PARTIALLY_RECEIVED):
@@ -1337,6 +1344,7 @@ def create_receive(
                 for loc in locations:
                     stock_repository.receive_into_stock(
                         session,
+                        warehouse_id=warehouse_id,
                         hardware_category=poli.hardware_category,
                         product_code=poli.product_code,
                         quantity=loc["quantity"],
@@ -1351,6 +1359,7 @@ def create_receive(
             else:
                 stock_repository.receive_into_stock(
                     session,
+                    warehouse_id=warehouse_id,
                     hardware_category=poli.hardware_category,
                     product_code=poli.product_code,
                     quantity=li_input["quantity_received"],
@@ -1368,6 +1377,7 @@ def create_receive(
                     project_id=po.project_id,
                     po_line_item_id=poli.id,
                     receive_line_item_id=receive_line_item.id,
+                    warehouse_id=warehouse_id,
                     hardware_category=poli.hardware_category,
                     product_code=poli.product_code,
                     quantity=loc["quantity"],
@@ -1384,6 +1394,7 @@ def create_receive(
                 project_id=po.project_id,
                 po_line_item_id=poli.id,
                 receive_line_item_id=receive_line_item.id,
+                warehouse_id=warehouse_id,
                 hardware_category=poli.hardware_category,
                 product_code=poli.product_code,
                 quantity=li_input["quantity_received"],

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -190,6 +190,30 @@ class UpdateVendorInput:
 
 
 @strawberry.input
+class CreateWarehouseInput:
+    name: str
+    code: str
+    address: str | None = None
+    city: str | None = None
+    province: str | None = None
+    postal_code: str | None = None
+    is_primary: bool = False
+    is_active: bool = True
+
+
+@strawberry.input
+class UpdateWarehouseInput:
+    name: str | None = None
+    code: str | None = None
+    address: str | None = None
+    city: str | None = None
+    province: str | None = None
+    postal_code: str | None = None
+    is_primary: bool | None = None
+    is_active: bool | None = None
+
+
+@strawberry.input
 class ReconciliationItemInput:
     opening_number: str
     hardware_category: str
@@ -217,6 +241,7 @@ class LocationInput:
 class CreateReceiveInput:
     po_id: strawberry.ID
     received_by: str
+    warehouse_id: strawberry.ID | None = None
     line_items: list[ReceiveLineItemInput] = strawberry.field(default_factory=list)
 
 

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -15,6 +15,7 @@ from app.repositories import (
     stock_repository,
     user_repository,
     vendor_repository,
+    warehouse_admin_repository,
     warehouse_repository,
 )
 
@@ -29,6 +30,7 @@ from .inputs import (
     CreateProjectInput,
     CreateReceiveInput,
     CreateVendorInput,
+    CreateWarehouseInput,
     DestockInventoryInput,
     FinalizeImportSessionInput,
     MoveStockLocationInput,
@@ -40,6 +42,7 @@ from .inputs import (
     ResolveDeficiencyInput,
     UpdateProjectInput,
     UpdateVendorInput,
+    UpdateWarehouseInput,
 )
 from .queries import (
     _deficiency_review_to_type,
@@ -58,6 +61,7 @@ from .queries import (
     _shop_assembly_request_to_type,
     _stock_item_to_type,
     _vendor_to_type,
+    _warehouse_to_type,
 )
 from .types import (
     ApproveResult,
@@ -81,6 +85,7 @@ from .types import (
     ShopAssemblyRequest,
     StockItem,
     Vendor,
+    Warehouse,
 )
 from .types import (
     PackingSlip as PackingSlipType,
@@ -521,8 +526,11 @@ class Mutation:
             }
             for li in input.line_items
         ]
+        warehouse_id = uuid.UUID(str(input.warehouse_id)) if input.warehouse_id else None
         with SessionLocal() as session:
-            receive_record = warehouse_repository.create_receive(session, po_id, received_by, line_items_data)
+            receive_record = warehouse_repository.create_receive(
+                session, po_id, received_by, line_items_data, warehouse_id=warehouse_id
+            )
             session.commit()
             session.refresh(receive_record)
             # Eagerly load line_items for the response
@@ -866,6 +874,51 @@ class Mutation:
     def delete_vendor(self, id: strawberry.ID) -> bool:
         with SessionLocal() as session:
             vendor_repository.delete_vendor(session, uuid.UUID(str(id)))
+            session.commit()
+            return True
+
+    # Warehouses
+    @strawberry.mutation
+    def create_warehouse(self, input: CreateWarehouseInput) -> Warehouse:
+        with SessionLocal() as session:
+            wh = warehouse_admin_repository.create_warehouse(
+                session,
+                name=input.name,
+                code=input.code,
+                address=input.address,
+                city=input.city,
+                province=input.province,
+                postal_code=input.postal_code,
+                is_primary=input.is_primary,
+                is_active=input.is_active,
+            )
+            session.commit()
+            session.refresh(wh)
+            return _warehouse_to_type(wh)
+
+    @strawberry.mutation
+    def update_warehouse(self, id: strawberry.ID, input: UpdateWarehouseInput) -> Warehouse:
+        with SessionLocal() as session:
+            wh = warehouse_admin_repository.update_warehouse(
+                session,
+                uuid.UUID(str(id)),
+                name=input.name,
+                code=input.code,
+                address=input.address,
+                city=input.city,
+                province=input.province,
+                postal_code=input.postal_code,
+                is_primary=input.is_primary,
+                is_active=input.is_active,
+            )
+            session.commit()
+            session.refresh(wh)
+            return _warehouse_to_type(wh)
+
+    @strawberry.mutation
+    def delete_warehouse(self, id: strawberry.ID) -> bool:
+        with SessionLocal() as session:
+            warehouse_admin_repository.delete_warehouse(session, uuid.UUID(str(id)))
             session.commit()
             return True
 

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -19,6 +19,7 @@ from app.repositories import (
     stock_repository,
     user_repository,
     vendor_repository,
+    warehouse_admin_repository,
     warehouse_repository,
 )
 
@@ -76,6 +77,7 @@ from .types import (
     ShopAssemblyStats,
     Vendor,
     VendorInventoryNode,
+    Warehouse,
     WarehouseDashboard,
 )
 from .types import (
@@ -162,6 +164,22 @@ def _vendor_to_type(v) -> Vendor:
         notes=v.notes,
         created_at=v.created_at,
         updated_at=v.updated_at,
+    )
+
+
+def _warehouse_to_type(w) -> Warehouse:
+    return Warehouse(
+        id=strawberry.ID(str(w.id)),
+        name=w.name,
+        code=w.code,
+        address=w.address,
+        city=w.city,
+        province=w.province,
+        postal_code=w.postal_code,
+        is_primary=w.is_primary,
+        is_active=w.is_active,
+        created_at=w.created_at,
+        updated_at=w.updated_at,
     )
 
 
@@ -295,6 +313,7 @@ def _inventory_location_to_type(il) -> InventoryLocationType:
         po_line_item_id=strawberry.ID(str(il.po_line_item_id)) if il.po_line_item_id else None,
         receive_line_item_id=(strawberry.ID(str(il.receive_line_item_id)) if il.receive_line_item_id else None),
         stock_item_id=strawberry.ID(str(stock_item_id)) if stock_item_id else None,
+        warehouse_id=strawberry.ID(str(il.warehouse_id)) if getattr(il, "warehouse_id", None) else None,
         hardware_category=il.hardware_category,
         product_code=il.product_code,
         quantity=il.quantity,
@@ -325,6 +344,7 @@ def _opening_item_to_type(oi) -> OpeningItem:
         id=strawberry.ID(str(oi.id)),
         project_id=strawberry.ID(str(oi.project_id)),
         opening_id=strawberry.ID(str(oi.opening_id)),
+        warehouse_id=strawberry.ID(str(oi.warehouse_id)) if getattr(oi, "warehouse_id", None) else None,
         opening_number=oi.opening_number,
         building=oi.building,
         floor=oi.floor,
@@ -457,6 +477,7 @@ def _stock_item_to_type(si) -> StockItemType:
     deficient_qty = getattr(si, "deficient_quantity", 0) or 0
     return StockItemType(
         id=strawberry.ID(str(si.id)),
+        warehouse_id=strawberry.ID(str(si.warehouse_id)) if getattr(si, "warehouse_id", None) else None,
         hardware_category=si.hardware_category,
         product_code=si.product_code,
         quantity=si.quantity,
@@ -906,6 +927,20 @@ class Query:
             return _vendor_to_type(v) if v is not None else None
 
     @strawberry.field
+    def warehouses(self, include_inactive: bool = True) -> list[Warehouse]:
+        with SessionLocal() as session:
+            return [
+                _warehouse_to_type(w)
+                for w in warehouse_admin_repository.list_warehouses(session, include_inactive=include_inactive)
+            ]
+
+    @strawberry.field
+    def warehouse(self, id: strawberry.ID) -> Warehouse | None:
+        with SessionLocal() as session:
+            w = session.get(warehouse_admin_repository.Warehouse, uuid.UUID(str(id)))
+            return _warehouse_to_type(w) if w is not None else None
+
+    @strawberry.field
     def expected_deliveries(self, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
         with SessionLocal() as session:
             pos = warehouse_repository.get_expected_deliveries(
@@ -1146,6 +1181,7 @@ class Query:
         hardware_category: str | None = None,
         aisle: str | None = None,
         only_deficient: bool = False,
+        warehouse_id: strawberry.ID | None = None,
     ) -> list[StockItemType]:
         with SessionLocal() as session:
             rows = stock_repository.get_stock_items(
@@ -1154,6 +1190,7 @@ class Query:
                 hardware_category=hardware_category,
                 aisle=aisle,
                 only_deficient=only_deficient,
+                warehouse_id=uuid.UUID(str(warehouse_id)) if warehouse_id else None,
             )
             return [_stock_item_to_type(r) for r in rows]
 

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -236,6 +236,7 @@ class InventoryLocation:
     po_line_item_id: strawberry.ID | None
     receive_line_item_id: strawberry.ID | None
     stock_item_id: strawberry.ID | None
+    warehouse_id: strawberry.ID | None
     hardware_category: str
     product_code: str
     quantity: int
@@ -264,6 +265,7 @@ class OpeningItem:
     id: strawberry.ID
     project_id: strawberry.ID
     opening_id: strawberry.ID
+    warehouse_id: strawberry.ID | None
     opening_number: str
     building: str | None
     floor: str | None
@@ -592,8 +594,24 @@ class AuditLogEntry:
 
 
 @strawberry.type
+class Warehouse:
+    id: strawberry.ID
+    name: str
+    code: str
+    address: str | None
+    city: str | None
+    province: str | None
+    postal_code: str | None
+    is_primary: bool
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+@strawberry.type
 class StockItem:
     id: strawberry.ID
+    warehouse_id: strawberry.ID | None
     hardware_category: str
     product_code: str
     quantity: int

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -20,7 +20,7 @@ from app.models.shop_assembly import (
     ShopAssemblyRequest,
 )
 from app.models.vendor import Vendor
-from app.repositories import import_repository, shop_assembly_repository
+from app.repositories import import_repository, shop_assembly_repository, warehouse_admin_repository
 
 
 def _make_project(session, project_id: str = "PROJ-001") -> Project:
@@ -277,6 +277,7 @@ def test_replace_schedule_preserves_inventory(db_session):
         id=uuid.uuid4(),
         project_id=project.id,
         opening_id=a01.id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(db_session),
         opening_number="A01",
         building="B1",
         floor="F2",

--- a/backend/tests/test_warehouse_repository_inventory_hierarchy.py
+++ b/backend/tests/test_warehouse_repository_inventory_hierarchy.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from app.models.inventory import InventoryLocation
 from app.models.project import Project
 from app.models.stock_item import StockItem
-from app.repositories import warehouse_repository
+from app.repositories import warehouse_admin_repository, warehouse_repository
 
 
 def _make_project(session) -> Project:
@@ -24,6 +24,7 @@ def _make_stock_item(session) -> StockItem:
     """A stock row used purely as a valid origin for InventoryLocation rows."""
     si = StockItem(
         id=uuid.uuid4(),
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
         hardware_category="HINGE",
         product_code="HG-100",
         quantity=10,
@@ -40,6 +41,7 @@ def _make_il(session, project_id, stock_item_id, *, quantity, product_code="HG-1
         id=uuid.uuid4(),
         project_id=project_id,
         stock_item_id=stock_item_id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
         hardware_category=hardware_category,
         product_code=product_code,
         quantity=quantity,

--- a/backend/tests/test_warehouse_repository_override_quantity.py
+++ b/backend/tests/test_warehouse_repository_override_quantity.py
@@ -10,7 +10,7 @@ from app.errors import ValidationError
 from app.models.inventory import InventoryLocation
 from app.models.project import Project
 from app.models.stock_item import StockItem
-from app.repositories import warehouse_repository
+from app.repositories import warehouse_admin_repository, warehouse_repository
 
 
 def _make_project(session) -> Project:
@@ -23,6 +23,7 @@ def _make_project(session) -> Project:
 def _make_stock_item(session) -> StockItem:
     si = StockItem(
         id=uuid.uuid4(),
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
         hardware_category="HINGE",
         product_code="HG-100",
         quantity=10,
@@ -39,6 +40,7 @@ def _make_il(session, project_id, stock_item_id, *, quantity, deficient=0, aisle
         id=uuid.uuid4(),
         project_id=project_id,
         stock_item_id=stock_item_id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
         hardware_category="HINGE",
         product_code="HG-100",
         quantity=quantity,

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -641,6 +641,42 @@ export const DELETE_VENDOR = gql`
   }
 `;
 
+const WAREHOUSE_FIELDS = `
+  id
+  name
+  code
+  address
+  city
+  province
+  postalCode
+  isPrimary
+  isActive
+  createdAt
+  updatedAt
+`;
+
+export const CREATE_WAREHOUSE = gql`
+  mutation CreateWarehouse($input: CreateWarehouseInput!) {
+    createWarehouse(input: $input) {
+      ${WAREHOUSE_FIELDS}
+    }
+  }
+`;
+
+export const UPDATE_WAREHOUSE = gql`
+  mutation UpdateWarehouse($id: ID!, $input: UpdateWarehouseInput!) {
+    updateWarehouse(id: $id, input: $input) {
+      ${WAREHOUSE_FIELDS}
+    }
+  }
+`;
+
+export const DELETE_WAREHOUSE = gql`
+  mutation DeleteWarehouse($id: ID!) {
+    deleteWarehouse(id: $id)
+  }
+`;
+
 // ---------------------------------------------------------------------------
 // Stock pool + deficiency mutations
 // ---------------------------------------------------------------------------

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -591,6 +591,24 @@ export const GET_VENDORS = gql`
   }
 `;
 
+export const GET_WAREHOUSES = gql`
+  query GetWarehouses($includeInactive: Boolean) {
+    warehouses(includeInactive: $includeInactive) {
+      id
+      name
+      code
+      address
+      city
+      province
+      postalCode
+      isPrimary
+      isActive
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
 export const GET_INVENTORY_BY_VENDOR = gql`
   query GetInventoryByVendor($projectId: ID) {
     inventoryByVendor(projectId: $projectId) {
@@ -807,14 +825,17 @@ export const GET_STOCK_ITEMS = gql`
     $hardwareCategory: String
     $aisle: String
     $onlyDeficient: Boolean
+    $warehouseId: ID
   ) {
     stockItems(
       productCodeContains: $productCodeContains
       hardwareCategory: $hardwareCategory
       aisle: $aisle
       onlyDeficient: $onlyDeficient
+      warehouseId: $warehouseId
     ) {
       id
+      warehouseId
       hardwareCategory
       productCode
       quantity

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Card, CardContent, CardActionArea, Grid } from '@mui/m
 import SummarizeIcon from '@mui/icons-material/Summarize';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import StoreIcon from '@mui/icons-material/Store';
+import WarehouseIcon from '@mui/icons-material/Warehouse';
 import FolderIcon from '@mui/icons-material/Folder';
 import GroupIcon from '@mui/icons-material/Group';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
@@ -47,6 +48,7 @@ const SUB_ROUTES = [
   { label: 'Project Purchasing Progress', path: '/app/admin/project-purchasing-progress', icon: <SummarizeIcon fontSize="large" /> },
   { label: 'Opening Status', path: '/app/admin/opening-status', icon: <VisibilityIcon fontSize="large" /> },
   { label: 'Vendors', path: '/app/admin/vendors', icon: <StoreIcon fontSize="large" /> },
+  { label: 'Warehouses', path: '/app/admin/warehouses', icon: <WarehouseIcon fontSize="large" /> },
   { label: 'Projects', path: '/app/admin/projects', icon: <FolderIcon fontSize="large" /> },
   { label: 'User Management', path: '/app/admin/users', icon: <GroupIcon fontSize="large" /> },
   { label: 'Location Cleanup', path: '/app/admin/location-cleanup', icon: <CleaningServicesIcon fontSize="large" /> },

--- a/frontend/src/modules/admin/WarehouseEditDialog.tsx
+++ b/frontend/src/modules/admin/WarehouseEditDialog.tsx
@@ -1,0 +1,228 @@
+import { useState, useCallback } from 'react';
+import { Button, Stack, TextField, FormControlLabel, Checkbox } from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import Modal from '../../components/Modal';
+import { useToast } from '../../components/Toast';
+import { CREATE_WAREHOUSE, UPDATE_WAREHOUSE } from '../../graphql/mutations';
+import { GET_WAREHOUSES } from '../../graphql/queries';
+
+export interface WarehouseFormValue {
+  id?: string;
+  name: string;
+  code: string;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  postalCode: string | null;
+  isPrimary: boolean;
+  isActive: boolean;
+}
+
+interface WarehouseEditDialogProps {
+  open: boolean;
+  warehouse: WarehouseFormValue | null;
+  onClose: () => void;
+  onSaved?: (warehouse: { id: string; name: string }) => void;
+}
+
+const EMPTY: WarehouseFormValue = {
+  name: '',
+  code: '',
+  address: '',
+  city: '',
+  province: '',
+  postalCode: '',
+  isPrimary: false,
+  isActive: true,
+};
+
+interface ContentProps {
+  initialWarehouse: WarehouseFormValue | null;
+  onClose: () => void;
+  onSaved?: (warehouse: { id: string; name: string }) => void;
+}
+
+function WarehouseEditDialogContent({ initialWarehouse, onClose, onSaved }: ContentProps) {
+  const { showToast } = useToast();
+  const [form, setForm] = useState<WarehouseFormValue>(() =>
+    initialWarehouse
+      ? {
+          id: initialWarehouse.id,
+          name: initialWarehouse.name,
+          code: initialWarehouse.code,
+          address: initialWarehouse.address ?? '',
+          city: initialWarehouse.city ?? '',
+          province: initialWarehouse.province ?? '',
+          postalCode: initialWarehouse.postalCode ?? '',
+          isPrimary: initialWarehouse.isPrimary,
+          isActive: initialWarehouse.isActive,
+        }
+      : EMPTY,
+  );
+  const [fieldError, setFieldError] = useState('');
+
+  const onError = (err: { message: string }) => {
+    if (err.message.toLowerCase().includes('already exists')) {
+      setFieldError(err.message);
+    } else {
+      showToast(err.message, 'error');
+    }
+  };
+
+  const [createWarehouse, { loading: creating }] = useMutation<{ createWarehouse: { id: string; name: string } }>(
+    CREATE_WAREHOUSE,
+    {
+      refetchQueries: [{ query: GET_WAREHOUSES, variables: { includeInactive: true } }],
+      onCompleted: (data) => {
+        showToast('Warehouse created', 'success');
+        onSaved?.(data.createWarehouse);
+        onClose();
+      },
+      onError,
+    },
+  );
+
+  const [updateWarehouse, { loading: updating }] = useMutation<{ updateWarehouse: { id: string; name: string } }>(
+    UPDATE_WAREHOUSE,
+    {
+      refetchQueries: [{ query: GET_WAREHOUSES, variables: { includeInactive: true } }],
+      onCompleted: (data) => {
+        showToast('Warehouse updated', 'success');
+        onSaved?.(data.updateWarehouse);
+        onClose();
+      },
+      onError,
+    },
+  );
+
+  const loading = creating || updating;
+
+  const handleSubmit = useCallback(() => {
+    const trimmedName = form.name.trim();
+    const trimmedCode = form.code.trim();
+    if (!trimmedName) {
+      setFieldError('Warehouse name is required');
+      return;
+    }
+    if (!trimmedCode) {
+      setFieldError('Warehouse code is required');
+      return;
+    }
+    const payload = {
+      name: trimmedName,
+      code: trimmedCode,
+      address: form.address?.trim() || null,
+      city: form.city?.trim() || null,
+      province: form.province?.trim() || null,
+      postalCode: form.postalCode?.trim() || null,
+      isPrimary: form.isPrimary,
+      isActive: form.isActive,
+    };
+    if (form.id) {
+      updateWarehouse({ variables: { id: form.id, input: payload } });
+    } else {
+      createWarehouse({ variables: { input: payload } });
+    }
+  }, [form, createWarehouse, updateWarehouse]);
+
+  const actions = (
+    <Stack direction="row" spacing={1}>
+      <Button onClick={onClose} disabled={loading}>
+        Cancel
+      </Button>
+      <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+        {loading ? 'Saving...' : form.id ? 'Save' : 'Create'}
+      </Button>
+    </Stack>
+  );
+
+  return (
+    <Modal open title={form.id ? 'Edit Warehouse' : 'Create Warehouse'} onClose={onClose} actions={actions} maxWidth="sm">
+      <Stack spacing={2} sx={{ pt: 1 }}>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Name"
+            value={form.name}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, name: e.target.value }));
+              if (fieldError) setFieldError('');
+            }}
+            required
+            autoFocus
+            fullWidth
+            size="small"
+            error={!!fieldError}
+            helperText={fieldError}
+          />
+          <TextField
+            label="Code"
+            value={form.code}
+            onChange={(e) => {
+              setForm((f) => ({ ...f, code: e.target.value }));
+              if (fieldError) setFieldError('');
+            }}
+            required
+            size="small"
+            sx={{ width: 140 }}
+            inputProps={{ maxLength: 20 }}
+          />
+        </Stack>
+        <TextField
+          label="Address"
+          value={form.address ?? ''}
+          onChange={(e) => setForm((f) => ({ ...f, address: e.target.value }))}
+          fullWidth
+          size="small"
+        />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="City"
+            value={form.city ?? ''}
+            onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label="Province"
+            value={form.province ?? ''}
+            onChange={(e) => setForm((f) => ({ ...f, province: e.target.value }))}
+            size="small"
+            sx={{ width: 140 }}
+          />
+          <TextField
+            label="Postal Code"
+            value={form.postalCode ?? ''}
+            onChange={(e) => setForm((f) => ({ ...f, postalCode: e.target.value }))}
+            size="small"
+            sx={{ width: 140 }}
+          />
+        </Stack>
+        <Stack direction="row" spacing={2}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={form.isPrimary}
+                onChange={(e) => setForm((f) => ({ ...f, isPrimary: e.target.checked }))}
+              />
+            }
+            label="Primary (default for new inventory)"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={form.isActive}
+                onChange={(e) => setForm((f) => ({ ...f, isActive: e.target.checked }))}
+              />
+            }
+            label="Active"
+          />
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+}
+
+export default function WarehouseEditDialog({ open, warehouse, onClose, onSaved }: WarehouseEditDialogProps) {
+  if (!open) return null;
+  return <WarehouseEditDialogContent initialWarehouse={warehouse} onClose={onClose} onSaved={onSaved} />;
+}

--- a/frontend/src/modules/admin/WarehousesPage.tsx
+++ b/frontend/src/modules/admin/WarehousesPage.tsx
@@ -1,0 +1,193 @@
+import { useState, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Stack,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { GET_WAREHOUSES } from '../../graphql/queries';
+import { DELETE_WAREHOUSE } from '../../graphql/mutations';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import WarehouseEditDialog, { type WarehouseFormValue } from './WarehouseEditDialog';
+
+interface Warehouse {
+  id: string;
+  name: string;
+  code: string;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  postalCode: string | null;
+  isPrimary: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const GET_WAREHOUSES_VARS = { includeInactive: true };
+
+export default function WarehousesPage() {
+  const { isAdmin } = useIdentity();
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState<WarehouseFormValue | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<Warehouse | null>(null);
+
+  const { data, loading } = useQuery<{ warehouses: Warehouse[] }>(GET_WAREHOUSES, {
+    variables: GET_WAREHOUSES_VARS,
+  });
+  const warehouses = useMemo(() => data?.warehouses ?? [], [data]);
+
+  const [deleteWarehouse, { loading: deleting }] = useMutation(DELETE_WAREHOUSE, {
+    refetchQueries: [{ query: GET_WAREHOUSES, variables: GET_WAREHOUSES_VARS }],
+    onCompleted: () => {
+      showToast('Warehouse deleted', 'success');
+      setPendingDelete(null);
+    },
+    onError: (err) => {
+      showToast(err.message, 'error');
+      setPendingDelete(null);
+    },
+  });
+
+  const handleRowClick = useCallback((params: GridRowParams<Warehouse>) => {
+    const r = params.row;
+    setEditing({
+      id: r.id,
+      name: r.name,
+      code: r.code,
+      address: r.address,
+      city: r.city,
+      province: r.province,
+      postalCode: r.postalCode,
+      isPrimary: r.isPrimary,
+      isActive: r.isActive,
+    });
+    setEditOpen(true);
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    setEditing(null);
+    setEditOpen(true);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (pendingDelete) {
+      deleteWarehouse({ variables: { id: pendingDelete.id } });
+    }
+  }, [pendingDelete, deleteWarehouse]);
+
+  const columns: GridColDef[] = useMemo(() => {
+    const cols: GridColDef[] = [
+      { field: 'name', headerName: 'Name', flex: 1.2, minWidth: 160 },
+      { field: 'code', headerName: 'Code', width: 100 },
+      {
+        field: 'city',
+        headerName: 'Location',
+        flex: 1,
+        minWidth: 160,
+        valueGetter: (_v, row: Warehouse) =>
+          [row.city, row.province].filter(Boolean).join(', ') || '—',
+      },
+      {
+        field: 'isPrimary',
+        headerName: 'Primary',
+        width: 110,
+        renderCell: (params) =>
+          params.row.isPrimary ? <Chip label="Primary" size="small" color="primary" /> : null,
+      },
+      {
+        field: 'isActive',
+        headerName: 'Status',
+        width: 110,
+        renderCell: (params) =>
+          params.row.isActive ? (
+            <Chip label="Active" size="small" color="success" variant="outlined" />
+          ) : (
+            <Chip label="Inactive" size="small" variant="outlined" />
+          ),
+      },
+    ];
+    if (isAdmin) {
+      cols.push({
+        field: 'actions',
+        headerName: '',
+        width: 60,
+        sortable: false,
+        filterable: false,
+        renderCell: (params) =>
+          params.row.isPrimary ? null : (
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                setPendingDelete(params.row as Warehouse);
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          ),
+      });
+    }
+    return cols;
+  }, [isAdmin]);
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Box>
+          <Typography variant="h5" gutterBottom>
+            Warehouses
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Physical buildings inventory lives in. Click a row to edit.
+          </Typography>
+        </Box>
+        <Button variant="contained" onClick={handleCreate}>
+          Create Warehouse
+        </Button>
+      </Stack>
+
+      <DataGrid
+        rows={warehouses}
+        columns={columns}
+        loading={loading}
+        onRowClick={handleRowClick}
+        autoHeight
+        disableRowSelectionOnClick
+        pageSizeOptions={[10, 25, 50]}
+        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+        sx={{ cursor: 'pointer' }}
+      />
+
+      <WarehouseEditDialog open={editOpen} warehouse={editing} onClose={() => setEditOpen(false)} />
+
+      <Dialog open={!!pendingDelete} onClose={() => setPendingDelete(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete warehouse?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Delete <strong>{pendingDelete?.name}</strong>? This is blocked if any inventory still references it.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingDelete(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button color="error" variant="contained" onClick={handleConfirmDelete} disabled={deleting}>
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -5,6 +5,7 @@ import ProjectPurchasingProgressPage from './ProjectPurchasingProgressPage';
 import OpeningStatusTab from './OpeningStatusTab';
 import UserManagementPage from './UserManagementPage';
 import VendorsPage from './VendorsPage';
+import WarehousesPage from './WarehousesPage';
 import ProjectsPage from './ProjectsPage';
 import LocationCleanupPage from './LocationCleanupPage';
 import AdminLanding from './AdminLanding';
@@ -26,6 +27,7 @@ export default function AdminModule() {
       <Route path="project-purchasing-progress" element={<AdminSubLayout><ProjectPurchasingProgressPage /></AdminSubLayout>} />
       <Route path="opening-status" element={<AdminSubLayout><OpeningStatusTab /></AdminSubLayout>} />
       <Route path="vendors" element={<AdminSubLayout><VendorsPage /></AdminSubLayout>} />
+      <Route path="warehouses" element={<AdminSubLayout><WarehousesPage /></AdminSubLayout>} />
       <Route path="projects" element={<AdminSubLayout><ProjectsPage /></AdminSubLayout>} />
       <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />
       <Route path="location-cleanup" element={<AdminSubLayout><LocationCleanupPage /></AdminSubLayout>} />

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -9,20 +9,24 @@ import {
   Paper,
   Switch,
   FormControlLabel,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
   Stack,
   IconButton,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
-import { useMutation } from '@apollo/client/react';
+import { useMutation, useQuery } from '@apollo/client/react';
 import { useApolloClient } from '@apollo/client/react';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useNavigate } from 'react-router-dom';
-import { GET_PO_RECEIVING_DETAILS } from '../../graphql/queries';
+import { GET_PO_RECEIVING_DETAILS, GET_WAREHOUSES } from '../../graphql/queries';
 import { CREATE_RECEIVE } from '../../graphql/mutations';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 
@@ -67,6 +71,13 @@ interface ReceiveModalProps {
   poIds: string[];
 }
 
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
+  isPrimary: boolean;
+}
+
 const MAX_LOC_LEN = 20;
 
 function emptyDraft(quantity: number): LocationDraft {
@@ -92,6 +103,20 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
 
   const [createReceive, { loading: submitLoading }] = useMutation(CREATE_RECEIVE);
+
+  // Warehouse the received goods land in (active warehouses only). Defaults to the primary.
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: false },
+  });
+  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+  const [warehouseId, setWarehouseId] = useState<string>('');
+
+  useEffect(() => {
+    if (!warehouseId && warehouses.length > 0) {
+      const primary = warehouses.find((w) => w.isPrimary) ?? warehouses[0];
+      setWarehouseId(primary.id);
+    }
+  }, [warehouses, warehouseId]);
 
   // ---- Fetch PO details on open ----
 
@@ -311,6 +336,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       const input = {
         poId,
         receivedBy: displayName,
+        warehouseId: warehouseId || null,
         lineItems: poLineItems.map((li) => {
           const receiveNow = receiveQuantities[li.id] ?? 0;
           const drafts = putAwayMode ? draftsFor(li.id, receiveNow) : [];
@@ -354,6 +380,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   }, [
     poIds,
     displayName,
+    warehouseId,
     lineItemsToReceive,
     receiveQuantities,
     putAwayMode,
@@ -576,6 +603,23 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
           <Alert severity="error" sx={{ mb: 2 }}>
             {mutationError}
           </Alert>
+        )}
+        {!poDetailsLoading && !poDetailsError && !succeeded && (
+          <FormControl size="small" sx={{ minWidth: 240, mb: 2 }}>
+            <InputLabel id="receive-warehouse-label">Receive into warehouse</InputLabel>
+            <Select
+              labelId="receive-warehouse-label"
+              label="Receive into warehouse"
+              value={warehouseId}
+              onChange={(e) => setWarehouseId(e.target.value)}
+            >
+              {warehouses.map((w) => (
+                <MenuItem key={w.id} value={w.id}>
+                  {w.name} ({w.code}){w.isPrimary ? ' · default' : ''}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
         {!poDetailsLoading && !poDetailsError && !succeeded && poIds.map(renderPOSection)}
 

--- a/frontend/src/modules/warehouse/StockPoolView.tsx
+++ b/frontend/src/modules/warehouse/StockPoolView.tsx
@@ -11,6 +11,10 @@ import {
   Alert,
   Card,
   CardContent,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useQuery } from '@apollo/client/react';
@@ -19,15 +23,22 @@ import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
-import { GET_STOCK_ITEMS } from '../../graphql/queries';
+import { GET_STOCK_ITEMS, GET_WAREHOUSES } from '../../graphql/queries';
 import AdjustStockModal from './stock/AdjustStockModal';
 import MoveStockLocationModal from './stock/MoveStockLocationModal';
 import ReclassifyStockModal from './stock/ReclassifyStockModal';
 import AllocateStockModal from './stock/AllocateStockModal';
 import ReportStockDeficiencyModal from './stock/ReportStockDeficiencyModal';
 
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
+}
+
 export interface StockItem {
   id: string;
+  warehouseId: string | null;
   hardwareCategory: string;
   productCode: string;
   quantity: number;
@@ -45,6 +56,7 @@ export default function StockPoolView() {
   const [productCodeFilter, setProductCodeFilter] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [onlyDeficient, setOnlyDeficient] = useState(false);
+  const [warehouseFilter, setWarehouseFilter] = useState('');
   const [selected, setSelected] = useState<StockItem | null>(null);
   const [modal, setModal] = useState<
     'adjust' | 'move' | 'reclassify' | 'allocate' | 'report-deficient' | null
@@ -57,10 +69,21 @@ export default function StockPoolView() {
         productCodeContains: productCodeFilter || null,
         hardwareCategory: categoryFilter || null,
         onlyDeficient,
+        warehouseId: warehouseFilter || null,
       },
       fetchPolicy: 'cache-and-network',
     },
   );
+
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: true },
+  });
+  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+  const warehouseCode = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const w of warehouses) map.set(w.id, w.code);
+    return map;
+  }, [warehouses]);
 
   const rows = useMemo(() => data?.stockItems ?? [], [data]);
 
@@ -100,6 +123,17 @@ export default function StockPoolView() {
       headerName: 'Available',
       width: 100,
       type: 'number',
+    },
+    {
+      field: 'warehouseId',
+      headerName: 'Warehouse',
+      width: 120,
+      renderCell: ({ row }) =>
+        row.warehouseId ? (
+          <Chip label={warehouseCode.get(row.warehouseId) ?? '—'} size="small" variant="outlined" />
+        ) : (
+          <span>—</span>
+        ),
     },
     {
       field: 'location',
@@ -206,6 +240,22 @@ export default function StockPoolView() {
           value={categoryFilter}
           onChange={(e) => setCategoryFilter(e.target.value)}
         />
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel id="stock-warehouse-filter-label">Warehouse</InputLabel>
+          <Select
+            labelId="stock-warehouse-filter-label"
+            label="Warehouse"
+            value={warehouseFilter}
+            onChange={(e) => setWarehouseFilter(e.target.value)}
+          >
+            <MenuItem value="">All warehouses</MenuItem>
+            {warehouses.map((w) => (
+              <MenuItem key={w.id} value={w.id}>
+                {w.name} ({w.code})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Stack>
 
       {error && <Alert severity="error">{error.message}</Alert>}


### PR DESCRIPTION
first of two PRs for #88. adds the warehouse dimension to inventory; no transfer flow yet (that's PR2).

data model
- new warehouses table (name, code, address fields, is_primary, is_active). migration 033 seeds Warden + VP, adds warehouse_id FK to inventory_locations / stock_items / opening_items, backfills every existing row to the primary (Warden), sets NOT NULL, indexes (warehouse_id, aisle, bay, bin).
- warehouse_id is stamped on every row-creation path: receive (the chosen warehouse), allocate-from-stock (inherits the source stock row), destock (inherits the source inventory row), override-split (inherits the source), assembly (primary). get_primary_warehouse_id is the fallback so NOT NULL always holds.

backend
- warehouse_admin_repository: list / get / create / update / delete + get_primary_warehouse_id. unique name + code, exactly one primary, delete blocked while the warehouse is primary or any inventory still references it.
- GraphQL: Warehouse type, warehouses / warehouse queries, createWarehouse / updateWarehouse / deleteWarehouse. warehouse_id added to InventoryLocation / StockItem / OpeningItem types. CreateReceiveInput gains warehouseId. stock_items gains a warehouseId filter.

frontend
- admin Warehouses page (DataGrid + create/edit dialog) wired into admin routes + landing.
- receive modal: a warehouse selector defaulting to the primary, fed into the receive.
- stock pool: warehouse filter dropdown + a warehouse chip column.
- LocationsTab + InventoryView still aggregate across all warehouses; chip/filter there is a follow-up since those views are server-aggregated.
