### PR TITLE
surface GP/eConnect errors end-to-end to the user (#187)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,14 @@ class ErrorHandlerExtension(SchemaExtension):
             extensions: dict[str, Any] = {"code": e.code}
             if e.field:
                 extensions["field"] = e.field
+            # A RelayCallError carries the relay's own error body ({error, message, context}) - the eConnect
+            # proc, numeric error_state, and its DYNAMICS.taErrorCode description. Surface it under
+            # `relayError` so the frontend can show the full GP failure (issue #187: end-user error
+            # screenshots are the main way these get reported, so the detail must reach the browser, not
+            # just the generic RELAY_CALL_FAILED code). Generic: any AppError that sets `.detail`.
+            detail = getattr(e, "detail", None)
+            if detail:
+                extensions["relayError"] = detail
             return GraphQLError(message=e.message, extensions=extensions)
         return GraphQLError(message=str(e), extensions={"code": "NOT_IMPLEMENTED"})
 

--- a/backend/tests/test_error_extension.py
+++ b/backend/tests/test_error_extension.py
@@ -1,0 +1,33 @@
+"""ErrorHandlerExtension: a RelayCallError's detail (the relay's eConnect proc / error_state /
+description) must survive into the GraphQL error extensions so the frontend can show the full GP
+failure to the end user (issue #187), not just the generic RELAY_CALL_FAILED code."""
+
+from app.errors import RelayCallError, ValidationError
+from main import ErrorHandlerExtension
+
+
+def test_relay_call_error_detail_surfaces_under_relay_error():
+    detail = {
+        "error": "econnect_error",
+        "message": "Duplicate Order",
+        "context": {"proc": "taPoLine", "error_state": 9127, "error_description": "Duplicate Order"},
+    }
+    err = ErrorHandlerExtension._to_graphql_error(RelayCallError("Duplicate Order", detail=detail))
+    assert err.message == "Duplicate Order"
+    assert err.extensions["code"] == "RELAY_CALL_FAILED"
+    assert err.extensions["relayError"] == detail
+    assert err.extensions["relayError"]["context"]["error_state"] == 9127
+
+
+def test_relay_call_error_with_empty_detail_omits_relay_error():
+    err = ErrorHandlerExtension._to_graphql_error(RelayCallError("something failed"))
+    assert err.extensions["code"] == "RELAY_CALL_FAILED"
+    assert "relayError" not in err.extensions
+
+
+def test_plain_app_error_is_unchanged():
+    err = ErrorHandlerExtension._to_graphql_error(ValidationError("bad thing", field="vendor"))
+    assert err.message == "bad thing"
+    assert err.extensions["code"] == "VALIDATION_ERROR"
+    assert err.extensions["field"] == "vendor"
+    assert "relayError" not in err.extensions

--- a/frontend/src/components/GpErrorAlert.tsx
+++ b/frontend/src/components/GpErrorAlert.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import { formatGpErrorText, type GpError } from '../graphql/gpError';
+
+interface GpErrorAlertProps {
+  error: GpError;
+  onClose?: () => void;
+  /** Heading override; defaults to a GP-write phrasing. */
+  title?: string;
+}
+
+/**
+ * Persistent, detailed, screenshot-friendly display of a GP/eConnect failure (issue #187). Unlike the
+ * transient toast, this stays until dismissed and shows the full detail the backend forwards from the
+ * relay - message, code, GP proc, error state, description - so the end user can screenshot or copy it.
+ */
+export default function GpErrorAlert({ error, onClose, title }: GpErrorAlertProps) {
+  const [copied, setCopied] = useState(false);
+  const ctx = error.relay?.context ?? {};
+  const rows: [string, string][] = [];
+  if (error.code) rows.push(['Code', error.code]);
+  if (error.relay?.error) rows.push(['Relay', error.relay.error]);
+  if (ctx.proc) rows.push(['GP proc', String(ctx.proc)]);
+  if (ctx.error_state != null) rows.push(['Error state', String(ctx.error_state)]);
+  if (ctx.error_description) rows.push(['Description', String(ctx.error_description)]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard?.writeText(formatGpErrorText(error));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may be unavailable; the on-screen detail is still screenshot-able */
+    }
+  };
+
+  return (
+    <Alert severity="error" onClose={onClose} sx={{ '& .MuiAlert-message': { width: '100%' } }}>
+      <AlertTitle>{title ?? 'GP could not complete this operation'}</AlertTitle>
+      <Box sx={{ fontWeight: 600, mb: rows.length ? 1 : 0, wordBreak: 'break-word' }}>{error.message}</Box>
+      {rows.length > 0 && (
+        <Box
+          component="table"
+          sx={{ fontFamily: 'monospace', fontSize: 12.5, borderCollapse: 'collapse', mb: 1, width: '100%' }}
+        >
+          <tbody>
+            {rows.map(([k, v]) => (
+              <tr key={k}>
+                <td
+                  style={{
+                    color: 'rgba(0,0,0,0.55)',
+                    paddingRight: 12,
+                    verticalAlign: 'top',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {k}
+                </td>
+                <td style={{ wordBreak: 'break-word' }}>{v}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Box>
+      )}
+      <Button
+        size="small"
+        color="inherit"
+        startIcon={copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+        onClick={copy}
+      >
+        {copied ? 'Copied' : 'Copy details'}
+      </Button>
+    </Alert>
+  );
+}

--- a/frontend/src/graphql/__tests__/gpError.test.ts
+++ b/frontend/src/graphql/__tests__/gpError.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+import { extractGpError, formatGpErrorText } from '../gpError';
+
+describe('extractGpError', () => {
+  it('pulls message + code + relayError detail from a CombinedGraphQLErrors', () => {
+    const relayError = {
+      error: 'econnect_error',
+      message: 'Duplicate Order',
+      context: { proc: 'taPoLine', error_state: 9127, error_description: 'Duplicate Order' },
+    };
+    const err = new CombinedGraphQLErrors({
+      errors: [{ message: 'Duplicate Order', extensions: { code: 'RELAY_CALL_FAILED', relayError } }],
+    });
+    const gp = extractGpError(err);
+    expect(gp?.message).toBe('Duplicate Order');
+    expect(gp?.code).toBe('RELAY_CALL_FAILED');
+    expect(gp?.relay?.error).toBe('econnect_error');
+    expect(gp?.relay?.context?.proc).toBe('taPoLine');
+    expect(gp?.relay?.context?.error_state).toBe(9127);
+  });
+
+  it('handles a GraphQL error with no relayError extension', () => {
+    const err = new CombinedGraphQLErrors({
+      errors: [{ message: 'no relay is currently connected', extensions: { code: 'RELAY_UNAVAILABLE' } }],
+    });
+    const gp = extractGpError(err);
+    expect(gp?.message).toBe('no relay is currently connected');
+    expect(gp?.code).toBe('RELAY_UNAVAILABLE');
+    expect(gp?.relay).toBeUndefined();
+  });
+
+  it('falls back to a plain Error message (e.g. a network error)', () => {
+    expect(extractGpError(new Error('Failed to fetch'))?.message).toBe('Failed to fetch');
+  });
+
+  it('returns null when there is nothing to show', () => {
+    expect(extractGpError(undefined)).toBeNull();
+    expect(extractGpError(null)).toBeNull();
+  });
+});
+
+describe('formatGpErrorText', () => {
+  it('renders the message and every present detail row', () => {
+    const text = formatGpErrorText({
+      message: 'Duplicate Order',
+      code: 'RELAY_CALL_FAILED',
+      relay: {
+        error: 'econnect_error',
+        context: { proc: 'taPoLine', error_state: 9127, error_description: 'Duplicate Order' },
+      },
+    });
+    expect(text).toContain('GP error: Duplicate Order');
+    expect(text).toContain('Code: RELAY_CALL_FAILED');
+    expect(text).toContain('GP proc: taPoLine');
+    expect(text).toContain('Error state: 9127');
+    expect(text).toContain('Description: Duplicate Order');
+  });
+
+  it('omits absent rows', () => {
+    const text = formatGpErrorText({ message: 'no relay is currently connected', code: 'RELAY_UNAVAILABLE' });
+    expect(text).toContain('GP error: no relay is currently connected');
+    expect(text).not.toContain('GP proc');
+  });
+});

--- a/frontend/src/graphql/gpError.ts
+++ b/frontend/src/graphql/gpError.ts
@@ -1,0 +1,55 @@
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+
+// The relay's own error body, forwarded by the backend under extensions.relayError (see backend
+// main.py ErrorHandlerExtension / issue #187). For an eConnect failure `context` carries the GP proc,
+// the numeric error_state, and its DYNAMICS.taErrorCode description.
+export interface RelayErrorDetail {
+  error?: string;
+  message?: string;
+  context?: {
+    proc?: string;
+    error_state?: number;
+    error_description?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface GpError {
+  message: string; // the human-readable top-level message (already the eConnect description when GP fails)
+  code?: string; // extensions.code, e.g. RELAY_CALL_FAILED / RELAY_UNAVAILABLE / RELAY_TIMEOUT
+  relay?: RelayErrorDetail; // extensions.relayError, present when the failure came from the relay/GP
+}
+
+/**
+ * Normalize an error thrown by an Apollo mutation/query into a GpError with the full GP detail so the
+ * UI can show the end user exactly what GP reported (issue #187: error screenshots are the main channel).
+ * Returns null when there is genuinely nothing to show.
+ */
+export function extractGpError(err: unknown): GpError | null {
+  if (CombinedGraphQLErrors.is(err)) {
+    const first = err.errors[0];
+    if (!first) return null;
+    const ext = (first.extensions ?? {}) as Record<string, unknown>;
+    return {
+      message: first.message || 'GP reported an error',
+      code: typeof ext.code === 'string' ? ext.code : undefined,
+      relay: (ext.relayError as RelayErrorDetail | undefined) ?? undefined,
+    };
+  }
+  if (err instanceof Error && err.message) {
+    return { message: err.message };
+  }
+  return null;
+}
+
+/** Plain-text rendering of a GpError, for the "Copy details" button (a paste-able alternative to a screenshot). */
+export function formatGpErrorText(e: GpError): string {
+  const ctx = e.relay?.context ?? {};
+  const rows: string[] = [`GP error: ${e.message}`];
+  if (e.code) rows.push(`Code: ${e.code}`);
+  if (e.relay?.error) rows.push(`Relay: ${e.relay.error}`);
+  if (ctx.proc) rows.push(`GP proc: ${ctx.proc}`);
+  if (ctx.error_state != null) rows.push(`Error state: ${ctx.error_state}`);
+  if (ctx.error_description) rows.push(`Description: ${ctx.error_description}`);
+  return rows.join('\n');
+}

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -24,6 +24,8 @@ import type { PurchaseOrder } from './index';
 import RelayStatusChip from '../../relay/RelayStatusChip';
 import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from './poVendorName';
+import GpErrorAlert from '../../components/GpErrorAlert';
+import { extractGpError, type GpError } from '../../graphql/gpError';
 
 // --- Types ---
 
@@ -132,6 +134,9 @@ export default function GpPurchaseOrderDialog({
   const [lineItems, setLineItems] = useState<LineItemRow[]>([{ key: 1, ...EMPTY_LINE_ITEM }]);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [gpBusy, setGpBusy] = useState(false);
+  // A GP/eConnect failure from create/register, shown persistently and in detail (issue #187) so the end
+  // user can screenshot it. Distinct from the field-level `errors` map.
+  const [gpError, setGpError] = useState<GpError | null>(null);
 
   const [createPO, { loading: createLoading }] = useMutation<{ createPo: { poNumber: string | null } }>(CREATE_PO);
   const [registerPoInGp, { loading: registerLoading }] = useMutation<{ registerPoInGp: { poNumber: string | null } }>(
@@ -325,6 +330,7 @@ export default function GpPurchaseOrderDialog({
     // Same key for every retry of this action so a retry is a no-op in GP (won't post a second PO).
     const idempotencyKey = (idempotencyKeyRef.current ??= crypto.randomUUID());
 
+    setGpError(null);
     setGpBusy(true);
     try {
       // GP-first, server-side (issue #199): the resolver pushes to GP via the relay before persisting
@@ -373,8 +379,10 @@ export default function GpPurchaseOrderDialog({
     } catch (err: unknown) {
       // Keep idempotencyKeyRef so a retry reuses the same key - the GP write may have committed even if
       // the mutation reported failure, and reusing the key makes the retry safe.
-      const message = err instanceof Error ? err.message : 'Failed to push PO to GP';
-      showToast(`Could not complete the PO in GP: ${message}. If it keeps failing, retry - a retry won't create a duplicate.`, 'error');
+      // Surface the full GP error persistently (issue #187) so the user can screenshot it; the toast
+      // just points at the detail panel.
+      setGpError(extractGpError(err) ?? { message: 'Failed to push PO to GP' });
+      showToast("Could not complete the PO in GP - see the error detail below. A retry won't create a duplicate.", 'error');
     } finally {
       setGpBusy(false);
     }
@@ -431,6 +439,11 @@ export default function GpPurchaseOrderDialog({
 
   return (
     <Modal open={open} title={title} onClose={onClose} actions={actions} maxWidth="md">
+      {gpError && (
+        <Box sx={{ mb: 2 }}>
+          <GpErrorAlert error={gpError} onClose={() => setGpError(null)} />
+        </Box>
+      )}
       {/* Header Fields */}
       <Stack spacing={2} sx={{ mb: 3 }}>
         <TextField

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -29,6 +29,8 @@ import { CREATE_RECEIVE } from '../../graphql/mutations';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
 import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from '../po/poVendorName';
+import GpErrorAlert from '../../components/GpErrorAlert';
+import { extractGpError, type GpError } from '../../graphql/gpError';
 
 // ---- Types ----
 
@@ -110,6 +112,9 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   // the live totalItemsToReceive read 0.
   const [receivedCount, setReceivedCount] = useState(0);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  // Structured GP/eConnect detail for a failed receipt, shown persistently (issue #187) so the user can
+  // screenshot it; mutationError carries the which-PO + retry-safe context line.
+  const [gpError, setGpError] = useState<GpError | null>(null);
   const [poDetailsMap, setPoDetailsMap] = useState<Record<string, PODetails>>({});
   const [poDetailsLoading, setPoDetailsLoading] = useState(false);
   const [poDetailsError, setPoDetailsError] = useState<string | null>(null);
@@ -175,6 +180,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     if (open && poIds.length > 0) {
       setReceiveQuantities({});
       setMutationError(null);
+      setGpError(null);
       setSucceeded(false);
       setLineLocations({});
       // Fresh open = fresh action set; drop any keys held from a prior batch.
@@ -363,6 +369,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   const handleSubmit = useCallback(async () => {
     setConfirmOpen(false);
     setMutationError(null);
+    setGpError(null);
     setSubmitting(true);
 
     // Each createReceive call brokers the GP receipt server-side (issue #199) before persisting the UC
@@ -372,6 +379,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     // re-post them.
     const completed: string[] = [];
     let failureMessage: string | null = null;
+    let capturedGpError: GpError | null = null;
 
     try {
       for (const poId of poIds) {
@@ -416,8 +424,12 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         } catch (err: unknown) {
           // Keep this PO's key so the retry reuses it - the GP receipt may have committed even if the
           // mutation reported failure, and reusing the key makes the retry safe.
-          const message = err instanceof Error ? err.message : 'An unknown error occurred';
-          failureMessage = `Receiving ${poLabel} failed: ${message}. If it keeps failing, retry - a retry won't post a duplicate receipt.`;
+          capturedGpError = extractGpError(err);
+          // When GP gave a structured error, the detail goes in the persistent GpErrorAlert (issue #187),
+          // so this line just carries the which-PO + retry-safe context; otherwise it carries the message.
+          failureMessage = capturedGpError
+            ? `Receiving ${poLabel} failed - see the GP error detail below. A retry won't post a duplicate receipt.`
+            : `Receiving ${poLabel} failed: ${err instanceof Error ? err.message : 'An unknown error occurred'}. If it keeps failing, retry - a retry won't post a duplicate receipt.`;
           break;
         }
 
@@ -451,6 +463,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     if (failureMessage) {
       // Stay open so the user can fix/retry the POs that didn't go through.
       setMutationError(failureMessage);
+      setGpError(capturedGpError);
       return;
     }
 
@@ -475,6 +488,7 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     setPoDetailsMap({});
     setPoDetailsError(null);
     setMutationError(null);
+    setGpError(null);
     setSucceeded(false);
     setConfirmOpen(false);
     setLineLocations({});
@@ -684,9 +698,21 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
           </Alert>
         )}
         {mutationError && (
-          <Alert severity="error" sx={{ mb: 2 }}>
+          <Alert severity="error" sx={{ mb: gpError ? 1 : 2 }}>
             {mutationError}
           </Alert>
+        )}
+        {gpError && (
+          <Box sx={{ mb: 2 }}>
+            <GpErrorAlert
+              error={gpError}
+              title="GP could not complete the receipt"
+              onClose={() => {
+                setGpError(null);
+                setMutationError(null);
+              }}
+            />
+          </Box>
         )}
         {/* A receive posts a GP receipt via the on-prem relay, so the relay must be up. */}
         {!poDetailsLoading && !poDetailsError && !succeeded && (


### PR DESCRIPTION
Fixes #187.

GP/eConnect errors reached the browser but showed in a 4-second auto-hiding toast - impossible for an end user to screenshot, which is the main way these get reported.

_to_graphql_error (main.py ErrorHandlerExtension) forwards AppError .detail as extensions.relayError. generic - any AppError with .detail.

RelayCallError .detail carries:
- eConnect proc
- numeric error_state
- DYNAMICS.taErrorCode description

extractGpError(err) in src/graphql/gpError.ts normalizes CombinedGraphQLErrors or a network Error -> { message, code, relay: {error, message, context: {proc, error_state, error_description}} }. formatGpErrorText builds the copy-button text.

src/components/GpErrorAlert.tsx renders a persistent Alert (no auto-hide) showing:
- message
- code
- proc
- error state
- description
- Copy details button

GpPurchaseOrderDialog (create + register) renders GpErrorAlert at the top of the dialog, stays until dismissed.
ReceiveModal (receive) shows a which-PO + retry-safe context line + GpErrorAlert with the GP detail.

test_error_extension (backend) covers: detail -> relayError, empty detail omitted, plain AppError unchanged.
gpError.test (frontend) covers: extract + format, no-relayError path, network-error path.

GP read errors on dropdowns (gpVendors, gpJobs, ...) still gated behind the relay-connected check; not surfaced; deferred.