### PR TITLE
relay: autostart + shortcuts launch the desktop app (app v2, part C)

### DIFF
--- a/localhost relay/install/install-relay-user.ps1
+++ b/localhost relay/install/install-relay-user.ps1
@@ -3,10 +3,14 @@
   Install the UC Nexus relay for the CURRENT USER with no admin rights.
 
 .DESCRIPTION
-  Stages ucnexus-relay.exe + a config.toml into a per-user install dir, then registers a no-admin logon
-  autostart via the HKCU Run key (the exe's `install-autostart` subcommand). Nothing here needs elevation
-  - use this on a workstation whose user is not a local admin. For an IT/fleet install that prefers a
-  Scheduled Task (restart-on-failure, start-when-available), use install-relay.ps1 instead (needs admin).
+  Stages ucnexus-relay.exe + a config.toml into a per-user install dir, registers a no-admin logon
+  autostart via the HKCU Run key (the exe's `install-autostart` subcommand, which launches the desktop
+  app minimized to the tray), and creates Desktop + Start-menu shortcuts. Nothing here needs elevation -
+  use this on a workstation whose user is not a local admin. For an IT/fleet install that prefers a
+  headless Scheduled Task, use install-relay.ps1 instead (needs admin).
+
+  The relay runs as the current interactive user on purpose: it authenticates to GP via Windows SSPI as
+  that domain user (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user.
 
   The relay runs as the current interactive user on purpose: it authenticates to GP via Windows SSPI as
   that domain user (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user.
@@ -19,7 +23,7 @@
   Where to stage the exe + config.toml. Defaults to %LOCALAPPDATA%\UCNexusRelay.
 
 .PARAMETER StartNow
-  Also launch the relay immediately after install. Only do this once config.toml is enrolled.
+  Also open the relay app immediately after install, so you can run Setup -> Enroll from its window.
 
 .EXAMPLE
   .\install-relay-user.ps1 -ExePath C:\Users\me\Downloads\ucnexus-relay.exe -StartNow
@@ -57,23 +61,32 @@ if (-not (Test-Path $destCfg)) {
     Write-Host "kept existing config.toml at $destCfg"
 }
 
-# no-admin logon autostart via the HKCU Run key (the exe registers itself, pointing the Run entry at the
-# staged exe). Runs as the current user at logon; no Task Scheduler, no elevation.
+# no-admin logon autostart via the HKCU Run key (the exe registers itself). The Run entry launches
+# `app --minimized` at logon, so the relay comes up in the system tray. No Task Scheduler, no elevation.
 & $destExe install-autostart
 if ($LASTEXITCODE -ne 0) { Write-Error "install-autostart failed (exit $LASTEXITCODE)"; exit 1 }
 
+# Desktop + Start-menu shortcuts that open the app (window + tray).
+$wsh = New-Object -ComObject WScript.Shell
+$startMenu = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+foreach ($lnkDir in @([Environment]::GetFolderPath("Desktop"), $startMenu)) {
+    $lnk = $wsh.CreateShortcut((Join-Path $lnkDir "UC Nexus Relay.lnk"))
+    $lnk.TargetPath = $destExe
+    $lnk.Arguments = "app"
+    $lnk.WorkingDirectory = $InstallDir
+    $lnk.Description = "UC Nexus Relay"
+    $lnk.Save()
+}
+Write-Host "created Desktop + Start-menu shortcuts (UC Nexus Relay)."
+
 if ($StartNow) {
-    Start-Process -FilePath $destExe -ArgumentList "serve" -WorkingDirectory $InstallDir -WindowStyle Hidden
-    Write-Host "launched the relay now."
+    Start-Process -FilePath $destExe -ArgumentList "app" -WorkingDirectory $InstallDir
+    Write-Host "launched the UC Nexus Relay app."
 }
 
 Write-Host ""
-Write-Host "next steps:"
-Write-Host "  1. edit $destCfg  ([sql] server/driver, [gp] companies, [channel] backend_url)"
-Write-Host "  2. enroll (writes the DPAPI-encrypted secret):"
-Write-Host "       cd `"$InstallDir`"; .\ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend>/graphql"
-Write-Host "  3. start it now (or just log off and back on):"
-Write-Host "       Start-Process `"$destExe`" -ArgumentList serve -WorkingDirectory `"$InstallDir`" -WindowStyle Hidden"
-Write-Host "  4. verify:    .\ucnexus-relay.exe health"
-Write-Host ""
-Write-Host "to remove the autostart later:  .\ucnexus-relay.exe uninstall-autostart"
+Write-Host "next steps (all in the relay app window - open it from the Desktop shortcut):"
+Write-Host "  1. Setup tab: pick the GP company, then Test GP connection."
+Write-Host "  2. In UC Nexus: Admin -> Relay Installs -> Provision install -> copy the one-time token."
+Write-Host "  3. Setup tab: paste the token into Enrollment token -> Enroll, then Restart relay (Status tab)."
+Write-Host "  The app runs in the system tray and starts at logon; minimizing hides it to the tray, X shuts it down."

--- a/localhost relay/src/ucnexus_relay/autostart.py
+++ b/localhost relay/src/ucnexus_relay/autostart.py
@@ -28,10 +28,11 @@ def _require_winreg() -> None:
 
 
 def default_command() -> str:
-    """The command the Run entry launches at logon: the packaged exe with `serve`, quoted so a path with
-    spaces survives. In a dev checkout sys.executable is python, so this is only meaningful for the frozen
-    exe - the installer and the UI always run the packaged exe."""
-    return f'"{sys.executable}" serve'
+    """The command the Run entry launches at logon: the packaged exe as the desktop app, started minimized
+    to the tray (the app supervises the relay). Quoted so a path with spaces survives. In a dev checkout
+    sys.executable is python, so this is only meaningful for the frozen exe - the installer and the UI
+    always run the packaged exe."""
+    return f'"{sys.executable}" app --minimized'
 
 
 def install_autostart(command: str | None = None, subkey: str = RUN_SUBKEY) -> str:

--- a/localhost relay/tests/test_autostart.py
+++ b/localhost relay/tests/test_autostart.py
@@ -52,4 +52,4 @@ def test_uninstall_reports_whether_it_existed(clean_test_key):
 
 def test_default_command_quotes_the_exe(monkeypatch):
     monkeypatch.setattr(autostart.sys, "executable", r"C:\Program Files\UC\ucnexus-relay.exe")
-    assert autostart.default_command() == '"C:\\Program Files\\UC\\ucnexus-relay.exe" serve'
+    assert autostart.default_command() == '"C:\\Program Files\\UC\\ucnexus-relay.exe" app --minimized'


### PR DESCRIPTION
autostart + shortcuts launch the desktop app instead of headless serve (relay app v2, part C)

autostart.default_command returns `app --minimized` - the no-admin HKCU logon autostart brings the relay up as the desktop app minimized to the system tray.

install-relay-user.ps1 creates Desktop + Start-menu shortcuts ("UC Nexus Relay") opening `app`, launches the app on -StartNow, and its next-steps point at the Setup tab + the Admin -> Relay Installs token flow.

install-relay.ps1 (admin scheduled-task) stays on headless serve - the fleet/no-UI path (support both).

test updated (default_command). 112 pass, ruff clean.