### PR TITLE
relay: distinct re-enrollment vs slot-busy signal on channel connect failure (#204)

### DIFF
--- a/localhost relay/src/ucnexus_relay/channel.py
+++ b/localhost relay/src/ucnexus_relay/channel.py
@@ -25,6 +25,41 @@ from .logging_setup import get_logger
 
 logger = get_logger()
 
+# WS close code the backend sends when a second relay connects while one already holds the single
+# connection slot (backend/main.py: try_register -> close(4409)). It arrives AFTER accept(), so the
+# client sees it as a close frame - distinct from a secret rejection, which is refused pre-accept.
+_SLOT_BUSY_CLOSE_CODE = 4409
+
+
+def _classify_connect_failure(exc: Exception) -> tuple[str, str]:
+    """Map a failed/dropped channel connection to a (category, operator_message) so the log says WHY,
+    not just "retrying" (issue #204).
+
+    The backend refuses a bad or orphaned secret BEFORE accepting the socket (authenticate_secret ->
+    close(4401) before websocket.accept()), which the websockets client sees as an HTTP 403 at the
+    handshake (InvalidStatusCode.status_code == 403), NOT a WS close frame - that means this relay's
+    enrolled secret no longer matches any relay_installs row and it needs re-enrollment (e.g. after a
+    dev DB wipe). A VALID secret that loses the single-connection race is accepted and then closed with
+    code 4409. Everything else (network drop, backend restart, proxy idle close) is a transient retry.
+
+    Attribute-based on purpose: robust across websockets versions, and unit-testable with the real
+    exception types without a live socket."""
+    status = getattr(exc, "status_code", None)  # websockets InvalidStatusCode: handshake was rejected
+    if status in (401, 403):
+        return (
+            "secret_rejected",
+            "backend rejected the relay secret - this relay likely needs re-enrollment: provision a new "
+            "token in UC Nexus admin, then re-run `ucnexus-relay enroll` and restart the relay. still retrying.",
+        )
+    rcvd = getattr(exc, "rcvd", None)  # websockets ConnectionClosed: the close frame we received
+    close_code = getattr(rcvd, "code", None) if rcvd is not None else getattr(exc, "code", None)
+    if close_code == _SLOT_BUSY_CLOSE_CODE:
+        return (
+            "slot_busy",
+            "another relay already holds the backend connection for this company; standing by. still retrying.",
+        )
+    return ("dropped", "channel connection dropped, retrying")
+
 
 def _run_list_vendors(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
@@ -207,6 +242,7 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.warning("channel connection dropped, retrying", extra={"error": str(e), "backoff": backoff})
+            category, message = _classify_connect_failure(e)
+            logger.warning(message, extra={"category": category, "error": str(e), "backoff": backoff})
             backoff = min(backoff * 2, cfg.reconnect_max_seconds)
         await asyncio.sleep(backoff)

--- a/localhost relay/tests/test_channel_reconnect.py
+++ b/localhost relay/tests/test_channel_reconnect.py
@@ -1,0 +1,43 @@
+"""Channel reconnect classification (issue #204): a failed connect must say WHY - a rejected secret
+(needs re-enrollment) vs a lost single-connection race (slot busy) vs a transient drop - not collapse
+every failure to a generic "retrying". Uses the real websockets exception types so an upgrade that
+renames the attributes the classifier reads is caught here."""
+
+from websockets.datastructures import Headers
+from websockets.exceptions import ConnectionClosedError, InvalidStatusCode
+from websockets.frames import Close
+
+from ucnexus_relay import channel
+
+
+def test_http_403_handshake_rejection_is_secret_rejected():
+    # The backend refuses a bad/orphaned secret before accept(); the client sees HTTP 403 at the
+    # handshake, not a WS close frame.
+    category, message = channel._classify_connect_failure(InvalidStatusCode(403, Headers()))
+    assert category == "secret_rejected"
+    assert "re-enroll" in message.lower()
+
+
+def test_http_401_handshake_rejection_is_secret_rejected():
+    category, _ = channel._classify_connect_failure(InvalidStatusCode(401, Headers()))
+    assert category == "secret_rejected"
+
+
+def test_4409_close_is_slot_busy():
+    # A valid secret that loses the single-connection race is accepted, then closed with 4409.
+    exc = ConnectionClosedError(Close(channel._SLOT_BUSY_CLOSE_CODE, ""), None)
+    category, message = channel._classify_connect_failure(exc)
+    assert category == "slot_busy"
+    assert "standing by" in message.lower()
+
+
+def test_network_drop_is_generic_retry():
+    category, message = channel._classify_connect_failure(OSError("connection refused"))
+    assert category == "dropped"
+    assert message == "channel connection dropped, retrying"
+
+
+def test_normal_close_is_generic_retry():
+    # A plain server-side close (e.g. backend restart) is a transient drop, not a secret problem.
+    exc = ConnectionClosedError(Close(1000, ""), None)
+    assert channel._classify_connect_failure(exc)[0] == "dropped"


### PR DESCRIPTION
Fixes #204.

before this, every /relay-link connect failure collapsed to "channel connection dropped, retrying" - a rejected secret after a dev DB wipe looked identical to a network drop.

_classify_connect_failure(exc) maps a failed connect to three categories; the loop logs the matching message:
- HTTP 401/403 handshake rejection -> secret_rejected -> "backend rejected the relay secret - this relay likely needs re-enrollment: provision a new token in UC Nexus admin, then re-run ucnexus-relay enroll and restart the relay. still retrying."
- 4409 close -> slot_busy -> "another relay already holds the backend connection for this company; standing by. still retrying."
- else -> dropped -> "channel connection dropped, retrying" (unchanged).

keeps retrying in every case.

backend refuses a bad/orphaned secret before accepting the socket. authenticate_secret -> close 4401 before websocket.accept(). handshake never accepted -> websockets client sees HTTP 403 (InvalidStatusCode.status_code == 403), not a WS close frame. confirmed empirically against the live backend. valid secret losing the single-connection race -> accepted then closed 4409.

attribute-based classification reads .status_code / .rcvd.code.

tests/test_channel_reconnect.py covers all three categories plus a normal 1000 close.

Nexus-side relay-installs admin view (last_seen_at + enrollment state) tracked separately.