### PR TITLE
inventory transfer between bins/warehouses (#88)

### DIFF
--- a/backend/alembic/versions/034_add_transfer_audit_action.py
+++ b/backend/alembic/versions/034_add_transfer_audit_action.py
@@ -1,0 +1,42 @@
+"""Add TRANSFER to the audit_action enum (issue #88 inventory transfer)
+
+Revision ID: 034
+Revises: 033
+Create Date: 2026-06-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "034"
+down_revision = "033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'TRANSFER'")
+
+
+def downgrade() -> None:
+    # Postgres has no DROP VALUE; rebuild the enum without TRANSFER (matches migration 027's pattern).
+    op.execute("ALTER TYPE audit_action RENAME TO audit_action_old")
+    new_action = sa.Enum(
+        "ADJUSTMENT",
+        "MOVE",
+        "UNLOCATE",
+        "RECEIVE",
+        "PULL_DEDUCTION",
+        "SPOT_CHECK",
+        "PUT_AWAY",
+        "DESTOCK",
+        "ALLOCATE_FROM_STOCK",
+        "RECLASSIFY",
+        "REPORT_DEFICIENT",
+        "RESOLVE_DEFICIENT",
+        name="audit_action",
+    )
+    new_action.create(op.get_bind(), checkfirst=False)
+    op.execute("ALTER TABLE inventory_audit_log ALTER COLUMN action TYPE audit_action USING action::text::audit_action")
+    op.execute("DROP TYPE audit_action_old")

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -92,6 +92,7 @@ class AuditAction(str, enum.Enum):
     RECLASSIFY = "RECLASSIFY"
     REPORT_DEFICIENT = "REPORT_DEFICIENT"
     RESOLVE_DEFICIENT = "RESOLVE_DEFICIENT"
+    TRANSFER = "TRANSFER"
 
 
 class DestockSource(str, enum.Enum):

--- a/backend/app/repositories/stock_repository.py
+++ b/backend/app/repositories/stock_repository.py
@@ -1111,3 +1111,171 @@ def receive_into_stock(
         },
     )
     return stock_row
+
+
+# ---------------------------------------------------------------------------
+# Transfer: move quantity between bins, same or across warehouses (issue #88)
+# ---------------------------------------------------------------------------
+
+
+def _find_matching_inventory_location(
+    session: Session,
+    src: InventoryLocationModel,
+    warehouse_id: uuid.UUID,
+    aisle: str | None,
+    bay: str | None,
+    bin: str | None,
+) -> InventoryLocationModel | None:
+    """An existing IL row sharing src's origin identity at the destination (warehouse, bin)."""
+    stmt = select(InventoryLocationModel).where(
+        InventoryLocationModel.id != src.id,
+        InventoryLocationModel.warehouse_id == warehouse_id,
+        InventoryLocationModel.project_id == src.project_id,
+        InventoryLocationModel.hardware_category == src.hardware_category,
+        InventoryLocationModel.product_code == src.product_code,
+        InventoryLocationModel.aisle == aisle,
+        InventoryLocationModel.bay == bay,
+        InventoryLocationModel.bin == bin,
+    )
+    for col, val in (
+        (InventoryLocationModel.po_line_item_id, src.po_line_item_id),
+        (InventoryLocationModel.receive_line_item_id, src.receive_line_item_id),
+        (InventoryLocationModel.stock_item_id, src.stock_item_id),
+    ):
+        stmt = stmt.where(col.is_(None)) if val is None else stmt.where(col == val)
+    return session.scalars(stmt).first()
+
+
+def transfer_inventory(
+    session: Session,
+    *,
+    source_type: str,
+    source_id: uuid.UUID,
+    quantity: int,
+    dest_warehouse_id: uuid.UUID,
+    dest_aisle: str,
+    dest_bay: str,
+    dest_bin: str,
+    performed_by: str,
+) -> dict:
+    """Move `quantity` available units from a source row to a destination bin/warehouse.
+
+    Partial + immediate. Source keeps the remainder (an InventoryLocation may sit at 0, a fully
+    drained stock row is hidden by the qty>0 list filter). The destination merges into a matching
+    row (same origin + bin) or a new row is created. Same- and cross-warehouse use one path.
+    """
+    from app.models.warehouse import Warehouse
+
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+    if not performed_by:
+        raise ValidationError("performed_by is required", field="performed_by")
+    if (
+        not (dest_aisle and dest_aisle.strip())
+        or not (dest_bay and dest_bay.strip())
+        or not (dest_bin and dest_bin.strip())
+    ):
+        raise ValidationError("destination aisle, bay, and bin are all required", field="destination")
+
+    dest_aisle, dest_bay, dest_bin = _normalize_optional_location_fields(dest_aisle, dest_bay, dest_bin)
+
+    dest_wh = session.get(Warehouse, dest_warehouse_id)
+    if dest_wh is None:
+        raise NotFoundError(f"Warehouse {dest_warehouse_id} not found")
+
+    now = datetime.utcnow()
+
+    if source_type == "INVENTORY_LOCATION":
+        il = session.get(InventoryLocationModel, source_id)
+        if il is None:
+            raise NotFoundError(f"Inventory location {source_id} not found")
+        available = il.quantity - (il.deficient_quantity or 0)
+        if quantity > available:
+            raise ValidationError("Transfer quantity exceeds available (non-deficient) quantity", field="quantity")
+        if il.warehouse_id == dest_warehouse_id and (il.aisle, il.bay, il.bin) == (dest_aisle, dest_bay, dest_bin):
+            raise ValidationError("Destination is the same as the source location", field="destination")
+
+        from_wh, from_loc = il.warehouse_id, {"aisle": il.aisle, "bay": il.bay, "bin": il.bin}
+        il.quantity -= quantity
+        target = _find_matching_inventory_location(session, il, dest_warehouse_id, dest_aisle, dest_bay, dest_bin)
+        if target is not None:
+            target.quantity += quantity
+        else:
+            target = InventoryLocationModel(
+                project_id=il.project_id,
+                po_line_item_id=il.po_line_item_id,
+                receive_line_item_id=il.receive_line_item_id,
+                stock_item_id=il.stock_item_id,
+                warehouse_id=dest_warehouse_id,
+                hardware_category=il.hardware_category,
+                product_code=il.product_code,
+                quantity=quantity,
+                deficient_quantity=0,
+                aisle=dest_aisle,
+                bay=dest_bay,
+                bin=dest_bin,
+                received_at=now,
+            )
+            session.add(target)
+        session.flush()
+        _log_audit_event(
+            session,
+            project_id=il.project_id,
+            entity_type=AuditEntityType.INVENTORY_LOCATION,
+            entity_id=il.id,
+            action=AuditAction.TRANSFER,
+            performed_by=performed_by,
+            detail={
+                "fromWarehouseId": str(from_wh),
+                "fromLocation": from_loc,
+                "toWarehouseId": str(dest_warehouse_id),
+                "toLocation": {"aisle": dest_aisle, "bay": dest_bay, "bin": dest_bin},
+                "quantity": quantity,
+                "targetInventoryLocationId": str(target.id),
+            },
+        )
+        return {"success": True, "quantity": quantity, "dest_warehouse_id": dest_warehouse_id}
+
+    if source_type == "STOCK_ITEM":
+        si = session.get(StockItem, source_id)
+        if si is None:
+            raise NotFoundError(f"Stock item {source_id} not found")
+        available = si.quantity - (si.deficient_quantity or 0)
+        if quantity > available:
+            raise ValidationError("Transfer quantity exceeds available (non-deficient) quantity", field="quantity")
+        if si.warehouse_id == dest_warehouse_id and (si.aisle, si.bay, si.bin) == (dest_aisle, dest_bay, dest_bin):
+            raise ValidationError("Destination is the same as the source location", field="destination")
+
+        from_wh, from_loc = si.warehouse_id, {"aisle": si.aisle, "bay": si.bay, "bin": si.bin}
+        si.quantity -= quantity
+        target = _find_or_create_stock_row(
+            session,
+            warehouse_id=dest_warehouse_id,
+            hardware_category=si.hardware_category,
+            product_code=si.product_code,
+            aisle=dest_aisle,
+            bay=dest_bay,
+            bin=dest_bin,
+            received_at=now,
+        )
+        target.quantity += quantity
+        session.flush()
+        _log_audit_event(
+            session,
+            project_id=None,
+            entity_type=AuditEntityType.STOCK_ITEM,
+            entity_id=si.id,
+            action=AuditAction.TRANSFER,
+            performed_by=performed_by,
+            detail={
+                "fromWarehouseId": str(from_wh),
+                "fromLocation": from_loc,
+                "toWarehouseId": str(dest_warehouse_id),
+                "toLocation": {"aisle": dest_aisle, "bay": dest_bay, "bin": dest_bin},
+                "quantity": quantity,
+                "targetStockItemId": str(target.id),
+            },
+        )
+        return {"success": True, "quantity": quantity, "dest_warehouse_id": dest_warehouse_id}
+
+    raise ValidationError("source_type must be INVENTORY_LOCATION or STOCK_ITEM", field="source_type")

--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -1139,18 +1139,31 @@ def assign_inventory_location(
     return il
 
 
-def move_opening_item_location(session: Session, oi_id: uuid.UUID, aisle: str, bay: str, bin: str) -> OpeningItemModel:
-    """Move an OpeningItem to a new aisle/bay/bin."""
+def move_opening_item_location(
+    session: Session,
+    oi_id: uuid.UUID,
+    aisle: str,
+    bay: str,
+    bin: str,
+    warehouse_id: uuid.UUID | None = None,
+) -> OpeningItemModel:
+    """Move an OpeningItem (whole kit) to a new aisle/bay/bin, optionally a different warehouse."""
     oi = session.get(OpeningItemModel, oi_id)
     if oi is None:
         raise NotFoundError(f"Opening item {oi_id} not found")
 
     aisle, bay, bin = _normalize_and_validate_location_fields(aisle, bay, bin)
 
-    old_aisle, old_bay, old_bin = oi.aisle, oi.bay, oi.bin
+    old_aisle, old_bay, old_bin, old_wh = oi.aisle, oi.bay, oi.bin, oi.warehouse_id
     oi.aisle = aisle
     oi.bay = bay
     oi.bin = bin
+    if warehouse_id is not None:
+        from app.models.warehouse import Warehouse
+
+        if session.get(Warehouse, warehouse_id) is None:
+            raise NotFoundError(f"Warehouse {warehouse_id} not found")
+        oi.warehouse_id = warehouse_id
 
     _log_audit_event(
         session,
@@ -1160,7 +1173,9 @@ def move_opening_item_location(session: Session, oi_id: uuid.UUID, aisle: str, b
         action=AuditAction.MOVE,
         performed_by="Admin/Manager",
         detail={
+            "fromWarehouseId": str(old_wh),
             "fromLocation": {"aisle": old_aisle, "bay": old_bay, "bin": old_bin},
+            "toWarehouseId": str(oi.warehouse_id),
             "toLocation": {"aisle": aisle, "bay": bay, "bin": bin},
         },
     )

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -92,3 +92,9 @@ class ReconciliationStatus(enum.Enum):
 class ApproveOutcome(enum.Enum):
     APPROVED = "approved"
     CANCELLED = "cancelled"
+
+
+@strawberry.enum
+class TransferSourceType(enum.Enum):
+    INVENTORY_LOCATION = "INVENTORY_LOCATION"
+    STOCK_ITEM = "STOCK_ITEM"

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -1,6 +1,6 @@
 import strawberry
 
-from .enums import Classification, DeficiencyResolution, DestockSource, PullRequestItemType
+from .enums import Classification, DeficiencyResolution, DestockSource, PullRequestItemType, TransferSourceType
 
 
 @strawberry.input
@@ -187,6 +187,18 @@ class UpdateVendorInput:
     email: str | None = None
     phone: str | None = None
     notes: str | None = None
+
+
+@strawberry.input
+class TransferInventoryInput:
+    source_type: TransferSourceType
+    source_id: strawberry.ID
+    quantity: int
+    dest_warehouse_id: strawberry.ID
+    dest_aisle: str
+    dest_bay: str
+    dest_bin: str
+    performed_by: str = ""
 
 
 @strawberry.input

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -40,6 +40,7 @@ from .inputs import (
     ReportInventoryDeficiencyInput,
     ReportStockDeficiencyInput,
     ResolveDeficiencyInput,
+    TransferInventoryInput,
     UpdateProjectInput,
     UpdateVendorInput,
     UpdateWarehouseInput,
@@ -84,6 +85,7 @@ from .types import (
     ShopAssemblyOpening,
     ShopAssemblyRequest,
     StockItem,
+    TransferResult,
     Vendor,
     Warehouse,
 )
@@ -703,10 +705,16 @@ class Mutation:
         aisle: str,
         bay: str,
         bin: str,
+        warehouse_id: strawberry.ID | None = None,
     ) -> OpeningItem:
         with SessionLocal() as session:
             result = warehouse_repository.move_opening_item_location(
-                session, uuid.UUID(str(opening_item_id)), aisle, bay, bin
+                session,
+                uuid.UUID(str(opening_item_id)),
+                aisle,
+                bay,
+                bin,
+                warehouse_id=uuid.UUID(str(warehouse_id)) if warehouse_id else None,
             )
             session.commit()
             session.refresh(result)
@@ -955,6 +963,27 @@ class Mutation:
             session.commit()
             session.refresh(result)
             return _stock_item_to_type(result)
+
+    @strawberry.mutation
+    def transfer_inventory(self, input: TransferInventoryInput) -> TransferResult:
+        with SessionLocal() as session:
+            result = stock_repository.transfer_inventory(
+                session,
+                source_type=input.source_type.value,
+                source_id=uuid.UUID(str(input.source_id)),
+                quantity=input.quantity,
+                dest_warehouse_id=uuid.UUID(str(input.dest_warehouse_id)),
+                dest_aisle=input.dest_aisle,
+                dest_bay=input.dest_bay,
+                dest_bin=input.dest_bin,
+                performed_by=input.performed_by or "Warehouse",
+            )
+            session.commit()
+            return TransferResult(
+                success=result["success"],
+                quantity=result["quantity"],
+                dest_warehouse_id=strawberry.ID(str(result["dest_warehouse_id"])),
+            )
 
     @strawberry.mutation
     def allocate_stock_to_project(self, input: AllocateStockToProjectInput) -> InventoryLocation:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -594,6 +594,13 @@ class AuditLogEntry:
 
 
 @strawberry.type
+class TransferResult:
+    success: bool
+    quantity: int
+    dest_warehouse_id: strawberry.ID
+
+
+@strawberry.type
 class Warehouse:
     id: strawberry.ID
     name: str

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -677,6 +677,16 @@ export const DELETE_WAREHOUSE = gql`
   }
 `;
 
+export const TRANSFER_INVENTORY = gql`
+  mutation TransferInventory($input: TransferInventoryInput!) {
+    transferInventory(input: $input) {
+      success
+      quantity
+      destWarehouseId
+    }
+  }
+`;
+
 // ---------------------------------------------------------------------------
 // Stock pool + deficiency mutations
 // ---------------------------------------------------------------------------

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -647,8 +647,8 @@ export const GET_LOCATION_CONTENTS = gql`
     locationContents(aisle: $aisle, bay: $bay, bin: $bin) {
       inventoryItems {
         inventoryLocation {
-          id projectId poLineItemId receiveLineItemId stockItemId
-          hardwareCategory productCode quantity
+          id projectId poLineItemId receiveLineItemId stockItemId warehouseId
+          hardwareCategory productCode quantity deficientQuantity available
           aisle row bay bin receivedAt createdAt updatedAt
         }
         poNumber
@@ -662,7 +662,7 @@ export const GET_LOCATION_CONTENTS = gql`
         installedHardware { id openingItemId productCode hardwareCategory quantity }
       }
       stockItems {
-        id hardwareCategory productCode quantity deficientQuantity available
+        id warehouseId hardwareCategory productCode quantity deficientQuantity available
         aisle bay bin receivedAt createdAt updatedAt
       }
     }

--- a/frontend/src/modules/warehouse/LocationsTab.tsx
+++ b/frontend/src/modules/warehouse/LocationsTab.tsx
@@ -30,6 +30,7 @@ import LocationActionDialog, {
   type LocationActionTarget,
 } from './LocationActionDialog';
 import LocationAuditStrip from './LocationAuditStrip';
+import TransferDialog, { type TransferSource } from './TransferDialog';
 
 interface LocationEntry {
   aisle: string;
@@ -42,9 +43,11 @@ interface LocationEntry {
 interface InventoryLocationItem {
   id: string;
   projectId: string;
+  warehouseId: string | null;
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  available: number;
   aisle: string | null;
   bay: string | null;
   bin: string | null;
@@ -70,6 +73,7 @@ interface ContentsOpeningItem {
 
 interface ContentsStockItem {
   id: string;
+  warehouseId: string | null;
   hardwareCategory: string;
   productCode: string;
   quantity: number;
@@ -155,12 +159,16 @@ function RowActionMenu({
   onMove,
   onAdjust,
   onUnlocate,
+  onTransfer,
   showAdjust,
+  showTransfer,
 }: {
   onMove: () => void;
   onAdjust: () => void;
   onUnlocate: () => void;
+  onTransfer?: () => void;
   showAdjust: boolean;
+  showTransfer?: boolean;
 }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   return (
@@ -177,6 +185,16 @@ function RowActionMenu({
         >
           Move
         </MenuItem>
+        {showTransfer && onTransfer && (
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              onTransfer();
+            }}
+          >
+            Transfer
+          </MenuItem>
+        )}
         {showAdjust && (
           <MenuItem
             onClick={() => {
@@ -221,6 +239,7 @@ function ContentsPanel({
     mode: LocationActionMode;
     targets: LocationActionTarget[];
   } | null>(null);
+  const [transferSource, setTransferSource] = useState<TransferSource | null>(null);
 
   const toggleSelect = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -371,9 +390,22 @@ function ContentsPanel({
                   </Box>
                   <RowActionMenu
                     showAdjust
+                    showTransfer
                     onMove={() => openSingle(target, 'move')}
                     onAdjust={() => openSingle(target, 'adjust')}
                     onUnlocate={() => openSingle(target, 'unlocate')}
+                    onTransfer={() =>
+                      setTransferSource({
+                        type: 'INVENTORY_LOCATION',
+                        id: il.id,
+                        productCode: il.productCode,
+                        available: il.available,
+                        warehouseId: il.warehouseId,
+                        aisle: il.aisle,
+                        bay: il.bay,
+                        bin: il.bin,
+                      })
+                    }
                   />
                 </Box>
               );
@@ -467,9 +499,22 @@ function ContentsPanel({
                   </Tooltip>
                   <RowActionMenu
                     showAdjust
+                    showTransfer
                     onMove={() => openSingle(target, 'move')}
                     onAdjust={() => openSingle(target, 'adjust')}
                     onUnlocate={() => openSingle(target, 'unlocate')}
+                    onTransfer={() =>
+                      setTransferSource({
+                        type: 'STOCK_ITEM',
+                        id: si.id,
+                        productCode: si.productCode,
+                        available: si.available,
+                        warehouseId: si.warehouseId,
+                        aisle: si.aisle,
+                        bay: si.bay,
+                        bin: si.bin,
+                      })
+                    }
                   />
                 </Box>
               );
@@ -490,6 +535,13 @@ function ContentsPanel({
           aisleOptions={aisleOptions}
           bayOptions={bayOptions}
           binOptions={binOptions}
+        />
+      )}
+      {transferSource && (
+        <TransferDialog
+          source={transferSource}
+          onClose={() => setTransferSource(null)}
+          onSuccess={handleSuccess}
         />
       )}
     </Paper>

--- a/frontend/src/modules/warehouse/StockPoolView.tsx
+++ b/frontend/src/modules/warehouse/StockPoolView.tsx
@@ -22,7 +22,9 @@ import EditIcon from '@mui/icons-material/Edit';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import TransferDialog from './TransferDialog';
 import { GET_STOCK_ITEMS, GET_WAREHOUSES } from '../../graphql/queries';
 import AdjustStockModal from './stock/AdjustStockModal';
 import MoveStockLocationModal from './stock/MoveStockLocationModal';
@@ -59,7 +61,7 @@ export default function StockPoolView() {
   const [warehouseFilter, setWarehouseFilter] = useState('');
   const [selected, setSelected] = useState<StockItem | null>(null);
   const [modal, setModal] = useState<
-    'adjust' | 'move' | 'reclassify' | 'allocate' | 'report-deficient' | null
+    'adjust' | 'move' | 'reclassify' | 'allocate' | 'report-deficient' | 'transfer' | null
   >(null);
 
   const { data, loading, error, refetch } = useQuery<{ stockItems: StockItem[] }>(
@@ -185,6 +187,18 @@ export default function StockPoolView() {
               <LocationOnIcon fontSize="small" />
             </IconButton>
           </Tooltip>
+          <Tooltip title="Transfer (same or other warehouse)">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setSelected(row);
+                setModal('transfer');
+              }}
+              disabled={row.available <= 0}
+            >
+              <SwapHorizIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Reclassify (split-capable)">
             <IconButton
               size="small"
@@ -304,6 +318,22 @@ export default function StockPoolView() {
       )}
       {selected && modal === 'report-deficient' && (
         <ReportStockDeficiencyModal item={selected} onClose={closeModal} onSuccess={onSuccess} />
+      )}
+      {selected && modal === 'transfer' && (
+        <TransferDialog
+          source={{
+            type: 'STOCK_ITEM',
+            id: selected.id,
+            productCode: selected.productCode,
+            available: selected.available,
+            warehouseId: selected.warehouseId,
+            aisle: selected.aisle,
+            bay: selected.bay,
+            bin: selected.bin,
+          }}
+          onClose={closeModal}
+          onSuccess={onSuccess}
+        />
       )}
     </Box>
   );

--- a/frontend/src/modules/warehouse/TransferDialog.tsx
+++ b/frontend/src/modules/warehouse/TransferDialog.tsx
@@ -1,0 +1,179 @@
+import { useState, useMemo } from 'react';
+import {
+  Button,
+  Stack,
+  TextField,
+  Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import { useQuery, useMutation } from '@apollo/client/react';
+import Modal from '../../components/Modal';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import { GET_WAREHOUSES } from '../../graphql/queries';
+import { TRANSFER_INVENTORY } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
+
+export interface TransferSource {
+  type: 'INVENTORY_LOCATION' | 'STOCK_ITEM';
+  id: string;
+  productCode: string;
+  available: number;
+  warehouseId: string | null;
+  aisle?: string | null;
+  bay?: string | null;
+  bin?: string | null;
+}
+
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
+}
+
+interface TransferDialogProps {
+  source: TransferSource;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export default function TransferDialog({ source, onClose, onSuccess }: TransferDialogProps) {
+  const { showToast } = useToast();
+  const { displayName } = useIdentity();
+
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: false },
+  });
+  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+
+  const [destWarehouseId, setDestWarehouseId] = useState<string>(source.warehouseId ?? '');
+  const [aisle, setAisle] = useState('');
+  const [bay, setBay] = useState('');
+  const [bin, setBin] = useState('');
+  const [quantity, setQuantity] = useState<string>(String(source.available));
+
+  const [transfer, { loading, error }] = useMutation(TRANSFER_INVENTORY, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    onCompleted: () => {
+      showToast(`Transferred ${quantity} ${source.productCode}`, 'success');
+      onSuccess?.();
+      onClose();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const q = Number(quantity);
+  const sameBin =
+    destWarehouseId === source.warehouseId &&
+    (source.aisle ?? '') === aisle.trim() &&
+    (source.bay ?? '') === bay.trim() &&
+    (source.bin ?? '') === bin.trim();
+  const valid =
+    !!destWarehouseId &&
+    !!aisle.trim() &&
+    !!bay.trim() &&
+    !!bin.trim() &&
+    Number.isInteger(q) &&
+    q >= 1 &&
+    q <= source.available &&
+    !sameBin;
+
+  const handleSubmit = () => {
+    if (!valid) return;
+    transfer({
+      variables: {
+        input: {
+          sourceType: source.type,
+          sourceId: source.id,
+          quantity: q,
+          destWarehouseId,
+          destAisle: aisle.trim(),
+          destBay: bay.trim(),
+          destBin: bin.trim(),
+          performedBy: displayName,
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Transfer ${source.productCode}`}
+      actions={
+        <>
+          <Button onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={!valid || loading}>
+            {loading ? 'Transferring...' : 'Transfer'}
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2} sx={{ pt: 1 }}>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        <Typography variant="body2" color="text.secondary">
+          {source.available} available to transfer.
+        </Typography>
+        <FormControl size="small" fullWidth>
+          <InputLabel id="transfer-dest-warehouse">Destination warehouse</InputLabel>
+          <Select
+            labelId="transfer-dest-warehouse"
+            label="Destination warehouse"
+            value={destWarehouseId}
+            onChange={(e) => setDestWarehouseId(e.target.value)}
+          >
+            {warehouses.map((w) => (
+              <MenuItem key={w.id} value={w.id}>
+                {w.name} ({w.code})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Aisle"
+            size="small"
+            value={aisle}
+            onChange={(e) => setAisle(e.target.value.slice(0, 20))}
+            required
+          />
+          <TextField
+            label="Bay"
+            size="small"
+            value={bay}
+            onChange={(e) => setBay(e.target.value.slice(0, 20))}
+            required
+          />
+          <TextField
+            label="Bin"
+            size="small"
+            value={bin}
+            onChange={(e) => setBin(e.target.value.slice(0, 20))}
+            required
+          />
+        </Stack>
+        <TextField
+          label="Quantity"
+          type="number"
+          size="small"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          error={q > source.available || q < 1}
+          helperText={q > source.available ? `Max ${source.available}` : undefined}
+          slotProps={{ htmlInput: { min: 1, max: source.available } }}
+          sx={{ width: 160 }}
+        />
+        {sameBin && (
+          <Alert severity="warning">Destination is the same as the source location.</Alert>
+        )}
+      </Stack>
+    </Modal>
+  );
+}


### PR DESCRIPTION
second and final PR for #88, on top of the warehouse model in #158. closes #88.

transfer mutation
- transferInventory(sourceType, sourceId, quantity, destWarehouseId, destAisle/Bay/Bin, performedBy) for InventoryLocation and StockItem. partial + immediate: moves N available units (quantity - deficient), source keeps the remainder (an InventoryLocation may sit at 0; a drained stock row is hidden by the qty>0 list filter). the destination merges into a matching row (same origin + warehouse + bin) or a new row is created. same- and cross-warehouse are one code path. logs AuditAction.TRANSFER with from/to warehouse + bin.
- migration 034 adds TRANSFER to the audit_action enum.
- opening items aren't partial-transferable - a kit row carries unique opening identity + installed_hardware children - so moveOpeningItemLocation instead gains an optional warehouseId and moves the whole kit.

frontend
- TransferDialog: destination warehouse select + aisle/bay/bin + quantity (default = available, capped at available). rejects a no-op same-bin transfer and refetches the warehouse query set on success.
- reachable from the row action menu in the Locations tab (project inventory + stock rows) and from the stock pool grid.
