### PR TITLE
fix(relay): read enrolled company before the /relay-link session closes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -89,8 +89,14 @@ async def relay_link(websocket: WebSocket):
 
     with SessionLocal() as session:
         install = relay_repository.authenticate_secret(session, secret.strip())
+        # Read the company while the row is still bound to the session. session.commit() below expires
+        # every attribute (expire_on_commit), and leaving the `with` block detaches `install` - so any
+        # later install.company access raises DetachedInstanceError. Because that access sat AFTER
+        # websocket.accept(), the exception tore down every already-accepted relay socket, so no relay
+        # could ever register (relayStatus stayed false).
+        company = install.company if install is not None else None
         session.commit()
-    if install is None:
+    if company is None:
         await websocket.close(code=4401)
         return
 
@@ -98,7 +104,7 @@ async def relay_link(websocket: WebSocket):
     # POC scope: one relay at a time, incumbent wins (issue #202 #6). If a relay is already connected,
     # reject this one rather than superseding - superseding could drop an in-flight reply for a GP write
     # that committed, and two enrolled relays would otherwise thrash by force-closing each other.
-    if not relay_gateway.try_register(install.company, websocket):
+    if not relay_gateway.try_register(company, websocket):
         await websocket.close(code=4409)
         return
     try:

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -1,0 +1,79 @@
+"""Regression coverage for the /relay-link WebSocket handshake - the relay's outbound channel connect
+path, which the PR that introduced it did not exercise in CI ("channel connect path not exercised").
+
+The route authenticated the relay's secret inside a `with SessionLocal()` block that ran
+session.commit() and then closed, which expired + detached the RelayInstall. Reading install.company
+afterwards (right after websocket.accept()) raised DetachedInstanceError, tearing down every accepted
+relay socket, so no relay ever registered and relayStatus stayed false. These tests drive the real
+route so that failure mode can't come back unnoticed.
+"""
+
+import os
+import time
+
+from cryptography.fernet import Fernet
+
+# The crypto layer reads RELAY_SECRET_ENC_KEY at call time; provide one before enroll/authenticate.
+os.environ.setdefault("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
+
+from fastapi.testclient import TestClient  # noqa: E402
+from starlette.websockets import WebSocketDisconnect  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models.relay_install import RelayInstall  # noqa: E402
+from app.repositories import relay_repository  # noqa: E402
+from app.services.relay_gateway import gateway  # noqa: E402
+from main import app  # noqa: E402
+
+
+def _enroll_committed(label: str, company: str, secret: str) -> str:
+    """Enroll an install and COMMIT it: the route opens its own SessionLocal(), so it only sees
+    committed rows, not this test's transaction. Returns the install id for cleanup."""
+    with SessionLocal() as session:
+        _, token = relay_repository.provision_install(session, label=label, company=company)
+        enrolled = relay_repository.enroll_install(session, token, hostname=label, secret=secret)
+        install_id = enrolled.id
+        session.commit()
+    return install_id
+
+
+def _delete_install(install_id: str) -> None:
+    with SessionLocal() as session:
+        obj = session.get(RelayInstall, install_id)
+        if obj is not None:
+            session.delete(obj)
+            session.commit()
+
+
+def _wait_until(predicate, timeout: float = 3.0) -> None:
+    # try_register runs just after accept(), concurrently with the test thread - poll rather than race.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not predicate():
+        time.sleep(0.02)
+
+
+def test_relay_link_handshake_registers_the_company(_migrate_database):
+    secret = "relay-link-regression-secret"
+    install_id = _enroll_committed("WS-REGRESSION", "TUBC", secret)
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}):
+                _wait_until(lambda: gateway.connected)
+                assert gateway.connected is True
+                assert gateway.company == "TUBC"
+            # Leaving the context closes the socket; the route's finally unregisters it.
+            _wait_until(lambda: not gateway.connected)
+            assert gateway.connected is False
+    finally:
+        _delete_install(install_id)
+
+
+def test_relay_link_rejects_an_unknown_secret(_migrate_database):
+    # An unenrolled secret closes with 4401 before accept(), which TestClient surfaces as a disconnect.
+    with TestClient(app) as client:
+        try:
+            with client.websocket_connect("/relay-link", headers={"Authorization": "Bearer not-enrolled"}):
+                pass
+        except WebSocketDisconnect:
+            pass
+    assert gateway.connected is False


### PR DESCRIPTION
Fixes /relay-link WebSocket handshake so on-prem relay registers with deployed backend. Found during testing of PR #201.

in backend/main.py relay_link route, authenticate_secret(session, secret) + session.commit() run inside `with SessionLocal() as session:`. expire_on_commit=True expires every install attribute at commit -> block exits -> session closes -> install detached -> after websocket.accept() route reads install.company (line 101) -> lazy refresh with no live session -> sqlalchemy.orm.exc.DetachedInstanceError. raised after accept() -> uvicorn tears down accepted socket -> relay reconnect-loops, backend logs one DetachedInstanceError per attempt.

relayStatus never goes true. no GP-first flow works end-to-end:
adopt GP job
createPo
createReceive
gpVendors
gpJobs
gpBuyers
gpCostCodes

read install.company into a plain str while row still session-bound, register with that string:
```
with SessionLocal() as session:
    install = authenticate_secret(session, secret.strip())
    company = install.company if install is not None else None
    session.commit()
if company is None:
    await websocket.close(code=4401)
    return
await websocket.accept()
if not relay_gateway.try_register(company, websocket):
```

adds tests/test_relay_link_route.py (the channel connect path PR #201 flagged as not exercised in CI), drives real /relay-link via FastAPI TestClient:
- enroll committed install -> connect with Bearer secret -> assert gateway.connected is True and gateway.company == "TUBC" -> assert unregister on disconnect
- assert unenrolled secret rejected

DB-backed tests not run locally (no local Postgres); run in CI.

wss handshake from relay box (Tagging3W10) to wss://backend-production-7866.up.railway.app/relay-link completes, authenticate_secret matches enrolled TUBC install.
websockets client must be 13.1 (extra_headers legacy param in channel.py). 16.0 silently fails to connect.
