### PR TITLE
ui space-efficiency law + warehouse-aware Locations page (#88)

### DIFF
--- a/backend/app/repositories/warehouse_repository.py
+++ b/backend/app/repositories/warehouse_repository.py
@@ -416,8 +416,14 @@ def get_inventory_by_vendor(session: Session, project_id: uuid.UUID | None = Non
     return result
 
 
-def get_location_contents(session: Session, aisle: str, bay: str | None = None, bin_name: str | None = None) -> dict:
-    """Get all inventory, opening, and stock items at a given location."""
+def get_location_contents(
+    session: Session,
+    aisle: str,
+    bay: str | None = None,
+    bin_name: str | None = None,
+    warehouse_id: uuid.UUID | None = None,
+) -> dict:
+    """Get all inventory, opening, and stock items at a given location, optionally scoped to one warehouse."""
     # Inventory locations (project-bound)
     inv_stmt = (
         select(InventoryLocationModel, POLineItemModel.unit_cost, POModel.po_number)
@@ -429,6 +435,8 @@ def get_location_contents(session: Session, aisle: str, bay: str | None = None, 
         inv_stmt = inv_stmt.where(InventoryLocationModel.bay == bay)
     if bin_name is not None:
         inv_stmt = inv_stmt.where(InventoryLocationModel.bin == bin_name)
+    if warehouse_id is not None:
+        inv_stmt = inv_stmt.where(InventoryLocationModel.warehouse_id == warehouse_id)
     inv_rows = session.execute(inv_stmt).all()
 
     # Opening items (project-bound, post-assembly)
@@ -441,6 +449,8 @@ def get_location_contents(session: Session, aisle: str, bay: str | None = None, 
         oi_stmt = oi_stmt.where(OpeningItemModel.bay == bay)
     if bin_name is not None:
         oi_stmt = oi_stmt.where(OpeningItemModel.bin == bin_name)
+    if warehouse_id is not None:
+        oi_stmt = oi_stmt.where(OpeningItemModel.warehouse_id == warehouse_id)
     opening_items = list(session.scalars(oi_stmt).unique().all())
 
     # Stock items (company-owned pool, not project-bound)
@@ -452,6 +462,8 @@ def get_location_contents(session: Session, aisle: str, bay: str | None = None, 
         si_stmt = si_stmt.where(StockItemModel.bay == bay)
     if bin_name is not None:
         si_stmt = si_stmt.where(StockItemModel.bin == bin_name)
+    if warehouse_id is not None:
+        si_stmt = si_stmt.where(StockItemModel.warehouse_id == warehouse_id)
     stock_items = list(session.scalars(si_stmt).all())
 
     return {
@@ -468,22 +480,27 @@ def get_location_contents(session: Session, aisle: str, bay: str | None = None, 
     }
 
 
-def get_location_utilization(session: Session) -> list[dict]:
-    """Distinct aisle/bay/bin combos with item counts and total quantities across all three sources."""
-    aggregated: dict[tuple[str, str | None, str | None], dict] = {}
+def get_location_utilization(session: Session, warehouse_id: uuid.UUID | None = None) -> list[dict]:
+    """Distinct (warehouse, aisle, bay, bin) combos with item counts and total quantities across all three sources.
 
-    def _bump(aisle: str | None, bay: str | None, bin_name: str | None, count: int, qty: int) -> None:
+    A bin string is one physical place only within a warehouse, so rows are grouped by warehouse too.
+    """
+    aggregated: dict[tuple, dict] = {}
+
+    def _bump(wh, aisle: str | None, bay: str | None, bin_name: str | None, count: int, qty: int) -> None:
         if aisle is None:
             return
-        key = (aisle, bay, bin_name)
+        key = (wh, aisle, bay, bin_name)
         slot = aggregated.setdefault(
-            key, {"aisle": aisle, "bay": bay, "bin": bin_name, "item_count": 0, "total_quantity": 0}
+            key,
+            {"warehouse_id": wh, "aisle": aisle, "bay": bay, "bin": bin_name, "item_count": 0, "total_quantity": 0},
         )
         slot["item_count"] += int(count)
         slot["total_quantity"] += int(qty)
 
-    inv_rows = session.execute(
+    inv_stmt = (
         select(
+            InventoryLocationModel.warehouse_id,
             InventoryLocationModel.aisle,
             InventoryLocationModel.bay,
             InventoryLocationModel.bin,
@@ -491,13 +508,16 @@ def get_location_utilization(session: Session) -> list[dict]:
             func.sum(InventoryLocationModel.quantity).label("total_quantity"),
         )
         .where(InventoryLocationModel.aisle.is_not(None), InventoryLocationModel.quantity > 0)
-        .group_by(InventoryLocationModel.aisle, InventoryLocationModel.bay, InventoryLocationModel.bin)
-    ).all()
-    for r in inv_rows:
-        _bump(r[0], r[1], r[2], r[3], r[4])
-
-    oi_rows = session.execute(
+        .group_by(
+            InventoryLocationModel.warehouse_id,
+            InventoryLocationModel.aisle,
+            InventoryLocationModel.bay,
+            InventoryLocationModel.bin,
+        )
+    )
+    oi_stmt = (
         select(
+            OpeningItemModel.warehouse_id,
             OpeningItemModel.aisle,
             OpeningItemModel.bay,
             OpeningItemModel.bin,
@@ -505,13 +525,11 @@ def get_location_utilization(session: Session) -> list[dict]:
             func.sum(OpeningItemModel.quantity).label("total_quantity"),
         )
         .where(OpeningItemModel.aisle.is_not(None))
-        .group_by(OpeningItemModel.aisle, OpeningItemModel.bay, OpeningItemModel.bin)
-    ).all()
-    for r in oi_rows:
-        _bump(r[0], r[1], r[2], r[3], r[4])
-
-    si_rows = session.execute(
+        .group_by(OpeningItemModel.warehouse_id, OpeningItemModel.aisle, OpeningItemModel.bay, OpeningItemModel.bin)
+    )
+    si_stmt = (
         select(
+            StockItemModel.warehouse_id,
             StockItemModel.aisle,
             StockItemModel.bay,
             StockItemModel.bin,
@@ -522,12 +540,21 @@ def get_location_utilization(session: Session) -> list[dict]:
             StockItemModel.aisle.is_not(None),
             StockItemModel.quantity + StockItemModel.deficient_quantity > 0,
         )
-        .group_by(StockItemModel.aisle, StockItemModel.bay, StockItemModel.bin)
-    ).all()
-    for r in si_rows:
-        _bump(r[0], r[1], r[2], r[3], r[4])
+        .group_by(StockItemModel.warehouse_id, StockItemModel.aisle, StockItemModel.bay, StockItemModel.bin)
+    )
+    if warehouse_id is not None:
+        inv_stmt = inv_stmt.where(InventoryLocationModel.warehouse_id == warehouse_id)
+        oi_stmt = oi_stmt.where(OpeningItemModel.warehouse_id == warehouse_id)
+        si_stmt = si_stmt.where(StockItemModel.warehouse_id == warehouse_id)
 
-    return sorted(aggregated.values(), key=lambda row: (row["aisle"] or "", row["bay"] or "", row["bin"] or ""))
+    for stmt in (inv_stmt, oi_stmt, si_stmt):
+        for r in session.execute(stmt).all():
+            _bump(r[0], r[1], r[2], r[3], r[4], r[5])
+
+    return sorted(
+        aggregated.values(),
+        key=lambda row: (str(row["warehouse_id"]), row["aisle"] or "", row["bay"] or "", row["bin"] or ""),
+    )
 
 
 def get_location_audit_history(
@@ -736,7 +763,9 @@ def merge_locations(
     return counts
 
 
-def get_inventory_hierarchy(session: Session, project_id: uuid.UUID | None = None) -> list[dict]:
+def get_inventory_hierarchy(
+    session: Session, project_id: uuid.UUID | None = None, warehouse_id: uuid.UUID | None = None
+) -> list[dict]:
     """
     Query all InventoryLocation rows joined with POLineItem for unit_cost,
     optionally filtered by project_id.
@@ -768,6 +797,8 @@ def get_inventory_hierarchy(session: Session, project_id: uuid.UUID | None = Non
     stmt = stmt.where(InventoryLocationModel.quantity > 0)
     if project_id is not None:
         stmt = stmt.where(InventoryLocationModel.project_id == project_id)
+    if warehouse_id is not None:
+        stmt = stmt.where(InventoryLocationModel.warehouse_id == warehouse_id)
     stmt = stmt.order_by(
         InventoryLocationModel.hardware_category,
         InventoryLocationModel.product_code,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -707,10 +707,14 @@ class Query:
             return _po_to_type(po, receive_records)
 
     @strawberry.field
-    def inventory_hierarchy(self, project_id: strawberry.ID | None = None) -> list[InventoryHierarchyNode]:
+    def inventory_hierarchy(
+        self, project_id: strawberry.ID | None = None, warehouse_id: strawberry.ID | None = None
+    ) -> list[InventoryHierarchyNode]:
         with SessionLocal() as session:
             hierarchy = warehouse_repository.get_inventory_hierarchy(
-                session, uuid.UUID(str(project_id)) if project_id else None
+                session,
+                uuid.UUID(str(project_id)) if project_id else None,
+                uuid.UUID(str(warehouse_id)) if warehouse_id else None,
             )
             return [
                 InventoryHierarchyNode(
@@ -1059,9 +1063,17 @@ class Query:
             ]
 
     @strawberry.field
-    def location_contents(self, aisle: str, bay: str | None = None, bin: str | None = None) -> LocationContents:
+    def location_contents(
+        self,
+        aisle: str,
+        bay: str | None = None,
+        bin: str | None = None,
+        warehouse_id: strawberry.ID | None = None,
+    ) -> LocationContents:
         with SessionLocal() as session:
-            data = warehouse_repository.get_location_contents(session, aisle, bay, bin)
+            data = warehouse_repository.get_location_contents(
+                session, aisle, bay, bin, uuid.UUID(str(warehouse_id)) if warehouse_id else None
+            )
             return LocationContents(
                 inventory_items=[
                     InventoryItemDetail(
@@ -1125,11 +1137,14 @@ class Query:
             ]
 
     @strawberry.field
-    def location_utilization(self) -> list[LocationUtilizationEntry]:
+    def location_utilization(self, warehouse_id: strawberry.ID | None = None) -> list[LocationUtilizationEntry]:
         with SessionLocal() as session:
-            rows = warehouse_repository.get_location_utilization(session)
+            rows = warehouse_repository.get_location_utilization(
+                session, uuid.UUID(str(warehouse_id)) if warehouse_id else None
+            )
             return [
                 LocationUtilizationEntry(
+                    warehouse_id=strawberry.ID(str(r["warehouse_id"])) if r.get("warehouse_id") else None,
                     aisle=r["aisle"],
                     row=r.get("row"),
                     bay=r["bay"],

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -501,6 +501,7 @@ class VendorInventoryNode:
 
 @strawberry.type
 class LocationUtilizationEntry:
+    warehouse_id: strawberry.ID | None
     aisle: str
     row: str | None
     bay: str | None

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -211,9 +211,9 @@ export const ASSIGN_INVENTORY_LOCATION = gql`
 `;
 
 export const MOVE_OPENING_ITEM_LOCATION = gql`
-  mutation MoveOpeningItemLocation($openingItemId: ID!, $aisle: String!, $bay: String!, $bin: String!) {
-    moveOpeningItemLocation(openingItemId: $openingItemId, aisle: $aisle, bay: $bay, bin: $bin) {
-      id projectId openingId openingNumber building floor location quantity assemblyCompletedAt state aisle bay bin createdAt updatedAt
+  mutation MoveOpeningItemLocation($openingItemId: ID!, $aisle: String!, $bay: String!, $bin: String!, $warehouseId: ID) {
+    moveOpeningItemLocation(openingItemId: $openingItemId, aisle: $aisle, bay: $bay, bin: $bin, warehouseId: $warehouseId) {
+      id projectId openingId warehouseId openingNumber building floor location quantity assemblyCompletedAt state aisle bay bin createdAt updatedAt
       installedHardware { id openingItemId productCode hardwareCategory quantity }
     }
   }

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -131,8 +131,8 @@ export const GET_PURCHASE_ORDERS = gql`
 `;
 
 export const GET_INVENTORY_HIERARCHY = gql`
-  query GetInventoryHierarchy($projectId: ID) {
-    inventoryHierarchy(projectId: $projectId) {
+  query GetInventoryHierarchy($projectId: ID, $warehouseId: ID) {
+    inventoryHierarchy(projectId: $projectId, warehouseId: $warehouseId) {
       hardwareCategory
       totalQuantity
       totalValue
@@ -630,8 +630,9 @@ export const GET_INVENTORY_BY_VENDOR = gql`
 `;
 
 export const GET_LOCATION_UTILIZATION = gql`
-  query GetLocationUtilization {
-    locationUtilization {
+  query GetLocationUtilization($warehouseId: ID) {
+    locationUtilization(warehouseId: $warehouseId) {
+      warehouseId
       aisle
       row
       bay
@@ -643,8 +644,8 @@ export const GET_LOCATION_UTILIZATION = gql`
 `;
 
 export const GET_LOCATION_CONTENTS = gql`
-  query GetLocationContents($aisle: String!, $bay: String, $bin: String) {
-    locationContents(aisle: $aisle, bay: $bay, bin: $bin) {
+  query GetLocationContents($aisle: String!, $bay: String, $bin: String, $warehouseId: ID) {
+    locationContents(aisle: $aisle, bay: $bay, bin: $bin, warehouseId: $warehouseId) {
       inventoryItems {
         inventoryLocation {
           id projectId poLineItemId receiveLineItemId stockItemId warehouseId
@@ -655,7 +656,7 @@ export const GET_LOCATION_CONTENTS = gql`
         unitCost
       }
       openingItems {
-        id projectId openingId openingNumber
+        id projectId openingId warehouseId openingNumber
         building floor location quantity
         assemblyCompletedAt state aisle row bay bin
         createdAt updatedAt

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
+/* UI law: no horizontal PAGE scroll, ever. The viewport never widens to reveal
+   primary content. This clips rather than scrolls, so layouts must fit (use
+   minWidth:0 on flex/grid children). Components may still scroll inside their
+   own bounded container. Safe with position:sticky because body is the scroll root. */
+html,
 body {
   margin: 0;
   min-height: 100vh;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 #root {

--- a/frontend/src/modules/admin/WarehousesPage.tsx
+++ b/frontend/src/modules/admin/WarehousesPage.tsx
@@ -129,6 +129,7 @@ export default function WarehousesPage() {
           params.row.isPrimary ? null : (
             <IconButton
               size="small"
+              aria-label={`Delete warehouse ${params.row.name}`}
               onClick={(e) => {
                 e.stopPropagation();
                 setPendingDelete(params.row as Warehouse);

--- a/frontend/src/modules/warehouse/LocationActionDialog.tsx
+++ b/frontend/src/modules/warehouse/LocationActionDialog.tsx
@@ -6,11 +6,16 @@ import {
   Button,
   Stack,
   Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
-import { useMutation } from '@apollo/client/react';
+import { useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import LocationAutocomplete from '../../components/LocationAutocomplete';
 import { useToast } from '../../components/Toast';
+import { GET_WAREHOUSES } from '../../graphql/queries';
 import {
   ADJUST_INVENTORY_QUANTITY,
   MOVE_INVENTORY_LOCATION,
@@ -27,10 +32,17 @@ export type LocationActionTarget = {
   kind: 'inventory' | 'opening' | 'stock';
   productCode: string;
   quantity: number;
+  warehouseId?: string | null;
   aisle: string | null;
   bay: string | null;
   bin: string | null;
 };
+
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
+}
 
 export type LocationActionMode = 'move' | 'adjust' | 'unlocate';
 
@@ -69,6 +81,16 @@ export default function LocationActionDialog({
   const [aisle, setAisle] = useState('');
   const [bay, setBay] = useState('');
   const [bin, setBin] = useState('');
+  const [warehouseId, setWarehouseId] = useState('');
+
+  // Opening-item kits can't be partial-transferred, so their move may also change warehouse.
+  // (inventory + stock change warehouse via the Transfer dialog instead.)
+  const allOpening = targets.length > 0 && targets.every((t) => t.kind === 'opening');
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: false },
+    skip: !allOpening,
+  });
+  const warehouses = warehousesData?.warehouses ?? [];
 
   // Adjust state
   const [adjustment, setAdjustment] = useState('');
@@ -83,10 +105,12 @@ export default function LocationActionDialog({
       setAisle(single?.aisle ?? '');
       setBay(single?.bay ?? '');
       setBin(single?.bin ?? '');
+      setWarehouseId(single?.warehouseId ?? '');
     } else {
       setAisle('');
       setBay('');
       setBin('');
+      setWarehouseId('');
     }
   }, [open, mode, single]);
 
@@ -153,6 +177,7 @@ export default function LocationActionDialog({
                 aisle: aisle.trim(),
                 bay: bay.trim(),
                 bin: bin.trim(),
+                warehouseId: warehouseId || null,
               },
             });
           } else {
@@ -247,6 +272,23 @@ export default function LocationActionDialog({
 
       {mode === 'move' && (
         <Stack spacing={2}>
+          {allOpening && (
+            <FormControl size="small" fullWidth>
+              <InputLabel id="move-warehouse">Warehouse</InputLabel>
+              <Select
+                labelId="move-warehouse"
+                label="Warehouse"
+                value={warehouseId}
+                onChange={(e) => setWarehouseId(e.target.value)}
+              >
+                {warehouses.map((w) => (
+                  <MenuItem key={w.id} value={w.id}>
+                    {w.name} ({w.code})
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <LocationAutocomplete
             label="Aisle"
             value={aisle}

--- a/frontend/src/modules/warehouse/LocationsTab.tsx
+++ b/frontend/src/modules/warehouse/LocationsTab.tsx
@@ -15,6 +15,9 @@ import {
   Tooltip,
   Stack,
   Paper,
+  FormControl,
+  InputLabel,
+  Select,
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
@@ -24,6 +27,7 @@ import {
   GET_LOCATION_UTILIZATION,
   GET_LOCATION_CONTENTS,
   GET_LOCATION_DISTINCT_VALUES,
+  GET_WAREHOUSES,
 } from '../../graphql/queries';
 import LocationActionDialog, {
   type LocationActionMode,
@@ -33,11 +37,18 @@ import LocationAuditStrip from './LocationAuditStrip';
 import TransferDialog, { type TransferSource } from './TransferDialog';
 
 interface LocationEntry {
+  warehouseId: string | null;
   aisle: string;
   bay: string | null;
   bin: string | null;
   itemCount: number;
   totalQuantity: number;
+}
+
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
 }
 
 interface InventoryLocationItem {
@@ -61,6 +72,7 @@ interface ContentsInventoryItem {
 
 interface ContentsOpeningItem {
   id: string;
+  warehouseId: string | null;
   openingNumber: string;
   building: string | null;
   floor: string | null;
@@ -112,43 +124,82 @@ function formatCurrency(value: number | null): string {
   return value.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 }
 
-const utilColumns: GridColDef<LocationEntry & { id: string }>[] = [
-  {
-    field: 'location',
-    headerName: 'Location',
-    flex: 1,
-    minWidth: 140,
-    valueGetter: (_v, row) => formatLocation(row.aisle, row.bay, row.bin),
-    renderCell: (p) => (
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <LocationOnIcon fontSize="small" color="action" />
-        <Typography variant="body2">{p.value as string}</Typography>
-      </Box>
-    ),
-  },
-  { field: 'aisle', headerName: 'Aisle', flex: 0.5, minWidth: 80 },
-  {
-    field: 'bay',
-    headerName: 'Bay',
-    flex: 0.5,
-    minWidth: 80,
-    valueFormatter: (v: string | null) => v ?? '—',
-  },
-  {
-    field: 'bin',
-    headerName: 'Bin',
-    flex: 0.5,
-    minWidth: 80,
-    valueFormatter: (v: string | null) => v ?? '—',
-  },
-  { field: 'itemCount', headerName: 'Items', flex: 0.5, minWidth: 80, type: 'number' },
-  { field: 'totalQuantity', headerName: 'Total Qty', flex: 0.5, minWidth: 100, type: 'number' },
-];
+type UtilRow = LocationEntry & { id: string };
+
+function warehouseChip(id: string | null, warehouseCode: Map<string, string>) {
+  return id ? (
+    <Chip label={warehouseCode.get(id) ?? '—'} size="small" variant="outlined" />
+  ) : (
+    <span>—</span>
+  );
+}
+
+// Two column sets, space-efficiency law: the full table drops the redundant aisle/bay/bin
+// columns (Location already encodes them) and keeps one flexible column. When a location is
+// selected the list collapses to a single compact rail so the contents panel gets the width.
+function buildUtilColumns(
+  compact: boolean,
+  warehouseCode: Map<string, string>,
+  showWarehouse: boolean,
+): GridColDef<UtilRow>[] {
+  if (compact) {
+    return [
+      {
+        field: 'location',
+        headerName: 'Location',
+        flex: 1,
+        minWidth: 0,
+        valueGetter: (_v, row) => formatLocation(row.aisle, row.bay, row.bin),
+        renderCell: ({ row }) => (
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0, width: '100%' }}>
+            <LocationOnIcon fontSize="small" color="action" />
+            <Typography variant="body2" noWrap sx={{ flex: 1, minWidth: 0 }}>
+              {formatLocation(row.aisle, row.bay, row.bin)}
+            </Typography>
+            {showWarehouse && warehouseChip(row.warehouseId, warehouseCode)}
+            <Typography variant="caption" color="text.secondary">
+              {row.totalQuantity}
+            </Typography>
+          </Stack>
+        ),
+      },
+    ];
+  }
+  return [
+    {
+      field: 'location',
+      headerName: 'Location',
+      flex: 1,
+      minWidth: 140,
+      valueGetter: (_v, row) => formatLocation(row.aisle, row.bay, row.bin),
+      renderCell: (p) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <LocationOnIcon fontSize="small" color="action" />
+          <Typography variant="body2">{p.value as string}</Typography>
+        </Box>
+      ),
+    },
+    // Per-row warehouse is redundant (and wasted space) when the list is already filtered to one warehouse.
+    ...(showWarehouse
+      ? [
+          {
+            field: 'warehouseId',
+            headerName: 'Warehouse',
+            width: 130,
+            renderCell: ({ row }: { row: UtilRow }) => warehouseChip(row.warehouseId, warehouseCode),
+          } as GridColDef<UtilRow>,
+        ]
+      : []),
+    { field: 'itemCount', headerName: 'Items', width: 100, type: 'number' },
+    { field: 'totalQuantity', headerName: 'Total Qty', width: 120, type: 'number' },
+  ];
+}
 
 // ----- side panel -----
 
 interface ContentsPanelProps {
   selected: LocationEntry;
+  warehouseLabel?: string;
   onClose: () => void;
   aisleOptions: string[];
   bayOptions: string[];
@@ -220,13 +271,19 @@ function RowActionMenu({
 
 function ContentsPanel({
   selected,
+  warehouseLabel,
   onClose,
   aisleOptions,
   bayOptions,
   binOptions,
 }: ContentsPanelProps) {
   const { data, loading, error } = useQuery<LocationContentsData>(GET_LOCATION_CONTENTS, {
-    variables: { aisle: selected.aisle, bay: selected.bay, bin: selected.bin },
+    variables: {
+      aisle: selected.aisle,
+      bay: selected.bay,
+      bin: selected.bin,
+      warehouseId: selected.warehouseId,
+    },
     fetchPolicy: 'cache-and-network',
   });
 
@@ -264,6 +321,7 @@ function ContentsPanel({
         kind: 'inventory',
         productCode: i.inventoryLocation.productCode,
         quantity: i.inventoryLocation.quantity,
+        warehouseId: i.inventoryLocation.warehouseId,
         aisle: i.inventoryLocation.aisle,
         bay: i.inventoryLocation.bay,
         bin: i.inventoryLocation.bin,
@@ -275,6 +333,7 @@ function ContentsPanel({
         kind: 'opening',
         productCode: o.openingNumber,
         quantity: o.quantity,
+        warehouseId: o.warehouseId,
         aisle: o.aisle,
         bay: o.bay,
         bin: o.bin,
@@ -286,6 +345,7 @@ function ContentsPanel({
         kind: 'stock',
         productCode: s.productCode,
         quantity: s.quantity,
+        warehouseId: s.warehouseId,
         aisle: s.aisle,
         bay: s.bay,
         bin: s.bin,
@@ -311,11 +371,16 @@ function ContentsPanel({
   const totalCount = invItems.length + oiItems.length + stockItems.length;
 
   return (
-    <Paper variant="outlined" sx={{ p: 2, position: 'sticky', top: 16 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-        <Typography variant="h6">
-          {formatLocation(selected.aisle, selected.bay, selected.bin)}
-        </Typography>
+    <Paper variant="outlined" sx={{ p: 2, position: 'sticky', top: 16, minWidth: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1, gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, minWidth: 0 }}>
+          <Typography variant="h6" noWrap>
+            {formatLocation(selected.aisle, selected.bay, selected.bin)}
+          </Typography>
+          {warehouseLabel && (
+            <Chip label={warehouseLabel} size="small" variant="outlined" />
+          )}
+        </Box>
         <Button size="small" onClick={onClose}>Close</Button>
       </Box>
 
@@ -553,10 +618,24 @@ function ContentsPanel({
 export default function LocationsTab() {
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<LocationEntry | null>(null);
+  const [warehouseFilter, setWarehouseFilter] = useState('');
+
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: true },
+  });
+  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+  const warehouseCode = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const w of warehouses) m.set(w.id, w.code);
+    return m;
+  }, [warehouses]);
 
   const { data: utilData, loading: utilLoading, error: utilError } = useQuery<{
     locationUtilization: LocationEntry[];
-  }>(GET_LOCATION_UTILIZATION, { fetchPolicy: 'cache-and-network' });
+  }>(GET_LOCATION_UTILIZATION, {
+    variables: { warehouseId: warehouseFilter || null },
+    fetchPolicy: 'cache-and-network',
+  });
 
   const { data: distinctData } = useQuery<DistinctValuesData>(GET_LOCATION_DISTINCT_VALUES, {
     fetchPolicy: 'cache-and-network',
@@ -587,13 +666,28 @@ export default function LocationsTab() {
         });
     return filtered.map((loc, i) => ({
       ...loc,
-      id: `${loc.aisle}-${loc.bay}-${loc.bin}-${i}`,
+      id: `${loc.warehouseId ?? 'none'}-${loc.aisle}-${loc.bay}-${loc.bin}-${i}`,
     }));
   }, [utilData, search]);
 
   const handleRowClick = useCallback((params: GridRowParams<LocationEntry & { id: string }>) => {
     setSelected(params.row);
   }, []);
+
+  const columns = useMemo(
+    () => buildUtilColumns(selected !== null, warehouseCode, !warehouseFilter),
+    [selected, warehouseCode, warehouseFilter],
+  );
+
+  const isSelectedRow = useCallback(
+    (row: LocationEntry) =>
+      selected !== null &&
+      row.warehouseId === selected.warehouseId &&
+      row.aisle === selected.aisle &&
+      row.bay === selected.bay &&
+      row.bin === selected.bin,
+    [selected],
+  );
 
   if (utilLoading && !utilData) {
     return (
@@ -617,10 +711,29 @@ export default function LocationsTab() {
           size="small"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          sx={{ minWidth: 320 }}
+          sx={{ minWidth: 280, flex: 1 }}
         />
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel id="loc-warehouse-filter">Warehouse</InputLabel>
+          <Select
+            labelId="loc-warehouse-filter"
+            label="Warehouse"
+            value={warehouseFilter}
+            onChange={(e) => {
+              setWarehouseFilter(e.target.value);
+              setSelected(null);
+            }}
+          >
+            <MenuItem value="">All warehouses</MenuItem>
+            {warehouses.map((w) => (
+              <MenuItem key={w.id} value={w.id}>
+                {w.name} ({w.code})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         <Typography variant="body2" color="text.secondary">
-          {totalLocations} locations — {totalQty.toLocaleString()} total items
+          {totalLocations} locations - {totalQty.toLocaleString()} total items
         </Typography>
       </Box>
 
@@ -635,31 +748,38 @@ export default function LocationsTab() {
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: selected ? '1fr 1fr' : '1fr' },
+            gridTemplateColumns: { xs: '1fr', lg: selected ? 'minmax(300px, 380px) 1fr' : '1fr' },
             gap: 2,
             alignItems: 'start',
           }}
         >
-          <Box sx={{ height: 600, width: '100%' }}>
+          <Box sx={{ height: 600, minWidth: 0 }}>
             <DataGrid
               rows={rows}
-              columns={utilColumns}
+              columns={columns}
               pageSizeOptions={[10, 25, 50]}
               initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
               disableRowSelectionOnClick
               onRowClick={handleRowClick}
               density="compact"
-              sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+              getRowClassName={(p) => (isSelectedRow(p.row) ? 'row-selected' : '')}
+              sx={{
+                '& .MuiDataGrid-row': { cursor: 'pointer' },
+                '& .row-selected': { bgcolor: 'action.selected' },
+              }}
             />
           </Box>
           {selected && (
-            <ContentsPanel
-              selected={selected}
-              onClose={() => setSelected(null)}
-              aisleOptions={aisles}
-              bayOptions={bays}
-              binOptions={bins}
-            />
+            <Box sx={{ minWidth: 0 }}>
+              <ContentsPanel
+                selected={selected}
+                warehouseLabel={selected.warehouseId ? warehouseCode.get(selected.warehouseId) : undefined}
+                onClose={() => setSelected(null)}
+                aisleOptions={aisles}
+                bayOptions={bays}
+                binOptions={bins}
+              />
+            </Box>
           )}
         </Box>
       )}

--- a/frontend/src/modules/warehouse/StockPoolView.tsx
+++ b/frontend/src/modules/warehouse/StockPoolView.tsx
@@ -241,7 +241,7 @@ export default function StockPoolView() {
         </Button>
       </Stack>
 
-      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap" sx={{ mb: 2 }}>
         <TextField
           label="Product code contains"
           size="small"

--- a/frontend/src/modules/warehouse/TransferDialog.tsx
+++ b/frontend/src/modules/warehouse/TransferDialog.tsx
@@ -12,9 +12,10 @@ import {
 } from '@mui/material';
 import { useQuery, useMutation } from '@apollo/client/react';
 import Modal from '../../components/Modal';
+import LocationAutocomplete from '../../components/LocationAutocomplete';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
-import { GET_WAREHOUSES } from '../../graphql/queries';
+import { GET_WAREHOUSES, GET_LOCATION_DISTINCT_VALUES } from '../../graphql/queries';
 import { TRANSFER_INVENTORY } from '../../graphql/mutations';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 
@@ -49,6 +50,13 @@ export default function TransferDialog({ source, onClose, onSuccess }: TransferD
     variables: { includeInactive: false },
   });
   const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+
+  const { data: distinctData } = useQuery<{
+    locationDistinctValues: { aisles: string[]; bays: string[]; bins: string[] };
+  }>(GET_LOCATION_DISTINCT_VALUES, { fetchPolicy: 'cache-and-network' });
+  const aisleOptions = distinctData?.locationDistinctValues.aisles ?? [];
+  const bayOptions = distinctData?.locationDistinctValues.bays ?? [];
+  const binOptions = distinctData?.locationDistinctValues.bins ?? [];
 
   const [destWarehouseId, setDestWarehouseId] = useState<string>(source.warehouseId ?? '');
   const [aisle, setAisle] = useState('');
@@ -137,27 +145,9 @@ export default function TransferDialog({ source, onClose, onSuccess }: TransferD
           </Select>
         </FormControl>
         <Stack direction="row" spacing={2}>
-          <TextField
-            label="Aisle"
-            size="small"
-            value={aisle}
-            onChange={(e) => setAisle(e.target.value.slice(0, 20))}
-            required
-          />
-          <TextField
-            label="Bay"
-            size="small"
-            value={bay}
-            onChange={(e) => setBay(e.target.value.slice(0, 20))}
-            required
-          />
-          <TextField
-            label="Bin"
-            size="small"
-            value={bin}
-            onChange={(e) => setBin(e.target.value.slice(0, 20))}
-            required
-          />
+          <LocationAutocomplete label="Aisle" value={aisle} onChange={setAisle} options={aisleOptions} />
+          <LocationAutocomplete label="Bay" value={bay} onChange={setBay} options={bayOptions} />
+          <LocationAutocomplete label="Bin" value={bin} onChange={setBin} options={binOptions} />
         </Stack>
         <TextField
           label="Quantity"


### PR DESCRIPTION
third PR for #88 - the deferred items + impeccable audit findings, and the Locations page made space-efficient.

two UI laws now govern the app, space is used efficiently always and no horizontal PAGE scroll. html, body { overflow-x: hidden } in index.css enforces the second, so layouts must fit; a component may still scroll inside its own bounded container.

Locations page
- was a 6-column table (redundant aisle/bay/bin columns spreading short values across gaps) beside a narrow contents panel, overflowing the page sideways. unselected, the table is Location / Warehouse / Items / Qty with one flexible column absorbing slack; selecting a row collapses the list to a compact rail (minmax(300px,380px)) and gives the contents panel the freed width. minWidth:0 on both grid children kills the page overflow.
- each bin is one physical place only within a warehouse, so locationUtilization groups by warehouse, the list gains a Warehouse column + filter, and locationContents is scoped to the selected warehouse. the Warehouse column drops out when one warehouse is filtered (redundant column = wasted space).

opening-item move, transfer dialog, stock pool
- opening-item move dialog gains a warehouse picker (kits move whole; wired to moveOpeningItemLocation warehouseId).
- TransferDialog dest bin uses LocationAutocomplete like the rest of the app, not bare text fields.
- stock-pool filter row wraps on narrow widths; delete buttons get aria-labels.
- inventory_hierarchy gains a warehouseId filter (backend), so the InventoryView warehouse dropdown is now just a small follow-up.
