### PR TITLE
relay: self-updater in the UI (Updates tab) via public GitHub releases

### DIFF
--- a/.github/workflows/relay-release.yml
+++ b/.github/workflows/relay-release.yml
@@ -38,6 +38,21 @@ jobs:
       - run: pip install poetry
       - run: poetry install --no-interaction --with dev
 
+      - name: Stamp build identity into the package
+        # Write the release tag into _build.py so the packaged exe knows its own version, which the UI's
+        # updater compares against the latest GitHub release. Matches the tag the publish steps below use
+        # (github.ref_name for a tag push, relay-v<version>-build.<run_number> for a master push).
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            build="${{ github.ref_name }}"
+          else
+            version=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+            build="relay-v${version}-build.${{ github.run_number }}"
+          fi
+          echo "BUILD = \"$build\"" > src/ucnexus_relay/_build.py
+          echo "stamped $build -> src/ucnexus_relay/_build.py"
+
       - name: Build exe
         run: poetry run pyinstaller --clean --noconfirm ucnexus-relay.spec
 

--- a/localhost relay/.gitignore
+++ b/localhost relay/.gitignore
@@ -7,6 +7,9 @@ config.toml
 # office temp / lock files
 ~$*
 
+# build identity stamped into the package by CI (relay-release.yml); never committed
+src/ucnexus_relay/_build.py
+
 # python
 __pycache__/
 *.py[cod]

--- a/localhost relay/src/ucnexus_relay/ui.py
+++ b/localhost relay/src/ucnexus_relay/ui.py
@@ -19,7 +19,7 @@ import tomllib
 import urllib.request
 from pathlib import Path
 
-from . import autostart
+from . import autostart, updater
 from .config import DEFAULT_CONFIG_PATH
 
 VERSION = "0.1.0"
@@ -141,6 +141,7 @@ def gather_status(config_path: str | Path | None = None) -> dict:
     health = relay_health(cfg.get("host", "127.0.0.1"), cfg.get("port", 7321)) if cfg.get("present") else relay_health()
     return {
         "ui_version": VERSION,
+        "build": updater.current_build(),
         "config": cfg,
         "relay": health,
         "channel": channel_state(config_path),
@@ -227,6 +228,24 @@ class Api:
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
 
+    # --- updater ---------------------------------------------------------------------------------------
+
+    def check_update(self) -> dict:
+        try:
+            return updater.check_update()
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": str(e)}
+
+    def apply_update(self, url: str) -> dict:
+        if not _frozen():
+            return {"ok": False, "error": "updates can only be applied to the packaged exe"}
+        if not (url or "").strip():
+            return {"ok": False, "error": "no download URL"}
+        try:
+            return updater.apply_update(url.strip(), DEFAULT_CONFIG_PATH.parent)
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": str(e)}
+
 
 _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Relay</title>
 <style>
@@ -270,7 +289,8 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
   <header><span id="hdot" class="dot"></span><h1>UC Nexus Relay</h1><span id="hstate" class="muted"></span>
     <span style="flex:1"></span>
     <nav><button id="tab-status" class="tab active" onclick="showView('status')">Status</button>
-      <button id="tab-setup" class="tab" onclick="showView('setup')">Setup</button></nav>
+      <button id="tab-setup" class="tab" onclick="showView('setup')">Setup</button>
+      <button id="tab-updates" class="tab" onclick="showView('updates')">Updates</button></nav>
     <span id="uiver" class="muted"></span></header>
   <main>
     <section id="view-status">
@@ -314,6 +334,20 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
         <div id="r-run" class="result"></div>
       </div>
     </section>
+    <section id="view-updates" hidden>
+      <div class="card">
+        <h2>Updates</h2>
+        <div class="grid" style="margin-bottom:10px">
+          <div class="k">Installed build</div><div class="v" id="u-current">-</div>
+          <div class="k">Latest release</div><div class="v" id="u-latest">-</div>
+        </div>
+        <div class="actions">
+          <button onclick="checkUpdate()">Check for updates</button>
+          <button id="u-apply" onclick="applyUpdate()" hidden>Update now</button></div>
+        <div id="r-update" class="result"></div>
+        <p class="muted" id="u-note" style="margin:6px 0 0"></p>
+      </div>
+    </section>
   </main>
 <script>
   const $ = id => document.getElementById(id);
@@ -325,11 +359,12 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
   function result(id, ok, text) { $(id).innerHTML = `<span class="${ok ? 'ok' : 'bad'}">${esc(text)}</span>`; }
 
   function showView(v) {
-    $('view-status').hidden = v !== 'status';
-    $('view-setup').hidden = v !== 'setup';
-    $('tab-status').classList.toggle('active', v === 'status');
-    $('tab-setup').classList.toggle('active', v === 'setup');
+    for (const name of ['status', 'setup', 'updates']) {
+      $('view-' + name).hidden = v !== name;
+      $('tab-' + name).classList.toggle('active', v === name);
+    }
     if (v === 'setup') loadSetup();
+    if (v === 'updates') loadUpdates();
   }
 
   async function refresh() {
@@ -341,6 +376,7 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
     $('hstate').innerText = connected ? 'connected to backend' : ('channel: ' + st);
     const c = s.config, r = s.relay, a = s.autostart;
     $('status').innerHTML =
+      row('Build', esc(s.build) || '-') +
       row('Relay process', r.running ? pill(true,'running v'+(r.version||'?')) : pill(false,'not running')) +
       row('Backend channel', pill(connected, st, st==='unknown')) +
       row('Config', c.present ? (c.parse_error ? pill(false,'parse error') : pill(true,'loaded')) : pill(false,'not set up')) +
@@ -407,6 +443,34 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
     const r = await window.pywebview.api.stop_relay();
     result('r-run', r.ok, r.ok ? 'relay stopped' : (r.error || 'failed'));
     setTimeout(refresh, 1000);
+  }
+
+  let _updateUrl = null;
+  async function loadUpdates() {
+    const s = await window.pywebview.api.get_status();
+    $('u-current').innerText = s.build || '-';
+  }
+  async function checkUpdate() {
+    $('r-update').innerHTML = '<span class="muted">checking…</span>';
+    $('u-apply').hidden = true; _updateUrl = null;
+    const r = await window.pywebview.api.check_update();
+    if (!r.ok) { result('r-update', false, r.error || 'check failed'); return; }
+    $('u-current').innerText = r.current; $('u-latest').innerText = r.latest;
+    if (r.update_available) {
+      _updateUrl = r.url; $('u-apply').hidden = false;
+      result('r-update', true, 'update available: ' + r.latest);
+    } else {
+      result('r-update', true, 'up to date');
+    }
+  }
+  async function applyUpdate() {
+    if (!_updateUrl) return;
+    $('r-update').innerHTML = '<span class="muted">downloading and applying… the relay will restart</span>';
+    $('u-apply').hidden = true;
+    const r = await window.pywebview.api.apply_update(_updateUrl);
+    result('r-update', r.ok, r.ok ? 'updated - relay restarted' : (r.error || 'update failed'));
+    $('u-note').innerText = r.note || '';
+    setTimeout(refresh, 2000);
   }
 
   window.addEventListener('pywebviewready', () => { refresh(); setInterval(() => { if ($('auto').checked) refresh(); }, 3000); });

--- a/localhost relay/src/ucnexus_relay/updater.py
+++ b/localhost relay/src/ucnexus_relay/updater.py
@@ -1,0 +1,105 @@
+"""Self-update from the public GitHub releases - the relay UI's third purpose (setup, updates, logs).
+
+The repo is public, so the relay checks the releases API and downloads the exe with no auth token and no
+backend involvement. Applying an update on Windows is the tricky part: a running exe is locked and can't
+be overwritten, but it CAN be renamed. So we download the new exe, rename the current one aside, drop the
+new one into its place, and restart serve. The ui process keeps running from the renamed file; reopening
+the window loads the new UI.
+
+The build identity comes from _build.py, which CI stamps into the package at build time (see
+.github/workflows/relay-release.yml). A dev checkout has no _build.py, so current_build() is 'dev', which
+compares unequal to any release tag (always "behind")."""
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+REPO = "Upper-Canada-Specialty-Hardware/uc-nexus"
+_RELEASES_API = f"https://api.github.com/repos/{REPO}/releases?per_page=30"
+_ASSET_NAME = "ucnexus-relay.exe"
+_MIN_EXE_BYTES = 5_000_000  # a real exe is ~20MB; guard against a truncated body / HTML error page
+
+
+def current_build() -> str:
+    try:
+        from ._build import BUILD
+
+        return BUILD
+    except ImportError:
+        return "dev"
+
+
+def latest_release() -> dict:
+    """The newest relay-v* release that carries the exe asset, from the public releases API. {} if none."""
+    req = urllib.request.Request(_RELEASES_API, headers={"Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(req, timeout=15) as r:  # noqa: S310 (fixed public GitHub API URL)
+        releases = json.loads(r.read().decode())
+    for rel in releases:  # the API returns releases newest-first
+        tag = rel.get("tag_name", "")
+        if not tag.startswith("relay-v"):
+            continue
+        asset = next((a for a in rel.get("assets", []) if a.get("name") == _ASSET_NAME), None)
+        if asset and asset.get("browser_download_url"):
+            return {"tag": tag, "url": asset["browser_download_url"], "published_at": rel.get("published_at")}
+    return {}
+
+
+def check_update() -> dict:
+    cur = current_build()
+    try:
+        latest = latest_release()
+    except OSError as e:
+        return {"ok": False, "error": f"could not reach GitHub releases: {e}"}
+    if not latest:
+        return {"ok": False, "error": "no relay release with an exe asset was found"}
+    return {
+        "ok": True,
+        "current": cur,
+        "latest": latest["tag"],
+        "update_available": latest["tag"] != cur,
+        "url": latest["url"],
+    }
+
+
+def apply_update(url: str, install_dir: str | Path) -> dict:
+    """Download `url` and swap it in for the installed exe, then restart serve (rename-while-running; see
+    the module docstring)."""
+    from . import setup
+
+    install_dir = Path(install_dir)
+    exe = install_dir / _ASSET_NAME
+    new = install_dir / (_ASSET_NAME + ".new")
+    old = install_dir / (_ASSET_NAME + ".old")
+
+    try:
+        urllib.request.urlretrieve(url, str(new))  # noqa: S310 (release asset URL from latest_release)
+    except OSError as e:
+        return {"ok": False, "error": f"download failed: {e}"}
+    if new.stat().st_size < _MIN_EXE_BYTES:
+        try:
+            new.unlink()
+        except OSError:
+            pass
+        return {"ok": False, "error": "the downloaded file is too small - aborting the swap"}
+
+    # Stop serve so its lock on the exe is released. The ui process (this one) still holds the exe image,
+    # which is why we rename rather than overwrite below.
+    setup.stop_serve(install_dir)
+
+    try:
+        if old.exists():
+            old.unlink()  # a stale .old from a prior update whose ui window has since closed
+    except OSError:
+        pass  # still locked by a running ui; os.replace below will surface a clear error if it conflicts
+    try:
+        os.replace(exe, old)  # rename the running exe aside (Windows permits renaming a running image)
+        os.replace(new, exe)  # move the new exe into place
+    except OSError as e:
+        return {
+            "ok": False,
+            "error": f"swap failed ({e}); a previous update's file may still be in use - reboot and retry",
+        }
+
+    r = setup.start_serve(exe, install_dir)
+    return {"ok": True, "restarted": bool(r.get("ok")), "note": "reopen this window to load the updated UI"}

--- a/localhost relay/tests/test_ui.py
+++ b/localhost relay/tests/test_ui.py
@@ -119,7 +119,7 @@ def test_gather_status_shape(tmp_path, monkeypatch):
     monkeypatch.setattr(ui, "relay_health", lambda host="127.0.0.1", port=7321: {"running": True, "version": "0.1.0"})
     monkeypatch.setattr(ui.autostart, "autostart_status", lambda: {"installed": True, "command": "x"})
     s = ui.gather_status(p)
-    assert set(s) == {"ui_version", "config", "relay", "channel", "autostart"}
+    assert set(s) == {"ui_version", "build", "config", "relay", "channel", "autostart"}
     assert s["channel"]["state"] == "connected"
     assert s["relay"]["running"] is True
     assert s["config"]["default_company"] == "TUBC"

--- a/localhost relay/tests/test_updater.py
+++ b/localhost relay/tests/test_updater.py
@@ -1,0 +1,111 @@
+"""Updater: release discovery over the public GitHub API, the current-vs-latest comparison, and the
+download + rename-swap that applies an update. No network (urlopen/urlretrieve mocked), no real exe."""
+
+import json
+from pathlib import Path
+
+from ucnexus_relay import setup, updater
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_current_build_falls_back_to_dev():
+    # a dev checkout has no _build.py (CI stamps it); the fallback keeps the updater always "behind"
+    assert updater.current_build() == "dev"
+
+
+def test_latest_release_picks_newest_relay_asset(monkeypatch):
+    payload = [
+        {"tag_name": "some-other-v1", "assets": []},
+        {
+            "tag_name": "relay-v0.1.0-build.9",
+            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build9.exe"}],
+            "published_at": "t9",
+        },
+        {
+            "tag_name": "relay-v0.1.0-build.8",
+            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build8.exe"}],
+        },
+    ]
+    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
+    r = updater.latest_release()
+    assert r["tag"] == "relay-v0.1.0-build.9"
+    assert r["url"].endswith("build9.exe")
+
+
+def test_latest_release_skips_releases_without_the_exe_asset(monkeypatch):
+    payload = [{"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "notes.txt", "browser_download_url": "u"}]}]
+    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
+    assert updater.latest_release() == {}
+
+
+def test_check_update_reports_available(monkeypatch):
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.7")
+    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "https://x/e.exe"})
+    r = updater.check_update()
+    assert r["ok"] is True
+    assert r["update_available"] is True
+    assert r["latest"] == "relay-v0.1.0-build.9"
+    assert r["url"].endswith("e.exe")
+
+
+def test_check_update_up_to_date(monkeypatch):
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.9")
+    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "u"})
+    assert updater.check_update()["update_available"] is False
+
+
+def test_check_update_no_release(monkeypatch):
+    monkeypatch.setattr(updater, "latest_release", lambda: {})
+    assert updater.check_update()["ok"] is False
+
+
+def test_apply_update_swaps_and_restarts(tmp_path, monkeypatch):
+    exe = tmp_path / "ucnexus-relay.exe"
+    exe.write_bytes(b"OLD-EXE")
+
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+    stopped, started = {}, {}
+
+    def _stop(d):
+        stopped["d"] = d
+        return {"ok": True}
+
+    def _start(e, d):
+        started["exe"] = e
+        return {"ok": True}
+
+    monkeypatch.setattr(setup, "stop_serve", _stop)
+    monkeypatch.setattr(setup, "start_serve", _start)
+
+    r = updater.apply_update("https://x/e.exe", tmp_path)
+    assert r["ok"] is True
+    assert exe.read_bytes()[:1] == b"N"  # exe now holds the new bytes
+    assert (tmp_path / "ucnexus-relay.exe.old").read_bytes() == b"OLD-EXE"  # old renamed aside
+    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # moved into place
+    assert started["exe"] == exe  # serve restarted from the new exe
+    assert stopped["d"] == tmp_path
+
+
+def test_apply_update_rejects_a_tiny_download(tmp_path, monkeypatch):
+    exe = tmp_path / "ucnexus-relay.exe"
+    exe.write_bytes(b"OLD")
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"tiny"))
+    monkeypatch.setattr(setup, "stop_serve", lambda d: {"ok": True})
+
+    r = updater.apply_update("u", tmp_path)
+    assert r["ok"] is False
+    assert "too small" in r["error"]
+    assert exe.read_bytes() == b"OLD"  # left untouched on a bad download


### PR DESCRIPTION
self-updater in the relay ui. third purpose alongside setup + logs.

repo public. relay checks the GitHub releases api, downloads the exe. no auth token, no backend.

Updates tab: installed build vs latest relay-v* release.
Check for updates -> updater.check_update -> releases api.
Update now -> download -> swap in.

apply_update. can't overwrite a running exe on Windows; rename works.
download new exe -> stop serve -> rename current exe aside (.old) -> move new into place -> restart serve.
ui keeps running from the renamed file. reopening the window loads the new ui.
size floor before the swap guards a truncated download.

build identity. CI relay-release.yml stamps the release tag into _build.py before pyinstaller (gitignored; matches the tag the publish steps use).
dev checkout has no _build.py -> current_build() = 'dev', always behind.

ui.py gains:
- get_status returns build
- Updates tab
- check_update / apply_update Api methods
- apply_update guarded to the frozen exe

test_updater covers:
- release discovery (newest relay-v* with the exe asset; skips assetless releases)
- current-vs-latest comparison
- download + rename-swap + restart

verified check_update against the live releases api (found relay-v0.1.0-build.5). Updates tab renders, check handler fires (browser preview). the frozen-exe path adds no native deps beyond the already-bundled pywebview.