### PR TITLE
relay: desktop tray app (app command) + updater swap-failure fix

### DIFF
--- a/localhost relay/poetry.lock
+++ b/localhost relay/poetry.lock
@@ -437,6 +437,131 @@ files = [
 ]
 
 [[package]]
+name = "pillow"
+version = "11.3.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
+    {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e"},
+    {file = "pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6"},
+    {file = "pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f"},
+    {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94"},
+    {file = "pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0"},
+    {file = "pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac"},
+    {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d"},
+    {file = "pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149"},
+    {file = "pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d"},
+    {file = "pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b"},
+    {file = "pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3"},
+    {file = "pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51"},
+    {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c"},
+    {file = "pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a"},
+    {file = "pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214"},
+    {file = "pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635"},
+    {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b"},
+    {file = "pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d"},
+    {file = "pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71"},
+    {file = "pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada"},
+    {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
+    {file = "pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["pyarrow"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -724,6 +849,76 @@ files = [
 packaging = ">=22.0"
 
 [[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_core-12.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:aa5c889961d79d7704f17eeb27f80ee791335819c1bb14babeff7b9ea665b5f0"},
+    {file = "pyobjc_core-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:24b76a63caf0b5369d4a377c7c0438cd70df81539057af3db839bfaa3579e04a"},
+    {file = "pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b"},
+    {file = "pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2"},
+    {file = "pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071"},
+    {file = "pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a"},
+    {file = "pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7"},
+    {file = "pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e"},
+    {file = "pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb"},
+    {file = "pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07"},
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+description = "Wrappers for the Cocoa frameworks on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_cocoa-12.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:05443c1494532779cccff83e9792fdd6f0a4800cac56620132bf28e0bf966e9d"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc6da84f4fc62cc25463bbb85e77a57b8d5ac6caf9a60702daf2edb601332f15"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103"},
+    {file = "pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1"},
+    {file = "pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.2.1"
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2.1"
+description = "Wrappers for the Quartz frameworks on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_quartz-12.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c8fed57ac8a1927e4fe4f48ab4042cbc1087d881743182b6f3f2e6e227a9209f"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60f29408b4f9ed5391a29c6b63e2aa56ddfb8b66b3fb47962930427981e14462"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbc214f1a216b5d3651bc832d0ac4589f029f3f37cd6cbb370aac12a7c77942c"},
+    {file = "pyobjc_framework_quartz-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca61624a0b0e6286d8a0f97f47eb9011e4e81e9a339db436d48af527e7065bb1"},
+    {file = "pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.2.1"
+pyobjc-framework-Cocoa = ">=12.2.1"
+
+[[package]]
 name = "pyodbc"
 version = "5.3.0"
 description = "DB API module for ODBC"
@@ -798,6 +993,23 @@ files = [
 ]
 
 [[package]]
+name = "pystray"
+version = "0.19.5"
+description = "Provides systray integration"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pystray-0.19.5-py2.py3-none-any.whl", hash = "sha256:a0c2229d02cf87207297c22d86ffc57c86c227517b038c0d3c59df79295ac617"},
+]
+
+[package.dependencies]
+Pillow = "*"
+pyobjc-framework-Quartz = {version = ">=7.0", markers = "sys_platform == \"darwin\""}
+python-xlib = {version = ">=0.17", markers = "sys_platform == \"linux\""}
+six = "*"
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
@@ -845,6 +1057,22 @@ files = [
     {file = "python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c"},
     {file = "python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd"},
 ]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+description = "Python X Library"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32"},
+    {file = "python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"},
+]
+
+[package.dependencies]
+six = ">=1.10.0"
 
 [[package]]
 name = "pythonnet"
@@ -1039,6 +1267,18 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
 
 [[package]]
 name = "sniffio"
@@ -1408,4 +1648,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "76c859e4d6e630539220a249af255d1570a45ebc4a3a4b19800a0618a9c1f712"
+content-hash = "09a888d1b87cc2af524a5eaf51b22377ac4ef9495677054e1d42ab806db97a4d"

--- a/localhost relay/pyproject.toml
+++ b/localhost relay/pyproject.toml
@@ -20,6 +20,8 @@ websockets = "^13.0"
 # transitive dep down to the source-only 2.5.2 (which fails to build).
 pywebview = {version = "^6.2", python = "<3.14", markers = "sys_platform == 'win32'"}
 pythonnet = {version = ">=3.0,<4", python = "<3.14", markers = "sys_platform == 'win32'"}
+pystray = "^0.19"
+pillow = "^11.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3"

--- a/localhost relay/src/ucnexus_relay/app.py
+++ b/localhost relay/src/ucnexus_relay/app.py
@@ -1,0 +1,159 @@
+"""The relay desktop app: a system-tray window that supervises the headless relay.
+
+One pywebview window (the control panel) + a pystray system-tray icon. The relay itself runs as a
+separate `serve` child process that this app starts and supervises via setup.start_serve/stop_serve - so
+the existing headless serve, its relay.pid, and the self-updater's swap-and-restart all keep working
+unchanged, and only `serve` holds the single backend connection.
+
+UX: minimize hides the window to the tray (the relay keeps running); the window's X asks
+"Shut down the relay? GP will stop" and, if confirmed, stops the relay and quits; the tray 'Open' brings
+the window back, the tray 'Shut down' quits. Autostart launches this minimized to the tray (PR C).
+"""
+
+import sys
+import threading
+import time
+
+from . import setup
+from .config import DEFAULT_CONFIG_PATH
+from .logging_setup import get_logger
+from .ui import Api, _HTML, config_summary, relay_health
+
+logger = get_logger()
+
+_APP: "RelayApp | None" = None
+
+
+def current() -> "RelayApp | None":
+    """The running RelayApp, so ui.Api.shutdown_app / restart_relay can reach it (None outside app mode)."""
+    return _APP
+
+
+class RelayApp:
+    def __init__(self) -> None:
+        self._window = None
+        self._tray = None
+        self._shutting_down = False
+
+    # --- serve child supervision ----------------------------------------------------------------------
+
+    def _install_dir(self):
+        return DEFAULT_CONFIG_PATH.parent
+
+    def _serve_running(self) -> bool:
+        cfg = config_summary()
+        return relay_health(cfg.get("host", "127.0.0.1"), cfg.get("port", 7321)).get("running", False)
+
+    def ensure_serve(self) -> None:
+        """Start the serve child if it isn't already answering /health. Only from the packaged exe (a dev
+        run has no exe to spawn)."""
+        if self._serve_running() or not getattr(sys, "frozen", False):
+            return
+        setup.start_serve(sys.executable, self._install_dir())
+
+    def restart_serve(self) -> None:
+        """Stop + start the serve child so it re-reads config (picks up a freshly enrolled secret)."""
+        setup.stop_serve(self._install_dir())
+        time.sleep(1.5)  # let port 7321 free before the fresh serve binds it
+        if getattr(sys, "frozen", False):
+            setup.start_serve(sys.executable, self._install_dir())
+
+    # --- lifecycle ------------------------------------------------------------------------------------
+
+    def _stop_relay_and_tray(self) -> None:
+        try:
+            setup.stop_serve(self._install_dir())
+        except Exception:
+            logger.exception("error stopping the relay on shutdown")
+        try:
+            if self._tray is not None:
+                self._tray.stop()
+        except Exception:
+            logger.exception("error stopping the tray")
+
+    def shutdown(self) -> None:
+        """Stop the relay + tray and close the window (used by the tray/Status 'Shut down')."""
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        self._stop_relay_and_tray()
+        try:
+            if self._window is not None:
+                self._window.destroy()
+        except Exception:
+            logger.exception("error destroying the window")
+
+    def _confirm_shutdown(self) -> bool:
+        try:
+            return bool(
+                self._window.create_confirmation_dialog(
+                    "Shut down the relay?",
+                    "Cloud GP operations will stop until the relay is started again.",
+                )
+            )
+        except Exception:
+            logger.exception("confirmation dialog failed; honoring the close")
+            return True
+
+    # --- window + tray events -------------------------------------------------------------------------
+
+    def _on_minimized(self) -> None:
+        try:
+            self._window.hide()  # minimize hides to the tray; the relay keeps running
+        except Exception:
+            logger.exception("error hiding the window on minimize")
+
+    def _on_closing(self) -> bool:
+        # X on the window: confirm, then either allow the close (after stopping the relay) or cancel it.
+        if self._shutting_down:
+            return True
+        if self._confirm_shutdown():
+            self._shutting_down = True
+            self._stop_relay_and_tray()  # the window closes naturally via the returned True
+            return True
+        return False
+
+    def _show_window(self) -> None:
+        try:
+            self._window.show()
+            self._window.restore()
+        except Exception:
+            logger.exception("error showing the window")
+
+    def _build_tray(self) -> None:
+        import pystray
+        from PIL import Image, ImageDraw
+
+        img = Image.new("RGB", (64, 64), (13, 16, 23))
+        ImageDraw.Draw(img).ellipse((16, 16, 48, 48), fill=(46, 204, 113))
+        menu = pystray.Menu(
+            pystray.MenuItem("Open", lambda: self._show_window(), default=True),
+            pystray.MenuItem("Shut down", lambda: self.shutdown()),
+        )
+        self._tray = pystray.Icon("ucnexus-relay", img, "UC Nexus Relay", menu)
+
+    def run(self, minimized: bool = False) -> int:
+        import webview
+
+        global _APP
+        _APP = self
+        self.ensure_serve()
+        self._window = webview.create_window(
+            "UC Nexus Relay",
+            html=_HTML,
+            js_api=Api(),
+            width=760,
+            height=680,
+            min_size=(560, 480),
+            hidden=minimized,
+        )
+        self._window.events.minimized += self._on_minimized
+        self._window.events.closing += self._on_closing
+        self._build_tray()
+        threading.Thread(target=self._tray.run, daemon=True).start()
+        webview.start()  # blocks on the GUI loop until the window is destroyed
+        return 0
+
+
+def run_app(minimized: bool = False) -> int:
+    return RelayApp().run(minimized=minimized)

--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -1,8 +1,8 @@
 """Single entry point for the packaged relay exe (and `python -m ucnexus_relay`).
 
 Subcommands:
-  serve (default)      run the relay - uvicorn on the configured [server] host/port
-  ui                   open the native desktop window (status + event log; setup/updates land here)
+  serve (default)      run the relay (headless) - uvicorn on the configured [server] host/port
+  app [--minimized]    the desktop app: window + system tray, supervising the relay (--minimized = start in tray)
   enroll  ...          one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
   protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
   health               GET the local /health endpoint and print it (exit 0 if status ok)
@@ -137,9 +137,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "serve":
         return _serve(rest)
-    if cmd == "ui":
-        from .ui import run_ui
-        return run_ui()
+    if cmd == "app":
+        from .app import run_app
+        return run_app(minimized="--minimized" in rest)
     if cmd == "enroll":
         from .enroll import main as enroll_main
         return enroll_main(rest)
@@ -156,7 +156,7 @@ def main(argv: list[str] | None = None) -> int:
         return _autostart_status(rest)
 
     print(
-        f"unknown command: {cmd!r} (expected: serve | ui | enroll | protect-secret | health | "
+        f"unknown command: {cmd!r} (expected: serve | app | enroll | protect-secret | health | "
         "install-autostart | uninstall-autostart | autostart-status)",
         file=sys.stderr,
     )

--- a/localhost relay/src/ucnexus_relay/ui.py
+++ b/localhost relay/src/ucnexus_relay/ui.py
@@ -248,6 +248,37 @@ class Api:
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
 
+    def restart_relay(self) -> dict:
+        """Restart the relay so it re-reads config (e.g. after enrolling). In the tray app this restarts
+        the supervised serve child; standalone it stop+starts serve directly."""
+        from . import app, setup
+
+        running = app.current()
+        if running is not None:
+            running.restart_serve()
+            return {"ok": True}
+        setup.stop_serve(DEFAULT_CONFIG_PATH.parent)
+        if _frozen():
+            setup.start_serve(sys.executable, DEFAULT_CONFIG_PATH.parent)
+        return {"ok": True}
+
+    def shutdown_app(self) -> dict:
+        """Stop the relay and quit the desktop app (the Status/tray 'Shut down'). The JS confirms first."""
+        from . import app
+
+        running = app.current()
+        if running is None:
+            return {"ok": False, "error": "not running as the desktop app"}
+        running.shutdown()
+        return {"ok": True}
+
+    def uninstall_autostart(self) -> dict:
+        try:
+            existed = autostart.uninstall_autostart()
+            return {"ok": True, "existed": existed}
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": str(e)}
+
     # --- updater ---------------------------------------------------------------------------------------
 
     def check_update(self) -> dict:
@@ -320,6 +351,14 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
   <main>
     <section id="view-status">
       <div class="card"><h2>Status</h2><div id="status" class="grid"></div></div>
+      <div class="card">
+        <h2>Controls</h2>
+        <label class="muted"><input type="checkbox" id="c-autostart" onchange="toggleAutostart()"> start at logon</label>
+        <div class="actions" style="margin-top:8px">
+          <button onclick="restartRelay()">Restart relay</button>
+          <button onclick="shutDown()">Shut down</button></div>
+        <div id="r-ctl" class="result"></div>
+      </div>
       <div class="card">
         <div class="bar"><h2 style="margin:0">Event log</h2><span style="flex:1"></span>
           <label class="muted"><input type="checkbox" id="auto" checked> auto-refresh</label>
@@ -402,6 +441,7 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
       row('SQL server', c.sql_server || '-') +
       row('Backend URL', c.backend_url || '-') +
       row('Autostart', a.installed===null ? '-' : pill(!!a.installed, a.installed?'installed':'not installed'));
+    if ($('c-autostart')) $('c-autostart').checked = !!a.installed;
     const logs = await window.pywebview.api.get_logs(200);
     $('logs').innerHTML = logs.slice().reverse().map(l =>
       `<tr><td class="muted">${esc(l.time)}</td><td class="lvl ${l.level||''}">${esc(l.level)}</td>`+
@@ -482,14 +522,22 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
     setTimeout(refresh, 2000);
   }
 
+  async function toggleAutostart() {
+    const on = $('c-autostart').checked;
+    const r = on ? await window.pywebview.api.install_autostart() : await window.pywebview.api.uninstall_autostart();
+    result('r-ctl', r.ok, r.ok ? ('start at logon ' + (on ? 'on' : 'off')) : (r.error || 'failed'));
+    refresh();
+  }
+  async function restartRelay() {
+    $('r-ctl').innerHTML = '<span class="muted">restarting the relay…</span>';
+    const r = await window.pywebview.api.restart_relay();
+    result('r-ctl', r.ok, r.ok ? 'relay restarting' : (r.error || 'failed'));
+    setTimeout(refresh, 3000);
+  }
+  async function shutDown() {
+    if (!confirm('Shut down the relay? Cloud GP operations will stop until it is started again.')) return;
+    await window.pywebview.api.shutdown_app();
+  }
+
   window.addEventListener('pywebviewready', () => { refresh(); setInterval(() => { if ($('auto').checked) refresh(); }, 3000); });
 </script></body></html>"""
-
-
-def run_ui() -> int:
-    """Open the native window. Blocks until the window is closed (webview.start runs the GUI loop)."""
-    import webview  # lazy: only the `ui` subcommand needs the GUI backend
-
-    webview.create_window("UC Nexus Relay", html=_HTML, js_api=Api(), width=760, height=680, min_size=(560, 480))
-    webview.start()
-    return 0

--- a/localhost relay/src/ucnexus_relay/updater.py
+++ b/localhost relay/src/ucnexus_relay/updater.py
@@ -62,44 +62,73 @@ def check_update() -> dict:
     }
 
 
+def _unlink_quietly(p: Path) -> None:
+    try:
+        p.unlink()
+    except OSError:
+        pass
+
+
+def _free_old_path(install_dir: Path) -> Path:
+    """A '.old' path to rename the running exe aside to that isn't currently locked. A prior update's
+    '.old' may still be held by an app/ui window that hasn't closed; picking a free variant instead of
+    reusing a locked one is what keeps a second update from failing the swap."""
+    base = install_dir / (_ASSET_NAME + ".old")
+    for candidate in [base, *(install_dir / f"{_ASSET_NAME}.old.{i}" for i in range(1, 20))]:
+        _unlink_quietly(candidate)  # clear a stale one if we can
+        if not candidate.exists():
+            return candidate
+    return install_dir / (_ASSET_NAME + ".old.x")  # last resort
+
+
+def _cleanup_old(install_dir: Path) -> None:
+    for p in install_dir.glob(_ASSET_NAME + ".old*"):
+        _unlink_quietly(p)
+
+
 def apply_update(url: str, install_dir: str | Path) -> dict:
-    """Download `url` and swap it in for the installed exe, then restart serve (rename-while-running; see
-    the module docstring)."""
+    """Download `url` and swap it in for the installed exe, then restart serve. The relay is ALWAYS
+    restarted on the way out, so a failed swap leaves it running on the CURRENT version rather than down
+    (rename-while-running; see the module docstring)."""
     from . import setup
 
     install_dir = Path(install_dir)
     exe = install_dir / _ASSET_NAME
     new = install_dir / (_ASSET_NAME + ".new")
-    old = install_dir / (_ASSET_NAME + ".old")
 
     try:
         urllib.request.urlretrieve(url, str(new))  # noqa: S310 (release asset URL from latest_release)
     except OSError as e:
         return {"ok": False, "error": f"download failed: {e}"}
     if new.stat().st_size < _MIN_EXE_BYTES:
-        try:
-            new.unlink()
-        except OSError:
-            pass
+        _unlink_quietly(new)
         return {"ok": False, "error": "the downloaded file is too small - aborting the swap"}
 
-    # Stop serve so its lock on the exe is released. The ui process (this one) still holds the exe image,
-    # which is why we rename rather than overwrite below.
+    # Stop serve (releases its exe lock), swap, then ALWAYS restart serve in the finally so GP comes back
+    # up even if the swap fails. The app/ui process still holds the exe image, hence rename-not-overwrite.
     setup.stop_serve(install_dir)
-
-    try:
-        if old.exists():
-            old.unlink()  # a stale .old from a prior update whose ui window has since closed
-    except OSError:
-        pass  # still locked by a running ui; os.replace below will surface a clear error if it conflicts
+    old = _free_old_path(install_dir)
+    swapped = False
+    error = None
     try:
         os.replace(exe, old)  # rename the running exe aside (Windows permits renaming a running image)
         os.replace(new, exe)  # move the new exe into place
+        swapped = True
     except OSError as e:
-        return {
-            "ok": False,
-            "error": f"swap failed ({e}); a previous update's file may still be in use - reboot and retry",
-        }
+        error = str(e)
+        if not exe.exists() and old.exists():  # renamed aside but couldn't drop the new one -> roll back
+            try:
+                os.replace(old, exe)
+            except OSError:
+                pass
+    finally:
+        setup.start_serve(exe, install_dir)
 
-    r = setup.start_serve(exe, install_dir)
-    return {"ok": True, "restarted": bool(r.get("ok")), "note": "reopen this window to load the updated UI"}
+    if swapped:
+        _cleanup_old(install_dir)
+        return {"ok": True, "restarted": True, "note": "reopen the window to load the updated UI"}
+    _unlink_quietly(new)
+    return {
+        "ok": False,
+        "error": f"swap failed ({error}); the relay was restarted on the current version - reboot and retry",
+    }

--- a/localhost relay/tests/test_app.py
+++ b/localhost relay/tests/test_app.py
@@ -1,0 +1,78 @@
+"""Tray-app supervision logic (no window, no tray, no GUI backend). The pywebview/pystray run() path is
+verified from the frozen exe; here we cover the serve supervision, the shutdown sequence, the X-close
+decision, and the Api methods that reach the app."""
+
+from ucnexus_relay import app as appmod
+from ucnexus_relay import setup, ui
+
+
+def test_ensure_serve_noop_when_already_running(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_serve_running", lambda: True)
+    started = []
+    monkeypatch.setattr(setup, "start_serve", lambda *args: started.append(args))
+    a.ensure_serve()
+    assert started == []
+
+
+def test_restart_serve_stops_then_starts_when_frozen(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(appmod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(appmod.sys, "frozen", True, raising=False)
+    seq = []
+    monkeypatch.setattr(setup, "stop_serve", lambda d: seq.append("stop"))
+    monkeypatch.setattr(setup, "start_serve", lambda e, d: seq.append("start"))
+    a.restart_serve()
+    assert seq == ["stop", "start"]
+
+
+def test_shutdown_stops_serve_then_tray_then_window_and_is_idempotent(monkeypatch):
+    a = appmod.RelayApp()
+    order = []
+    monkeypatch.setattr(setup, "stop_serve", lambda d: order.append("serve"))
+
+    class _Tray:
+        def stop(self):
+            order.append("tray")
+
+    class _Win:
+        def destroy(self):
+            order.append("window")
+
+    a._tray = _Tray()
+    a._window = _Win()
+    a.shutdown()
+    assert order == ["serve", "tray", "window"]
+    a.shutdown()  # already shutting down -> no-op
+    assert order == ["serve", "tray", "window"]
+
+
+def test_on_closing_cancels_when_not_confirmed(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_confirm_shutdown", lambda: False)
+    assert a._on_closing() is False
+
+
+def test_on_closing_proceeds_when_confirmed(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_confirm_shutdown", lambda: True)
+    stopped = []
+    monkeypatch.setattr(a, "_stop_relay_and_tray", lambda: stopped.append(True))
+    assert a._on_closing() is True
+    assert stopped == [True]
+
+
+def test_api_restart_relay_uses_the_running_app(monkeypatch):
+    a = appmod.RelayApp()
+    called = []
+    monkeypatch.setattr(a, "restart_serve", lambda: called.append(True))
+    monkeypatch.setattr(appmod, "_APP", a)
+    assert ui.Api().restart_relay() == {"ok": True}
+    assert called == [True]
+
+
+def test_api_shutdown_app_errors_when_not_in_app_mode(monkeypatch):
+    monkeypatch.setattr(appmod, "_APP", None)
+    r = ui.Api().shutdown_app()
+    assert r["ok"] is False
+    assert "desktop app" in r["error"]

--- a/localhost relay/tests/test_updater.py
+++ b/localhost relay/tests/test_updater.py
@@ -93,10 +93,29 @@ def test_apply_update_swaps_and_restarts(tmp_path, monkeypatch):
     r = updater.apply_update("https://x/e.exe", tmp_path)
     assert r["ok"] is True
     assert exe.read_bytes()[:1] == b"N"  # exe now holds the new bytes
-    assert (tmp_path / "ucnexus-relay.exe.old").read_bytes() == b"OLD-EXE"  # old renamed aside
+    assert not (tmp_path / "ucnexus-relay.exe.old").exists()  # cleaned up after a successful swap
     assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # moved into place
     assert started["exe"] == exe  # serve restarted from the new exe
     assert stopped["d"] == tmp_path
+
+
+def test_apply_update_restarts_serve_even_when_the_swap_fails(tmp_path, monkeypatch):
+    # regression: a failed swap must NOT leave the relay stopped (it took GP down once).
+    exe = tmp_path / "ucnexus-relay.exe"
+    exe.write_bytes(b"OLD")
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+    started = []
+    monkeypatch.setattr(setup, "stop_serve", lambda d: {"ok": True})
+    monkeypatch.setattr(setup, "start_serve", lambda e, d: started.append(e) or {"ok": True})
+
+    def _raise(a, b):
+        raise OSError("locked")
+
+    monkeypatch.setattr(updater.os, "replace", _raise)
+    r = updater.apply_update("u", tmp_path)
+    assert r["ok"] is False
+    assert "swap failed" in r["error"]
+    assert started == [exe]  # serve was restarted on the current version despite the failure
 
 
 def test_apply_update_rejects_a_tiny_download(tmp_path, monkeypatch):

--- a/localhost relay/ucnexus-relay.spec
+++ b/localhost relay/ucnexus-relay.spec
@@ -22,7 +22,7 @@ hiddenimports = collect_submodules("uvicorn") + [
 # also ships a PyInstaller hook that PyInstaller auto-discovers, but collecting explicitly is belt-and-braces.
 datas = []
 binaries = []
-for _pkg in ("webview", "clr_loader", "pythonnet"):
+for _pkg in ("webview", "clr_loader", "pythonnet", "pystray", "PIL"):
     _d, _b, _h = collect_all(_pkg)
     datas += _d
     binaries += _b


### PR DESCRIPTION
`app [--minimized]` = relay desktop tray app + a fix to the self-updater that took GP down.

`app [--minimized]` = desktop app: a pywebview window + a pystray tray icon supervising the headless relay (a `serve` child via setup.start_serve/stop_serve). serve holds the single backend connection.

unchanged: headless serve, relay.pid, updater swap-and-restart.

UX:
- minimize -> hide window to tray, relay keeps running
- X -> native confirm "Shut down the relay? GP will stop" -> quit (stop relay + tray) or cancel
- tray icon: Open, Shut down
- Status tab lifecycle controls: Restart relay (re-reads config after enroll), Shut down, start-at-logon toggle

replaces the old `ui` command.

deps: pystray + pillow. spec bundles pystray/PIL alongside pywebview/pythonnet.

launch verified from the frozen exe. supervision/shutdown/close unit-tested (test_app.py).

updater fix - this is what took the live relay offline during a self-update: apply_update stopped serve, failed the exe swap because a prior update's .old was still locked, and returned without restarting serve, leaving the relay down. now apply_update ALWAYS restarts serve on the way out (a failed swap leaves the relay on the current version, not down), renames the running exe aside to a non-colliding .old (.old, .old.1, ...) so a locked prior .old can't block the swap, and cleans up stale .old after a successful swap. regression test added.