### PR TITLE
PO GP sync follow-ups: SYNCED -> ORDERED + gpSyncStatus chip

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -105,14 +105,17 @@ def record_gp_sync_result(
     po_number: str | None = None,
 ) -> PurchaseOrder:
     """Record the outcome of a relay GP push: GP's returned PONUMBER (on success) and the sync status.
-    The PO status transition (DRAFT -> ORDERED) is driven by the existing PO status flow, not here, so
-    this stays a pure record of the GP-side result that the create-in-both orchestration calls."""
+    On SYNCED the PO is now a real GP purchase order, so a DRAFT advances to ORDERED (mirroring
+    mark_po_as_ordered's preconditions: po_number + vendor present)."""
     po = session.get(PurchaseOrder, po_id)
     if po is None:
         raise NotFoundError(f"Purchase order {po_id} not found")
     po.gp_sync_status = gp_sync_status
     if po_number is not None:
         po.po_number = po_number.strip() or None
+    if gp_sync_status == GpSyncStatus.SYNCED and po.status == POStatus.DRAFT and po.po_number and po.vendor_id:
+        po.status = POStatus.ORDERED
+        po.ordered_at = datetime.utcnow()
     session.flush()
     return po
 

--- a/backend/tests/test_relay_gp_fields.py
+++ b/backend/tests/test_relay_gp_fields.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from app.models.enums import GpSyncStatus
+from app.models.enums import GpSyncStatus, POStatus
 from app.models.vendor import Vendor
 from app.repositories import po_repository, vendor_repository
 
@@ -57,3 +57,5 @@ def test_record_gp_sync_result_sets_status_and_po_number(db_session):
     db_session.refresh(po)
     assert po.gp_sync_status == GpSyncStatus.SYNCED
     assert po.po_number == "PO123456"
+    assert po.status == POStatus.ORDERED  # SYNCED advances a DRAFT to ORDERED (it's a real GP PO now)
+    assert po.ordered_at is not None

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -74,6 +74,7 @@ export const GET_PURCHASE_ORDERS = gql`
       requestNumber
       projectId
       status
+      gpSyncStatus
       vendor {
         id
         name

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -97,6 +97,7 @@ export interface PurchaseOrder {
   requestNumber: string;
   projectId: string | null;
   status: string;
+  gpSyncStatus: string;
   vendor: VendorRef | null;
   vendorQuoteNumber: string | null;
   notes: string | null;
@@ -472,11 +473,19 @@ function POTableRow({ po, expanded, onToggle, onOpen }: POTableRowProps) {
           )}
         </TableCell>
         <TableCell sx={dataCellSx} onClick={onOpen}>
-          <Chip
-            label={formatStatus(po.status)}
-            color={STATUS_CHIP_COLOR[po.status] ?? 'default'}
-            size="small"
-          />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+            <Chip
+              label={formatStatus(po.status)}
+              color={STATUS_CHIP_COLOR[po.status] ?? 'default'}
+              size="small"
+            />
+            {po.gpSyncStatus === 'SYNCED' && (
+              <Chip label="GP" color="success" size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+            )}
+            {po.gpSyncStatus === 'FAILED' && (
+              <Chip label="GP failed" color="error" size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+            )}
+          </Box>
         </TableCell>
         <TableCell sx={dataCellSx} onClick={onOpen}>
           {po.vendor?.name || '-'}


### PR DESCRIPTION
two small follow-ups from the create-in-both Create PO work (#170).

a SYNCED PO is now a real GP purchase order, so recordPoGpSync advances a DRAFT to ORDERED (mirroring mark_po_as_ordered's preconditions - po_number + vendor present) and stamps ordered_at. before this a PO created through GP stayed labelled DRAFT despite having a live GP PO number.

the PO list now shows a small GP chip next to the status: "GP" (green) when gpSyncStatus is SYNCED, "GP failed" (red) when FAILED, nothing for a UC-Nexus-only PO. gpSyncStatus is added to the purchaseOrders query.
