### PR TITLE
docs: fernet-over-AES-GCM rationale note for relay crypto

### DIFF
--- a/localhost relay/docs/cryptography/why we're using fernet (im sorry).txt
+++ b/localhost relay/docs/cryptography/why we're using fernet (im sorry).txt
@@ -1,0 +1,1 @@
+https://soatok.blog/2020/05/13/why-aes-gcm-sucks/


### PR DESCRIPTION
adds a short note under localhost relay/docs/cryptography/ recording why the relay uses fernet for symmetric encryption rather than AES-GCM. the file is a one-line pointer to soatok's "why AES-GCM sucks" writeup, kept as a rationale breadcrumb for anyone revisiting the relay crypto choice later.