### PR TITLE
shipment returns: re-enter shipped loose hardware to project / non-stock / RMA (#89)

### DIFF
--- a/backend/alembic/versions/035_shipment_returns.py
+++ b/backend/alembic/versions/035_shipment_returns.py
@@ -1,0 +1,123 @@
+"""Shipment returns: ShipmentReturn + ShipmentReturnItem, RETURN audit action,
+inventory_locations return origin (issue #89)
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-06-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "035"
+down_revision = "034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. RETURN audit action (safe to add inside the transaction; not referenced until runtime)
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'RETURN'")
+
+    # 2. return_disposition enum (created implicitly by the create_table below, per migration 030)
+    return_disposition = sa.Enum(
+        "RETURN_TO_PROJECT",
+        "NON_STOCK",
+        "RMA_DEFECTIVE",
+        name="return_disposition",
+    )
+
+    # 3. shipment_returns header
+    op.create_table(
+        "shipment_returns",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("packing_slip_id", sa.Uuid(), sa.ForeignKey("packing_slips.id"), nullable=False),
+        sa.Column(
+            "warehouse_id",
+            sa.Uuid(),
+            sa.ForeignKey("warehouses.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("returned_by", sa.String(), nullable=False),
+        sa.Column("returned_at", sa.DateTime(), nullable=False),
+        sa.Column("reference", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_shipment_returns_packing_slip", "shipment_returns", ["packing_slip_id"])
+
+    # 4. shipment_return_items (FKs target tables that already exist: packing_slip_items,
+    #    inventory_locations, stock_items — so no circular create-order problem here)
+    op.create_table(
+        "shipment_return_items",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("shipment_return_id", sa.Uuid(), sa.ForeignKey("shipment_returns.id"), nullable=False),
+        sa.Column("packing_slip_item_id", sa.Uuid(), sa.ForeignKey("packing_slip_items.id"), nullable=False),
+        sa.Column("disposition", return_disposition, nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("hardware_category", sa.String(), nullable=False),
+        sa.Column("product_code", sa.String(), nullable=False),
+        sa.Column("opening_number", sa.String(), nullable=True),
+        sa.Column("rma_reference", sa.String(100), nullable=True),
+        sa.Column("reason_text", sa.Text(), nullable=True),
+        sa.Column(
+            "resulting_inventory_location_id",
+            sa.Uuid(),
+            sa.ForeignKey("inventory_locations.id"),
+            nullable=True,
+        ),
+        sa.Column("resulting_stock_item_id", sa.Uuid(), sa.ForeignKey("stock_items.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("quantity >= 1", name="ck_shipment_return_items_quantity_positive"),
+    )
+    op.create_index("ix_shipment_return_items_return", "shipment_return_items", ["shipment_return_id"])
+    op.create_index(
+        "ix_shipment_return_items_packing_slip_item",
+        "shipment_return_items",
+        ["packing_slip_item_id"],
+    )
+
+    # 5. inventory_locations: new return origin column + relaxed origin CHECK
+    op.add_column(
+        "inventory_locations",
+        sa.Column(
+            "shipment_return_item_id",
+            sa.Uuid(),
+            sa.ForeignKey("shipment_return_items.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_inventory_locations_shipment_return_item",
+        "inventory_locations",
+        ["shipment_return_item_id"],
+    )
+    op.drop_constraint("ck_inventory_locations_has_origin", "inventory_locations", type_="check")
+    op.create_check_constraint(
+        "ck_inventory_locations_has_origin",
+        "inventory_locations",
+        "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) "
+        "OR stock_item_id IS NOT NULL "
+        "OR shipment_return_item_id IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_inventory_locations_has_origin", "inventory_locations", type_="check")
+    op.create_check_constraint(
+        "ck_inventory_locations_has_origin",
+        "inventory_locations",
+        "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) OR stock_item_id IS NOT NULL",
+    )
+    op.drop_index("ix_inventory_locations_shipment_return_item", table_name="inventory_locations")
+    op.drop_column("inventory_locations", "shipment_return_item_id")
+
+    op.drop_index("ix_shipment_return_items_packing_slip_item", table_name="shipment_return_items")
+    op.drop_index("ix_shipment_return_items_return", table_name="shipment_return_items")
+    op.drop_table("shipment_return_items")
+    op.drop_index("ix_shipment_returns_packing_slip", table_name="shipment_returns")
+    op.drop_table("shipment_returns")
+
+    op.execute("DROP TYPE return_disposition")
+    # audit_action 'RETURN' is left in place - Postgres can't drop an enum value without a full
+    # rebuild, and a leftover unused value is harmless.

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -157,6 +157,49 @@ type PackingSlipItem {
   quantity: Int!
 }
 
+enum ReturnDisposition {
+  RETURN_TO_PROJECT
+  NON_STOCK
+  RMA_DEFECTIVE
+}
+
+type ReturnableLine {
+  packing_slip_item_id: ID!
+  opening_number: String
+  product_code: String!
+  hardware_category: String!
+  shipped_quantity: Int!
+  returned_quantity: Int!
+  returnable_quantity: Int!
+}
+
+type ShipmentReturnItem {
+  id: ID!
+  shipment_return_id: ID!
+  packing_slip_item_id: ID!
+  disposition: ReturnDisposition!
+  quantity: Int!
+  hardware_category: String!
+  product_code: String!
+  opening_number: String
+  rma_reference: String
+  reason_text: String
+  resulting_inventory_location_id: ID
+  resulting_stock_item_id: ID
+  created_at: DateTime!
+}
+
+type ShipmentReturn {
+  id: ID!
+  packing_slip_id: ID!
+  warehouse_id: ID!
+  returned_by: String!
+  returned_at: DateTime!
+  reference: String
+  created_at: DateTime!
+  items: [ShipmentReturnItem!]!
+}
+
 type Notification {
   id: ID!
   project_id: ID!
@@ -202,6 +245,22 @@ input ShipmentItemInput {
   quantity: Int!
 }
 
+input CreateShipmentReturnInput {
+  packing_slip_id: ID!
+  warehouse_id: ID!
+  returned_by: String!
+  reference: String
+  items: [ShipmentReturnItemInput!]!
+}
+
+input ShipmentReturnItemInput {
+  packing_slip_item_id: ID!
+  quantity: Int!
+  disposition: ReturnDisposition!
+  rma_reference: String
+  reason_text: String
+}
+
 type RecentReceiveRecord {
   receive_record: ReceiveRecord!
   po_number: String
@@ -232,6 +291,8 @@ type Query {
   pullRequestDetails(id: ID!): PullRequest!
   shipReadyItems(projectId: ID!): ShipReadyItems!
   projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
+  packingSlips(projectId: ID): [PackingSlip!]!
+  returnableLines(packingSlipId: ID!): [ReturnableLine!]!
   notifications(projectId: ID!, recipientRole: String!, unreadOnly: Boolean, limit: Int = 5): [Notification!]!
 }
 
@@ -240,6 +301,7 @@ type Mutation {
   approvePullRequest(id: ID!, approvedBy: String!): ApproveResult!
   completePullRequest(id: ID!): PullRequest!
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
+  createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
   adjustInventoryQuantity(inventoryLocationId: ID!, adjustment: Int!, reason: String!): InventoryLocation!
   moveInventoryLocation(inventoryLocationId: ID!, newAisle: String!, newBay: String!, newBin: String!): InventoryLocation!
   markInventoryUnlocated(inventoryLocationId: ID!): InventoryLocation!

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,7 +17,12 @@ from .project_excluded_item import ProjectExcludedItem  # noqa: E402, F401
 from .pull_request import PullRequest, PullRequestItem  # noqa: E402, F401
 from .purchase_order import PODocument, POLineItem, PurchaseOrder  # noqa: E402, F401
 from .receiving import ReceiveLineItem, ReceiveRecord  # noqa: E402, F401
-from .shipping import PackingSlip, PackingSlipItem  # noqa: E402, F401
+from .shipping import (  # noqa: E402, F401
+    PackingSlip,
+    PackingSlipItem,
+    ShipmentReturn,
+    ShipmentReturnItem,
+)
 from .shop_assembly import (  # noqa: E402, F401
     ShopAssemblyOpening,
     ShopAssemblyOpeningItem,

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -93,6 +93,15 @@ class AuditAction(str, enum.Enum):
     REPORT_DEFICIENT = "REPORT_DEFICIENT"
     RESOLVE_DEFICIENT = "RESOLVE_DEFICIENT"
     TRANSFER = "TRANSFER"
+    RETURN = "RETURN"
+
+
+class ReturnDisposition(str, enum.Enum):
+    """Where a returned loose-hardware line goes when a shipment comes back."""
+
+    RETURN_TO_PROJECT = "RETURN_TO_PROJECT"
+    NON_STOCK = "NON_STOCK"
+    RMA_DEFECTIVE = "RMA_DEFECTIVE"
 
 
 class DestockSource(str, enum.Enum):

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -18,6 +18,7 @@ class InventoryLocation(Base):
         ),
         Index("ix_inventory_locations_aisle", "aisle"),
         Index("ix_inventory_locations_stock_item", "stock_item_id"),
+        Index("ix_inventory_locations_shipment_return_item", "shipment_return_item_id"),
         Index("ix_inventory_locations_warehouse", "warehouse_id", "aisle", "bay", "bin"),
         CheckConstraint("quantity >= 0", name="ck_inventory_locations_quantity_nonneg"),
         CheckConstraint(
@@ -29,7 +30,9 @@ class InventoryLocation(Base):
             name="ck_inventory_locations_deficient_within_quantity",
         ),
         CheckConstraint(
-            "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) OR stock_item_id IS NOT NULL",
+            "(po_line_item_id IS NOT NULL AND receive_line_item_id IS NOT NULL) "
+            "OR stock_item_id IS NOT NULL "
+            "OR shipment_return_item_id IS NOT NULL",
             name="ck_inventory_locations_has_origin",
         ),
     )
@@ -40,6 +43,9 @@ class InventoryLocation(Base):
     receive_line_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("receive_line_items.id"), nullable=True)
     stock_item_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("stock_items.id", ondelete="SET NULL"), nullable=True
+    )
+    shipment_return_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("shipment_return_items.id", ondelete="SET NULL"), nullable=True
     )
     warehouse_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)

--- a/backend/app/models/shipping.py
+++ b/backend/app/models/shipping.py
@@ -1,11 +1,11 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
-from .enums import PullRequestItemType
+from .enums import PullRequestItemType, ReturnDisposition
 
 
 class PackingSlip(Base):
@@ -46,3 +46,53 @@ class PackingSlipItem(Base):
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
 
     packing_slip: Mapped["PackingSlip"] = relationship(back_populates="items")
+
+
+class ShipmentReturn(Base):
+    """A shipment came back from site. Header mirrors PackingSlip; only loose lines are returnable."""
+
+    __tablename__ = "shipment_returns"
+    __table_args__ = (Index("ix_shipment_returns_packing_slip", "packing_slip_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    packing_slip_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("packing_slips.id"), nullable=False)
+    # Where the returned stock physically lands (new inventory / stock rows are created here).
+    warehouse_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
+    returned_by: Mapped[str] = mapped_column(String, nullable=False)
+    returned_at: Mapped[datetime] = mapped_column(nullable=False)
+    reference: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+
+    items: Mapped[list["ShipmentReturnItem"]] = relationship(back_populates="shipment_return")
+
+
+class ShipmentReturnItem(Base):
+    """One returned loose-hardware line, routed by its disposition into project inventory or stock."""
+
+    __tablename__ = "shipment_return_items"
+    __table_args__ = (
+        Index("ix_shipment_return_items_return", "shipment_return_id"),
+        Index("ix_shipment_return_items_packing_slip_item", "packing_slip_item_id"),
+        CheckConstraint("quantity >= 1", name="ck_shipment_return_items_quantity_positive"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    shipment_return_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("shipment_returns.id"), nullable=False)
+    packing_slip_item_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("packing_slip_items.id"), nullable=False)
+    disposition: Mapped[ReturnDisposition] = mapped_column(
+        Enum(ReturnDisposition, name="return_disposition", create_constraint=True),
+        nullable=False,
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    hardware_category: Mapped[str] = mapped_column(String, nullable=False)
+    product_code: Mapped[str] = mapped_column(String, nullable=False)
+    opening_number: Mapped[str | None] = mapped_column(String, nullable=True)
+    rma_reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    reason_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resulting_inventory_location_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("inventory_locations.id"), nullable=True
+    )
+    resulting_stock_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("stock_items.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+
+    shipment_return: Mapped["ShipmentReturn"] = relationship(back_populates="items")

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -9,12 +9,16 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
 from app.models.enums import (
+    AuditAction,
+    AuditEntityType,
     NotificationType,
     OpeningItemState,
     PullRequestItemType,
     PullRequestSource,
     PullRequestStatus,
+    ReturnDisposition,
 )
+from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.pull_request import (
     PullRequest as PullRequestModel,
@@ -22,7 +26,14 @@ from app.models.pull_request import (
 from app.models.pull_request import (
     PullRequestItem as PullRequestItemModel,
 )
-from app.models.shipping import PackingSlip, PackingSlipItem
+from app.models.shipping import (
+    PackingSlip,
+    PackingSlipItem,
+    ShipmentReturn,
+    ShipmentReturnItem,
+)
+from app.models.warehouse import Warehouse
+from app.repositories.stock_repository import _find_or_create_stock_row, _log_audit_event
 from app.services import notification_service
 from app.services.locking import lock_rows
 
@@ -261,3 +272,234 @@ def confirm_shipment(
     )
 
     return packing_slip
+
+
+# ---------------------------------------------------------------------------
+# Shipment returns (issue #89): a shipment comes back from site.
+# Only loose-hardware lines are returnable; opening items never re-enter.
+# ---------------------------------------------------------------------------
+
+
+def list_packing_slips(
+    session: Session,
+    project_id: uuid.UUID | None = None,
+) -> list[PackingSlip]:
+    """List confirmed packing slips (newest first), optionally scoped to one project."""
+    stmt = select(PackingSlip).options(selectinload(PackingSlip.items)).order_by(PackingSlip.shipped_at.desc())
+    if project_id is not None:
+        stmt = stmt.where(PackingSlip.project_id == project_id)
+    return list(session.scalars(stmt).unique().all())
+
+
+def _returned_quantities(session: Session, packing_slip_id: uuid.UUID) -> dict[uuid.UUID, int]:
+    """Sum of already-returned quantity per packing_slip_item_id for a slip."""
+    rows = session.execute(
+        select(
+            ShipmentReturnItem.packing_slip_item_id,
+            func.sum(ShipmentReturnItem.quantity).label("total_returned"),
+        )
+        .join(ShipmentReturn, ShipmentReturnItem.shipment_return_id == ShipmentReturn.id)
+        .where(ShipmentReturn.packing_slip_id == packing_slip_id)
+        .group_by(ShipmentReturnItem.packing_slip_item_id)
+    ).all()
+    return {row.packing_slip_item_id: row.total_returned for row in rows}
+
+
+def get_returnable_lines(session: Session, packing_slip_id: uuid.UUID) -> list[dict]:
+    """For a slip, list each LOOSE line with shipped / already-returned / still-returnable quantity."""
+    ps = session.scalars(
+        select(PackingSlip).options(selectinload(PackingSlip.items)).where(PackingSlip.id == packing_slip_id)
+    ).first()
+    if ps is None:
+        raise NotFoundError(f"Packing slip {packing_slip_id} not found")
+
+    already = _returned_quantities(session, packing_slip_id)
+    lines = []
+    for psi in ps.items:
+        if psi.item_type != PullRequestItemType.LOOSE:
+            continue
+        returned = already.get(psi.id, 0)
+        lines.append(
+            {
+                "packing_slip_item_id": psi.id,
+                "opening_number": psi.opening_number,
+                "product_code": psi.product_code,
+                "hardware_category": psi.hardware_category,
+                "shipped_quantity": psi.quantity,
+                "returned_quantity": returned,
+                "returnable_quantity": psi.quantity - returned,
+            }
+        )
+    return lines
+
+
+def create_shipment_return(
+    session: Session,
+    *,
+    packing_slip_id: uuid.UUID,
+    warehouse_id: uuid.UUID,
+    returned_by: str,
+    reference: str | None,
+    items: list[dict],
+) -> ShipmentReturn:
+    """Record a shipment return and route each loose line to its disposition.
+
+    Each item dict carries: packing_slip_item_id, quantity, disposition (ReturnDisposition),
+    and optional rma_reference / reason_text.
+
+    RETURN_TO_PROJECT re-creates a fresh, unlocated InventoryLocation for the slip's project
+    (drops into Put-Away). NON_STOCK / RMA_DEFECTIVE merge into the stock pool at the chosen
+    warehouse; RMA also flags the merged units deficient so they surface in Deficient Items review.
+    """
+    if not returned_by:
+        raise ValidationError("returned_by is required", field="returned_by")
+    if not items:
+        raise ValidationError("items must not be empty", field="items")
+    reference = (reference or "").strip() or None
+
+    # 1. Lock the slip, then load it with items
+    locked = lock_rows(session, PackingSlip, [packing_slip_id])
+    if not locked:
+        raise NotFoundError(f"Packing slip {packing_slip_id} not found")
+    ps = session.scalars(
+        select(PackingSlip).options(selectinload(PackingSlip.items)).where(PackingSlip.id == packing_slip_id)
+    ).first()
+
+    # 2. Validate destination warehouse
+    warehouse = session.get(Warehouse, warehouse_id)
+    if warehouse is None:
+        raise NotFoundError(f"Warehouse {warehouse_id} not found")
+    if not warehouse.is_active:
+        raise ValidationError("Destination warehouse is not active", field="warehouse_id")
+
+    psi_by_id = {psi.id: psi for psi in ps.items}
+    already = _returned_quantities(session, packing_slip_id)
+
+    # 3. Validate every line up front (cumulative within this call too)
+    requested_per_psi: dict[uuid.UUID, int] = defaultdict(int)
+    for item in items:
+        qty = item["quantity"]
+        if qty < 1:
+            raise ValidationError("quantity must be >= 1", field="quantity")
+        psi = psi_by_id.get(item["packing_slip_item_id"])
+        if psi is None:
+            raise ValidationError("Line is not part of this packing slip", field="packing_slip_item_id")
+        if psi.item_type != PullRequestItemType.LOOSE:
+            raise ValidationError("Only loose-hardware lines can be returned", field="packing_slip_item_id")
+        rma_ref = item.get("rma_reference")
+        if rma_ref is not None and len(rma_ref) > 100:
+            raise ValidationError("rma_reference must be 100 characters or fewer", field="rma_reference")
+        requested_per_psi[psi.id] += qty
+
+    for psi_id, requested in requested_per_psi.items():
+        psi = psi_by_id[psi_id]
+        returnable = psi.quantity - already.get(psi_id, 0)
+        if requested > returnable:
+            raise ValidationError(
+                f"Return quantity {requested} exceeds returnable {returnable} for {psi.product_code}",
+                field="quantity",
+            )
+
+    # 4. Create the return header
+    now = datetime.utcnow()
+    shipment_return = ShipmentReturn(
+        id=uuid.uuid4(),
+        packing_slip_id=ps.id,
+        warehouse_id=warehouse_id,
+        returned_by=returned_by,
+        returned_at=now,
+        reference=reference,
+    )
+    session.add(shipment_return)
+    session.flush()
+
+    # 5. Process each returned line
+    for item in items:
+        psi = psi_by_id[item["packing_slip_item_id"]]
+        qty = item["quantity"]
+        disposition = item["disposition"]
+        rma_reference = item.get("rma_reference")
+        reason_text = item.get("reason_text")
+
+        return_item = ShipmentReturnItem(
+            id=uuid.uuid4(),
+            shipment_return_id=shipment_return.id,
+            packing_slip_item_id=psi.id,
+            disposition=disposition,
+            quantity=qty,
+            hardware_category=psi.hardware_category,
+            product_code=psi.product_code,
+            opening_number=psi.opening_number,
+            rma_reference=rma_reference,
+            reason_text=reason_text,
+        )
+        session.add(return_item)
+        session.flush()
+
+        detail = {
+            "shipmentReturnId": str(shipment_return.id),
+            "packingSlipId": str(ps.id),
+            "packingSlipNumber": ps.packing_slip_number,
+            "disposition": disposition.value,
+            "quantity": qty,
+            "hardwareCategory": psi.hardware_category,
+            "productCode": psi.product_code,
+            "rmaReference": rma_reference,
+        }
+
+        if disposition == ReturnDisposition.RETURN_TO_PROJECT:
+            # Fresh, unlocated inventory for the origin project — re-enters Put-Away.
+            inv_loc = InventoryLocationModel(
+                id=uuid.uuid4(),
+                project_id=ps.project_id,
+                warehouse_id=warehouse_id,
+                hardware_category=psi.hardware_category,
+                product_code=psi.product_code,
+                quantity=qty,
+                deficient_quantity=0,
+                aisle=None,
+                bay=None,
+                bin=None,
+                shipment_return_item_id=return_item.id,
+                received_at=now,
+            )
+            session.add(inv_loc)
+            session.flush()
+            return_item.resulting_inventory_location_id = inv_loc.id
+            _log_audit_event(
+                session,
+                project_id=ps.project_id,
+                entity_type=AuditEntityType.INVENTORY_LOCATION,
+                entity_id=inv_loc.id,
+                action=AuditAction.RETURN,
+                performed_by=returned_by,
+                detail=detail,
+            )
+        else:
+            # NON_STOCK or RMA_DEFECTIVE — merge into the stock pool.
+            stock_row = _find_or_create_stock_row(
+                session,
+                warehouse_id=warehouse_id,
+                hardware_category=psi.hardware_category,
+                product_code=psi.product_code,
+                aisle=None,
+                bay=None,
+                bin=None,
+                received_at=now,
+            )
+            stock_row.quantity += qty
+            if disposition == ReturnDisposition.RMA_DEFECTIVE:
+                stock_row.deficient_quantity += qty
+            session.flush()
+            return_item.resulting_stock_item_id = stock_row.id
+            _log_audit_event(
+                session,
+                project_id=None,
+                entity_type=AuditEntityType.STOCK_ITEM,
+                entity_id=stock_row.id,
+                action=AuditAction.RETURN,
+                performed_by=returned_by,
+                detail=detail,
+            )
+
+    return shipment_return

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -51,6 +51,9 @@ from app.models.enums import (
     PullStatus as PullStatusDB,
 )
 from app.models.enums import (
+    ReturnDisposition as ReturnDispositionDB,
+)
+from app.models.enums import (
     ShopAssemblyRequestStatus as ShopAssemblyRequestStatusDB,
 )
 
@@ -72,6 +75,7 @@ PODocumentType = strawberry.enum(PODocumentTypeDB)
 DestockSource = strawberry.enum(DestockSourceDB)
 DeficiencyResolution = strawberry.enum(DeficiencyResolutionDB)
 DeficientItemSource = strawberry.enum(DeficientItemSourceDB)
+ReturnDisposition = strawberry.enum(ReturnDispositionDB)
 
 
 # GraphQL-only enums (not stored in database)

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -1,6 +1,13 @@
 import strawberry
 
-from .enums import Classification, DeficiencyResolution, DestockSource, PullRequestItemType, TransferSourceType
+from .enums import (
+    Classification,
+    DeficiencyResolution,
+    DestockSource,
+    PullRequestItemType,
+    ReturnDisposition,
+    TransferSourceType,
+)
 
 
 @strawberry.input
@@ -273,6 +280,24 @@ class ConfirmShipmentInput:
     packing_slip_number: str
     shipped_by: str
     items: list[ShipmentItemInput] = strawberry.field(default_factory=list)
+
+
+@strawberry.input
+class ShipmentReturnItemInput:
+    packing_slip_item_id: strawberry.ID
+    quantity: int
+    disposition: ReturnDisposition
+    rma_reference: str | None = None
+    reason_text: str | None = None
+
+
+@strawberry.input
+class CreateShipmentReturnInput:
+    packing_slip_id: strawberry.ID
+    warehouse_id: strawberry.ID
+    returned_by: str
+    reference: str | None = None
+    items: list[ShipmentReturnItemInput] = strawberry.field(default_factory=list)
 
 
 @strawberry.input

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -29,6 +29,7 @@ from .inputs import (
     CreatePOInput,
     CreateProjectInput,
     CreateReceiveInput,
+    CreateShipmentReturnInput,
     CreateVendorInput,
     CreateWarehouseInput,
     DestockInventoryInput,
@@ -58,6 +59,7 @@ from .queries import (
     _pull_request_item_to_type,
     _pull_request_to_type,
     _receive_record_to_type,
+    _shipment_return_to_type,
     _shop_assembly_opening_to_type,
     _shop_assembly_request_to_type,
     _stock_item_to_type,
@@ -82,6 +84,7 @@ from .types import (
     ReceiveRecord,
     ReclassifyStockResult,
     SAReplacementResult,
+    ShipmentReturn,
     ShopAssemblyOpening,
     ShopAssemblyRequest,
     StockItem,
@@ -627,6 +630,40 @@ class Mutation:
             stmt = select(PSModel).options(selectinload(PSModel.items)).where(PSModel.id == ps.id)
             refreshed = session.scalars(stmt).unique().first()
             return _packing_slip_to_type(refreshed)
+
+    @strawberry.mutation
+    def create_shipment_return(self, input: CreateShipmentReturnInput) -> ShipmentReturn:
+        from app.models.enums import ReturnDisposition
+
+        items_data = [
+            {
+                "packing_slip_item_id": uuid.UUID(str(it.packing_slip_item_id)),
+                "quantity": it.quantity,
+                "disposition": ReturnDisposition(it.disposition.value),
+                "rma_reference": it.rma_reference,
+                "reason_text": it.reason_text,
+            }
+            for it in input.items
+        ]
+
+        with SessionLocal() as session:
+            sr = shipping_repository.create_shipment_return(
+                session,
+                packing_slip_id=uuid.UUID(str(input.packing_slip_id)),
+                warehouse_id=uuid.UUID(str(input.warehouse_id)),
+                returned_by=input.returned_by,
+                reference=input.reference,
+                items=items_data,
+            )
+            session.commit()
+            # Re-load with items
+            from sqlalchemy.orm import selectinload
+
+            from app.models.shipping import ShipmentReturn as SRModel
+
+            stmt = select(SRModel).options(selectinload(SRModel.items)).where(SRModel.id == sr.id)
+            refreshed = session.scalars(stmt).unique().first()
+            return _shipment_return_to_type(refreshed)
 
     # Warehouse - Admin Corrections
     @strawberry.mutation

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -69,6 +69,9 @@ from .types import (
     ReceiveRecord,
     RecentReceiveRecord,
     ReconciliationResult,
+    ReturnableLine,
+    ShipmentReturn,
+    ShipmentReturnItem,
     ShipReadyItems,
     ShipReadyLooseItem,
     ShopAssemblyOpening,
@@ -473,6 +476,41 @@ def _packing_slip_to_type(ps) -> PackingSlipType:
     )
 
 
+def _shipment_return_item_to_type(sri) -> ShipmentReturnItem:
+    return ShipmentReturnItem(
+        id=strawberry.ID(str(sri.id)),
+        shipment_return_id=strawberry.ID(str(sri.shipment_return_id)),
+        packing_slip_item_id=strawberry.ID(str(sri.packing_slip_item_id)),
+        disposition=sri.disposition,
+        quantity=sri.quantity,
+        hardware_category=sri.hardware_category,
+        product_code=sri.product_code,
+        opening_number=sri.opening_number,
+        rma_reference=sri.rma_reference,
+        reason_text=sri.reason_text,
+        resulting_inventory_location_id=(
+            strawberry.ID(str(sri.resulting_inventory_location_id)) if sri.resulting_inventory_location_id else None
+        ),
+        resulting_stock_item_id=(
+            strawberry.ID(str(sri.resulting_stock_item_id)) if sri.resulting_stock_item_id else None
+        ),
+        created_at=sri.created_at,
+    )
+
+
+def _shipment_return_to_type(sr) -> ShipmentReturn:
+    return ShipmentReturn(
+        id=strawberry.ID(str(sr.id)),
+        packing_slip_id=strawberry.ID(str(sr.packing_slip_id)),
+        warehouse_id=strawberry.ID(str(sr.warehouse_id)),
+        returned_by=sr.returned_by,
+        returned_at=sr.returned_at,
+        reference=sr.reference,
+        created_at=sr.created_at,
+        items=[_shipment_return_item_to_type(i) for i in sr.items],
+    )
+
+
 def _stock_item_to_type(si) -> StockItemType:
     deficient_qty = getattr(si, "deficient_quantity", 0) or 0
     return StockItemType(
@@ -832,6 +870,29 @@ class Query:
                     for li in data["loose_items"]
                 ],
             )
+
+    @strawberry.field
+    def packing_slips(self, project_id: strawberry.ID | None = None) -> list[PackingSlipType]:
+        with SessionLocal() as session:
+            slips = shipping_repository.list_packing_slips(session, uuid.UUID(str(project_id)) if project_id else None)
+            return [_packing_slip_to_type(ps) for ps in slips]
+
+    @strawberry.field
+    def returnable_lines(self, packing_slip_id: strawberry.ID) -> list[ReturnableLine]:
+        with SessionLocal() as session:
+            lines = shipping_repository.get_returnable_lines(session, uuid.UUID(str(packing_slip_id)))
+            return [
+                ReturnableLine(
+                    packing_slip_item_id=strawberry.ID(str(line["packing_slip_item_id"])),
+                    opening_number=line["opening_number"],
+                    product_code=line["product_code"],
+                    hardware_category=line["hardware_category"],
+                    shipped_quantity=line["shipped_quantity"],
+                    returned_quantity=line["returned_quantity"],
+                    returnable_quantity=line["returnable_quantity"],
+                )
+                for line in lines
+            ]
 
     @strawberry.field
     def notifications(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -20,6 +20,7 @@ from .enums import (
     PullRequestStatus,
     PullStatus,
     ReconciliationStatus,
+    ReturnDisposition,
     ShopAssemblyRequestStatus,
 )
 
@@ -373,6 +374,48 @@ class PackingSlip:
     shipped_at: datetime
     created_at: datetime
     items: list[PackingSlipItem]
+
+
+@strawberry.type
+class ReturnableLine:
+    """A loose packing-slip line plus how much of it is still returnable."""
+
+    packing_slip_item_id: strawberry.ID
+    opening_number: str | None
+    product_code: str
+    hardware_category: str
+    shipped_quantity: int
+    returned_quantity: int
+    returnable_quantity: int
+
+
+@strawberry.type
+class ShipmentReturnItem:
+    id: strawberry.ID
+    shipment_return_id: strawberry.ID
+    packing_slip_item_id: strawberry.ID
+    disposition: ReturnDisposition
+    quantity: int
+    hardware_category: str
+    product_code: str
+    opening_number: str | None
+    rma_reference: str | None
+    reason_text: str | None
+    resulting_inventory_location_id: strawberry.ID | None
+    resulting_stock_item_id: strawberry.ID | None
+    created_at: datetime
+
+
+@strawberry.type
+class ShipmentReturn:
+    id: strawberry.ID
+    packing_slip_id: strawberry.ID
+    warehouse_id: strawberry.ID
+    returned_by: str
+    returned_at: datetime
+    reference: str | None
+    created_at: datetime
+    items: list[ShipmentReturnItem]
 
 
 @strawberry.type

--- a/backend/tests/test_shipping_repository_returns.py
+++ b/backend/tests/test_shipping_repository_returns.py
@@ -1,0 +1,233 @@
+"""Tests for shipping_repository shipment-return flow (issue #89)."""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import ValidationError
+from app.models.enums import PullRequestItemType, ReturnDisposition
+from app.models.inventory import InventoryLocation
+from app.models.project import Project
+from app.models.shipping import PackingSlip, PackingSlipItem
+from app.models.stock_item import StockItem
+from app.repositories import shipping_repository, warehouse_admin_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_slip(session, project_id) -> PackingSlip:
+    ps = PackingSlip(
+        id=uuid.uuid4(),
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:8]}",
+        project_id=project_id,
+        shipped_by="shipper",
+        shipped_at=datetime.utcnow(),
+    )
+    session.add(ps)
+    session.flush()
+    return ps
+
+
+def _make_loose_item(session, slip_id, *, qty=5, code="HG-100", cat="HINGE", opening="101") -> PackingSlipItem:
+    psi = PackingSlipItem(
+        id=uuid.uuid4(),
+        packing_slip_id=slip_id,
+        item_type=PullRequestItemType.LOOSE,
+        opening_number=opening,
+        product_code=code,
+        hardware_category=cat,
+        quantity=qty,
+    )
+    session.add(psi)
+    session.flush()
+    return psi
+
+
+def _wh(session) -> uuid.UUID:
+    return warehouse_admin_repository.get_primary_warehouse_id(session)
+
+
+def _return(session, slip_id, wh_id, items):
+    return shipping_repository.create_shipment_return(
+        session,
+        packing_slip_id=slip_id,
+        warehouse_id=wh_id,
+        returned_by="tester",
+        reference=None,
+        items=items,
+    )
+
+
+def test_return_to_project_creates_unlocated_inventory(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    item = _make_loose_item(db_session, slip.id, qty=5)
+    wh_id = _wh(db_session)
+
+    _return(
+        db_session,
+        slip.id,
+        wh_id,
+        [{"packing_slip_item_id": item.id, "quantity": 3, "disposition": ReturnDisposition.RETURN_TO_PROJECT}],
+    )
+
+    rows = list(db_session.scalars(select(InventoryLocation).where(InventoryLocation.project_id == project.id)).all())
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.quantity == 3
+    assert (row.aisle, row.bay, row.bin) == (None, None, None)  # unlocated -> Put-Away
+    assert row.shipment_return_item_id is not None
+    assert row.po_line_item_id is None and row.stock_item_id is None
+
+
+def test_non_stock_merges_into_stock_pool(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    item = _make_loose_item(db_session, slip.id, qty=4, code="NS-1", cat="STRIKE")
+    wh_id = _wh(db_session)
+
+    _return(
+        db_session,
+        slip.id,
+        wh_id,
+        [{"packing_slip_item_id": item.id, "quantity": 4, "disposition": ReturnDisposition.NON_STOCK}],
+    )
+
+    stock = list(
+        db_session.scalars(
+            select(StockItem).where(StockItem.product_code == "NS-1", StockItem.warehouse_id == wh_id)
+        ).all()
+    )
+    assert len(stock) == 1
+    assert stock[0].quantity == 4
+    assert stock[0].deficient_quantity == 0
+
+
+def test_rma_defective_flags_stock_deficient(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    item = _make_loose_item(db_session, slip.id, qty=2, code="RMA-1", cat="CLOSER")
+    wh_id = _wh(db_session)
+
+    _return(
+        db_session,
+        slip.id,
+        wh_id,
+        [
+            {
+                "packing_slip_item_id": item.id,
+                "quantity": 2,
+                "disposition": ReturnDisposition.RMA_DEFECTIVE,
+                "rma_reference": "RMA-9000",
+            }
+        ],
+    )
+
+    stock = db_session.scalars(
+        select(StockItem).where(StockItem.product_code == "RMA-1", StockItem.warehouse_id == wh_id)
+    ).first()
+    assert stock is not None
+    assert stock.quantity == 2
+    assert stock.deficient_quantity == 2
+
+
+def test_over_return_rejected(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    item = _make_loose_item(db_session, slip.id, qty=5)
+    wh_id = _wh(db_session)
+
+    with pytest.raises(ValidationError):
+        _return(
+            db_session,
+            slip.id,
+            wh_id,
+            [{"packing_slip_item_id": item.id, "quantity": 6, "disposition": ReturnDisposition.RETURN_TO_PROJECT}],
+        )
+
+
+def test_cumulative_over_return_across_events_rejected(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    item = _make_loose_item(db_session, slip.id, qty=5)
+    wh_id = _wh(db_session)
+
+    _return(
+        db_session,
+        slip.id,
+        wh_id,
+        [{"packing_slip_item_id": item.id, "quantity": 4, "disposition": ReturnDisposition.RETURN_TO_PROJECT}],
+    )
+    # 4 already returned; only 1 left, so returning 2 more must fail
+    with pytest.raises(ValidationError):
+        _return(
+            db_session,
+            slip.id,
+            wh_id,
+            [{"packing_slip_item_id": item.id, "quantity": 2, "disposition": ReturnDisposition.NON_STOCK}],
+        )
+
+
+def test_opening_item_line_not_returnable(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    oi_item = PackingSlipItem(
+        id=uuid.uuid4(),
+        packing_slip_id=slip.id,
+        item_type=PullRequestItemType.OPENING_ITEM,
+        opening_number="201",
+        product_code="DOOR-1",
+        hardware_category="ASSEMBLY",
+        quantity=1,
+    )
+    db_session.add(oi_item)
+    db_session.flush()
+    wh_id = _wh(db_session)
+
+    with pytest.raises(ValidationError):
+        _return(
+            db_session,
+            slip.id,
+            wh_id,
+            [{"packing_slip_item_id": oi_item.id, "quantity": 1, "disposition": ReturnDisposition.RETURN_TO_PROJECT}],
+        )
+
+
+def test_returnable_lines_tracks_returned_and_excludes_openings(db_session):
+    project = _make_project(db_session)
+    slip = _make_slip(db_session, project.id)
+    loose = _make_loose_item(db_session, slip.id, qty=5)
+    db_session.add(
+        PackingSlipItem(
+            id=uuid.uuid4(),
+            packing_slip_id=slip.id,
+            item_type=PullRequestItemType.OPENING_ITEM,
+            opening_number="201",
+            product_code="DOOR-1",
+            hardware_category="ASSEMBLY",
+            quantity=1,
+        )
+    )
+    db_session.flush()
+    wh_id = _wh(db_session)
+
+    _return(
+        db_session,
+        slip.id,
+        wh_id,
+        [{"packing_slip_item_id": loose.id, "quantity": 2, "disposition": ReturnDisposition.RETURN_TO_PROJECT}],
+    )
+
+    lines = shipping_repository.get_returnable_lines(db_session, slip.id)
+    assert len(lines) == 1  # opening item excluded
+    line = lines[0]
+    assert line["shipped_quantity"] == 5
+    assert line["returned_quantity"] == 2
+    assert line["returnable_quantity"] == 3

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -61,6 +61,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
       { label: 'Receiving', path: '/app/warehouse/receiving' },
       { label: 'Put Away', path: '/app/warehouse/put-away' },
       { label: 'Pull Requests', path: '/app/warehouse/pull-requests' },
+      { label: 'Shipments', path: '/app/warehouse/shipments' },
     ],
   },
   {

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -414,6 +414,31 @@ export const CONFIRM_SHIPMENT = gql`
   }
 `;
 
+export const CREATE_SHIPMENT_RETURN = gql`
+  mutation CreateShipmentReturn($input: CreateShipmentReturnInput!) {
+    createShipmentReturn(input: $input) {
+      id
+      packingSlipId
+      warehouseId
+      returnedBy
+      returnedAt
+      reference
+      items {
+        id
+        packingSlipItemId
+        disposition
+        quantity
+        productCode
+        hardwareCategory
+        openingNumber
+        rmaReference
+        resultingInventoryLocationId
+        resultingStockItemId
+      }
+    }
+  }
+`;
+
 export const CREATE_PO = gql`
   mutation CreatePO($input: CreatePOInput!) {
     createPo(input: $input) {

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -609,6 +609,41 @@ export const GET_WAREHOUSES = gql`
   }
 `;
 
+export const GET_PACKING_SLIPS = gql`
+  query GetPackingSlips($projectId: ID) {
+    packingSlips(projectId: $projectId) {
+      id
+      packingSlipNumber
+      projectId
+      shippedBy
+      shippedAt
+      createdAt
+      items {
+        id
+        itemType
+        openingNumber
+        productCode
+        hardwareCategory
+        quantity
+      }
+    }
+  }
+`;
+
+export const GET_RETURNABLE_LINES = gql`
+  query GetReturnableLines($packingSlipId: ID!) {
+    returnableLines(packingSlipId: $packingSlipId) {
+      packingSlipItemId
+      openingNumber
+      productCode
+      hardwareCategory
+      shippedQuantity
+      returnedQuantity
+      returnableQuantity
+    }
+  }
+`;
+
 export const GET_INVENTORY_BY_VENDOR = gql`
   query GetInventoryByVendor($projectId: ID) {
     inventoryByVendor(projectId: $projectId) {

--- a/frontend/src/modules/shipping/ReturnShipmentDialog.tsx
+++ b/frontend/src/modules/shipping/ReturnShipmentDialog.tsx
@@ -1,0 +1,330 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation, useQuery } from '@apollo/client/react';
+import Modal from '../../components/Modal';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import { GET_RETURNABLE_LINES, GET_WAREHOUSES } from '../../graphql/queries';
+import { CREATE_SHIPMENT_RETURN } from '../../graphql/mutations';
+import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
+
+type Disposition = 'RETURN_TO_PROJECT' | 'NON_STOCK' | 'RMA_DEFECTIVE';
+
+const DISPOSITION_OPTIONS: { value: Disposition; label: string }[] = [
+  { value: 'RETURN_TO_PROJECT', label: 'Return to project inventory' },
+  { value: 'NON_STOCK', label: 'Move to non-stock' },
+  { value: 'RMA_DEFECTIVE', label: 'Defective / RMA' },
+];
+
+const DEFAULT_DRAFT: LineDraft = {
+  quantity: '',
+  disposition: 'RETURN_TO_PROJECT',
+  rmaReference: '',
+  reasonText: '',
+};
+
+interface ReturnableLine {
+  packingSlipItemId: string;
+  openingNumber: string | null;
+  productCode: string;
+  hardwareCategory: string;
+  shippedQuantity: number;
+  returnedQuantity: number;
+  returnableQuantity: number;
+}
+
+interface WarehouseOption {
+  id: string;
+  name: string;
+  code: string;
+  isPrimary: boolean;
+  isActive: boolean;
+}
+
+interface LineDraft {
+  quantity: string;
+  disposition: Disposition;
+  rmaReference: string;
+  reasonText: string;
+}
+
+export interface ReturnSlip {
+  id: string;
+  packingSlipNumber: string;
+  projectName: string;
+}
+
+interface Props {
+  slip: ReturnSlip;
+  onClose: () => void;
+  onCompleted: () => void;
+}
+
+export default function ReturnShipmentDialog({ slip, onClose, onCompleted }: Props) {
+  const { displayName } = useIdentity();
+  const { showToast } = useToast();
+
+  const { data, loading, error } = useQuery<{ returnableLines: ReturnableLine[] }>(GET_RETURNABLE_LINES, {
+    variables: { packingSlipId: slip.id },
+    fetchPolicy: 'cache-and-network',
+  });
+  const lines = useMemo(
+    () => (data?.returnableLines ?? []).filter((l) => l.returnableQuantity > 0),
+    [data],
+  );
+
+  const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
+    variables: { includeInactive: false },
+  });
+  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
+
+  const [warehouseId, setWarehouseId] = useState('');
+  const [reference, setReference] = useState('');
+  const [drafts, setDrafts] = useState<Record<string, LineDraft>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Default the destination warehouse to the primary; the user can still override it.
+  const defaultWarehouseId = useMemo(() => {
+    const primary = warehouses.find((w) => w.isPrimary) ?? warehouses[0];
+    return primary?.id ?? '';
+  }, [warehouses]);
+  const effectiveWarehouseId = warehouseId || defaultWarehouseId;
+
+  // Drafts are created lazily on first edit; unedited lines fall back to DEFAULT_DRAFT.
+  const getDraft = (id: string): LineDraft => drafts[id] ?? DEFAULT_DRAFT;
+  const setDraft = (id: string, patch: Partial<LineDraft>) =>
+    setDrafts((prev) => ({ ...prev, [id]: { ...(prev[id] ?? DEFAULT_DRAFT), ...patch } }));
+
+  const [mutate, { loading: submitting }] = useMutation(CREATE_SHIPMENT_RETURN, {
+    refetchQueries: WAREHOUSE_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
+    onCompleted: () => {
+      showToast(`Return recorded for ${slip.packingSlipNumber}`, 'success');
+      onCompleted();
+    },
+    onError: (err) => setFormError(err.message),
+  });
+
+  // Pre-fill a full return-to-project for every line (shipment cancellation shortcut).
+  const handleCancelShipment = () => {
+    setDrafts((prev) => {
+      const next = { ...prev };
+      for (const line of lines) {
+        next[line.packingSlipItemId] = {
+          ...(prev[line.packingSlipItemId] ?? DEFAULT_DRAFT),
+          quantity: String(line.returnableQuantity),
+          disposition: 'RETURN_TO_PROJECT',
+          rmaReference: '',
+        };
+      }
+      return next;
+    });
+  };
+
+  const buildItems = () => {
+    const items: {
+      packingSlipItemId: string;
+      quantity: number;
+      disposition: Disposition;
+      rmaReference: string | null;
+      reasonText: string | null;
+    }[] = [];
+    for (const line of lines) {
+      const draft = getDraft(line.packingSlipItemId);
+      const qty = Number(draft.quantity);
+      if (!draft.quantity || !Number.isInteger(qty) || qty <= 0) continue;
+      if (qty > line.returnableQuantity) {
+        return { error: `${line.productCode}: cannot return more than ${line.returnableQuantity}` };
+      }
+      items.push({
+        packingSlipItemId: line.packingSlipItemId,
+        quantity: qty,
+        disposition: draft.disposition,
+        rmaReference:
+          draft.disposition === 'RMA_DEFECTIVE' && draft.rmaReference.trim()
+            ? draft.rmaReference.trim()
+            : null,
+        reasonText: draft.reasonText.trim() || null,
+      });
+    }
+    return { items };
+  };
+
+  const handleSubmit = () => {
+    setFormError(null);
+    if (!effectiveWarehouseId) {
+      setFormError('Select a destination warehouse');
+      return;
+    }
+    const built = buildItems();
+    if (built.error) {
+      setFormError(built.error);
+      return;
+    }
+    if (!built.items || built.items.length === 0) {
+      setFormError('Enter a return quantity for at least one line');
+      return;
+    }
+    mutate({
+      variables: {
+        input: {
+          packingSlipId: slip.id,
+          warehouseId: effectiveWarehouseId,
+          returnedBy: displayName,
+          reference: reference.trim() || null,
+          items: built.items,
+        },
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Return shipment ${slip.packingSlipNumber}`}
+      actions={
+        <>
+          <Button onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={submitting || loading || lines.length === 0}
+            startIcon={submitting ? <CircularProgress size={16} /> : undefined}
+          >
+            {submitting ? 'Recording…' : 'Record return'}
+          </Button>
+        </>
+      }
+    >
+      <Stack spacing={2}>
+        {formError && <Alert severity="error">{formError}</Alert>}
+        {error && <Alert severity="error">{error.message}</Alert>}
+
+        <Typography variant="body2" color="text.secondary">
+          {slip.projectName} · loose hardware only. Opening items are not returned.
+        </Typography>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <FormControl size="small" sx={{ minWidth: 200 }} required>
+            <InputLabel>Destination warehouse</InputLabel>
+            <Select
+              label="Destination warehouse"
+              value={effectiveWarehouseId}
+              onChange={(e) => setWarehouseId(e.target.value)}
+            >
+              {warehouses.map((w) => (
+                <MenuItem key={w.id} value={w.id}>
+                  {w.name} ({w.code})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            size="small"
+            label="Reference / note (optional)"
+            value={reference}
+            onChange={(e) => setReference(e.target.value)}
+            fullWidth
+          />
+          <Button onClick={handleCancelShipment} disabled={lines.length === 0} sx={{ whiteSpace: 'nowrap' }}>
+            Cancel whole shipment
+          </Button>
+        </Stack>
+
+        {loading && lines.length === 0 && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+
+        {!loading && lines.length === 0 && (
+          <Alert severity="info">Nothing left to return on this shipment.</Alert>
+        )}
+
+        {lines.map((line) => {
+          const draft = getDraft(line.packingSlipItemId);
+          const isRma = draft.disposition === 'RMA_DEFECTIVE';
+          return (
+            <Paper key={line.packingSlipItemId} variant="outlined" sx={{ p: 1.5 }}>
+              <Stack spacing={1.5}>
+                <Box
+                  sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}
+                >
+                  <Typography variant="subtitle2">{line.productCode}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {line.hardwareCategory}
+                    {line.openingNumber ? ` · opening ${line.openingNumber}` : ''}
+                  </Typography>
+                  <Box sx={{ flexGrow: 1 }} />
+                  <Chip size="small" label={`returnable ${line.returnableQuantity}`} />
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+                  <TextField
+                    size="small"
+                    label="Qty"
+                    type="number"
+                    value={draft.quantity}
+                    onChange={(e) => setDraft(line.packingSlipItemId, { quantity: e.target.value })}
+                    inputProps={{ min: 0, max: line.returnableQuantity }}
+                    sx={{ width: 90 }}
+                  />
+                  <FormControl size="small" sx={{ minWidth: 210 }}>
+                    <InputLabel>Disposition</InputLabel>
+                    <Select
+                      label="Disposition"
+                      value={draft.disposition}
+                      onChange={(e) =>
+                        setDraft(line.packingSlipItemId, { disposition: e.target.value as Disposition })
+                      }
+                    >
+                      {DISPOSITION_OPTIONS.map((o) => (
+                        <MenuItem key={o.value} value={o.value}>
+                          {o.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  {isRma && (
+                    <TextField
+                      size="small"
+                      label="PO / RMA reference (optional)"
+                      value={draft.rmaReference}
+                      onChange={(e) =>
+                        setDraft(line.packingSlipItemId, { rmaReference: e.target.value })
+                      }
+                      sx={{ minWidth: 220 }}
+                    />
+                  )}
+                  <TextField
+                    size="small"
+                    label="Reason (optional)"
+                    value={draft.reasonText}
+                    onChange={(e) => setDraft(line.packingSlipItemId, { reasonText: e.target.value })}
+                    sx={{ flexGrow: 1, minWidth: 180 }}
+                  />
+                </Box>
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/shipping/ShipmentsList.tsx
+++ b/frontend/src/modules/shipping/ShipmentsList.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import KeyboardReturnIcon from '@mui/icons-material/KeyboardReturn';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery } from '@apollo/client/react';
+import { GET_PACKING_SLIPS, GET_PROJECTS } from '../../graphql/queries';
+import ReturnShipmentDialog, { type ReturnSlip } from './ReturnShipmentDialog';
+
+interface PackingSlipItem {
+  id: string;
+  itemType: string;
+  openingNumber: string | null;
+  productCode: string;
+  hardwareCategory: string;
+  quantity: number;
+}
+
+interface PackingSlip {
+  id: string;
+  packingSlipNumber: string;
+  projectId: string;
+  shippedBy: string;
+  shippedAt: string;
+  createdAt: string;
+  items: PackingSlipItem[];
+}
+
+interface Project {
+  id: string;
+  projectId: string;
+  description: string | null;
+}
+
+interface ShipmentRow {
+  id: string;
+  packingSlipNumber: string;
+  projectId: string;
+  projectName: string;
+  shippedBy: string;
+  shippedAt: string;
+  looseUnits: number;
+}
+
+interface Props {
+  /** Scope to a single project (its UUID). Omit for the global, all-projects view. */
+  projectId?: string;
+  heading?: string;
+}
+
+function looseUnits(slip: PackingSlip): number {
+  return slip.items
+    .filter((i) => i.itemType === 'LOOSE')
+    .reduce((sum, i) => sum + i.quantity, 0);
+}
+
+export default function ShipmentsList({ projectId, heading }: Props) {
+  const isGlobal = !projectId;
+  const [search, setSearch] = useState('');
+  const [projectFilter, setProjectFilter] = useState('');
+  const [activeSlip, setActiveSlip] = useState<ReturnSlip | null>(null);
+
+  const { data, loading, refetch } = useQuery<{ packingSlips: PackingSlip[] }>(GET_PACKING_SLIPS, {
+    variables: { projectId: projectId ?? null },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  // Project names only matter for the global view's project column / filter.
+  const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS, {
+    skip: !isGlobal,
+  });
+  const projectName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projectsData?.projects ?? []) {
+      map.set(p.id, p.description || p.projectId);
+    }
+    return map;
+  }, [projectsData]);
+
+  const rows: ShipmentRow[] = useMemo(() => {
+    const slips = data?.packingSlips ?? [];
+    return slips
+      .filter((s) => (projectFilter ? s.projectId === projectFilter : true))
+      .filter((s) =>
+        search ? s.packingSlipNumber.toLowerCase().includes(search.trim().toLowerCase()) : true,
+      )
+      .map((s) => ({
+        id: s.id,
+        packingSlipNumber: s.packingSlipNumber,
+        projectId: s.projectId,
+        projectName: projectName.get(s.projectId) ?? '—',
+        shippedBy: s.shippedBy,
+        shippedAt: s.shippedAt,
+        looseUnits: looseUnits(s),
+      }));
+  }, [data, projectFilter, search, projectName]);
+
+  const columns: GridColDef<ShipmentRow>[] = useMemo(() => {
+    const cols: GridColDef<ShipmentRow>[] = [
+      { field: 'packingSlipNumber', headerName: 'Packing slip', flex: 1, minWidth: 150 },
+    ];
+    if (isGlobal) {
+      cols.push({ field: 'projectName', headerName: 'Project', flex: 1, minWidth: 160 });
+    }
+    cols.push(
+      { field: 'shippedBy', headerName: 'Shipped by', flex: 1, minWidth: 130 },
+      {
+        field: 'shippedAt',
+        headerName: 'Shipped',
+        width: 120,
+        renderCell: ({ row }) => new Date(row.shippedAt).toLocaleDateString(),
+      },
+      { field: 'looseUnits', headerName: 'Loose units', width: 110, type: 'number' },
+      {
+        field: 'actions',
+        headerName: '',
+        width: 130,
+        sortable: false,
+        filterable: false,
+        renderCell: ({ row }) => (
+          <Button
+            size="small"
+            startIcon={<KeyboardReturnIcon fontSize="small" />}
+            disabled={row.looseUnits === 0}
+            onClick={() =>
+              setActiveSlip({
+                id: row.id,
+                packingSlipNumber: row.packingSlipNumber,
+                projectName: row.projectName !== '—' ? row.projectName : 'This project',
+              })
+            }
+          >
+            Return
+          </Button>
+        ),
+      },
+    );
+    return cols;
+  }, [isGlobal]);
+
+  return (
+    <Box>
+      {heading && (
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          {heading}
+        </Typography>
+      )}
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
+        <TextField
+          size="small"
+          label="Search packing slip #"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ minWidth: 220 }}
+        />
+        {isGlobal && (
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel>Project</InputLabel>
+            <Select label="Project" value={projectFilter} onChange={(e) => setProjectFilter(e.target.value)}>
+              <MenuItem value="">All projects</MenuItem>
+              {(projectsData?.projects ?? []).map((p) => (
+                <MenuItem key={p.id} value={p.id}>
+                  {p.description || p.projectId}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      </Stack>
+
+      <Box sx={{ height: 560, width: '100%' }}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          loading={loading}
+          disableRowSelectionOnClick
+          pageSizeOptions={[25, 50, 100]}
+          initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+        />
+      </Box>
+
+      {activeSlip && (
+        <ReturnShipmentDialog
+          slip={activeSlip}
+          onClose={() => setActiveSlip(null)}
+          onCompleted={() => {
+            setActiveSlip(null);
+            refetch();
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/modules/shipping/index.tsx
+++ b/frontend/src/modules/shipping/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
-import { Box, Typography, Badge, IconButton, Button } from '@mui/material';
+import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import { Box, Typography, Badge, IconButton, Button, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useCart } from '../../contexts/CartContext';
 import ShipReadyBrowser from './ShipReadyBrowser';
+import ShipmentsList from './ShipmentsList';
 import ShippingCart from './ShippingCart';
 import ProjectLandingPage from '../../components/ProjectLandingPage';
 import type { Project } from '../../types/project';
@@ -13,6 +14,9 @@ export default function ShippingModule() {
   const [selectedProject, setSelectedProject] = useState<Project | 'all' | null>(null);
   const [cartOpen, setCartOpen] = useState(false);
   const { itemCount } = useCart();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const view = location.pathname.endsWith('/returns') ? 'returns' : 'ship';
 
   if (selectedProject === null) {
     return (
@@ -40,14 +44,28 @@ export default function ShippingModule() {
           </Button>
           <Typography variant="h5">Shipping — {projectName}</Typography>
         </Box>
-        <IconButton onClick={() => setCartOpen(true)}>
-          <Badge badgeContent={itemCount} color="primary">
-            <ShoppingCartIcon />
-          </Badge>
-        </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={view}
+            onChange={(_, v) => {
+              if (v) navigate(v === 'returns' ? 'returns' : 'browse');
+            }}
+          >
+            <ToggleButton value="ship">Ship</ToggleButton>
+            <ToggleButton value="returns">Returns</ToggleButton>
+          </ToggleButtonGroup>
+          <IconButton onClick={() => setCartOpen(true)}>
+            <Badge badgeContent={itemCount} color="primary">
+              <ShoppingCartIcon />
+            </Badge>
+          </IconButton>
+        </Box>
       </Box>
       <Routes>
         <Route path="browse" element={<ShipReadyBrowser projectId={projectId} />} />
+        <Route path="returns" element={<ShipmentsList projectId={projectId} />} />
         <Route index element={<Navigate to="browse" replace />} />
       </Routes>
       <ShippingCart

--- a/frontend/src/modules/warehouse/ShipmentsPage.tsx
+++ b/frontend/src/modules/warehouse/ShipmentsPage.tsx
@@ -1,0 +1,6 @@
+import ShipmentsList from '../shipping/ShipmentsList';
+
+// Global, all-projects shipment history for warehouse staff to process returns from.
+export default function ShipmentsPage() {
+  return <ShipmentsList heading="Shipments" />;
+}

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -8,6 +8,7 @@ import MoveToInboxIcon from '@mui/icons-material/MoveToInbox';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import WarehouseIcon from '@mui/icons-material/Warehouse';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import AssignmentReturnIcon from '@mui/icons-material/AssignmentReturn';
 import { useNavigate } from 'react-router-dom';
 import DashboardCards from './DashboardCards';
 
@@ -39,6 +40,7 @@ const SUB_ROUTES = [
   { label: 'Pull Requests', path: '/app/warehouse/pull-requests', icon: <AssignmentIcon fontSize="large" /> },
   { label: 'Stock Pool', path: '/app/warehouse/stock-pool', icon: <WarehouseIcon fontSize="large" /> },
   { label: 'Deficient Items', path: '/app/warehouse/deficient-items', icon: <ReportProblemIcon fontSize="large" /> },
+  { label: 'Shipments', path: '/app/warehouse/shipments', icon: <AssignmentReturnIcon fontSize="large" /> },
 ];
 
 export default function WarehouseLanding() {

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -10,6 +10,7 @@ import PullRequestQueue from './PullRequestQueue';
 import PutAwayTab from './PutAwayTab';
 import StockPoolView from './StockPoolView';
 import DeficientItemsReview from './DeficientItemsReview';
+import ShipmentsPage from './ShipmentsPage';
 import BackToModule from '../../components/BackToModule';
 
 function WarehouseSubLayout({ children }: { children: ReactNode }) {
@@ -33,6 +34,7 @@ export default function WarehouseModule() {
       <Route path="pull-requests" element={<WarehouseSubLayout><PullRequestQueue /></WarehouseSubLayout>} />
       <Route path="stock-pool" element={<WarehouseSubLayout><StockPoolView /></WarehouseSubLayout>} />
       <Route path="deficient-items" element={<WarehouseSubLayout><DeficientItemsReview /></WarehouseSubLayout>} />
+      <Route path="shipments" element={<WarehouseSubLayout><ShipmentsPage /></WarehouseSubLayout>} />
       <Route path="*" element={<Navigate to="" replace />} />
     </Routes>
   );


### PR DESCRIPTION
closes #89

returns shipped loose hardware back into the system. openings are never returned (business rule); only loose lines on a packing slip are returnable.

each returned loose line picks a disposition:
- return to project: a fresh, unlocated InventoryLocation for the slip's project, so it drops back into put-away
- non-stock: merge into the stock pool
- defective / RMA: merge into the stock pool flagged deficient, with an optional po/rma reference; surfaces in the existing Deficient Items review where resolve_deficiency(RETURN_TO_VENDOR) finishes the vendor return

shipment cancellation is just a full-qty return-to-project for every loose line (one-click shortcut in the dialog).

why loose returns re-create inventory
loose hardware is FIFO-deducted from inventory_locations at pull-request approval, not at ship time, so once shipped those units are gone from inventory. a return re-introduces them as fresh rows. opening items only carry a state flag and per business rule never come back.

data model (migration 035)
- shipment_returns + shipment_return_items
- inventory_locations gains a shipment_return_item_id origin; CHECK relaxed to (po + receive) OR stock_item_id OR shipment_return_item_id
- AuditAction.RETURN, ReturnDisposition enum

backend
- create_shipment_return: loose-only, quantity <= shipped minus already-returned (cumulative across return events), routes each line, logs a RETURN audit row, single transaction with the slip locked
- packingSlips / returnableLines queries, createShipmentReturn mutation

frontend
- global warehouse Shipments page (slip list, search, project filter) and a project-scoped Returns tab in Shipping, both opening a shared ReturnShipmentDialog
- per-line qty + disposition + rma reference (RMA only) + reason, a destination-warehouse picker, and the cancel-shipment shortcut

ran 7 new repo tests covering all three dispositions plus the over-return and opening-item guards, and drove the feature end-to-end against local postgres through all three routes.
