### PR TITLE
nexus-side localhost relay: schema/api + secret enrollment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,7 @@ BUCKET_ENDPOINT=
 BUCKET_ACCESS_KEY_ID=
 BUCKET_SECRET_ACCESS_KEY=
 BUCKET_NAME=
+
+# Fernet key for encrypting relay install secrets at rest (relay_installs.secret_encrypted).
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+RELAY_SECRET_ENC_KEY=

--- a/backend/alembic/versions/036_relay_gp_fields.py
+++ b/backend/alembic/versions/036_relay_gp_fields.py
@@ -1,0 +1,46 @@
+"""Relay/GP integration fields: vendors.gp_vendor_id, purchase_orders.cost_code +
+gp_sync_status (uc nexus <-> relay full spec, schema + api changes)
+
+Revision ID: 036
+Revises: 035
+Create Date: 2026-06-25
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "036"
+down_revision = "035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # GP VENDORID populated by the vendor sync (PM00200 -> Vendor.gp_vendor_id).
+    op.add_column("vendors", sa.Column("gp_vendor_id", sa.String(length=15), nullable=True))
+
+    # Per-PO GP cost code (issue #121 dropdown), applied to job-cost lines at GP push time.
+    op.add_column("purchase_orders", sa.Column("cost_code", sa.String(length=50), nullable=True))
+
+    # Whether this PO's GP job-cost PO has been created via the relay. NOT NULL with a server default so
+    # existing rows backfill to NOT_PUSHED.
+    gp_sync_status = postgresql.ENUM("NOT_PUSHED", "SYNCED", "FAILED", name="gp_sync_status")
+    gp_sync_status.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "purchase_orders",
+        sa.Column(
+            "gp_sync_status",
+            postgresql.ENUM("NOT_PUSHED", "SYNCED", "FAILED", name="gp_sync_status", create_type=False),
+            nullable=False,
+            server_default="NOT_PUSHED",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("purchase_orders", "gp_sync_status")
+    op.drop_column("purchase_orders", "cost_code")
+    op.drop_column("vendors", "gp_vendor_id")
+    op.execute("DROP TYPE gp_sync_status")

--- a/backend/alembic/versions/037_relay_installs.py
+++ b/backend/alembic/versions/037_relay_installs.py
@@ -1,0 +1,38 @@
+"""relay_installs: per-install relay Bearer secret (encrypted) + one-time enrollment token
+(uc nexus <-> relay full spec, backend-issued per-install secret)
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-06-25
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "037"
+down_revision = "036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "relay_installs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("company", sa.String(), nullable=False),
+        sa.Column("hostname", sa.String(), nullable=True),
+        sa.Column("secret_encrypted", sa.Text(), nullable=True),
+        sa.Column("enrollment_token_hash", sa.String(), nullable=True),
+        sa.Column("enrollment_token_expires_at", sa.DateTime(), nullable=True),
+        sa.Column("enrolled_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_relay_installs_enrollment_token_hash", "relay_installs", ["enrollment_token_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_relay_installs_enrollment_token_hash", table_name="relay_installs")
+    op.drop_table("relay_installs")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -107,6 +107,21 @@ def _bearer_token(request) -> str | None:
     return value.strip()
 
 
+def require_user(info) -> dict:
+    """Enforce that the caller is an authenticated UC Nexus user (any role). Returns {user_id}.
+    No Clerk Backend API role lookup, so it's cheaper than require_admin."""
+    request = info.context["request"]
+    token = _bearer_token(request)
+    if not token:
+        raise AuthError("Authentication required")
+
+    claims = verify_clerk_token(token)
+    user_id = claims.get("sub")
+    if not user_id:
+        raise AuthError("Authentication token has no subject")
+    return {"user_id": user_id}
+
+
 def require_admin(info) -> dict:
     """Enforce that the caller holds the Admin/Manager role. Returns {user_id, roles}."""
     request = info.context["request"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,3 +15,7 @@ BUCKET_NAME = os.getenv("BUCKET_NAME", "")
 # Clerk authentication config
 CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY", "")
 TESTING_ENABLED = os.getenv("TESTING_ENABLED", "").lower() in ("true", "1", "yes")
+
+# Fernet key used to encrypt relay install secrets at rest (relay_installs.secret_encrypted).
+# Generate with:  python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+RELAY_SECRET_ENC_KEY = os.getenv("RELAY_SECRET_ENC_KEY", "")

--- a/backend/app/crypto.py
+++ b/backend/app/crypto.py
@@ -1,0 +1,32 @@
+"""Encryption + hashing for relay install credentials.
+
+The relay's long-lived Bearer secret is stored ENCRYPTED (Fernet) - not hashed - because the frontend
+needs the raw value back to send as the Authorization header (relayCredential returns it decrypted).
+The one-time enrollment token is stored HASHED (we only ever verify a presented token, never return it)."""
+
+import hashlib
+import os
+
+from cryptography.fernet import Fernet
+
+from app.errors import AppError
+
+
+def _fernet() -> Fernet:
+    key = os.getenv("RELAY_SECRET_ENC_KEY", "")
+    if not key:
+        raise AppError("RELAY_SECRET_ENC_KEY is not configured", "CONFIG_ERROR")
+    return Fernet(key.encode())
+
+
+def encrypt_secret(plaintext: str) -> str:
+    return _fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_secret(token: str) -> str:
+    return _fernet().decrypt(token.encode()).decode()
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 of a one-time enrollment token (stored, then compared on enroll)."""
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from .project_excluded_item import ProjectExcludedItem  # noqa: E402, F401
 from .pull_request import PullRequest, PullRequestItem  # noqa: E402, F401
 from .purchase_order import PODocument, POLineItem, PurchaseOrder  # noqa: E402, F401
 from .receiving import ReceiveLineItem, ReceiveRecord  # noqa: E402, F401
+from .relay_install import RelayInstall  # noqa: E402, F401
 from .shipping import (  # noqa: E402, F401
     PackingSlip,
     PackingSlipItem,

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -20,6 +20,16 @@ class POStatus(str, enum.Enum):
     CANCELLED = "CANCELLED"
 
 
+class GpSyncStatus(str, enum.Enum):
+    """Whether this PO has been pushed to Microsoft GP (the job-cost PO) via the localhost relay.
+    NOT_PUSHED: created in UC Nexus only. SYNCED: GP PO created, po_number recorded. FAILED: the
+    relay/GP push errored and is retryable."""
+
+    NOT_PUSHED = "NOT_PUSHED"
+    SYNCED = "SYNCED"
+    FAILED = "FAILED"
+
+
 class PullRequestSource(str, enum.Enum):
     SHOP_ASSEMBLY = "SHOP_ASSEMBLY"
     SHIPPING_OUT = "SHIPPING_OUT"

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -6,7 +6,7 @@ from sqlalchemy import CheckConstraint, Date, DateTime, Enum, ForeignKey, Index,
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
-from .enums import Classification, PODocumentType, POStatus
+from .enums import Classification, GpSyncStatus, PODocumentType, POStatus
 from .vendor import Vendor
 
 
@@ -38,6 +38,16 @@ class PurchaseOrder(Base):
         ForeignKey("vendors.id", ondelete="RESTRICT"), nullable=True, index=True
     )
     status: Mapped[POStatus] = mapped_column(Enum(POStatus, name="po_status", create_constraint=True), nullable=False)
+    # GP cost code chosen per-PO (the issue #121 dropdown, 'phase-step-element' e.g. '210-200-2'),
+    # applied to every job-cost line when pushed to GP. Null for stock POs / not-yet-pushed.
+    cost_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Whether this PO's job-cost PO has been created in GP via the relay (see GpSyncStatus).
+    gp_sync_status: Mapped[GpSyncStatus] = mapped_column(
+        Enum(GpSyncStatus, name="gp_sync_status", create_constraint=True),
+        nullable=False,
+        default=GpSyncStatus.NOT_PUSHED,
+        server_default=GpSyncStatus.NOT_PUSHED.value,
+    )
     vendor_quote_number: Mapped[str | None] = mapped_column(String, nullable=True)
     expected_delivery_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     ordered_at: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/backend/app/models/relay_install.py
+++ b/backend/app/models/relay_install.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class RelayInstall(Base):
+    """One on-prem relay install (one workstation). The relay generates its own long-lived Bearer
+    secret and registers it here via the one-time enrollment token (the backend can't reach the relay,
+    but the relay can reach the backend). The frontend then fetches the secret via relayCredential."""
+
+    __tablename__ = "relay_installs"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    label: Mapped[str] = mapped_column(String, nullable=False)
+    company: Mapped[str] = mapped_column(String, nullable=False)
+    hostname: Mapped[str | None] = mapped_column(String, nullable=True)  # filled by the relay at enrollment
+    # long-lived relay Bearer secret, Fernet-encrypted at rest. NULL until the relay enrolls.
+    secret_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # one-time enrollment token: only the SHA-256 hash is stored (it's a credential, shown once at provision).
+    enrollment_token_hash: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    enrollment_token_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    enrolled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/models/vendor.py
+++ b/backend/app/models/vendor.py
@@ -13,6 +13,9 @@ class Vendor(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String, nullable=False)
+    # GP VENDORID (char 15), populated by the vendor sync from GP PM00200. Required before this vendor
+    # can be used on a GP job-cost PO; a vendor without it is blocked at PO push time.
+    gp_vendor_id: Mapped[str | None] = mapped_column(String(15), nullable=True)
     contact_name: Mapped[str | None] = mapped_column(String, nullable=True)
     email: Mapped[str | None] = mapped_column(String, nullable=True)
     phone: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -9,7 +9,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import InvalidStateTransitionError, NotFoundError, ValidationError
-from app.models.enums import Classification, PODocumentType, POStatus
+from app.models.enums import Classification, GpSyncStatus, PODocumentType, POStatus
 from app.models.purchase_order import PODocument, POLineItem, PurchaseOrder
 from app.models.receiving import ReceiveRecord
 
@@ -35,6 +35,7 @@ def create_po(
     project_id: uuid.UUID | None = None,
     vendor_id: uuid.UUID | None = None,
     notes: str | None = None,
+    cost_code: str | None = None,
 ) -> PurchaseOrder:
     """Create a manual PO with line items. No hardware items are created."""
     if not line_items:
@@ -57,6 +58,8 @@ def create_po(
 
     request_number = generate_next_request_number(session)
 
+    cleaned_cost_code = cost_code.strip() if cost_code and cost_code.strip() else None
+
     po = PurchaseOrder(
         id=uuid.uuid4(),
         request_number=request_number,
@@ -64,6 +67,7 @@ def create_po(
         vendor_id=vendor_id,
         status=POStatus.DRAFT,
         notes=notes,
+        cost_code=cleaned_cost_code,
     )
     session.add(po)
     session.flush()
@@ -90,6 +94,25 @@ def create_po(
         )
         session.add(poli)
 
+    session.flush()
+    return po
+
+
+def record_gp_sync_result(
+    session: Session,
+    po_id: uuid.UUID,
+    gp_sync_status: GpSyncStatus,
+    po_number: str | None = None,
+) -> PurchaseOrder:
+    """Record the outcome of a relay GP push: GP's returned PONUMBER (on success) and the sync status.
+    The PO status transition (DRAFT -> ORDERED) is driven by the existing PO status flow, not here, so
+    this stays a pure record of the GP-side result that the create-in-both orchestration calls."""
+    po = session.get(PurchaseOrder, po_id)
+    if po is None:
+        raise NotFoundError(f"Purchase order {po_id} not found")
+    po.gp_sync_status = gp_sync_status
+    if po_number is not None:
+        po.po_number = po_number.strip() or None
     session.flush()
     return po
 

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -1,0 +1,90 @@
+"""Relay install provisioning + enrollment + credential lookup.
+
+Trust model: the Railway backend cannot reach the relay (it binds to localhost on a workstation), but
+the relay CAN reach the backend. So provisioning mints a one-time enrollment token (shown once in the
+UC Nexus admin UI); the relay, during its one-time setup, generates its OWN long-lived Bearer secret and
+registers it here with that token. Nothing long-lived is ever hand-copied."""
+
+import secrets
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.crypto import decrypt_secret, encrypt_secret, hash_token
+from app.errors import ConflictError, NotFoundError, ValidationError
+from app.models.relay_install import RelayInstall
+
+_ENROLLMENT_TTL = timedelta(hours=24)
+
+
+def list_installs(session: Session) -> list[RelayInstall]:
+    return list(session.scalars(select(RelayInstall).order_by(RelayInstall.created_at.desc())).all())
+
+
+def provision_install(session: Session, label: str, company: str) -> tuple[RelayInstall, str]:
+    """Create an install row + a one-time enrollment token. Returns (install, raw_token); the raw token
+    is shown to the admin ONCE and only its hash is stored."""
+    label = (label or "").strip()
+    company = (company or "").strip()
+    if not label:
+        raise ValidationError("label is required", field="label")
+    if not company:
+        raise ValidationError("company is required", field="company")
+
+    token = secrets.token_urlsafe(32)
+    install = RelayInstall(
+        id=uuid.uuid4(),
+        label=label,
+        company=company,
+        enrollment_token_hash=hash_token(token),
+        enrollment_token_expires_at=datetime.utcnow() + _ENROLLMENT_TTL,
+    )
+    session.add(install)
+    session.flush()
+    return install, token
+
+
+def enroll_install(session: Session, enrollment_token: str, hostname: str, secret: str) -> RelayInstall:
+    """Called by the relay (authenticated by the enrollment token, not Clerk). Stores the relay's
+    self-generated secret encrypted and consumes the one-time token."""
+    secret = (secret or "").strip()
+    if not secret:
+        raise ValidationError("secret is required", field="secret")
+
+    install = session.scalars(
+        select(RelayInstall).where(RelayInstall.enrollment_token_hash == hash_token(enrollment_token))
+    ).first()
+    if install is None:
+        raise ValidationError("invalid enrollment token", field="enrollment_token")
+    if install.enrolled_at is not None:
+        raise ConflictError("this enrollment token has already been used", field="enrollment_token")
+    if install.enrollment_token_expires_at and install.enrollment_token_expires_at < datetime.utcnow():
+        raise ValidationError("enrollment token has expired", field="enrollment_token")
+
+    now = datetime.utcnow()
+    install.hostname = (hostname or "").strip() or None
+    install.secret_encrypted = encrypt_secret(secret)
+    install.enrolled_at = now
+    install.last_seen_at = now
+    # single use: consume the token
+    install.enrollment_token_hash = None
+    install.enrollment_token_expires_at = None
+    session.flush()
+    return install
+
+
+def get_credential(session: Session) -> str:
+    """Return the decrypted Bearer secret for the enrolled install. POC: the single (most recently)
+    enrolled install. Production keys this per workstation/user assignment."""
+    install = session.scalars(
+        select(RelayInstall)
+        .where(RelayInstall.secret_encrypted.is_not(None))
+        .order_by(RelayInstall.enrolled_at.desc())
+    ).first()
+    if install is None:
+        raise NotFoundError("no enrolled relay install found")
+    install.last_seen_at = datetime.utcnow()
+    session.flush()
+    return decrypt_secret(install.secret_encrypted)

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -48,7 +48,8 @@ def provision_install(session: Session, label: str, company: str) -> tuple[Relay
 
 def enroll_install(session: Session, enrollment_token: str, hostname: str, secret: str) -> RelayInstall:
     """Called by the relay (authenticated by the enrollment token, not Clerk). Stores the relay's
-    self-generated secret encrypted and consumes the one-time token."""
+    self-generated secret encrypted; the token is single-use (a second attempt is rejected as
+    already-used via the enrolled_at guard)."""
     secret = (secret or "").strip()
     if not secret:
         raise ValidationError("secret is required", field="secret")
@@ -68,9 +69,9 @@ def enroll_install(session: Session, enrollment_token: str, hostname: str, secre
     install.secret_encrypted = encrypt_secret(secret)
     install.enrolled_at = now
     install.last_seen_at = now
-    # single use: consume the token
-    install.enrollment_token_hash = None
-    install.enrollment_token_expires_at = None
+    # single use is enforced by the enrolled_at guard above: a second attempt with the same token finds
+    # this now-enrolled row and is rejected as already-used. (Keeping the hash makes that a clear error
+    # rather than a generic "invalid token".)
     session.flush()
     return install
 

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -79,9 +79,7 @@ def get_credential(session: Session) -> str:
     """Return the decrypted Bearer secret for the enrolled install. POC: the single (most recently)
     enrolled install. Production keys this per workstation/user assignment."""
     install = session.scalars(
-        select(RelayInstall)
-        .where(RelayInstall.secret_encrypted.is_not(None))
-        .order_by(RelayInstall.enrolled_at.desc())
+        select(RelayInstall).where(RelayInstall.secret_encrypted.is_not(None)).order_by(RelayInstall.enrolled_at.desc())
     ).first()
     if install is None:
         raise NotFoundError("no enrolled relay install found")

--- a/backend/app/repositories/vendor_repository.py
+++ b/backend/app/repositories/vendor_repository.py
@@ -14,6 +14,31 @@ def list_vendors(session: Session) -> list[Vendor]:
     return list(session.scalars(select(Vendor).order_by(Vendor.name)).all())
 
 
+def sync_gp_vendors(session: Session, gp_vendors: list[dict]) -> dict:
+    """Match UC Nexus vendors to GP vendors by name (case-insensitive, trimmed) and set gp_vendor_id.
+
+    gp_vendors is the relay's PM00200 read: [{"gp_vendor_id": str, "vendor_name": str}, ...]. Vendors
+    that don't match an existing UC Nexus vendor are returned for a one-time manual mapping rather than
+    auto-created. Returns {matched: [names], unmatched_gp: [names]}."""
+    local = list(session.scalars(select(Vendor)).all())
+    by_name: dict[str, Vendor] = {v.name.strip().lower(): v for v in local}
+    matched: list[str] = []
+    unmatched_gp: list[str] = []
+    for gv in gp_vendors:
+        name = (gv.get("vendor_name") or "").strip()
+        gp_id = (gv.get("gp_vendor_id") or "").strip()
+        if not name or not gp_id:
+            continue
+        vendor = by_name.get(name.lower())
+        if vendor is None:
+            unmatched_gp.append(name)
+            continue
+        vendor.gp_vendor_id = gp_id
+        matched.append(vendor.name)
+    session.flush()
+    return {"matched": matched, "unmatched_gp": unmatched_gp}
+
+
 def get_vendor(session: Session, vendor_id: uuid.UUID) -> Vendor:
     vendor = session.get(Vendor, vendor_id)
     if vendor is None:

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -24,6 +24,9 @@ from app.models.enums import (
     DestockSource as DestockSourceDB,
 )
 from app.models.enums import (
+    GpSyncStatus as GpSyncStatusDB,
+)
+from app.models.enums import (
     HardwareItemState as HardwareItemStateDB,
 )
 from app.models.enums import (
@@ -73,6 +76,7 @@ AssemblyStatus = strawberry.enum(AssemblyStatusDB)
 NotificationType = strawberry.enum(NotificationTypeDB)
 PODocumentType = strawberry.enum(PODocumentTypeDB)
 DestockSource = strawberry.enum(DestockSourceDB)
+GpSyncStatus = strawberry.enum(GpSyncStatusDB)
 DeficiencyResolution = strawberry.enum(DeficiencyResolutionDB)
 DeficientItemSource = strawberry.enum(DeficientItemSourceDB)
 ReturnDisposition = strawberry.enum(ReturnDispositionDB)

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -176,6 +176,26 @@ class CreatePOInput:
     project_id: strawberry.ID | None = None
     vendor_id: strawberry.ID | None = None
     notes: str | None = None
+    # GP cost code for a project-linked PO (the issue #121 dropdown, 'phase-step-element').
+    # Applied to every job-cost line when the PO is pushed to GP via the relay.
+    cost_code: str | None = None
+
+
+@strawberry.input
+class GpVendorInput:
+    """One vendor read from GP PM00200 by the relay, posted to syncGpVendors."""
+
+    gp_vendor_id: str
+    vendor_name: str
+
+
+@strawberry.input
+class EnrollRelayInstallInput:
+    """Posted by the relay during one-time setup (authenticated by the enrollment token, not Clerk)."""
+
+    enrollment_token: str
+    hostname: str
+    secret: str
 
 
 @strawberry.input

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -10,6 +10,7 @@ from app.repositories import (
     notification_repository,
     po_repository,
     project_repository,
+    relay_repository,
     shipping_repository,
     shop_assembly_repository,
     stock_repository,
@@ -19,7 +20,7 @@ from app.repositories import (
     warehouse_repository,
 )
 
-from .enums import ApproveOutcome, PODocumentType
+from .enums import ApproveOutcome, GpSyncStatus, PODocumentType
 from .inputs import (
     AdjustStockQuantityInput,
     AllocateStockToProjectInput,
@@ -33,7 +34,9 @@ from .inputs import (
     CreateVendorInput,
     CreateWarehouseInput,
     DestockInventoryInput,
+    EnrollRelayInstallInput,
     FinalizeImportSessionInput,
+    GpVendorInput,
     MoveStockLocationInput,
     OverrideInventoryQuantityInput,
     ReclassifyStockItemInput,
@@ -83,11 +86,14 @@ from .types import (
     PurchaseOrder,
     ReceiveRecord,
     ReclassifyStockResult,
+    RelayEnrollResult,
+    RelayInstallProvision,
     SAReplacementResult,
     ShipmentReturn,
     ShopAssemblyOpening,
     ShopAssemblyRequest,
     StockItem,
+    SyncGpVendorsResult,
     TransferResult,
     Vendor,
     Warehouse,
@@ -381,6 +387,7 @@ class Mutation:
                 project_id=project_id,
                 vendor_id=vendor_id,
                 notes=input.notes,
+                cost_code=input.cost_code,
             )
             session.commit()
 
@@ -394,6 +401,38 @@ class Mutation:
                         selectinload(POModel.vendor),
                     )
                     .where(POModel.id == po.id)
+                )
+                .unique()
+                .first()
+            )
+            return _po_to_type(refreshed_po)
+
+    @strawberry.mutation
+    def record_po_gp_sync(
+        self,
+        po_id: strawberry.ID,
+        gp_sync_status: GpSyncStatus,
+        po_number: str | None = None,
+    ) -> PurchaseOrder:
+        """Record the result of pushing this PO to GP via the relay (the create-in-both orchestration's
+        second step): store GP's returned PONUMBER on success and set gp_sync_status (SYNCED/FAILED)."""
+        from sqlalchemy.orm import selectinload
+
+        from app.models.purchase_order import PurchaseOrder as POModel
+
+        pid = uuid.UUID(str(po_id))
+        with SessionLocal() as session:
+            po_repository.record_gp_sync_result(session, pid, gp_sync_status, po_number=po_number)
+            session.commit()
+            refreshed_po = (
+                session.scalars(
+                    select(POModel)
+                    .options(
+                        selectinload(POModel.line_items),
+                        selectinload(POModel.documents),
+                        selectinload(POModel.vendor),
+                    )
+                    .where(POModel.id == pid)
                 )
                 .unique()
                 .first()
@@ -921,6 +960,54 @@ class Mutation:
             vendor_repository.delete_vendor(session, uuid.UUID(str(id)))
             session.commit()
             return True
+
+    @strawberry.mutation
+    def sync_gp_vendors(self, vendors: list[GpVendorInput]) -> SyncGpVendorsResult:
+        """Match UC Nexus vendors to the GP PM00200 list (by name) and set gp_vendor_id. The relay
+        reads PM00200 on the workstation and the frontend posts the list here. Unmatched GP vendors are
+        returned for a one-time manual mapping."""
+        with SessionLocal() as session:
+            result = vendor_repository.sync_gp_vendors(
+                session,
+                [{"gp_vendor_id": v.gp_vendor_id, "vendor_name": v.vendor_name} for v in vendors],
+            )
+            session.commit()
+            return SyncGpVendorsResult(
+                matched_count=len(result["matched"]),
+                matched_vendor_names=result["matched"],
+                unmatched_gp_vendor_names=result["unmatched_gp"],
+            )
+
+    # Relay installs (localhost relay <-> GP)
+    @strawberry.mutation
+    def provision_relay_install(self, info: strawberry.Info, label: str, company: str) -> RelayInstallProvision:
+        """Admin: create a relay install + a one-time enrollment token shown ONCE. The relay uses the
+        token during setup to register its self-generated Bearer secret (which never comes back here)."""
+        require_admin(info)
+        with SessionLocal() as session:
+            install, token = relay_repository.provision_install(session, label=label, company=company)
+            session.commit()
+            return RelayInstallProvision(
+                install_id=strawberry.ID(str(install.id)),
+                label=install.label,
+                company=install.company,
+                enrollment_token=token,
+                enrollment_token_expires_at=install.enrollment_token_expires_at,
+            )
+
+    @strawberry.mutation
+    def enroll_relay_install(self, input: EnrollRelayInstallInput) -> RelayEnrollResult:
+        """Called BY THE RELAY during one-time setup, authenticated by the enrollment token (not Clerk).
+        Stores the relay's self-generated secret encrypted and consumes the token."""
+        with SessionLocal() as session:
+            install = relay_repository.enroll_install(
+                session,
+                enrollment_token=input.enrollment_token,
+                hostname=input.hostname,
+                secret=input.secret,
+            )
+            session.commit()
+            return RelayEnrollResult(ok=True, install_id=strawberry.ID(str(install.id)))
 
     # Warehouses
     @strawberry.mutation

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -4,7 +4,7 @@ import strawberry
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
-from app.auth import require_admin
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.models.enums import POStatus as DBPOStatus
 from app.models.project import Opening as OpeningModel
@@ -14,6 +14,7 @@ from app.repositories import (
     dashboard_repository,
     notification_repository,
     po_repository,
+    relay_repository,
     shipping_repository,
     shop_assembly_repository,
     stock_repository,
@@ -69,6 +70,8 @@ from .types import (
     ReceiveRecord,
     RecentReceiveRecord,
     ReconciliationResult,
+    RelayCredential,
+    RelayInstallInfo,
     ReturnableLine,
     ShipmentReturn,
     ShipmentReturnItem,
@@ -161,12 +164,26 @@ def _vendor_to_type(v) -> Vendor:
     return Vendor(
         id=strawberry.ID(str(v.id)),
         name=v.name,
+        gp_vendor_id=v.gp_vendor_id,
         contact_name=v.contact_name,
         email=v.email,
         phone=v.phone,
         notes=v.notes,
         created_at=v.created_at,
         updated_at=v.updated_at,
+    )
+
+
+def _relay_install_to_type(ri) -> RelayInstallInfo:
+    return RelayInstallInfo(
+        id=strawberry.ID(str(ri.id)),
+        label=ri.label,
+        company=ri.company,
+        hostname=ri.hostname,
+        enrolled=ri.enrolled_at is not None,
+        enrolled_at=ri.enrolled_at,
+        last_seen_at=ri.last_seen_at,
+        created_at=ri.created_at,
     )
 
 
@@ -195,6 +212,8 @@ def _po_to_type(po, receive_records=None) -> PurchaseOrder:
         request_number=po.request_number,
         project_id=strawberry.ID(str(po.project_id)) if po.project_id else None,
         status=po.status,
+        cost_code=po.cost_code,
+        gp_sync_status=po.gp_sync_status,
         vendor=_vendor_to_type(vendor) if vendor is not None else None,
         vendor_quote_number=po.vendor_quote_number,
         notes=po.notes,
@@ -990,6 +1009,22 @@ class Query:
         with SessionLocal() as session:
             v = session.get(VendorModel, uuid.UUID(str(id)))
             return _vendor_to_type(v) if v is not None else None
+
+    @strawberry.field
+    def relay_credential(self, info: strawberry.Info) -> RelayCredential:
+        """Return the relay Bearer secret to the authenticated user (the frontend sends it to the
+        on-prem relay). POC: the single enrolled install's secret."""
+        require_user(info)
+        with SessionLocal() as session:
+            secret = relay_repository.get_credential(session)
+            session.commit()
+            return RelayCredential(secret=secret)
+
+    @strawberry.field
+    def relay_installs(self, info: strawberry.Info) -> list[RelayInstallInfo]:
+        require_admin(info)
+        with SessionLocal() as session:
+            return [_relay_install_to_type(ri) for ri in relay_repository.list_installs(session)]
 
     @strawberry.field
     def warehouses(self, include_inactive: bool = True) -> list[Warehouse]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -10,6 +10,7 @@ from .enums import (
     Classification,
     DeficiencyResolution,
     DeficientItemSource,
+    GpSyncStatus,
     HardwareItemState,
     NotificationType,
     OpeningItemState,
@@ -87,12 +88,54 @@ class HardwareItem:
 class Vendor:
     id: strawberry.ID
     name: str
+    gp_vendor_id: str | None
     contact_name: str | None
     email: str | None
     phone: str | None
     notes: str | None
     created_at: datetime
     updated_at: datetime
+
+
+@strawberry.type
+class SyncGpVendorsResult:
+    matched_count: int
+    matched_vendor_names: list[str]
+    unmatched_gp_vendor_names: list[str]
+
+
+@strawberry.type
+class RelayInstallProvision:
+    """Result of provisioning a relay install. enrollment_token is shown ONCE - it never comes back."""
+
+    install_id: strawberry.ID
+    label: str
+    company: str
+    enrollment_token: str
+    enrollment_token_expires_at: datetime
+
+
+@strawberry.type
+class RelayEnrollResult:
+    ok: bool
+    install_id: strawberry.ID
+
+
+@strawberry.type
+class RelayCredential:
+    secret: str
+
+
+@strawberry.type
+class RelayInstallInfo:
+    id: strawberry.ID
+    label: str
+    company: str
+    hostname: str | None
+    enrolled: bool
+    enrolled_at: datetime | None
+    last_seen_at: datetime | None
+    created_at: datetime
 
 
 @strawberry.type
@@ -163,6 +206,8 @@ class PurchaseOrder:
     request_number: str
     project_id: strawberry.ID | None
     status: POStatus
+    cost_code: str | None
+    gp_sync_status: GpSyncStatus
     vendor: Vendor | None
     vendor_quote_number: str | None
     notes: str | None

--- a/backend/tests/test_relay_gp_fields.py
+++ b/backend/tests/test_relay_gp_fields.py
@@ -1,0 +1,59 @@
+"""Vendor sync + PO GP-sync fields (uc nexus <-> relay, schema + api changes)."""
+
+import uuid
+
+from app.models.enums import GpSyncStatus
+from app.models.vendor import Vendor
+from app.repositories import po_repository, vendor_repository
+
+
+def _make_vendor(session, name: str) -> Vendor:
+    v = Vendor(id=uuid.uuid4(), name=name)
+    session.add(v)
+    session.flush()
+    return v
+
+
+def _line_item() -> dict:
+    return {
+        "hardware_category": "HINGE",
+        "product_code": "AB123",
+        "ordered_quantity": 1,
+        "unit_cost": 12.50,
+        "classification": None,
+        "order_as": "ML2010",
+    }
+
+
+def test_sync_gp_vendors_matches_by_name_case_insensitive(db_session):
+    v = _make_vendor(db_session, f"Ingersoll-{uuid.uuid4().hex[:6]}")
+    result = vendor_repository.sync_gp_vendors(db_session, [{"gp_vendor_id": "ING100", "vendor_name": v.name.upper()}])
+    db_session.refresh(v)
+    assert v.gp_vendor_id == "ING100"
+    assert result["matched"] == [v.name]
+    assert result["unmatched_gp"] == []
+
+
+def test_sync_gp_vendors_reports_unmatched(db_session):
+    result = vendor_repository.sync_gp_vendors(
+        db_session, [{"gp_vendor_id": "ZZZ999", "vendor_name": f"NoSuchVendor-{uuid.uuid4().hex[:6]}"}]
+    )
+    assert result["matched"] == []
+    assert len(result["unmatched_gp"]) == 1
+
+
+def test_create_po_stores_cost_code_and_defaults_not_pushed(db_session):
+    v = _make_vendor(db_session, f"Acme-{uuid.uuid4().hex[:6]}")
+    po = po_repository.create_po(db_session, line_items=[_line_item()], vendor_id=v.id, cost_code="  210-200-2  ")
+    db_session.refresh(po)
+    assert po.cost_code == "210-200-2"
+    assert po.gp_sync_status == GpSyncStatus.NOT_PUSHED
+
+
+def test_record_gp_sync_result_sets_status_and_po_number(db_session):
+    v = _make_vendor(db_session, f"Acme-{uuid.uuid4().hex[:6]}")
+    po = po_repository.create_po(db_session, line_items=[_line_item()], vendor_id=v.id)
+    po_repository.record_gp_sync_result(db_session, po.id, GpSyncStatus.SYNCED, po_number="PO123456")
+    db_session.refresh(po)
+    assert po.gp_sync_status == GpSyncStatus.SYNCED
+    assert po.po_number == "PO123456"

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -1,0 +1,41 @@
+"""Relay install provisioning + enrollment + credential round-trip."""
+
+import os
+
+import pytest
+from cryptography.fernet import Fernet
+
+# Provide an encryption key before any crypto call (the app reads RELAY_SECRET_ENC_KEY at call time).
+os.environ.setdefault("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
+
+from app.errors import ConflictError, ValidationError  # noqa: E402
+from app.repositories import relay_repository  # noqa: E402
+
+
+def test_provision_returns_token_and_stores_hash_only(db_session):
+    install, token = relay_repository.provision_install(db_session, label="Tagging3W10", company="TUBC")
+    assert token
+    assert install.secret_encrypted is None
+    assert install.enrollment_token_hash and install.enrollment_token_hash != token  # hashed, not raw
+
+
+def test_enroll_stores_secret_and_consumes_token(db_session):
+    install, token = relay_repository.provision_install(db_session, label="WS1", company="TUBC")
+    enrolled = relay_repository.enroll_install(db_session, token, hostname="WS1", secret="s3cr3t-value")
+    assert enrolled.id == install.id
+    assert enrolled.enrolled_at is not None
+    assert enrolled.enrollment_token_hash is None  # consumed (single use)
+    # credential round-trips back to the raw secret the frontend needs for the Bearer header
+    assert relay_repository.get_credential(db_session) == "s3cr3t-value"
+
+
+def test_enroll_rejects_reused_token(db_session):
+    _, token = relay_repository.provision_install(db_session, label="WS2", company="TUBC")
+    relay_repository.enroll_install(db_session, token, hostname="WS2", secret="abc")
+    with pytest.raises(ConflictError):
+        relay_repository.enroll_install(db_session, token, hostname="WS2", secret="def")
+
+
+def test_enroll_rejects_invalid_token(db_session):
+    with pytest.raises(ValidationError):
+        relay_repository.enroll_install(db_session, "not-a-real-token", hostname="WS3", secret="abc")

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -19,12 +19,11 @@ def test_provision_returns_token_and_stores_hash_only(db_session):
     assert install.enrollment_token_hash and install.enrollment_token_hash != token  # hashed, not raw
 
 
-def test_enroll_stores_secret_and_consumes_token(db_session):
+def test_enroll_stores_secret_and_returns_credential(db_session):
     install, token = relay_repository.provision_install(db_session, label="WS1", company="TUBC")
     enrolled = relay_repository.enroll_install(db_session, token, hostname="WS1", secret="s3cr3t-value")
     assert enrolled.id == install.id
-    assert enrolled.enrolled_at is not None
-    assert enrolled.enrollment_token_hash is None  # consumed (single use)
+    assert enrolled.enrolled_at is not None  # single use is enforced via enrolled_at, not by clearing the hash
     # credential round-trips back to the raw secret the frontend needs for the Bearer header
     assert relay_repository.get_credential(db_session) == "s3cr3t-value"
 

--- a/localhost relay/README.md
+++ b/localhost relay/README.md
@@ -25,6 +25,19 @@ cp config.example.toml config.toml          # then set [auth] shared_secret
 poetry install
 ```
 
+enrollment (one-time, gets the relay's Bearer secret without hand-copying it)
+
+the relay's `[auth] shared_secret` can be set by hand, or provisioned from UC Nexus so nothing long-lived
+is pasted. in UC Nexus an admin runs "provision relay install" and gets a one-time enrollment token. then,
+on this workstation:
+```
+poetry run python -m ucnexus_relay.enroll --token <ENROLLMENT_TOKEN> --backend-url https://<backend-host>/graphql
+```
+the relay generates its own long-lived secret, registers it with the backend using that one-time token
+(the backend can't reach the relay, but the relay can reach the backend), and writes the secret into
+`config.toml`. restart the relay afterwards. the frontend then fetches the same secret at runtime via the
+`relayCredential` query - it's never baked into the build.
+
 run
 ```
 poetry run uvicorn ucnexus_relay.main:app --app-dir src --host 127.0.0.1 --port 7321
@@ -48,7 +61,10 @@ poetry run ruff check src tests
 
 endpoints
 - `GET /health` — liveness, no auth
-- `GET /info` — config + read-only SQL identity, bearer auth
+- `GET /info` — config + read-only SQL identity + the workstation `hostname` and the `resolved_buyer` that hostname maps to, bearer auth
+- `GET /vendors` — active PM00200 vendors (VENDORID / VENDNAME / class / status) for the vendor sync, bearer auth. takes `?company=` (defaults to `default_company`)
 - `POST /po/next-number` — reserve a PO number via `taGetPONextNumber`, bearer auth
-- `POST /po` — create a PO end-to-end via the 5-step orchestration, bearer auth
+- `POST /po` — create a PO end-to-end via the 5-step orchestration, bearer auth. `buyer_id` is optional in the request — when omitted the relay fills `BUYERID` from the workstation via `[gp.buyers]`, resolving `by_host` (explicit map) → `by_login` → `use_hostname` (the device's own traceable name) → `default`
 - `POST /receipt` — receive against a PO (taPopRcptLineInsert xN then taPopRcptHdrInsert, autocosted), and for a company mapped in `[gp.custom_db]` also writes the matching `WHRECLINE101` rows (the custom warehouse table the dashboards read) in the same transaction. needs a `rack_location` per line. bearer auth
+
+browser hop (the cloud frontend → `http://localhost:7321` call) is governed by Chrome Local Network Access from Chrome 142: the frontend fetch must set `targetAddressSpace: "loopback"` and the user grants a one-time loopback permission prompt (or IT pre-grants it via enterprise policy). that is a client-side gate — the relay needs no LNA server header. the relay does echo the legacy `Access-Control-Allow-Private-Network: true` on the preflight for stragglers on a pre-LNA Chrome, but it is not the mechanism.

--- a/localhost relay/config.example.toml
+++ b/localhost relay/config.example.toml
@@ -38,6 +38,23 @@ allowed_companies = ["TUBC", "TUCSH"]
 UBC = "PMUBC"
 UCSH = "PMUCSH"
 
+[gp.buyers]
+# GP BUYERID is free text in POP10100 (no buyer-master to validate against). the relay fills it from
+# the WORKSTATION when the /po request omits buyer_id - the machine that knows the device is the relay.
+# company device names are traceable to individuals via an internal system, so the device name itself
+# is a valid buyer handle. resolution order:
+#   by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
+# matching is case-insensitive; the result is truncated to GP's char(15) BUYERID width.
+use_hostname = true   # use socket.gethostname() as the buyer on every workstation, no per-host config
+default = "mira"      # final fallback if use_hostname is off / the hostname is empty (TUBC test = "mira")
+
+[gp.buyers.by_host]
+# explicit override for a machine whose name should NOT be the buyer:
+# WORKSTATION-HOSTNAME = "Buyer Name"
+
+[gp.buyers.by_login]
+# "DOMAIN\\login" = "Buyer Name"
+
 [logging]
 level = "INFO"
 file = "relay.log"

--- a/localhost relay/src/ucnexus_relay/buyers.py
+++ b/localhost relay/src/ucnexus_relay/buyers.py
@@ -1,0 +1,33 @@
+"""Resolve the GP BUYERID from the workstation identity.
+
+GP has no buyer-master at this customer — BUYERID is a free-text human name written straight to
+POP10100 (verified in the GP discovery: "Buyers are free-text human names ... No buyer-master
+enforcement"). So there is nothing to validate against; the relay just maps the device to a name.
+
+The relay fills the buyer when the /po request omits it, because the machine that knows the device
+is the relay, not the cloud frontend. Company device names are traceable to individuals via an
+internal system, so the device name itself is a valid buyer handle. Resolution order:
+  by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
+Matching is case-insensitive (Windows hostnames/logins are). The result is truncated to GP's
+char(15) BUYERID width.
+"""
+
+from .config import BuyersCfg
+
+_MAX_BUYERID = 15  # POP10100.BUYERID is char(15)
+
+
+def resolve_buyer(cfg: BuyersCfg, hostname: str, login: str | None = None) -> str | None:
+    """Return the buyer name for this workstation, or None if nothing matches and no default is set."""
+    by_host = {k.upper(): v for k, v in cfg.by_host.items()}
+    buyer = by_host.get((hostname or "").upper())
+    if not buyer and login:
+        by_login = {k.upper(): v for k, v in cfg.by_login.items()}
+        buyer = by_login.get(login.upper())
+    if not buyer and cfg.use_hostname and hostname:
+        buyer = hostname  # the device name is itself a traceable buyer identity
+    if not buyer:
+        buyer = cfg.default
+    if buyer:
+        buyer = buyer.strip()[:_MAX_BUYERID]
+    return buyer or None

--- a/localhost relay/src/ucnexus_relay/config.py
+++ b/localhost relay/src/ucnexus_relay/config.py
@@ -33,12 +33,25 @@ class SqlCfg(BaseModel):
     command_timeout: int = 30
 
 
+class BuyersCfg(BaseModel):
+    # GP BUYERID is free text written to POP10100 (no buyer-master to validate against). the relay
+    # fills it from the WORKSTATION when the /po request omits buyer_id, because the machine that knows
+    # the device is the relay. company device names are traceable to individuals via an internal system,
+    # so the device name itself is a valid buyer handle. resolution order:
+    #   by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
+    default: str | None = None
+    use_hostname: bool = False     # use socket.gethostname() as the buyer when nothing else maps
+    by_host: dict[str, str] = {}   # device hostname -> buyer name (explicit override)
+    by_login: dict[str, str] = {}  # SQL/SSPI login -> buyer name
+
+
 class GpCfg(BaseModel):
     default_company: str = "TUBC"
     allowed_companies: list[str] = ["TUBC"]
     # company -> paired custom warehouse DB that holds WHRECLINE101 (the table the company dashboards
     # read). A company with no entry gets GP-only receipts (no WHRECLINE101 write). Sandboxes have none.
     custom_db: dict[str, str] = {}
+    buyers: BuyersCfg = BuyersCfg()
 
 
 class LoggingCfg(BaseModel):

--- a/localhost relay/src/ucnexus_relay/db.py
+++ b/localhost relay/src/ucnexus_relay/db.py
@@ -48,6 +48,18 @@ def get_connection(company: str):
         conn.close()
 
 
+@contextmanager
+def get_read_connection(company: str):
+    """Read-only connection (autocommit) for plain SELECTs — no eConnect, no writes, no held
+    transaction. Used by /vendors and any other pure read."""
+    conn = pyodbc.connect(build_conn_string(company), autocommit=True)
+    conn.timeout = get_settings().sql.command_timeout
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
 def connection_info(company: str) -> dict:
     """Read-only identity probe for /info. Opens an autocommit connection, runs a
     metadata SELECT, returns who we are. No eConnect calls, no writes."""

--- a/localhost relay/src/ucnexus_relay/econnect.py
+++ b/localhost relay/src/ucnexus_relay/econnect.py
@@ -355,6 +355,29 @@ def read_po_receipt_context(conn, po_number: str):
     return hdr.vendor, hdr.vendname, lines
 
 
+def list_vendors(conn, *, active_only: bool = True) -> list[dict]:
+    """Read-only: PM00200 vendor list for the vendor sync (feeds UC Nexus's Vendor.gp_vendor_id).
+    Returns VENDORID / VENDNAME / VNDCLSID (class) / VENDSTTS (status). VENDSTTS 1 = active; the
+    sync only wants vendors usable on a new PO, so active_only filters to those."""
+    sql = (
+        "SELECT RTRIM(VENDORID) AS vendor_id, RTRIM(VENDNAME) AS vendor_name, "
+        "RTRIM(VNDCLSID) AS vendor_class, VENDSTTS AS status FROM dbo.PM00200 "
+    )
+    if active_only:
+        sql += "WHERE VENDSTTS = 1 "
+    sql += "ORDER BY VENDNAME"
+    rows = conn.cursor().execute(sql).fetchall()
+    return [
+        {
+            "vendor_id": r.vendor_id,
+            "vendor_name": r.vendor_name,
+            "vendor_class": r.vendor_class or None,
+            "status": int(r.status),
+        }
+        for r in rows
+    ]
+
+
 def create_receipt_header(conn, *, receipt_number, po_number, vendor_id, receipt_date, batch_number, subtotal) -> None:
     sql = """
     DECLARE @err int = 0;

--- a/localhost relay/src/ucnexus_relay/enroll.py
+++ b/localhost relay/src/ucnexus_relay/enroll.py
@@ -1,0 +1,84 @@
+"""One-time relay enrollment CLI.
+
+Run during setup with an enrollment token minted in UC Nexus (admin -> provision relay install):
+
+    python -m ucnexus_relay.enroll --token <ENROLLMENT_TOKEN> --backend-url https://<backend-host>/graphql
+
+The relay generates its OWN long-lived Bearer secret, registers it with the UC Nexus backend using the
+one-time token (the backend can't reach the relay, but the relay can reach the backend), and writes that
+secret into this install's config.toml [auth] shared_secret. Restart the relay afterwards. Nothing
+long-lived is ever hand-copied - only the throwaway enrollment token is carried from UC Nexus to here.
+"""
+
+import argparse
+import json
+import re
+import secrets
+import socket
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from .config import DEFAULT_CONFIG_PATH, get_settings
+
+_MUTATION = (
+    "mutation Enroll($input: EnrollRelayInstallInput!) { "
+    "enrollRelayInstall(input: $input) { ok installId } }"
+)
+
+
+def _post_graphql(url: str, query: str, variables: dict) -> dict:
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted backend URL from operator)
+        return json.loads(resp.read().decode())
+
+
+def write_secret_to_config(config_path: Path, secret: str) -> None:
+    """Replace the [auth] shared_secret value in config.toml, preserving the rest of the file.
+    token_urlsafe secrets contain only URL-safe chars, so there's nothing to escape in the TOML string."""
+    text = config_path.read_text(encoding="utf-8")
+    pattern = re.compile(r'^(\s*shared_secret\s*=\s*)".*?"', re.MULTILINE)
+    if not pattern.search(text):
+        raise SystemExit(f"could not find [auth] shared_secret in {config_path}; set it manually to the new secret")
+    config_path.write_text(pattern.sub(rf'\1"{secret}"', text, count=1), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Enroll this relay with UC Nexus (one-time setup).")
+    parser.add_argument("--token", required=True, help="one-time enrollment token from UC Nexus")
+    parser.add_argument("--backend-url", required=True, help="UC Nexus backend GraphQL URL, e.g. https://host/graphql")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="path to config.toml")
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config)
+    hostname = socket.gethostname()
+    company = get_settings(args.config).gp.default_company
+    secret = secrets.token_urlsafe(32)
+
+    variables = {"input": {"enrollmentToken": args.token, "hostname": hostname, "secret": secret}}
+    try:
+        result = _post_graphql(args.backend_url, _MUTATION, variables)
+    except urllib.error.URLError as e:
+        print(f"enrollment request failed: {e}", file=sys.stderr)
+        return 1
+
+    if result.get("errors"):
+        print(f"enrollment rejected: {json.dumps(result['errors'])}", file=sys.stderr)
+        return 1
+    data = (result.get("data") or {}).get("enrollRelayInstall") or {}
+    if not data.get("ok"):
+        print(f"enrollment did not succeed: {json.dumps(result)}", file=sys.stderr)
+        return 1
+
+    write_secret_to_config(config_path, secret)
+    print(
+        f"enrolled install {data.get('installId')} as host {hostname} (company {company}); "
+        f"secret written to {config_path}. restart the relay."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/localhost relay/src/ucnexus_relay/main.py
+++ b/localhost relay/src/ucnexus_relay/main.py
@@ -2,18 +2,21 @@
 
 Endpoints:
   GET  /health           — liveness, no auth
-  GET  /info             — config + read-only SQL identity probe, auth required
+  GET  /info             — config + read-only SQL identity probe (+ workstation hostname), auth required
+  GET  /vendors          — PM00200 vendor list for the vendor sync, auth required
   POST /po/next-number   — reserve a PO number (live taGetPONextNumber), auth required
   POST /po               — create a PO end-to-end (5-step orchestration), auth required
+  POST /receipt          — receive against a PO, auth required
 """
 
+import socket
 import time
 from datetime import date
 
 import pyodbc
 from fastapi import Depends, FastAPI, HTTPException
 
-from . import auth, db, econnect, errors, models
+from . import auth, buyers, db, econnect, errors, models
 from .config import get_settings
 from .cors import configure_cors
 from .logging_setup import configure_logging, get_logger
@@ -52,6 +55,18 @@ def create_app() -> FastAPI:
     app = FastAPI(title="UC Nexus Relay", version=VERSION)
     configure_cors(app)
 
+    @app.middleware("http")
+    async def add_pna_header(request, call_next):
+        # Legacy Private Network Access answer, for stragglers on a pre-LNA Chrome. The browser hop
+        # from the https Railway page to http://localhost is governed by Local Network Access (a
+        # client-side permission prompt + targetAddressSpace:"loopback" on the fetch) on current
+        # Chrome, NOT by this header. We echo it only when the browser asks (the PNA preflight sends
+        # Access-Control-Request-Private-Network: true); it is harmless and not the mechanism.
+        response = await call_next(request)
+        if request.method == "OPTIONS" and request.headers.get("access-control-request-private-network") == "true":
+            response.headers["Access-Control-Allow-Private-Network"] = "true"
+        return response
+
     if not db.driver_available():
         logger.warning(
             "configured ODBC driver not found", extra={"driver": settings.sql.driver, "available": pyodbc.drivers()}
@@ -80,6 +95,7 @@ def create_app() -> FastAPI:
     @app.get("/info")
     def info(_=Depends(auth.verify_token)):
         s = get_settings()
+        hostname = socket.gethostname()
         out = {
             "version": VERSION,
             "configured_companies": s.gp.allowed_companies,
@@ -87,12 +103,28 @@ def create_app() -> FastAPI:
             "sql_server": s.sql.server,
             "odbc_driver": s.sql.driver,
             "driver_installed": db.driver_available(),
+            "hostname": hostname,  # the device name the relay maps to a GP buyer
         }
         try:
             out.update(db.connection_info(s.gp.default_company))
         except pyodbc.Error as e:
             out["connection_error"] = str(e)
+        # which buyer this workstation resolves to (confirm hostname->BUYERID during deployment)
+        out["resolved_buyer"] = buyers.resolve_buyer(s.gp.buyers, hostname, out.get("connected_as"))
         return out
+
+    @app.get("/vendors", response_model=models.VendorsResponse)
+    def vendors(company: str | None = None, _=Depends(auth.verify_token)):
+        """Read PM00200 (active vendors) for the vendor sync. The frontend posts this list to UC
+        Nexus's syncGpVendors, which fills Vendor.gp_vendor_id by matching on name."""
+        company = company or get_settings().gp.default_company
+        _check_company(company)
+        try:
+            with db.get_read_connection(company) as conn:
+                rows = econnect.list_vendors(conn, active_only=True)
+        except pyodbc.Error as e:
+            raise HTTPException(status_code=502, detail={"error": "sql_error", "message": str(e)})
+        return models.VendorsResponse(company=company, vendors=[models.VendorOut(**r) for r in rows])
 
     @app.post("/po/next-number")
     def next_number(request: models.NextNumberRequest, _=Depends(auth.verify_token)):
@@ -119,6 +151,26 @@ def create_app() -> FastAPI:
         try:
             with db.get_connection(request.company) as conn:
                 try:
+                    # 0. buyer: the frontend doesn't send one — the relay fills BUYERID from the
+                    #    workstation (the machine that knows the device is the relay). by_host needs no
+                    #    DB; only read the SSPI login if a by_login map is configured.
+                    buyer_id = h.buyer_id
+                    if not buyer_id:
+                        bcfg = get_settings().gp.buyers
+                        login = None
+                        if bcfg.by_login:
+                            login = conn.cursor().execute("SELECT SUSER_NAME()").fetchone()[0]
+                        buyer_id = buyers.resolve_buyer(bcfg, socket.gethostname(), login)
+                        if not buyer_id:
+                            raise HTTPException(
+                                status_code=400,
+                                detail={
+                                    "error": "buyer_unresolved",
+                                    "message": "could not resolve a GP buyer for this workstation "
+                                               f"({socket.gethostname()}); set [gp.buyers] default or map this device",
+                                },
+                            )
+
                     # 1. PO number: use UC Nexus's own number (e.g. 'ucnexus...') if supplied,
                     #    else reserve GP's next 'PO' number via taGetPONextNumber.
                     if request.po_number:
@@ -133,7 +185,7 @@ def create_app() -> FastAPI:
                         po_number=po_number,
                         vendor_id=h.vendor_id,
                         doc_date=h.doc_date,
-                        buyer_id=h.buyer_id,
+                        buyer_id=buyer_id,
                         confirm_with=h.confirm_with,
                         currency_id=h.currency_id,
                         vendor_address_code=h.vendor_address_code,
@@ -174,7 +226,7 @@ def create_app() -> FastAPI:
                         po_number=po_number,
                         vendor_id=h.vendor_id,
                         doc_date=h.doc_date,
-                        buyer_id=h.buyer_id,
+                        buyer_id=buyer_id,
                         confirm_with=h.confirm_with,
                         currency_id=h.currency_id,
                         vendor_address_code=h.vendor_address_code,

--- a/localhost relay/src/ucnexus_relay/models.py
+++ b/localhost relay/src/ucnexus_relay/models.py
@@ -37,7 +37,9 @@ class POLine(BaseModel):
 
 class POHeader(BaseModel):
     vendor_id: str = Field(..., max_length=15)
-    buyer_id: str = Field(..., max_length=15)
+    # optional: when omitted, the relay fills BUYERID from the workstation (see buyers.resolve_buyer).
+    # an explicit value here overrides the relay's device-based resolution.
+    buyer_id: str | None = Field(default=None, max_length=15)
     confirm_with: str = Field(..., max_length=20)
     doc_date: date
     currency_id: str = "CAD"
@@ -99,3 +101,17 @@ class ReceiptResponse(BaseModel):
     company: str
     lines_received: int
     custom_db_written: bool  # whether the WHRECLINE101 rows were written (false for sandboxes / unmapped companies)
+
+
+# --- vendor sync (feeds Vendor.gp_vendor_id in UC Nexus) ---
+
+class VendorOut(BaseModel):
+    vendor_id: str       # GP VENDORID (char 15)
+    vendor_name: str     # GP VENDNAME
+    vendor_class: str | None = None  # GP VNDCLSID
+    status: int          # GP VENDSTTS (1 = active)
+
+
+class VendorsResponse(BaseModel):
+    company: str
+    vendors: list[VendorOut]

--- a/localhost relay/tests/test_buyers.py
+++ b/localhost relay/tests/test_buyers.py
@@ -1,0 +1,53 @@
+"""Pure unit tests for workstation -> BUYERID resolution. No config file, no SQL."""
+
+from ucnexus_relay.buyers import resolve_buyer
+from ucnexus_relay.config import BuyersCfg
+
+
+def test_resolve_by_host_case_insensitive():
+    cfg = BuyersCfg(default="fallback", by_host={"WS-ALICE": "Alice Smith"})
+    assert resolve_buyer(cfg, "ws-alice") == "Alice Smith"
+
+
+def test_resolve_by_login_when_host_misses():
+    cfg = BuyersCfg(by_host={}, by_login={"DOMAIN\\bob": "Bob Jones"})
+    assert resolve_buyer(cfg, "unknown-host", "domain\\bob") == "Bob Jones"
+
+
+def test_host_wins_over_login():
+    cfg = BuyersCfg(by_host={"H": "FromHost"}, by_login={"L": "FromLogin"})
+    assert resolve_buyer(cfg, "h", "l") == "FromHost"
+
+
+def test_falls_back_to_default():
+    cfg = BuyersCfg(default="Default Buyer", by_host={"x": "y"})
+    assert resolve_buyer(cfg, "other") == "Default Buyer"
+
+
+def test_none_when_nothing_matches_and_no_default():
+    assert resolve_buyer(BuyersCfg(), "host", None) is None
+
+
+def test_truncates_to_char_15():
+    cfg = BuyersCfg(by_host={"H": "ThisNameIsWayTooLong"})
+    assert resolve_buyer(cfg, "H") == "ThisNameIsWayTo"  # GP BUYERID is char(15)
+
+
+def test_use_hostname_when_enabled_and_unmapped():
+    cfg = BuyersCfg(use_hostname=True)
+    assert resolve_buyer(cfg, "Tagging3W10") == "Tagging3W10"
+
+
+def test_use_hostname_off_falls_through_to_default():
+    cfg = BuyersCfg(use_hostname=False, default="fallback")
+    assert resolve_buyer(cfg, "Tagging3W10") == "fallback"
+
+
+def test_by_host_overrides_use_hostname():
+    cfg = BuyersCfg(use_hostname=True, by_host={"Tagging3W10": "Real Person"})
+    assert resolve_buyer(cfg, "Tagging3W10") == "Real Person"
+
+
+def test_use_hostname_truncated_to_char_15():
+    cfg = BuyersCfg(use_hostname=True)
+    assert resolve_buyer(cfg, "VeryLongHostnameABCDEF") == "VeryLongHostnam"  # 15 chars

--- a/localhost relay/tests/test_cors.py
+++ b/localhost relay/tests/test_cors.py
@@ -1,0 +1,43 @@
+"""CORS preflight + the legacy PNA header echo. These exercise the browser-hop preflight path
+(the genuinely-new piece for the cloud frontend -> loopback relay call). No SQL, no auth body."""
+
+from fastapi.testclient import TestClient
+
+from ucnexus_relay.config import get_settings
+from ucnexus_relay.main import create_app
+
+client = TestClient(create_app())
+ORIGIN = get_settings().cors.allowed_origins[0]  # a configured UC Nexus origin (e.g. the Railway page)
+
+
+def test_preflight_allows_configured_origin():
+    r = client.options(
+        "/po",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == ORIGIN
+    assert "POST" in r.headers.get("access-control-allow-methods", "")
+
+
+def test_preflight_echoes_pna_header_when_requested():
+    r = client.options(
+        "/po",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Private-Network": "true",
+        },
+    )
+    assert r.headers.get("Access-Control-Allow-Private-Network") == "true"
+
+
+def test_no_pna_header_when_not_requested():
+    r = client.options(
+        "/po",
+        headers={"Origin": ORIGIN, "Access-Control-Request-Method": "POST"},
+    )
+    assert r.headers.get("Access-Control-Allow-Private-Network") is None

--- a/localhost relay/tests/test_enroll.py
+++ b/localhost relay/tests/test_enroll.py
@@ -1,0 +1,22 @@
+"""Enrollment config-rewrite (the non-network part). Network enroll is exercised manually during setup."""
+
+import pytest
+
+from ucnexus_relay.enroll import write_secret_to_config
+
+
+def test_write_secret_replaces_shared_secret(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[auth]\nshared_secret = "OLD_VALUE"\n\n[gp]\ndefault_company = "TUBC"\n', encoding="utf-8")
+    write_secret_to_config(cfg, "NEW_SECRET_xyz")
+    text = cfg.read_text(encoding="utf-8")
+    assert 'shared_secret = "NEW_SECRET_xyz"' in text
+    assert "OLD_VALUE" not in text
+    assert 'default_company = "TUBC"' in text  # rest of the file preserved
+
+
+def test_write_secret_errors_when_no_shared_secret(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[gp]\ndefault_company = "TUBC"\n', encoding="utf-8")
+    with pytest.raises(SystemExit):
+        write_secret_to_config(cfg, "NEW")

--- a/localhost relay/tests/test_vendors.py
+++ b/localhost relay/tests/test_vendors.py
@@ -1,0 +1,15 @@
+"""Auth gate for /vendors. The 401 short-circuits before any SQL, so this never touches GP."""
+
+from fastapi.testclient import TestClient
+
+from ucnexus_relay.main import create_app
+
+client = TestClient(create_app())
+
+
+def test_vendors_requires_token():
+    assert client.get("/vendors").status_code == 401
+
+
+def test_vendors_rejects_bad_token():
+    assert client.get("/vendors", headers={"Authorization": "Bearer wrong"}).status_code == 401


### PR DESCRIPTION
the nexus-side of the localhost relay work (the relay <-> gp half is already merged). gets UC Nexus's backend + the relay ready so creating a PO in UC Nexus can also create the GP job-cost PO in one action, and so receiving can post the GP receipt. this is the schema/api + secret plumbing; the frontend (relayClient, create-po dialog, vendor-sync screen, receiving) comes after the browser-hop gate is proven.

relay side (localhost relay/):
- buyer id is resolved from the workstation when a /po omits it. GP BUYERID is free text (no buyer-master), so the relay maps the device to a name: by_host -> by_login -> use_hostname (the device's own traceable name) -> default. company device names are traceable to individuals internally, so use_hostname is the primary mechanism.
- GET /vendors reads active PM00200 vendors for the vendor sync
- /info now exposes the workstation hostname + the resolved buyer (for deployment confirmation)
- legacy Access-Control-Allow-Private-Network echo on the preflight, for stragglers on a pre-LNA chrome (not the mechanism; LNA is a client-side gate)
- enroll CLI (python -m ucnexus_relay.enroll): generates the relay's own bearer secret, registers it with the backend via a one-time token, writes it to config.toml

backend (backend/):
- Vendor.gp_vendor_id + syncGpVendors mutation (name-match upsert from the relay's PM00200 read; unmatched returned for manual mapping)
- PurchaseOrder.cost_code + gp_sync_status (NOT_PUSHED/SYNCED/FAILED); cost_code threaded through createPo; recordPoGpSync mutation to store GP's PONUMBER + status after a relay push
- relay_installs table + backend-issued per-install secret: provisionRelayInstall mints a one-time enrollment token (shown once), the relay self-registers its generated secret via enrollRelayInstall (token-authed, not clerk), stored Fernet-encrypted; relayCredential returns it to an authenticated user for the bearer header
- require_user auth helper (authenticated, any role) for relayCredential
- migrations 036 (gp fields) + 037 (relay_installs)

needs RELAY_SECRET_ENC_KEY set on the backend service (Fernet key) for the secret encryption.