### PR TITLE
relay: no-admin logon autostart (HKCU Run) + user install script

### DIFF
--- a/localhost relay/install/install-relay-user.ps1
+++ b/localhost relay/install/install-relay-user.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+  Install the UC Nexus relay for the CURRENT USER with no admin rights.
+
+.DESCRIPTION
+  Stages ucnexus-relay.exe + a config.toml into a per-user install dir, then registers a no-admin logon
+  autostart via the HKCU Run key (the exe's `install-autostart` subcommand). Nothing here needs elevation
+  - use this on a workstation whose user is not a local admin. For an IT/fleet install that prefers a
+  Scheduled Task (restart-on-failure, start-when-available), use install-relay.ps1 instead (needs admin).
+
+  The relay runs as the current interactive user on purpose: it authenticates to GP via Windows SSPI as
+  that domain user (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user.
+
+.PARAMETER ExePath
+  Path to ucnexus-relay.exe. Defaults to ..\dist\ucnexus-relay.exe (a local build). For a real install,
+  pass the exe downloaded from the GitHub Release.
+
+.PARAMETER InstallDir
+  Where to stage the exe + config.toml. Defaults to %LOCALAPPDATA%\UCNexusRelay.
+
+.PARAMETER StartNow
+  Also launch the relay immediately after install. Only do this once config.toml is enrolled.
+
+.EXAMPLE
+  .\install-relay-user.ps1 -ExePath C:\Users\me\Downloads\ucnexus-relay.exe -StartNow
+#>
+[CmdletBinding()]
+param(
+    [string]$ExePath = (Join-Path $PSScriptRoot "..\dist\ucnexus-relay.exe"),
+    [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "UCNexusRelay"),
+    [switch]$StartNow
+)
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ExePath)) {
+    Write-Error "exe not found at $ExePath - download ucnexus-relay.exe from the GitHub Release (or build it with build.ps1) and pass -ExePath."
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$destExe = Join-Path $InstallDir "ucnexus-relay.exe"
+Copy-Item -Path $ExePath -Destination $destExe -Force
+Write-Host "staged exe -> $destExe"
+
+# seed config.toml from the example if this workstation doesn't have one yet (never overwrite a real one -
+# it may hold the enrolled DPAPI secret)
+$destCfg = Join-Path $InstallDir "config.toml"
+if (-not (Test-Path $destCfg)) {
+    $exampleCfg = Join-Path $PSScriptRoot "..\config.example.toml"
+    if (Test-Path $exampleCfg) {
+        Copy-Item -Path $exampleCfg -Destination $destCfg -Force
+        Write-Host "seeded config.toml from config.example.toml -> $destCfg (EDIT it: [sql], [gp], [channel], then enroll)"
+    } else {
+        Write-Warning "no config.example.toml beside the script; create $destCfg by hand before starting the relay."
+    }
+} else {
+    Write-Host "kept existing config.toml at $destCfg"
+}
+
+# no-admin logon autostart via the HKCU Run key (the exe registers itself, pointing the Run entry at the
+# staged exe). Runs as the current user at logon; no Task Scheduler, no elevation.
+& $destExe install-autostart
+if ($LASTEXITCODE -ne 0) { Write-Error "install-autostart failed (exit $LASTEXITCODE)"; exit 1 }
+
+if ($StartNow) {
+    Start-Process -FilePath $destExe -ArgumentList "serve" -WorkingDirectory $InstallDir -WindowStyle Hidden
+    Write-Host "launched the relay now."
+}
+
+Write-Host ""
+Write-Host "next steps:"
+Write-Host "  1. edit $destCfg  ([sql] server/driver, [gp] companies, [channel] backend_url)"
+Write-Host "  2. enroll (writes the DPAPI-encrypted secret):"
+Write-Host "       cd `"$InstallDir`"; .\ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend>/graphql"
+Write-Host "  3. start it now (or just log off and back on):"
+Write-Host "       Start-Process `"$destExe`" -ArgumentList serve -WorkingDirectory `"$InstallDir`" -WindowStyle Hidden"
+Write-Host "  4. verify:    .\ucnexus-relay.exe health"
+Write-Host ""
+Write-Host "to remove the autostart later:  .\ucnexus-relay.exe uninstall-autostart"

--- a/localhost relay/src/ucnexus_relay/autostart.py
+++ b/localhost relay/src/ucnexus_relay/autostart.py
@@ -1,0 +1,65 @@
+"""User-level (no-admin) autostart via the HKCU Run key.
+
+A workstation user is not necessarily a local admin (e.g. jayp on TAGGING3W10 is not), so the relay
+can't rely on the admin-only Scheduled Task to launch at logon. Writing
+HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run needs no elevation and launches the exe at
+logon as that user - which is exactly the account the relay must run as (SSPI to GP, DPAPI CurrentUser
+secret). The admin Scheduled Task script is kept for IT/fleet installs ("support both"); this Run-key
+path is the default for self-service setup and is what the guided-setup UI calls.
+
+Registry ops take an overridable `subkey` so the unit tests can exercise the real winreg calls against a
+throwaway HKCU key instead of the live Run key.
+"""
+
+import sys
+
+try:
+    import winreg  # Windows-only; the relay only ever runs on Windows workstations
+except ImportError:  # pragma: no cover - importing on a non-Windows dev machine
+    winreg = None
+
+RUN_SUBKEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+VALUE_NAME = "UC Nexus Relay"
+
+
+def _require_winreg() -> None:
+    if winreg is None:
+        raise RuntimeError("autostart requires Windows (winreg is unavailable)")
+
+
+def default_command() -> str:
+    """The command the Run entry launches at logon: the packaged exe with `serve`, quoted so a path with
+    spaces survives. In a dev checkout sys.executable is python, so this is only meaningful for the frozen
+    exe - the installer and the UI always run the packaged exe."""
+    return f'"{sys.executable}" serve'
+
+
+def install_autostart(command: str | None = None, subkey: str = RUN_SUBKEY) -> str:
+    """Register (or overwrite) the logon Run entry. Returns the command that was written. No admin needed."""
+    _require_winreg()
+    command = command or default_command()
+    with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_SET_VALUE) as key:
+        winreg.SetValueEx(key, VALUE_NAME, 0, winreg.REG_SZ, command)
+    return command
+
+
+def uninstall_autostart(subkey: str = RUN_SUBKEY) -> bool:
+    """Remove the Run entry. Returns True if it existed, False if there was nothing to remove."""
+    _require_winreg()
+    try:
+        with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, VALUE_NAME)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def autostart_status(subkey: str = RUN_SUBKEY) -> dict:
+    """Whether the logon Run entry is present, and the command it launches."""
+    _require_winreg()
+    try:
+        with winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_READ) as key:
+            value, _ = winreg.QueryValueEx(key, VALUE_NAME)
+        return {"installed": True, "command": value}
+    except FileNotFoundError:
+        return {"installed": False, "command": None}

--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -1,10 +1,13 @@
 """Single entry point for the packaged relay exe (and `python -m ucnexus_relay`).
 
 Subcommands:
-  serve (default)   run the relay - uvicorn on the configured [server] host/port
-  enroll  ...       one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
-  protect-secret    DPAPI-encrypt the shared_secret currently in config.toml
-  health            GET the local /health endpoint and print it (exit 0 if status ok)
+  serve (default)      run the relay - uvicorn on the configured [server] host/port
+  enroll  ...          one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
+  protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
+  health               GET the local /health endpoint and print it (exit 0 if status ok)
+  install-autostart    register a no-admin logon autostart (HKCU Run) so the relay starts at logon
+  uninstall-autostart  remove that logon autostart entry
+  autostart-status     print whether the logon autostart is installed (JSON)
 
 The packaged exe bundles all of these so a workstation needs only the .exe + config.toml (no Poetry).
 """
@@ -74,6 +77,40 @@ def _health(argv: list[str]) -> int:
         return 1
 
 
+def _install_autostart(argv: list[str]) -> int:
+    from .autostart import default_command, install_autostart
+
+    if getattr(sys, "frozen", False):
+        command = install_autostart()
+    else:
+        # a dev checkout would register python.exe, which isn't a relay - refuse unless the packaged exe.
+        print(
+            "install-autostart is for the packaged exe (sys.frozen). In a dev checkout the Run entry would "
+            f"point at python, not the relay. default command would be: {default_command()}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"autostart installed (HKCU Run '{command}'); the relay will start at your next logon.")
+    return 0
+
+
+def _uninstall_autostart(argv: list[str]) -> int:
+    from .autostart import uninstall_autostart
+
+    existed = uninstall_autostart()
+    print("autostart removed." if existed else "autostart was not installed (nothing to remove).")
+    return 0
+
+
+def _autostart_status(argv: list[str]) -> int:
+    import json
+
+    from .autostart import autostart_status
+
+    print(json.dumps(autostart_status()))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and not argv[0].startswith("-"):
@@ -91,8 +128,18 @@ def main(argv: list[str] | None = None) -> int:
         return protect_main(rest)
     if cmd == "health":
         return _health(rest)
+    if cmd == "install-autostart":
+        return _install_autostart(rest)
+    if cmd == "uninstall-autostart":
+        return _uninstall_autostart(rest)
+    if cmd == "autostart-status":
+        return _autostart_status(rest)
 
-    print(f"unknown command: {cmd!r} (expected: serve | enroll | protect-secret | health)", file=sys.stderr)
+    print(
+        f"unknown command: {cmd!r} (expected: serve | enroll | protect-secret | health | "
+        "install-autostart | uninstall-autostart | autostart-status)",
+        file=sys.stderr,
+    )
     return 2
 
 

--- a/localhost relay/tests/test_autostart.py
+++ b/localhost relay/tests/test_autostart.py
@@ -1,0 +1,55 @@
+"""No-admin autostart (HKCU Run) registration. Exercises the real winreg calls against a THROWAWAY
+HKCU subkey - never the live Run key - so a test run can't leave a stray logon entry behind."""
+
+import pytest
+
+from ucnexus_relay import autostart
+
+pytestmark = pytest.mark.skipif(autostart.winreg is None, reason="Windows-only (winreg unavailable)")
+
+_TEST_SUBKEY = r"Software\UCNexusRelayTest\Run"
+_TEST_PARENT = r"Software\UCNexusRelayTest"
+
+
+@pytest.fixture
+def clean_test_key():
+    yield
+    wr = autostart.winreg
+    try:
+        with wr.CreateKeyEx(wr.HKEY_CURRENT_USER, _TEST_SUBKEY, 0, wr.KEY_SET_VALUE) as k:
+            try:
+                wr.DeleteValue(k, autostart.VALUE_NAME)
+            except FileNotFoundError:
+                pass
+        wr.DeleteKey(wr.HKEY_CURRENT_USER, _TEST_SUBKEY)
+        wr.DeleteKey(wr.HKEY_CURRENT_USER, _TEST_PARENT)
+    except OSError:
+        pass
+
+
+def test_status_false_when_absent(clean_test_key):
+    assert autostart.autostart_status(subkey=_TEST_SUBKEY) == {"installed": False, "command": None}
+
+
+def test_install_then_status_reports_command(clean_test_key):
+    autostart.install_autostart(command='"C:\\x\\ucnexus-relay.exe" serve', subkey=_TEST_SUBKEY)
+    st = autostart.autostart_status(subkey=_TEST_SUBKEY)
+    assert st["installed"] is True
+    assert st["command"] == '"C:\\x\\ucnexus-relay.exe" serve'
+
+
+def test_install_overwrites(clean_test_key):
+    autostart.install_autostart(command='"old" serve', subkey=_TEST_SUBKEY)
+    autostart.install_autostart(command='"new" serve', subkey=_TEST_SUBKEY)
+    assert autostart.autostart_status(subkey=_TEST_SUBKEY)["command"] == '"new" serve'
+
+
+def test_uninstall_reports_whether_it_existed(clean_test_key):
+    autostart.install_autostart(command='"x" serve', subkey=_TEST_SUBKEY)
+    assert autostart.uninstall_autostart(subkey=_TEST_SUBKEY) is True
+    assert autostart.uninstall_autostart(subkey=_TEST_SUBKEY) is False
+
+
+def test_default_command_quotes_the_exe(monkeypatch):
+    monkeypatch.setattr(autostart.sys, "executable", r"C:\Program Files\UC\ucnexus-relay.exe")
+    assert autostart.default_command() == '"C:\\Program Files\\UC\\ucnexus-relay.exe" serve'


### PR DESCRIPTION
no-admin logon autostart for the relay. a workstation user isn't necessarily a local admin (jayp on TAGGING3W10 isn't), so install-relay.ps1 (Register-ScheduledTask) can't run and the "UC Nexus Relay" task can't be re-registered.

relay runs as the interactive user:
- SSPI to GP as the DYNGRP domain user
- DPAPI shared_secret bound to CurrentUser

HKCU\Software\Microsoft\Windows\CurrentVersion\Run launches the exe at logon as that user, no elevation.

autostart.py adds HKCU Run-key helpers:
- install_autostart
- uninstall_autostart
- autostart_status
- registry subkey overridable; tests run real winreg against a throwaway HKCU key, never the live Run key.

CLI adds subcommands:
- install-autostart
- uninstall-autostart
- autostart-status
- install-autostart refuses in a dev checkout (sys.frozen false) because the Run entry would point at python, not the relay.

install-relay-user.ps1 does a no-admin per-user install:
- stage exe + config into %LOCALAPPDATA%\UCNexusRelay
- register the Run autostart
- optionally start

keep install-relay.ps1 (admin Scheduled Task) for IT/fleet installs (support both).

tests/test_autostart.py covers status-absent, install+status, overwrite, uninstall-existed-vs-not, default-command quoting.