### PR TITLE
GP vendor sync UI + relay buyer correction (POP00101)

### DIFF
--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -832,3 +832,17 @@ export const RESOLVE_DEFICIENCY = gql`
     }
   }
 `;
+
+// ---------------------------------------------------------------------------
+// GP relay vendor sync
+// ---------------------------------------------------------------------------
+
+export const SYNC_GP_VENDORS = gql`
+  mutation SyncGpVendors($vendors: [GpVendorInput!]!) {
+    syncGpVendors(vendors: $vendors) {
+      matchedCount
+      matchedVendorNames
+      unmatchedGpVendorNames
+    }
+  }
+`;

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -581,12 +581,21 @@ export const GET_VENDORS = gql`
     vendors {
       id
       name
+      gpVendorId
       contactName
       email
       phone
       notes
       createdAt
       updatedAt
+    }
+  }
+`;
+
+export const GET_RELAY_CREDENTIAL = gql`
+  query GetRelayCredential {
+    relayCredential {
+      secret
     }
   }
 `;

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Card, CardContent, CardActionArea, Grid } from '@mui/m
 import SummarizeIcon from '@mui/icons-material/Summarize';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import StoreIcon from '@mui/icons-material/Store';
+import SyncIcon from '@mui/icons-material/Sync';
 import WarehouseIcon from '@mui/icons-material/Warehouse';
 import FolderIcon from '@mui/icons-material/Folder';
 import GroupIcon from '@mui/icons-material/Group';
@@ -48,6 +49,7 @@ const SUB_ROUTES = [
   { label: 'Project Purchasing Progress', path: '/app/admin/project-purchasing-progress', icon: <SummarizeIcon fontSize="large" /> },
   { label: 'Opening Status', path: '/app/admin/opening-status', icon: <VisibilityIcon fontSize="large" /> },
   { label: 'Vendors', path: '/app/admin/vendors', icon: <StoreIcon fontSize="large" /> },
+  { label: 'GP Vendor Sync', path: '/app/admin/gp-vendor-sync', icon: <SyncIcon fontSize="large" /> },
   { label: 'Warehouses', path: '/app/admin/warehouses', icon: <WarehouseIcon fontSize="large" /> },
   { label: 'Projects', path: '/app/admin/projects', icon: <FolderIcon fontSize="large" /> },
   { label: 'User Management', path: '/app/admin/users', icon: <GroupIcon fontSize="large" /> },

--- a/frontend/src/modules/admin/GpVendorSyncPage.tsx
+++ b/frontend/src/modules/admin/GpVendorSyncPage.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  Stack,
+  Typography,
+  Chip,
+  Alert,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+  FormControl,
+  InputLabel,
+  CircularProgress,
+} from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import SyncIcon from '@mui/icons-material/Sync';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { GET_VENDORS } from '../../graphql/queries';
+import { SYNC_GP_VENDORS } from '../../graphql/mutations';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import { checkRelayHealth, getRelayVendors, type RelayHealth } from '../../relay/relayClient';
+
+interface Vendor {
+  id: string;
+  name: string;
+  gpVendorId: string | null;
+}
+
+interface SyncResult {
+  matchedCount: number;
+  matchedVendorNames: string[];
+  unmatchedGpVendorNames: string[];
+}
+
+const COMPANIES = ['TUBC', 'TUCSH'];
+
+export default function GpVendorSyncPage() {
+  const { isAdmin } = useIdentity();
+  const { showToast } = useToast();
+  const [company, setCompany] = useState('TUBC');
+  const [health, setHealth] = useState<RelayHealth | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [result, setResult] = useState<SyncResult | null>(null);
+
+  const { data, loading, refetch } = useQuery<{ vendors: Vendor[] }>(GET_VENDORS);
+  const vendors = useMemo(() => data?.vendors ?? [], [data]);
+
+  const [syncGpVendors] = useMutation<{ syncGpVendors: SyncResult }>(SYNC_GP_VENDORS);
+
+  const refreshHealth = useCallback(async () => {
+    setHealth(await checkRelayHealth());
+  }, []);
+
+  useEffect(() => {
+    void refreshHealth();
+  }, [refreshHealth]);
+
+  const handleSync = useCallback(async () => {
+    setSyncing(true);
+    setResult(null);
+    try {
+      const relayVendors = await getRelayVendors(company);
+      const payload = relayVendors.map((v) => ({ gpVendorId: v.vendor_id, vendorName: v.vendor_name }));
+      const res = await syncGpVendors({ variables: { vendors: payload } });
+      const r = res.data?.syncGpVendors ?? null;
+      setResult(r);
+      await refetch();
+      showToast(`Linked ${r?.matchedCount ?? 0} vendor(s) from GP`, 'success');
+    } catch (e) {
+      showToast((e as Error).message, 'error');
+    } finally {
+      setSyncing(false);
+    }
+  }, [company, syncGpVendors, refetch, showToast]);
+
+  if (!isAdmin) {
+    return <Alert severity="warning">You need the Admin/Manager role to sync GP vendors.</Alert>;
+  }
+
+  const columns: GridColDef<Vendor>[] = [
+    { field: 'name', headerName: 'Vendor', flex: 1, minWidth: 220 },
+    {
+      field: 'gpVendorId',
+      headerName: 'GP Vendor ID',
+      width: 200,
+      renderCell: (params) =>
+        params.value ? (
+          <Chip size="small" color="success" label={params.value as string} />
+        ) : (
+          <Chip size="small" variant="outlined" label="not linked" />
+        ),
+    },
+  ];
+
+  const relayConnected = health?.ok === true;
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        GP Vendor Sync
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Reads vendors from Microsoft GP (PM00200) via the on-prem relay and links them to UC Nexus vendors by name. A
+        linked GP Vendor ID is required before a vendor can be used on a GP purchase order.
+      </Typography>
+
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
+        {health === null ? (
+          <Chip size="small" label="checking relay…" />
+        ) : relayConnected ? (
+          <Chip size="small" color="success" label={`GP relay connected (v${health.version})`} />
+        ) : (
+          <Chip size="small" color="error" label="GP relay not detected on this machine" />
+        )}
+        <FormControl size="small" sx={{ minWidth: 140 }}>
+          <InputLabel id="gp-company-label">Company</InputLabel>
+          <Select
+            labelId="gp-company-label"
+            label="Company"
+            value={company}
+            onChange={(e: SelectChangeEvent) => setCompany(e.target.value)}
+          >
+            {COMPANIES.map((c) => (
+              <MenuItem key={c} value={c}>
+                {c}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          startIcon={syncing ? <CircularProgress size={16} /> : <SyncIcon />}
+          disabled={!relayConnected || syncing}
+          onClick={() => void handleSync()}
+        >
+          {syncing ? 'Syncing…' : 'Sync from GP'}
+        </Button>
+        <Button size="small" onClick={() => void refreshHealth()}>
+          Recheck relay
+        </Button>
+      </Stack>
+
+      {!relayConnected && health !== null && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          The GP relay must be running on this workstation (127.0.0.1:7321) to sync. Start it, then &quot;Recheck
+          relay&quot;.
+        </Alert>
+      )}
+
+      {result && (
+        <Alert severity={result.unmatchedGpVendorNames.length ? 'warning' : 'success'} sx={{ mb: 2 }}>
+          Linked {result.matchedCount} vendor(s).{' '}
+          {result.unmatchedGpVendorNames.length
+            ? `${result.unmatchedGpVendorNames.length} GP vendor(s) had no UC Nexus match: ${result.unmatchedGpVendorNames
+                .slice(0, 10)
+                .join(', ')}${result.unmatchedGpVendorNames.length > 10 ? '…' : ''}`
+            : 'All GP vendors matched a UC Nexus vendor.'}
+        </Alert>
+      )}
+
+      <div style={{ height: 520, width: '100%' }}>
+        <DataGrid
+          rows={vendors}
+          columns={columns}
+          loading={loading}
+          getRowId={(r) => r.id}
+          density="compact"
+          disableRowSelectionOnClick
+        />
+      </div>
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -5,6 +5,7 @@ import ProjectPurchasingProgressPage from './ProjectPurchasingProgressPage';
 import OpeningStatusTab from './OpeningStatusTab';
 import UserManagementPage from './UserManagementPage';
 import VendorsPage from './VendorsPage';
+import GpVendorSyncPage from './GpVendorSyncPage';
 import WarehousesPage from './WarehousesPage';
 import ProjectsPage from './ProjectsPage';
 import LocationCleanupPage from './LocationCleanupPage';
@@ -27,6 +28,7 @@ export default function AdminModule() {
       <Route path="project-purchasing-progress" element={<AdminSubLayout><ProjectPurchasingProgressPage /></AdminSubLayout>} />
       <Route path="opening-status" element={<AdminSubLayout><OpeningStatusTab /></AdminSubLayout>} />
       <Route path="vendors" element={<AdminSubLayout><VendorsPage /></AdminSubLayout>} />
+      <Route path="gp-vendor-sync" element={<AdminSubLayout><GpVendorSyncPage /></AdminSubLayout>} />
       <Route path="warehouses" element={<AdminSubLayout><WarehousesPage /></AdminSubLayout>} />
       <Route path="projects" element={<AdminSubLayout><ProjectsPage /></AdminSubLayout>} />
       <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />

--- a/frontend/src/relay/relayClient.ts
+++ b/frontend/src/relay/relayClient.ts
@@ -1,0 +1,125 @@
+// Client for the on-prem GP relay (http://localhost:7321 on the same workstation).
+//
+// The browser hop to the loopback relay is gated by Chrome Local Network Access from Chrome 142+:
+// every fetch sets `targetAddressSpace: "loopback"` (relaxes the https->http loopback mixed-content
+// block and requests the LNA permission). The bearer is fetched at runtime from the backend
+// (relayCredential) - it's never baked into the build.
+
+import client from '../apollo';
+import { GET_RELAY_CREDENTIAL } from '../graphql/queries';
+
+// The relay always binds 127.0.0.1:7321 on the same machine. Overridable for non-default setups.
+const RELAY_BASE = import.meta.env.VITE_RELAY_URL || 'http://localhost:7321';
+
+// `targetAddressSpace` (Chrome LNA) isn't in the standard DOM lib types yet.
+type LoopbackRequestInit = RequestInit & { targetAddressSpace?: 'loopback' | 'local' | 'public' };
+
+export class RelayError extends Error {
+  code: string;
+  constructor(message: string, code = 'relay_error') {
+    super(message);
+    this.name = 'RelayError';
+    this.code = code;
+  }
+}
+
+export interface RelayVendor {
+  vendor_id: string;
+  vendor_name: string;
+  vendor_class: string | null;
+  status: number;
+}
+
+export interface RelayHealth {
+  ok: boolean;
+  version?: string;
+}
+
+export type LoopbackPermission = PermissionState | 'unsupported';
+
+let cachedSecret: string | null = null;
+
+export function resetRelaySecretCache(): void {
+  cachedSecret = null;
+}
+
+async function getSecret(): Promise<string> {
+  if (cachedSecret) return cachedSecret;
+  const res = await client.query<{ relayCredential: { secret: string } }>({
+    query: GET_RELAY_CREDENTIAL,
+    fetchPolicy: 'no-cache',
+  });
+  const secret = res.data?.relayCredential?.secret;
+  if (!secret) throw new RelayError('no relay credential available for this user', 'no_credential');
+  cachedSecret = secret;
+  return secret;
+}
+
+function extractError(body: unknown, status: number): RelayError {
+  const detail = (body as { detail?: unknown })?.detail;
+  if (typeof detail === 'string') return new RelayError(detail);
+  if (Array.isArray(detail)) {
+    // FastAPI 422 validation errors
+    const msg = detail
+      .map((d) => (d as { msg?: string }).msg)
+      .filter(Boolean)
+      .join('; ');
+    return new RelayError(msg || `relay request failed (${status})`, 'validation_error');
+  }
+  if (detail && typeof detail === 'object') {
+    const d = detail as { error?: string; message?: string; error_description?: string };
+    return new RelayError(
+      d.message || d.error_description || d.error || `relay request failed (${status})`,
+      d.error || 'relay_error',
+    );
+  }
+  return new RelayError(`relay request failed (${status})`);
+}
+
+async function relayFetch(path: string, init: LoopbackRequestInit = {}, auth = true): Promise<Response> {
+  const headers = new Headers(init.headers);
+  if (auth) headers.set('Authorization', `Bearer ${await getSecret()}`);
+  const reqInit: LoopbackRequestInit = { ...init, headers, targetAddressSpace: 'loopback' };
+  try {
+    return await fetch(`${RELAY_BASE}${path}`, reqInit as RequestInit);
+  } catch (e) {
+    throw new RelayError(`GP relay not reachable at ${RELAY_BASE}: ${(e as Error).message}`, 'relay_unreachable');
+  }
+}
+
+export async function checkRelayHealth(): Promise<RelayHealth> {
+  try {
+    const r = await relayFetch('/health', {}, false);
+    if (!r.ok) return { ok: false };
+    const body = (await r.json()) as { status?: string; version?: string };
+    return { ok: body.status === 'ok', version: body.version };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function getRelayVendors(company: string): Promise<RelayVendor[]> {
+  const r = await relayFetch(`/vendors?company=${encodeURIComponent(company)}`);
+  const body = await r.json();
+  if (!r.ok) throw extractError(body, r.status);
+  return (body as { vendors: RelayVendor[] }).vendors;
+}
+
+export async function getRelayBuyers(company: string): Promise<string[]> {
+  const r = await relayFetch(`/buyers?company=${encodeURIComponent(company)}`);
+  const body = await r.json();
+  if (!r.ok) throw extractError(body, r.status);
+  return (body as { buyers: string[] }).buyers;
+}
+
+export async function getLoopbackPermissionState(): Promise<LoopbackPermission> {
+  try {
+    const permissions = navigator.permissions as unknown as {
+      query: (d: { name: string }) => Promise<PermissionStatus>;
+    };
+    const status = await permissions.query({ name: 'loopback-network' });
+    return status.state;
+  } catch {
+    return 'unsupported';
+  }
+}

--- a/localhost relay/README.md
+++ b/localhost relay/README.md
@@ -63,8 +63,9 @@ endpoints
 - `GET /health` — liveness, no auth
 - `GET /info` — config + read-only SQL identity + the workstation `hostname` and the `resolved_buyer` that hostname maps to, bearer auth
 - `GET /vendors` — active PM00200 vendors (VENDORID / VENDNAME / class / status) for the vendor sync, bearer auth. takes `?company=` (defaults to `default_company`)
+- `GET /buyers` — registered GP buyers (`POP00101`) for the Create PO buyer dropdown, bearer auth. `?company=` like `/vendors`. eConnect validates `BUYERID` against this, so the UI must pick from it
 - `POST /po/next-number` — reserve a PO number via `taGetPONextNumber`, bearer auth
-- `POST /po` — create a PO end-to-end via the 5-step orchestration, bearer auth. `buyer_id` is optional in the request — when omitted the relay fills `BUYERID` from the workstation via `[gp.buyers]`, resolving `by_host` (explicit map) → `by_login` → `use_hostname` (the device's own traceable name) → `default`
+- `POST /po` — create a PO end-to-end via the 5-step orchestration, bearer auth. the request's `buyer_id` (picked from `/buyers`) is validated against `POP00101`; if omitted, falls back to `[gp.buyers]` (`by_host` → `by_login` → `default`). a device hostname is NOT a registered buyer, so it can't be used as one
 - `POST /receipt` — receive against a PO (taPopRcptLineInsert xN then taPopRcptHdrInsert, autocosted), and for a company mapped in `[gp.custom_db]` also writes the matching `WHRECLINE101` rows (the custom warehouse table the dashboards read) in the same transaction. needs a `rack_location` per line. bearer auth
 
 browser hop (the cloud frontend → `http://localhost:7321` call) is governed by Chrome Local Network Access from Chrome 142: the frontend fetch must set `targetAddressSpace: "loopback"` and the user grants a one-time loopback permission prompt (or IT pre-grants it via enterprise policy). that is a client-side gate — the relay needs no LNA server header. the relay does echo the legacy `Access-Control-Allow-Private-Network: true` on the preflight for stragglers on a pre-LNA Chrome, but it is not the mechanism.

--- a/localhost relay/config.example.toml
+++ b/localhost relay/config.example.toml
@@ -10,7 +10,7 @@ shared_secret = "REPLACE_ME_RANDOM_TOKEN"
 
 [cors]
 allowed_origins = [
-  "https://ucnexus-frontend-production.up.railway.app",
+  "https://frontend-production-34fc.up.railway.app",
   "http://localhost:5173",
   "http://localhost:8000",
 ]
@@ -39,21 +39,17 @@ UBC = "PMUBC"
 UCSH = "PMUCSH"
 
 [gp.buyers]
-# GP BUYERID is free text in POP10100 (no buyer-master to validate against). the relay fills it from
-# the WORKSTATION when the /po request omits buyer_id - the machine that knows the device is the relay.
-# company device names are traceable to individuals via an internal system, so the device name itself
-# is a valid buyer handle. resolution order:
-#   by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
-# matching is case-insensitive; the result is truncated to GP's char(15) BUYERID width.
-use_hostname = true   # use socket.gethostname() as the buyer on every workstation, no per-host config
-default = "mira"      # final fallback if use_hostname is off / the hostname is empty (TUBC test = "mira")
+# Normally the Create PO dropdown sends the buyer (picked from GET /buyers = GP's registered buyers in
+# POP00101). [gp.buyers] is only the FALLBACK when a /po omits buyer_id. The value MUST be a REGISTERED
+# GP buyer - eConnect taPoHdr rejects an unregistered BUYERID (error 269); a device hostname is NOT a
+# registered buyer. Resolution: by_host -> by_login -> default. Matching is case-insensitive.
+default = "mira"   # fallback registered buyer (TUBC registered buyers: donr, mira)
 
 [gp.buyers.by_host]
-# explicit override for a machine whose name should NOT be the buyer:
-# WORKSTATION-HOSTNAME = "Buyer Name"
+# WORKSTATION-HOSTNAME = "registered-buyer"   # device hostname -> a registered GP buyer
 
 [gp.buyers.by_login]
-# "DOMAIN\\login" = "Buyer Name"
+# "DOMAIN\\login" = "registered-buyer"
 
 [logging]
 level = "INFO"

--- a/localhost relay/src/ucnexus_relay/buyers.py
+++ b/localhost relay/src/ucnexus_relay/buyers.py
@@ -1,15 +1,12 @@
-"""Resolve the GP BUYERID from the workstation identity.
+"""Fallback resolution of the GP BUYERID when a /po omits buyer_id.
 
-GP has no buyer-master at this customer — BUYERID is a free-text human name written straight to
-POP10100 (verified in the GP discovery: "Buyers are free-text human names ... No buyer-master
-enforcement"). So there is nothing to validate against; the relay just maps the device to a name.
+Normally the Create PO dropdown sends a buyer_id picked from GP's registered buyers (POP00101, via
+GET /buyers). This is just the fallback when the request omits it. The value MUST be a REGISTERED GP
+buyer: eConnect taPoHdr validates BUYERID against POP00101 and rejects an unregistered one (error
+269) - a device hostname is NOT a registered buyer, which is why there's no use_hostname option.
 
-The relay fills the buyer when the /po request omits it, because the machine that knows the device
-is the relay, not the cloud frontend. Company device names are traceable to individuals via an
-internal system, so the device name itself is a valid buyer handle. Resolution order:
-  by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
-Matching is case-insensitive (Windows hostnames/logins are). The result is truncated to GP's
-char(15) BUYERID width.
+Resolution order: by_host (device hostname -> registered buyer) -> by_login (SSPI login -> registered
+buyer) -> default. Matching is case-insensitive. The result is truncated to GP's char(15) width.
 """
 
 from .config import BuyersCfg
@@ -24,8 +21,6 @@ def resolve_buyer(cfg: BuyersCfg, hostname: str, login: str | None = None) -> st
     if not buyer and login:
         by_login = {k.upper(): v for k, v in cfg.by_login.items()}
         buyer = by_login.get(login.upper())
-    if not buyer and cfg.use_hostname and hostname:
-        buyer = hostname  # the device name is itself a traceable buyer identity
     if not buyer:
         buyer = cfg.default
     if buyer:

--- a/localhost relay/src/ucnexus_relay/config.py
+++ b/localhost relay/src/ucnexus_relay/config.py
@@ -34,15 +34,13 @@ class SqlCfg(BaseModel):
 
 
 class BuyersCfg(BaseModel):
-    # GP BUYERID is free text written to POP10100 (no buyer-master to validate against). the relay
-    # fills it from the WORKSTATION when the /po request omits buyer_id, because the machine that knows
-    # the device is the relay. company device names are traceable to individuals via an internal system,
-    # so the device name itself is a valid buyer handle. resolution order:
-    #   by_host (explicit map) -> by_login (SSPI login) -> use_hostname (the device's own name) -> default.
+    # Fallback buyer when the Create PO request omits buyer_id (normally the UI sends one picked from
+    # GET /buyers). The value MUST be a REGISTERED GP buyer (POP00101) - eConnect taPoHdr rejects an
+    # unregistered BUYERID (error 269). A device hostname is NOT a registered buyer, so there's no
+    # use_hostname option. Resolution order: by_host -> by_login -> default.
     default: str | None = None
-    use_hostname: bool = False     # use socket.gethostname() as the buyer when nothing else maps
-    by_host: dict[str, str] = {}   # device hostname -> buyer name (explicit override)
-    by_login: dict[str, str] = {}  # SQL/SSPI login -> buyer name
+    by_host: dict[str, str] = {}   # device hostname -> registered buyer
+    by_login: dict[str, str] = {}  # SQL/SSPI login -> registered buyer
 
 
 class GpCfg(BaseModel):

--- a/localhost relay/src/ucnexus_relay/econnect.py
+++ b/localhost relay/src/ucnexus_relay/econnect.py
@@ -378,6 +378,16 @@ def list_vendors(conn, *, active_only: bool = True) -> list[dict]:
     ]
 
 
+def list_buyers(conn) -> list[str]:
+    """Registered GP buyer IDs from the buyer master POP00101. eConnect taPoHdr validates BUYERID against
+    this and rejects an unregistered buyer (error 269), so /po pre-checks against this list and the
+    Create PO buyer dropdown is populated from it. (A device hostname is NOT a registered buyer.)"""
+    rows = conn.cursor().execute(
+        "SELECT RTRIM(BUYERID) AS b FROM dbo.POP00101 WHERE BUYERID <> '' ORDER BY BUYERID"
+    ).fetchall()
+    return [r.b for r in rows]
+
+
 def create_receipt_header(conn, *, receipt_number, po_number, vendor_id, receipt_date, batch_number, subtotal) -> None:
     sql = """
     DECLARE @err int = 0;

--- a/localhost relay/src/ucnexus_relay/main.py
+++ b/localhost relay/src/ucnexus_relay/main.py
@@ -126,6 +126,19 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=502, detail={"error": "sql_error", "message": str(e)})
         return models.VendorsResponse(company=company, vendors=[models.VendorOut(**r) for r in rows])
 
+    @app.get("/buyers", response_model=models.BuyersResponse)
+    def gp_buyers(company: str | None = None, _=Depends(auth.verify_token)):
+        """Registered GP buyers (POP00101) for the Create PO buyer dropdown. eConnect validates BUYERID
+        against this, so the UI must pick from it (a device hostname is not a registered buyer)."""
+        company = company or get_settings().gp.default_company
+        _check_company(company)
+        try:
+            with db.get_read_connection(company) as conn:
+                ids = econnect.list_buyers(conn)
+        except pyodbc.Error as e:
+            raise HTTPException(status_code=502, detail={"error": "sql_error", "message": str(e)})
+        return models.BuyersResponse(company=company, buyers=ids)
+
     @app.post("/po/next-number")
     def next_number(request: models.NextNumberRequest, _=Depends(auth.verify_token)):
         _check_company(request.company)
@@ -151,9 +164,9 @@ def create_app() -> FastAPI:
         try:
             with db.get_connection(request.company) as conn:
                 try:
-                    # 0. buyer: the frontend doesn't send one — the relay fills BUYERID from the
-                    #    workstation (the machine that knows the device is the relay). by_host needs no
-                    #    DB; only read the SSPI login if a by_login map is configured.
+                    # 0. buyer: the Create PO dropdown sends a buyer_id picked from GP's registered
+                    #    buyers (POP00101, see GET /buyers). If omitted, fall back to the [gp.buyers]
+                    #    config (by_host -> by_login -> default). The value MUST be a registered GP buyer.
                     buyer_id = h.buyer_id
                     if not buyer_id:
                         bcfg = get_settings().gp.buyers
@@ -166,10 +179,23 @@ def create_app() -> FastAPI:
                                 status_code=400,
                                 detail={
                                     "error": "buyer_unresolved",
-                                    "message": "could not resolve a GP buyer for this workstation "
-                                               f"({socket.gethostname()}); set [gp.buyers] default or map this device",
+                                    "message": "no buyer_id sent and none resolved from [gp.buyers]; "
+                                               "pick a buyer from GET /buyers",
                                 },
                             )
+
+                    # validate against GP's buyer master: eConnect taPoHdr rejects an unregistered BUYERID
+                    # with error 269, so give a clear error here instead.
+                    registered = econnect.list_buyers(conn)
+                    if buyer_id not in registered:
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "error": "buyer_not_registered",
+                                "message": f"buyer '{buyer_id}' is not a registered GP buyer for "
+                                           f"{request.company} (registered: {registered})",
+                            },
+                        )
 
                     # 1. PO number: use UC Nexus's own number (e.g. 'ucnexus...') if supplied,
                     #    else reserve GP's next 'PO' number via taGetPONextNumber.

--- a/localhost relay/src/ucnexus_relay/models.py
+++ b/localhost relay/src/ucnexus_relay/models.py
@@ -115,3 +115,8 @@ class VendorOut(BaseModel):
 class VendorsResponse(BaseModel):
     company: str
     vendors: list[VendorOut]
+
+
+class BuyersResponse(BaseModel):
+    company: str
+    buyers: list[str]  # registered GP buyer IDs (POP00101) for the Create PO buyer dropdown

--- a/localhost relay/tests/test_buyers.py
+++ b/localhost relay/tests/test_buyers.py
@@ -31,23 +31,3 @@ def test_none_when_nothing_matches_and_no_default():
 def test_truncates_to_char_15():
     cfg = BuyersCfg(by_host={"H": "ThisNameIsWayTooLong"})
     assert resolve_buyer(cfg, "H") == "ThisNameIsWayTo"  # GP BUYERID is char(15)
-
-
-def test_use_hostname_when_enabled_and_unmapped():
-    cfg = BuyersCfg(use_hostname=True)
-    assert resolve_buyer(cfg, "Tagging3W10") == "Tagging3W10"
-
-
-def test_use_hostname_off_falls_through_to_default():
-    cfg = BuyersCfg(use_hostname=False, default="fallback")
-    assert resolve_buyer(cfg, "Tagging3W10") == "fallback"
-
-
-def test_by_host_overrides_use_hostname():
-    cfg = BuyersCfg(use_hostname=True, by_host={"Tagging3W10": "Real Person"})
-    assert resolve_buyer(cfg, "Tagging3W10") == "Real Person"
-
-
-def test_use_hostname_truncated_to_char_15():
-    cfg = BuyersCfg(use_hostname=True)
-    assert resolve_buyer(cfg, "VeryLongHostnameABCDEF") == "VeryLongHostnam"  # 15 chars

--- a/localhost relay/tests/test_vendors.py
+++ b/localhost relay/tests/test_vendors.py
@@ -13,3 +13,11 @@ def test_vendors_requires_token():
 
 def test_vendors_rejects_bad_token():
     assert client.get("/vendors", headers={"Authorization": "Bearer wrong"}).status_code == 401
+
+
+def test_buyers_requires_token():
+    assert client.get("/buyers").status_code == 401
+
+
+def test_buyers_rejects_bad_token():
+    assert client.get("/buyers", headers={"Authorization": "Bearer wrong"}).status_code == 401


### PR DESCRIPTION
the vendor-sync half of the nexus<->relay work, plus the buyer correction the write-hop test turned up. backend (gp_vendor_id + syncGpVendors) already landed in #168; this wires the frontend + fixes the relay buyer handling.

what the write-hop proof found (real PO0000045 created on TUBC): GP eConnect DOES validate BUYERID against the buyer master POP00101 - the "buyers are free-text, no master" assumption was wrong. a device hostname is not a registered buyer, so use_hostname could only ever fail. TUBC's registered buyers are donr, mira.

relay (localhost relay/):
- GET /buyers reads the registered buyers from POP00101 (for the Create PO buyer dropdown), like GET /vendors
- /po validates the buyer against POP00101 and returns a clear "not a registered GP buyer" error instead of the raw eConnect 269
- dropped use_hostname (a hostname can't be a registered buyer); resolution is now by_host -> by_login -> default, and the buyer is normally sent by the UI
- fixed the [cors] allowed origin to the live frontend (frontend-production-34fc); the stale one would have failed the browser preflight

frontend:
- relayClient module: typed wrappers over the relay with targetAddressSpace:"loopback" on every fetch, the bearer fetched at runtime from relayCredential (never baked into the build), loopback-permission + presence detection, and relay error mapping
- new admin screen "GP Vendor Sync": shows the relay connection state, a company selector, a "Sync from GP" button that reads PM00200 via the relay and posts syncGpVendors, and a grid of UC Nexus vendors with their linked GP Vendor ID (or "not linked"). unmatched GP vendors are surfaced for manual mapping
- gpVendorId added to the vendors query

the browser hop itself is already proven live end to end against TUBC: read (193 vendors), buyers (donr/mira), and write (PO0000045) all went through from the deployed frontend in Chrome 149 to the relay to GP.
