### PR TITLE
Create PO create-in-both (GP-first)

### DIFF
--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -439,6 +439,17 @@ export const CREATE_SHIPMENT_RETURN = gql`
   }
 `;
 
+export const RECORD_PO_GP_SYNC = gql`
+  mutation RecordPoGpSync($poId: ID!, $gpSyncStatus: GpSyncStatus!, $poNumber: String) {
+    recordPoGpSync(poId: $poId, gpSyncStatus: $gpSyncStatus, poNumber: $poNumber) {
+      id
+      poNumber
+      status
+      gpSyncStatus
+    }
+  }
+`;
+
 export const CREATE_PO = gql`
   mutation CreatePO($input: CreatePOInput!) {
     createPo(input: $input) {

--- a/frontend/src/modules/po/CreatePODialog.tsx
+++ b/frontend/src/modules/po/CreatePODialog.tsx
@@ -1,7 +1,9 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
+  Alert,
   Box,
   Button,
+  Chip,
   IconButton,
   MenuItem,
   Stack,
@@ -14,9 +16,16 @@ import { useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import VendorSelect from '../../components/VendorSelect';
 import { useToast } from '../../components/Toast';
-import { CREATE_PO } from '../../graphql/mutations';
-import { GET_PROJECTS } from '../../graphql/queries';
+import { CREATE_PO, RECORD_PO_GP_SYNC } from '../../graphql/mutations';
+import { GET_PROJECTS, GET_VENDORS } from '../../graphql/queries';
 import type { Project } from '../../types/project';
+import {
+  checkRelayHealth,
+  getRelayBuyers,
+  postRelayPo,
+  type RelayHealth,
+  type RelayPoRequest,
+} from '../../relay/relayClient';
 
 // --- Types ---
 
@@ -28,6 +37,13 @@ interface LineItemRow {
   unitCost: string;
   classification: string;
   orderAs: string;
+}
+
+interface VendorOption {
+  id: string;
+  name: string;
+  gpVendorId: string | null;
+  contactName: string | null;
 }
 
 const EMPTY_LINE_ITEM: Omit<LineItemRow, 'key'> = {
@@ -45,6 +61,26 @@ const CLASSIFICATIONS = [
   { value: 'SHOP_HARDWARE', label: 'Shop Hardware' },
 ];
 
+// GP companies the relay is allowed to write to (sandboxes for the POC).
+const COMPANIES = ['TUBC', 'TUCSH'];
+
+// Issue #121 cost codes (the two DO-NOT-USE rows excluded). The 3rd segment (Cost_Element) defaults to 2.
+const COST_CODES = [
+  { value: '210-200', label: '210-200 · Supply Hardware' },
+  { value: '220-000', label: '220-000 · Supply Washroom Accessories' },
+  { value: '230-000', label: '230-000 · Supply of Entrance Mats' },
+  { value: '240-000', label: '240-000 · Supply of Misc. Spec. Material' },
+  { value: '250-000', label: '250-000 · Supply of ADO' },
+  { value: '310-000', label: '310-000 · Supply HM Frames & Screens' },
+  { value: '320-000', label: '320-000 · Supply Hollow Metal Doors' },
+  { value: '330-000', label: '330-000 · Supply Wood Doors & Frames' },
+  { value: '340-000', label: '340-000 · Supply Glazing' },
+  { value: '350-000', label: '350-000 · Specialty Doors & Frames' },
+  { value: '360-000', label: '360-000 · Supply of Washroom Partitions' },
+  { value: '370-000', label: '370-000 · Supply of Lockers' },
+];
+const COST_ELEMENT = '2';
+
 // --- Props ---
 
 interface CreatePODialogProps {
@@ -60,18 +96,58 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
   const { showToast } = useToast();
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
   const projects = projectsData?.projects ?? [];
+  const { data: vendorsData } = useQuery<{ vendors: VendorOption[] }>(GET_VENDORS);
 
   // Form state
   const [projectId, setProjectId] = useState(defaultProjectId ?? '');
   const [vendorId, setVendorId] = useState<string | null>(null);
   const [notes, setNotes] = useState('');
+  const [company, setCompany] = useState('TUBC');
+  const [buyerId, setBuyerId] = useState('');
+  const [costCode, setCostCode] = useState('');
   const [nextKey, setNextKey] = useState(2);
-  const [lineItems, setLineItems] = useState<LineItemRow[]>([
-    { key: 1, ...EMPTY_LINE_ITEM },
-  ]);
+  const [lineItems, setLineItems] = useState<LineItemRow[]>([{ key: 1, ...EMPTY_LINE_ITEM }]);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  // GP relay state
+  const [relayHealth, setRelayHealth] = useState<RelayHealth | null>(null);
+  const [buyers, setBuyers] = useState<string[]>([]);
+  const [gpBusy, setGpBusy] = useState(false);
+
   const [createPO, { loading }] = useMutation(CREATE_PO);
+  const [recordPoGpSync] = useMutation(RECORD_PO_GP_SYNC);
+
+  const selectedVendor = useMemo(
+    () => vendorsData?.vendors.find((v) => v.id === vendorId) ?? null,
+    [vendorsData, vendorId],
+  );
+  const selectedProject = useMemo(() => projects.find((p) => p.id === projectId) ?? null, [projects, projectId]);
+  const isJob = !!projectId && !!selectedProject;
+  const relayConnected = relayHealth?.ok === true;
+
+  // Check relay presence + load registered buyers for the chosen company while the dialog is open.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      const h = await checkRelayHealth();
+      if (cancelled) return;
+      setRelayHealth(h);
+      if (!h.ok) {
+        setBuyers([]);
+        return;
+      }
+      try {
+        const b = await getRelayBuyers(company);
+        if (!cancelled) setBuyers(b);
+      } catch {
+        if (!cancelled) setBuyers([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, company]);
 
   // --- Handlers ---
 
@@ -84,20 +160,13 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
     setLineItems((prev) => prev.filter((li) => li.key !== key));
   }, []);
 
-  const updateLineItem = useCallback(
-    (key: number, field: keyof Omit<LineItemRow, 'key'>, value: string) => {
-      setLineItems((prev) =>
-        prev.map((li) => (li.key === key ? { ...li, [field]: value } : li)),
-      );
-    },
-    [],
-  );
+  const updateLineItem = useCallback((key: number, field: keyof Omit<LineItemRow, 'key'>, value: string) => {
+    setLineItems((prev) => prev.map((li) => (li.key === key ? { ...li, [field]: value } : li)));
+  }, []);
 
   const validate = useCallback(() => {
     const errs: Record<string, string> = {};
-    if (lineItems.length === 0) {
-      errs.lineItems = 'At least one line item is required';
-    }
+    if (lineItems.length === 0) errs.lineItems = 'At least one line item is required';
     for (let i = 0; i < lineItems.length; i++) {
       const li = lineItems[i];
       if (!li.hardwareCategory.trim()) errs[`li_${i}_cat`] = 'Required';
@@ -108,14 +177,22 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
       if (isNaN(cost) || cost < 0) errs[`li_${i}_cost`] = 'Must be >= 0';
       if (!li.orderAs.trim()) errs[`li_${i}_orderAs`] = 'Required';
     }
+    // GP is mandatory: a PO that can't be created in GP isn't created at all.
+    if (!relayConnected) errs.gp = 'GP relay not detected on this machine - it must be running to create a PO';
+    if (!vendorId) errs.vendor = 'Select a vendor';
+    else if (!selectedVendor?.gpVendorId) errs.vendor = 'This vendor is not linked to GP yet (run GP Vendor Sync)';
+    if (!buyerId) errs.buyer = 'Select a buyer';
+    if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems]);
+  }, [lineItems, relayConnected, vendorId, selectedVendor, buyerId, isJob, costCode]);
 
   const handleReset = useCallback(() => {
     setProjectId(defaultProjectId ?? '');
     setVendorId(null);
     setNotes('');
+    setBuyerId('');
+    setCostCode('');
     setLineItems([{ key: 1, ...EMPTY_LINE_ITEM }]);
     setNextKey(2);
     setErrors({});
@@ -124,10 +201,35 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
 
-    const input = {
+    const gpCostCode = isJob ? `${costCode}-${COST_ELEMENT}` : null;
+    const today = new Date().toISOString().slice(0, 10);
+
+    const relayReq: RelayPoRequest = {
+      company,
+      header: {
+        vendor_id: selectedVendor!.gpVendorId!,
+        buyer_id: buyerId,
+        confirm_with: (selectedVendor?.contactName || buyerId).slice(0, 20),
+        doc_date: today,
+      },
+      lines: lineItems.map((li) => ({
+        item_number: (li.orderAs.trim() || li.productCode.trim()).slice(0, 30),
+        item_description: `${li.productCode.trim()} ${li.hardwareCategory.trim()}`.trim().slice(0, 100),
+        quantity: parseInt(li.orderedQuantity, 10),
+        unit_cost: parseFloat(li.unitCost),
+        location_code: 'VANCOUVER',
+        uofm: 'Each',
+        product_indicator: isJob ? 2 : 1,
+        job_number: isJob ? selectedProject!.projectId : null,
+        cost_code: gpCostCode,
+      })),
+    };
+
+    const ucInput = {
       projectId: projectId || null,
       vendorId: vendorId || null,
       notes: notes.trim() || null,
+      costCode: gpCostCode,
       lineItems: lineItems.map((li) => ({
         hardwareCategory: li.hardwareCategory.trim(),
         productCode: li.productCode.trim(),
@@ -138,16 +240,47 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
       })),
     };
 
+    setGpBusy(true);
+    let gpPoNumber: string | null = null;
     try {
-      await createPO({ variables: { input } });
-      showToast('Purchase order created successfully', 'success');
+      // GP first: if GP rejects it, nothing is created in UC Nexus.
+      const gpResp = await postRelayPo(relayReq);
+      gpPoNumber = gpResp.po_number;
+      // GP succeeded - now record it in UC Nexus and mark it SYNCED with GP's PO number.
+      const created = await createPO({ variables: { input: ucInput } });
+      const poId = (created.data as { createPo: { id: string } }).createPo.id;
+      await recordPoGpSync({ variables: { poId, gpSyncStatus: 'SYNCED', poNumber: gpPoNumber } });
+      showToast(`PO ${gpPoNumber} created in GP and UC Nexus`, 'success');
       onCreated();
       handleReset();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to create PO';
-      showToast(message, 'error');
+      if (!gpPoNumber) {
+        showToast(`GP did not accept the PO, so nothing was created: ${message}`, 'error');
+      } else {
+        showToast(`GP PO ${gpPoNumber} was created, but recording it in UC Nexus failed: ${message}`, 'error');
+      }
+    } finally {
+      setGpBusy(false);
     }
-  }, [validate, projectId, vendorId, notes, lineItems, createPO, showToast, onCreated, handleReset]);
+  }, [
+    validate,
+    isJob,
+    costCode,
+    company,
+    selectedVendor,
+    buyerId,
+    lineItems,
+    selectedProject,
+    projectId,
+    vendorId,
+    notes,
+    createPO,
+    recordPoGpSync,
+    showToast,
+    onCreated,
+    handleReset,
+  ]);
 
   const handleClose = useCallback(() => {
     handleReset();
@@ -156,13 +289,15 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
 
   // --- Render ---
 
+  const busy = loading || gpBusy;
+
   const actions = (
     <Stack direction="row" spacing={1}>
-      <Button onClick={handleClose} disabled={loading}>
+      <Button onClick={handleClose} disabled={busy}>
         Cancel
       </Button>
-      <Button variant="contained" onClick={handleSubmit} disabled={loading || lineItems.length === 0}>
-        {loading ? 'Creating...' : 'Create PO'}
+      <Button variant="contained" onClick={handleSubmit} disabled={busy || lineItems.length === 0}>
+        {gpBusy ? 'Creating in GP…' : loading ? 'Saving…' : 'Create PO'}
       </Button>
     </Stack>
   );
@@ -179,7 +314,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
           size="small"
           fullWidth
         >
-          <MenuItem value="">No Project</MenuItem>
+          <MenuItem value="">No Project (stock PO)</MenuItem>
           {projects.map((p) => (
             <MenuItem key={p.id} value={p.id}>
               {p.description || p.projectId}
@@ -187,7 +322,7 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
           ))}
         </TextField>
 
-        <VendorSelect value={vendorId} onChange={setVendorId} />
+        <VendorSelect value={vendorId} onChange={setVendorId} error={!!errors.vendor} helperText={errors.vendor} />
         <TextField
           label="Notes"
           value={notes}
@@ -200,6 +335,82 @@ export default function CreatePODialog({ open, onClose, onCreated, defaultProjec
           placeholder="Optional notes for this purchase order"
         />
       </Stack>
+
+      {/* GP purchase order (every PO is created in GP - it's the source of truth) */}
+      <Box sx={{ mb: 3, p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            GP purchase order
+          </Typography>
+          {relayHealth === null ? (
+            <Chip size="small" label="checking relay…" />
+          ) : relayConnected ? (
+            <Chip size="small" color="success" label={`relay connected (v${relayHealth.version})`} />
+          ) : (
+            <Chip size="small" color="error" label="GP relay not detected on this machine" />
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+          <TextField
+            select
+            label="GP company"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            size="small"
+            sx={{ minWidth: 140 }}
+          >
+            {COMPANIES.map((c) => (
+              <MenuItem key={c} value={c}>
+                {c}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="Buyer"
+            value={buyerId}
+            onChange={(e) => setBuyerId(e.target.value)}
+            size="small"
+            sx={{ minWidth: 180 }}
+            disabled={!relayConnected || buyers.length === 0}
+            error={!!errors.buyer}
+            helperText={errors.buyer}
+          >
+            {buyers.map((b) => (
+              <MenuItem key={b} value={b}>
+                {b}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label={isJob ? 'Cost code (required)' : 'Cost code (project POs)'}
+            value={costCode}
+            onChange={(e) => setCostCode(e.target.value)}
+            size="small"
+            sx={{ minWidth: 260 }}
+            disabled={!isJob}
+            error={!!errors.costCode}
+            helperText={errors.costCode}
+          >
+            {COST_CODES.map((c) => (
+              <MenuItem key={c.value} value={c.value}>
+                {c.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+        {errors.gp && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {errors.gp}
+          </Alert>
+        )}
+        {selectedVendor && !selectedVendor.gpVendorId && (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            {selectedVendor.name} is not linked to GP yet. Link it via Admin → GP Vendor Sync before creating a PO.
+          </Alert>
+        )}
+      </Box>
 
       {/* Line Items */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>

--- a/frontend/src/relay/relayClient.ts
+++ b/frontend/src/relay/relayClient.ts
@@ -112,6 +112,44 @@ export async function getRelayBuyers(company: string): Promise<string[]> {
   return (body as { buyers: string[] }).buyers;
 }
 
+export interface RelayPoLine {
+  item_number: string;
+  item_description: string;
+  quantity: number;
+  unit_cost: number;
+  location_code?: string;
+  uofm?: string;
+  product_indicator: number; // 1 non-inv, 2 job cost
+  job_number?: string | null;
+  cost_code?: string | null; // 'phase-step-element' e.g. '210-200-2'
+}
+
+export interface RelayPoRequest {
+  company: string;
+  header: { vendor_id: string; buyer_id: string; confirm_with: string; doc_date: string };
+  lines: RelayPoLine[];
+}
+
+export interface RelayPoResponse {
+  po_number: string;
+  company: string;
+  lines_created: number;
+  subtotal: string;
+  doc_date: string;
+  vendor_id: string;
+}
+
+export async function postRelayPo(req: RelayPoRequest): Promise<RelayPoResponse> {
+  const r = await relayFetch('/po', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  const body = await r.json();
+  if (!r.ok) throw extractError(body, r.status);
+  return body as RelayPoResponse;
+}
+
 export async function getLoopbackPermissionState(): Promise<LoopbackPermission> {
   try {
     const permissions = navigator.permissions as unknown as {


### PR DESCRIPTION
the create-in-both Create PO flow (spec step 5). backend (cost_code, gp_sync_status, recordPoGpSync) already landed in #168; this is the frontend orchestration.

GP is the source of truth, so a PO that can't be created in GP isn't created at all. the submit goes GP-first - it calls the relay /po first, and only after GP returns a PO number does the UC Nexus PO get created (and marked SYNCED with that number). if GP rejects it, nothing is created in UC Nexus.

the Create PO dialog gains a "GP purchase order" section:
- relay presence chip (connected / not detected)
- GP company selector (TUBC/TUCSH sandboxes for now)
- buyer dropdown, populated from the relay GET /buyers (the registered POP00101 buyers)
- cost-code dropdown from issue #121 (the two DO-NOT-USE rows excluded), required for a project PO
- a warning when the chosen vendor isn't GP-linked yet (no gpVendorId)

the GP field mapping on submit: vendor_id = vendor.gpVendorId, buyer_id from the dropdown, per line product_indicator 2 + job_number = project.projectId + cost_code for a project PO (1 / no job for a stock PO), item_number = orderAs or productCode, doc_date = today.

orchestration + failure modes:
- relay /po succeeds -> createPo (DRAFT, carrying cost_code) -> recordPoGpSync(SYNCED, poNumber). toast shows the GP PO number.
- relay /po fails -> nothing created in UC Nexus, error surfaced.
- relay /po succeeds but the UC Nexus record fails -> the GP PO number is surfaced so it's recoverable (GP is source of truth, so this is the acceptable edge).

new relayClient.postRelayPo + RECORD_PO_GP_SYNC mutation document. validation blocks submit when the relay is down, the vendor isn't GP-linked, or no buyer is set.
