### PR TITLE
relay: native desktop UI window (status + event log) via pywebview

### DIFF
--- a/localhost relay/poetry.lock
+++ b/localhost relay/poetry.lock
@@ -45,6 +45,19 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.32.0)"]
 
 [[package]]
+name = "bottle"
+version = "0.13.4"
+description = "Fast and simple WSGI-framework for small web-applications."
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "bottle-0.13.4-py2.py3-none-any.whl", hash = "sha256:045684fbd2764eac9cdeb824861d1551d113e8b683d8d26e296898d3dd99a12e"},
+    {file = "bottle-0.13.4.tar.gz", hash = "sha256:787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47"},
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -55,6 +68,120 @@ files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
+    {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd"},
+    {file = "cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f"},
+    {file = "cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e"},
+    {file = "cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479"},
+    {file = "cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458"},
+    {file = "cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b"},
+    {file = "cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a"},
+    {file = "cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384"},
+    {file = "cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a"},
+    {file = "cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2"},
+    {file = "cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512"},
+    {file = "cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326"},
+    {file = "cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd"},
+    {file = "cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb"},
+    {file = "cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94"},
+    {file = "cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629"},
+    {file = "cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6"},
+    {file = "cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853"},
+    {file = "cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9"},
+    {file = "cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
+    {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "click"
@@ -70,6 +197,22 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "clr-loader"
+version = "0.3.1"
+description = "Generic pure Python loader for .NET runtimes"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "clr_loader-0.3.1-py3-none-any.whl", hash = "sha256:cbad189de20d202a7d621956b0fc38049e13c9bf7ca2923441eff725cd121aa1"},
+    {file = "clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366"},
+]
+
+[package.dependencies]
+cffi = ">=1.17"
 
 [[package]]
 name = "colorama"
@@ -308,6 +451,31 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "proxy-tools"
+version = "0.1.0"
+description = "Proxy Implementation"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "proxy_tools-0.1.0.tar.gz", hash = "sha256:ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010"},
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
 
 [[package]]
 name = "pydantic"
@@ -677,6 +845,54 @@ files = [
     {file = "python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c"},
     {file = "python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd"},
 ]
+
+[[package]]
+name = "pythonnet"
+version = "3.1.0"
+description = ".NET and Mono integration for Python"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "pythonnet-3.1.0-cp310.cp311.cp312.cp313.cp314-none-any.whl", hash = "sha256:698dd88edc198819ad63b624a6ebe76208c7b46e4fe13626f65e484f0358d6ba"},
+    {file = "pythonnet-3.1.0-cp310.cp311.cp312.cp313.cp314-none-win32.win_amd64.whl", hash = "sha256:7bdd4de03df3547a48122a3989265c8b31d5be0d19dadffa009eec7df8085e0b"},
+    {file = "pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991"},
+]
+
+[package.dependencies]
+clr_loader = ">=0.3.1,<0.4.0"
+
+[[package]]
+name = "pywebview"
+version = "6.2.1"
+description = "Build GUI for your Python program with JavaScript, HTML, and CSS"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform == \"win32\" and python_version < \"3.14\""
+files = [
+    {file = "pywebview-6.2.1-py3-none-any.whl", hash = "sha256:9d07275f53894ab4d5e2e0e996227193e7187dec276d9b624dccbce029216b46"},
+    {file = "pywebview-6.2.1.tar.gz", hash = "sha256:71b7136752e40824655304d938efb62014218d1a90bd8e87e1cbdb1ce9c466af"},
+]
+
+[package.dependencies]
+bottle = "*"
+proxy_tools = "*"
+pythonnet = {version = "*", markers = "sys_platform == \"win32\""}
+typing_extensions = "*"
+
+[package.extras]
+android = ["jnius"]
+cef = ["cefpython3"]
+dev = ["build", "pre-commit", "pytest", "ruff", "twine"]
+gtk = ["PyGObject (==3.50.0)", "PyGObject-stubs"]
+pyside2 = ["PySide2", "QtPy"]
+pyside6 = ["PySide6", "QtPy"]
+qt = ["PyQt6", "PyQt6-WebEngine", "QtPy"]
+qt5 = ["PyQt5", "QtPy", "pyqtwebengine"]
+qt6 = ["PyQt6", "PyQt6-WebEngine", "QtPy"]
+ssl = ["cryptography"]
 
 [[package]]
 name = "pywin32-ctypes"
@@ -1192,4 +1408,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "948ffb2400ea5363f565519f45867da16e6bd9531d3b819f4df2f7c8d0e7722b"
+content-hash = "76c859e4d6e630539220a249af255d1570a45ebc4a3a4b19800a0618a9c1f712"

--- a/localhost relay/pyproject.toml
+++ b/localhost relay/pyproject.toml
@@ -14,6 +14,12 @@ pydantic-settings = "^2.6"
 pyodbc = "^5.2"
 python-json-logger = "^2.0"
 websockets = "^13.0"
+# Native desktop UI (the `ui` subcommand). Windows-only: pywebview uses the Edge WebView2 backend via
+# pythonnet. Scoped to <3.14 like pyinstaller below because pythonnet's wheels don't cover newer pythons;
+# CI + dev build on 3.11. pythonnet is pinned to 3.x directly so poetry doesn't resolve pywebview's
+# transitive dep down to the source-only 2.5.2 (which fails to build).
+pywebview = {version = "^6.2", python = "<3.14", markers = "sys_platform == 'win32'"}
+pythonnet = {version = ">=3.0,<4", python = "<3.14", markers = "sys_platform == 'win32'"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3"

--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -2,6 +2,7 @@
 
 Subcommands:
   serve (default)      run the relay - uvicorn on the configured [server] host/port
+  ui                   open the native desktop window (status + event log; setup/updates land here)
   enroll  ...          one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
   protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
   health               GET the local /health endpoint and print it (exit 0 if status ok)
@@ -120,6 +121,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "serve":
         return _serve(rest)
+    if cmd == "ui":
+        from .ui import run_ui
+        return run_ui()
     if cmd == "enroll":
         from .enroll import main as enroll_main
         return enroll_main(rest)
@@ -136,7 +140,7 @@ def main(argv: list[str] | None = None) -> int:
         return _autostart_status(rest)
 
     print(
-        f"unknown command: {cmd!r} (expected: serve | enroll | protect-secret | health | "
+        f"unknown command: {cmd!r} (expected: serve | ui | enroll | protect-secret | health | "
         "install-autostart | uninstall-autostart | autostart-status)",
         file=sys.stderr,
     )

--- a/localhost relay/src/ucnexus_relay/ui.py
+++ b/localhost relay/src/ucnexus_relay/ui.py
@@ -1,0 +1,235 @@
+"""Native desktop UI for the relay (pywebview window).
+
+Purpose (per the product goal): guided first-time setup, updates, and event-log viewing. This first slice
+is the always-available status + event-log window; the setup wizard and the updater land on top of it.
+
+Model: the relay runs headless in the background (the autostarted `serve` process). This `ui` process is a
+SEPARATE window that observes + (later) controls it. It reads the same on-disk config.toml and relay.log the
+serve process uses, and probes the local /health endpoint - so it works whether or not the relay is running,
+which matters for first-run setup when nothing is serving yet.
+
+The window talks to Python through pywebview's js_api bridge (Api below); the data-gathering functions are
+plain and importable without a display, so they unit-test without opening a window. `webview` is imported
+lazily inside run_ui() for the same reason (and so a headless test host never needs the GUI backend).
+"""
+
+import json
+import tomllib
+import urllib.request
+from pathlib import Path
+
+from . import autostart
+from .config import DEFAULT_CONFIG_PATH
+
+VERSION = "0.1.0"
+
+
+def _resolve_log_path(config_path: Path, logging_file: str) -> Path:
+    """The relay writes [logging].file relative to its working dir, which for the installed relay is the
+    dir holding config.toml (Start-Process -WorkingDirectory %LOCALAPPDATA%\\UCNexusRelay). Resolve the log
+    beside config.toml so the UI reads the same file the serve process writes, wherever it's launched from."""
+    p = Path(logging_file)
+    return p if p.is_absolute() else config_path.parent / p
+
+
+def config_summary(config_path: str | Path | None = None) -> dict:
+    """Non-secret view of config.toml for the status panel. Never returns the shared_secret value - only
+    whether one is set (enrolled). Tolerant of a missing or unparseable file (first-run has neither)."""
+    p = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    if not p.exists():
+        return {"present": False, "path": str(p)}
+    try:
+        with open(p, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        return {"present": True, "path": str(p), "parse_error": str(e)}
+
+    gp = data.get("gp") or {}
+    sql = data.get("sql") or {}
+    channel = data.get("channel") or {}
+    server = data.get("server") or {}
+    auth = data.get("auth") or {}
+    secret = auth.get("shared_secret") or ""
+    return {
+        "present": True,
+        "path": str(p),
+        "default_company": gp.get("default_company"),
+        "allowed_companies": gp.get("allowed_companies") or [],
+        "sql_server": sql.get("server"),
+        "odbc_driver": sql.get("driver"),
+        "backend_url": channel.get("backend_url") or "",
+        "host": server.get("host", "127.0.0.1"),
+        "port": server.get("port", 7321),
+        "enrolled": bool(secret),
+        "logging_file": (data.get("logging") or {}).get("file", "relay.log"),
+    }
+
+
+def relay_health(host: str = "127.0.0.1", port: int = 7321) -> dict:
+    """Probe the local relay /health. `running` is False if nothing answers (relay stopped / first-run)."""
+    url = f"http://{host}:{port}/health"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:  # noqa: S310 (fixed localhost URL)
+            body = json.loads(resp.read().decode())
+        return {
+            "running": True,
+            "status": body.get("status"),
+            "version": body.get("version"),
+            "uptime_seconds": body.get("uptime_seconds"),
+        }
+    except (OSError, json.JSONDecodeError):
+        return {"running": False}
+
+
+def _tail_lines(path: Path, limit: int) -> list[str]:
+    if not path.exists():
+        return []
+    # relay.log stays small (a few events per op); reading it whole and slicing is fine and avoids
+    # seek-based tailing edge cases with the JSON-per-line format.
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.readlines()[-limit:]
+
+
+def recent_log_events(config_path: str | Path | None = None, limit: int = 200) -> list[dict]:
+    """Parse the last `limit` relay.log lines (structured JSON) into UI rows, newest last. A non-JSON line
+    (shouldn't happen with the JSON formatter, but be safe) becomes a raw row."""
+    summ = config_summary(config_path)
+    p = Path(summ["path"])
+    log_path = _resolve_log_path(p, summ.get("logging_file", "relay.log"))
+    rows: list[dict] = []
+    for line in _tail_lines(log_path, limit):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            o = json.loads(line)
+            rows.append(
+                {
+                    "time": o.get("asctime"),
+                    "level": o.get("levelname"),
+                    "message": o.get("message"),
+                    "category": o.get("category"),
+                    "detail": o.get("path") or o.get("op") or o.get("error"),
+                }
+            )
+        except json.JSONDecodeError:
+            rows.append({"time": None, "level": "RAW", "message": line, "category": None, "detail": None})
+    return rows
+
+
+def channel_state(config_path: str | Path | None = None) -> dict:
+    """Infer the live channel state from the newest channel-related log event. The #204 fix tags a failed
+    connect with a `category` (secret_rejected / slot_busy / dropped); a success logs 'channel connected'.
+    Returns state in {connected, secret_rejected, slot_busy, disconnected, unknown}."""
+    for row in reversed(recent_log_events(config_path, limit=400)):
+        msg = (row.get("message") or "").lower()
+        cat = row.get("category")
+        if "channel connected" in msg:
+            return {"state": "connected", "at": row.get("time")}
+        if cat in ("secret_rejected", "slot_busy", "dropped"):
+            mapped = "disconnected" if cat == "dropped" else cat
+            return {"state": mapped, "at": row.get("time"), "message": row.get("message")}
+        if "channel connection dropped" in msg:  # pre-#204 relays logged this without a category
+            return {"state": "disconnected", "at": row.get("time")}
+    return {"state": "unknown"}
+
+
+def gather_status(config_path: str | Path | None = None) -> dict:
+    """Everything the status panel shows, in one call."""
+    cfg = config_summary(config_path)
+    health = relay_health(cfg.get("host", "127.0.0.1"), cfg.get("port", 7321)) if cfg.get("present") else relay_health()
+    return {
+        "ui_version": VERSION,
+        "config": cfg,
+        "relay": health,
+        "channel": channel_state(config_path),
+        "autostart": autostart.autostart_status() if autostart.winreg is not None else {"installed": None},
+    }
+
+
+class Api:
+    """Exposed to the window's JS as window.pywebview.api. Methods must return JSON-serializable values."""
+
+    def get_status(self) -> dict:
+        return gather_status()
+
+    def get_logs(self, limit: int = 200) -> list[dict]:
+        return recent_log_events(limit=int(limit))
+
+
+_HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Relay</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font-family: 'Segoe UI', system-ui, sans-serif; margin: 0; background:#12151c; color:#e6e8ee; }
+  header { padding:14px 18px; background:#0d1017; border-bottom:1px solid #232838; display:flex; align-items:center; gap:12px; }
+  header h1 { font-size:16px; margin:0; font-weight:600; }
+  .dot { width:11px; height:11px; border-radius:50%; background:#5a6072; box-shadow:0 0 0 3px rgba(255,255,255,0.04); }
+  .dot.ok { background:#2ecc71; } .dot.bad { background:#e74c3c; } .dot.warn { background:#f39c12; }
+  main { padding:16px 18px; }
+  .card { background:#171b24; border:1px solid #232838; border-radius:10px; padding:14px 16px; margin-bottom:16px; }
+  .card h2 { font-size:12px; text-transform:uppercase; letter-spacing:.06em; color:#8b93a7; margin:0 0 10px; }
+  .grid { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; font-size:13px; }
+  .grid .k { color:#8b93a7; } .grid .v { color:#e6e8ee; word-break:break-all; }
+  .pill { display:inline-block; padding:1px 8px; border-radius:999px; font-size:12px; }
+  .pill.ok { background:rgba(46,204,113,.15); color:#5be29a; } .pill.bad { background:rgba(231,76,60,.15); color:#f0857b; }
+  .pill.warn { background:rgba(243,156,18,.15); color:#f6bd5b; }
+  table { width:100%; border-collapse:collapse; font-size:12.5px; }
+  th { text-align:left; color:#8b93a7; font-weight:500; padding:4px 8px; position:sticky; top:0; background:#171b24; }
+  td { padding:3px 8px; border-top:1px solid #1f2431; vertical-align:top; }
+  .lvl { font-weight:600; } .lvl.INFO{color:#7fb2ff;} .lvl.WARNING{color:#f6bd5b;} .lvl.ERROR{color:#f0857b;} .lvl.RAW{color:#8b93a7;}
+  .logwrap { max-height:340px; overflow:auto; }
+  .bar { display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+  button { background:#20283a; color:#cdd3e1; border:1px solid #2c364b; border-radius:7px; padding:5px 12px; cursor:pointer; font-size:12.5px; }
+  button:hover { background:#28324a; }
+  .muted { color:#6b7386; font-size:12px; }
+</style></head>
+<body>
+  <header><span id="hdot" class="dot"></span><h1>UC Nexus Relay</h1><span id="hstate" class="muted"></span>
+    <span style="flex:1"></span><span id="uiver" class="muted"></span></header>
+  <main>
+    <div class="card"><h2>Status</h2><div id="status" class="grid"></div></div>
+    <div class="card">
+      <div class="bar"><h2 style="margin:0">Event log</h2><span style="flex:1"></span>
+        <label class="muted"><input type="checkbox" id="auto" checked> auto-refresh</label>
+        <button onclick="refresh()">Refresh</button></div>
+      <div class="logwrap"><table><thead><tr><th>Time</th><th>Level</th><th>Message</th><th>Detail</th></tr></thead>
+        <tbody id="logs"></tbody></table></div>
+    </div>
+  </main>
+<script>
+  const $ = id => document.getElementById(id);
+  function row(k, v) { return `<div class="k">${k}</div><div class="v">${v}</div>`; }
+  function pill(ok, txt, warn) { const c = warn ? 'warn' : (ok ? 'ok' : 'bad'); return `<span class="pill ${c}">${txt}</span>`; }
+  async function refresh() {
+    if (!window.pywebview) return;
+    const s = await window.pywebview.api.get_status();
+    $('uiver').innerText = 'ui ' + s.ui_version;
+    const st = s.channel.state, connected = st === 'connected';
+    $('hdot').className = 'dot ' + (connected ? 'ok' : (st === 'unknown' ? '' : 'bad'));
+    $('hstate').innerText = connected ? 'connected to backend' : ('channel: ' + st);
+    const c = s.config, r = s.relay, a = s.autostart;
+    $('status').innerHTML =
+      row('Relay process', r.running ? pill(true,'running v'+(r.version||'?')) : pill(false,'not running')) +
+      row('Backend channel', pill(connected, st, st==='unknown')) +
+      row('Config', c.present ? (c.parse_error ? pill(false,'parse error') : pill(true,'loaded')) : pill(false,'not set up')) +
+      row('Enrolled', c.present ? pill(!!c.enrolled, c.enrolled?'yes':'no') : '-') +
+      row('Companies', (c.allowed_companies||[]).join(', ') || '-') +
+      row('SQL server', c.sql_server || '-') +
+      row('Backend URL', c.backend_url || '-') +
+      row('Autostart', a.installed===null ? '-' : pill(!!a.installed, a.installed?'installed':'not installed'));
+    const logs = await window.pywebview.api.get_logs(200);
+    $('logs').innerHTML = logs.slice().reverse().map(l =>
+      `<tr><td class="muted">${l.time||''}</td><td class="lvl ${l.level||''}">${l.level||''}</td>`+
+      `<td>${(l.message||'').replace(/</g,'&lt;')}</td><td class="muted">${(l.detail||'')}</td></tr>`).join('');
+  }
+  window.addEventListener('pywebviewready', () => { refresh(); setInterval(() => { if ($('auto').checked) refresh(); }, 3000); });
+</script></body></html>"""
+
+
+def run_ui() -> int:
+    """Open the native window. Blocks until the window is closed (webview.start runs the GUI loop)."""
+    import webview  # lazy: only the `ui` subcommand needs the GUI backend
+
+    webview.create_window("UC Nexus Relay", html=_HTML, js_api=Api(), width=760, height=680, min_size=(560, 480))
+    webview.start()
+    return 0

--- a/localhost relay/tests/test_ui.py
+++ b/localhost relay/tests/test_ui.py
@@ -1,0 +1,133 @@
+"""UI status-gathering (the pywebview window's data layer). Pure functions over a temp config.toml +
+relay.log - no window, no network, no registry (those are monkeypatched)."""
+
+import json
+
+from ucnexus_relay import ui
+
+
+def _cfg(tmp_path, body: str):
+    p = tmp_path / "config.toml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _log(tmp_path, *events: dict):
+    (tmp_path / "relay.log").write_text(
+        "".join(json.dumps(e) + "\n" for e in events), encoding="utf-8"
+    )
+
+
+def test_config_summary_absent(tmp_path):
+    p = tmp_path / "nope.toml"
+    assert ui.config_summary(p) == {"present": False, "path": str(p)}
+
+
+def test_config_summary_parses_fields_without_leaking_secret(tmp_path):
+    p = _cfg(
+        tmp_path,
+        """
+[server]
+host = "127.0.0.1"
+port = 7321
+[auth]
+shared_secret = "enc:dpapi:AQAAsecret"
+[sql]
+server = "10.0.0.246,1435"
+driver = "ODBC Driver 17 for SQL Server"
+[gp]
+default_company = "TUBC"
+allowed_companies = ["TUBC", "TUCSH"]
+[channel]
+backend_url = "wss://host/relay-link"
+[logging]
+file = "relay.log"
+""",
+    )
+    s = ui.config_summary(p)
+    assert s["present"] is True
+    assert s["enrolled"] is True
+    assert s["default_company"] == "TUBC"
+    assert s["allowed_companies"] == ["TUBC", "TUCSH"]
+    assert s["sql_server"] == "10.0.0.246,1435"
+    assert s["backend_url"].endswith("/relay-link")
+    assert "AQAAsecret" not in json.dumps(s)  # the secret VALUE must never appear
+
+
+def test_config_summary_not_enrolled_when_secret_blank(tmp_path):
+    assert ui.config_summary(_cfg(tmp_path, '[auth]\nshared_secret = ""\n'))["enrolled"] is False
+
+
+def test_config_summary_parse_error(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text("definitely = not [[[ valid toml", encoding="utf-8")
+    s = ui.config_summary(p)
+    assert s["present"] is True
+    assert "parse_error" in s
+
+
+def test_recent_log_events_parses_json_and_raw(tmp_path):
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    _log(
+        tmp_path,
+        {"asctime": "t1", "levelname": "INFO", "message": "channel connected"},
+        {"asctime": "t2", "levelname": "WARNING", "message": "drop", "category": "secret_rejected"},
+    )
+    with open(tmp_path / "relay.log", "a", encoding="utf-8") as f:
+        f.write("this is not json\n")
+    rows = ui.recent_log_events(p, limit=10)
+    assert len(rows) == 3
+    assert rows[0]["message"] == "channel connected"
+    assert rows[1]["category"] == "secret_rejected"
+    assert rows[2]["level"] == "RAW"
+
+
+def test_recent_log_events_limit(tmp_path):
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    _log(tmp_path, *[{"asctime": f"t{i}", "levelname": "INFO", "message": str(i)} for i in range(50)])
+    assert len(ui.recent_log_events(p, limit=10)) == 10
+
+
+def test_channel_state_connected_wins_over_earlier_drop(tmp_path):
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    _log(
+        tmp_path,
+        {"asctime": "t1", "levelname": "WARNING", "message": "channel connection dropped, retrying", "category": "dropped"},
+        {"asctime": "t2", "levelname": "INFO", "message": "channel connected"},
+    )
+    assert ui.channel_state(p)["state"] == "connected"
+
+
+def test_channel_state_secret_rejected(tmp_path):
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    _log(tmp_path, {"asctime": "t2", "levelname": "WARNING", "message": "backend rejected the relay secret", "category": "secret_rejected"})
+    assert ui.channel_state(p)["state"] == "secret_rejected"
+
+
+def test_channel_state_unknown_without_log(tmp_path):
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    assert ui.channel_state(p)["state"] == "unknown"
+
+
+def test_relay_health_down_on_closed_port():
+    assert ui.relay_health("127.0.0.1", 1)["running"] is False
+
+
+def test_gather_status_shape(tmp_path, monkeypatch):
+    p = _cfg(tmp_path, '[gp]\ndefault_company = "TUBC"\nallowed_companies = ["TUBC"]\n[logging]\nfile = "relay.log"\n')
+    _log(tmp_path, {"asctime": "t1", "levelname": "INFO", "message": "channel connected"})
+    monkeypatch.setattr(ui, "relay_health", lambda host="127.0.0.1", port=7321: {"running": True, "version": "0.1.0"})
+    monkeypatch.setattr(ui.autostart, "autostart_status", lambda: {"installed": True, "command": "x"})
+    s = ui.gather_status(p)
+    assert set(s) == {"ui_version", "config", "relay", "channel", "autostart"}
+    assert s["channel"]["state"] == "connected"
+    assert s["relay"]["running"] is True
+    assert s["config"]["default_company"] == "TUBC"
+
+
+def test_api_delegates(monkeypatch):
+    monkeypatch.setattr(ui, "gather_status", lambda: {"ok": 1})
+    monkeypatch.setattr(ui, "recent_log_events", lambda limit=200: [{"n": limit}])
+    api = ui.Api()
+    assert api.get_status() == {"ok": 1}
+    assert api.get_logs(50) == [{"n": 50}]

--- a/localhost relay/ucnexus-relay.spec
+++ b/localhost relay/ucnexus-relay.spec
@@ -5,7 +5,7 @@
 # .github/workflows/relay-release.yml. config.toml is NOT bundled - it lives next to the exe on each
 # workstation and is created at install/enroll time (see docs/relay-deployment.md).
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_all, collect_submodules
 
 # uvicorn imports its loop/protocol/lifespan backends lazily by string, so PyInstaller's static analysis
 # misses them - pull the whole package in. pyodbc is a C-extension and the json logger is imported by name.
@@ -13,13 +13,26 @@ hiddenimports = collect_submodules("uvicorn") + [
     "pyodbc",
     "pythonjsonlogger",
     "pythonjsonlogger.jsonlogger",
+    "clr",  # pythonnet's runtime import name (the `ui` window loads the WebView2 backend through it)
 ]
+
+# The `ui` subcommand's native window (pywebview) reaches the Edge WebView2 backend through pythonnet/clr.
+# Those are loaded dynamically (clr assemblies, pywebview's bundled JS + WebView2 loader), so static
+# analysis misses them - collect_all pulls each package's submodules, data files, and binaries. pywebview
+# also ships a PyInstaller hook that PyInstaller auto-discovers, but collecting explicitly is belt-and-braces.
+datas = []
+binaries = []
+for _pkg in ("webview", "clr_loader", "pythonnet"):
+    _d, _b, _h = collect_all(_pkg)
+    datas += _d
+    binaries += _b
+    hiddenimports += _h
 
 a = Analysis(
     ["relay_entry.py"],
     pathex=["src"],
-    binaries=[],
-    datas=[],
+    binaries=binaries,
+    datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[],
     runtime_hooks=[],


### PR DESCRIPTION
native desktop UI window for the relay. first slice of the guided-setup + updates + event-log UI.

the `ui` subcommand opens a pywebview (Edge WebView2) native window. it displays:
- relay process up (probes /health)
- backend channel state from the newest channel event in relay.log (#204 category tag)
- config summary
- autostart installed
- live event-log table of relay.log, auto-refresh every 3s

channel state is one of: connected / secret_rejected / slot_busy / disconnected / unknown.

config summary shows companies, SQL server, backend URL, enrolled (secret present, value never shown).

relay runs headless (the autostarted serve process). ui is a separate observer window: reads the same config.toml + relay.log, probes /health, works whether the relay is running or stopped (matters for first-run setup when nothing is serving yet).

these data functions read config.toml + relay.log: config_summary / relay_health / recent_log_events / channel_state / gather_status. unit-tested with a temp config + log, no window. the window calls them via pywebview js_api. webview is imported lazily inside run_ui.

pywebview ^6.2 + pythonnet 3.x, scoped win32 + python <3.14. pythonnet is pinned to 3.x directly so poetry doesn't resolve pywebview's transitive dep down to the source-only 2.5.2 that fails to build. the spec bundles via collect_all (+ clr hidden import): webview / clr_loader / pythonnet.

the window opens from the frozen exe (verified locally, because CI's headless runner can't test a GUI): ui launched from the bundle -> spawned msedgewebview2 -> no error. the released build exe gets the same check post-merge.

setup wizard and updater come next:
- setup wizard -> write config -> enroll -> register autostart -> start/stop serve
- updater -> check latest release -> download -> swap