### PR TITLE
fix(receiving): show the real received-unit count on the success screen

### DIFF
--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -110,6 +110,10 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   const [receiveQuantities, setReceiveQuantities] = useState<Record<string, number>>({});
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [succeeded, setSucceeded] = useState(false);
+  // Count of units received, captured at success time. Held in state because the success screen renders
+  // after receiveQuantities is cleared (so a committed PO can't be re-posted), which would otherwise make
+  // the live totalItemsToReceive read 0.
+  const [receivedCount, setReceivedCount] = useState(0);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [poDetailsMap, setPoDetailsMap] = useState<Record<string, PODetails>>({});
   const [poDetailsLoading, setPoDetailsLoading] = useState(false);
@@ -499,6 +503,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
       return;
     }
 
+    setReceivedCount(totalItemsToReceive);
     showToast(`Receive completed successfully. ${totalItemsToReceive} items added to inventory.`, 'success');
     setSucceeded(true);
   }, [
@@ -726,7 +731,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         )}
         {succeeded && (
           <Alert severity="success" sx={{ mb: 2 }}>
-            Receive completed successfully! {totalItemsToReceive} items added to inventory.
+            Receive completed successfully! {receivedCount} items added to inventory.
           </Alert>
         )}
         {mutationError && (


### PR DESCRIPTION
caught during live testing of #181: receiving a GP-registered PO posts the GP receipt and records the UC Nexus receive correctly, but the success screen read "Receive completed successfully! 0 items added to inventory." even though 1 was received.

the cause is the per-PO receive rework in #181. after the receive loop commits, ReceiveModal now clears the committed POs' receiveQuantities so a retry of any remaining POs can't re-post the ones that already went through. totalItemsToReceive is a useMemo over receiveQuantities, so clearing it makes the live value recompute to 0 - and the success Alert renders after that, off the now-zero value.

the fix captures the received-unit count into state (receivedCount) at success time, right before setSucceeded(true), and the success Alert reads that instead of the live totalItemsToReceive. the toast keeps using the closure value (still the pre-clear count), so both now agree.

verified live against Railway with the local relay: received PO0000049 (1 unit) end to end, GP receipt posted, UC Nexus receive recorded, PO closed, and the success screen now reads "1 items added to inventory". tsc and eslint clean.