### PR TITLE
relay: honest backend-channel state + self-terminating self-update

### DIFF
--- a/localhost relay/src/ucnexus_relay/channel.py
+++ b/localhost relay/src/ucnexus_relay/channel.py
@@ -25,6 +25,24 @@ from .logging_setup import get_logger
 
 logger = get_logger()
 
+# Live channel state, updated by run_forever and exposed on /health, so the desktop app shows the REAL
+# backend-channel status instead of inferring it from relay.log (a killed serve never writes a clean
+# disconnect line, so the log's last event goes stale). `state` mirrors _classify_connect_failure.
+_STATE: dict = {"connected": False, "state": "unknown"}
+
+
+def channel_state_snapshot() -> dict:
+    return dict(_STATE)
+
+
+def _mark_connected() -> None:
+    _STATE.update(connected=True, state="connected")
+
+
+def _mark_disconnected(state: str = "disconnected") -> None:
+    _STATE.update(connected=False, state=state)
+
+
 # WS close code the backend sends when a second relay connects while one already holds the single
 # connection slot (backend/main.py: try_register -> close(4409)). It arrives AFTER accept(), so the
 # client sees it as a close frame - distinct from a secret rejection, which is refused pre-accept.
@@ -186,6 +204,7 @@ async def _run_once(url: str, secret: str, cfg) -> None:
         ping_timeout=cfg.ping_timeout,
     ) as ws:
         logger.info("channel connected", extra={"url": url})
+        _mark_connected()
 
         # Dispatch each job as its own task so the read loop keeps pulling frames instead of blocking on
         # the current job's GP round-trip (issue #202 #5). The Create-PO page fires list_vendors +
@@ -239,10 +258,12 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
         try:
             await _run_once(cfg.backend_url, secret, cfg)
             backoff = cfg.reconnect_min_seconds  # clean run - reset backoff before the next attempt
+            _mark_disconnected()  # _run_once returned -> the socket closed; reconnecting on the next loop
         except asyncio.CancelledError:
             raise
         except Exception as e:
             category, message = _classify_connect_failure(e)
             logger.warning(message, extra={"category": category, "error": str(e), "backoff": backoff})
+            _mark_disconnected(category if category in ("secret_rejected", "slot_busy") else "disconnected")
             backoff = min(backoff * 2, cfg.reconnect_max_seconds)
         await asyncio.sleep(backoff)

--- a/localhost relay/src/ucnexus_relay/main.py
+++ b/localhost relay/src/ucnexus_relay/main.py
@@ -17,7 +17,7 @@ import time
 import pyodbc
 from fastapi import Depends, FastAPI, HTTPException
 
-from . import auth, buyers, db, econnect, errors, models, ops
+from . import auth, buyers, channel, db, econnect, errors, models, ops
 from .config import get_settings
 from .cors import configure_cors
 from .logging_setup import configure_logging, get_logger
@@ -86,7 +86,12 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     def health():
-        return {"status": "ok", "version": VERSION, "uptime_seconds": round(time.monotonic() - _START, 1)}
+        return {
+            "status": "ok",
+            "version": VERSION,
+            "uptime_seconds": round(time.monotonic() - _START, 1),
+            "channel": channel.channel_state_snapshot(),  # the REAL backend-channel state, for the app UI
+        }
 
     @app.get("/info")
     def info(_=Depends(auth.verify_token)):

--- a/localhost relay/src/ucnexus_relay/ui.py
+++ b/localhost relay/src/ucnexus_relay/ui.py
@@ -80,6 +80,7 @@ def relay_health(host: str = "127.0.0.1", port: int = 7321) -> dict:
             "status": body.get("status"),
             "version": body.get("version"),
             "uptime_seconds": body.get("uptime_seconds"),
+            "channel": body.get("channel"),  # the serve process's REAL backend-channel state
         }
     except (OSError, json.JSONDecodeError):
         return {"running": False}
@@ -142,13 +143,22 @@ def gather_status(config_path: str | Path | None = None) -> dict:
     """Everything the status panel shows, in one call."""
     cfg = config_summary(config_path)
     health = relay_health(cfg.get("host", "127.0.0.1"), cfg.get("port", 7321)) if cfg.get("present") else relay_health()
+    # Backend-channel state: trust the serve process's LIVE report (/health.channel). If serve isn't
+    # running the channel can't be up (it lives inside serve) -> disconnected. Fall back to the log
+    # inference only if a running serve didn't report a channel (an older serve build).
+    if not health.get("running"):
+        channel = {"state": "disconnected"}
+    elif health.get("channel"):
+        channel = {"state": health["channel"].get("state", "unknown")}
+    else:
+        channel = channel_state(config_path)
     return {
         "ui_version": VERSION,
         "build": updater.current_build(),
         "known_companies": KNOWN_COMPANIES,  # dev-determined options for the Setup company dropdowns
         "config": cfg,
         "relay": health,
-        "channel": channel_state(config_path),
+        "channel": channel,
         "autostart": autostart.autostart_status() if autostart.winreg is not None else {"installed": None},
     }
 
@@ -292,8 +302,21 @@ class Api:
             return {"ok": False, "error": "updates can only be applied to the packaged exe"}
         if not (url or "").strip():
             return {"ok": False, "error": "no download URL"}
+        from . import app
+
+        running = app.current()
         try:
-            return updater.apply_update(url.strip(), DEFAULT_CONFIG_PATH.parent)
+            if running is None:
+                # standalone (not the desktop app): the hardened in-process swap
+                return updater.apply_update(url.strip(), DEFAULT_CONFIG_PATH.parent)
+            # desktop app: stage the update, then shut ourselves down so the helper can swap the now-
+            # unlocked exe and relaunch - no renaming of a running exe.
+            import os
+
+            result = updater.stage_update(url.strip(), DEFAULT_CONFIG_PATH.parent, os.getpid())
+            if result.get("ok"):
+                running.shutdown()
+            return result
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
 
@@ -514,7 +537,7 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
   }
   async function applyUpdate() {
     if (!_updateUrl) return;
-    $('r-update').innerHTML = '<span class="muted">downloading and applying… the relay will restart</span>';
+    $('r-update').innerHTML = '<span class="muted">downloading and applying… the app will close and reopen on the new version</span>';
     $('u-apply').hidden = true;
     const r = await window.pywebview.api.apply_update(_updateUrl);
     result('r-update', r.ok, r.ok ? 'updated - relay restarted' : (r.error || 'update failed'));

--- a/localhost relay/src/ucnexus_relay/updater.py
+++ b/localhost relay/src/ucnexus_relay/updater.py
@@ -12,6 +12,7 @@ compares unequal to any release tag (always "behind")."""
 
 import json
 import os
+import subprocess
 import urllib.request
 from pathlib import Path
 
@@ -132,3 +133,60 @@ def apply_update(url: str, install_dir: str | Path) -> dict:
         "ok": False,
         "error": f"swap failed ({error}); the relay was restarted on the current version - reboot and retry",
     }
+
+
+# A running exe can't reliably be renamed/overwritten in place, so the desktop app updates by exiting
+# first: this helper waits for the app process (pid) to be gone, then moves the downloaded .new over the
+# now-unlocked exe and relaunches it, retrying the move while any bootloader child is still releasing the
+# image. It deletes itself at the end.
+_HELPER_BAT = r"""@echo off
+:waitapp
+tasklist /fi "PID eq {pid}" /nh 2>nul | find /i "ucnexus-relay" >nul
+if not errorlevel 1 (
+  timeout /t 1 /nobreak >nul
+  goto waitapp
+)
+set _n=0
+:swap
+move /y "{new}" "{exe}" >nul 2>&1
+if not errorlevel 1 goto relaunch
+set /a _n+=1
+if %_n% geq 30 goto done
+timeout /t 1 /nobreak >nul
+goto swap
+:relaunch
+start "" "{exe}" app
+:done
+del "%~f0"
+"""
+
+
+def stage_update(url: str, install_dir: str | Path, app_pid: int) -> dict:
+    """Download the new exe and spawn a detached helper that waits for `app_pid` to exit, swaps the exe
+    (unlocked once the app is gone), and relaunches the app. The caller MUST then shut the app down so the
+    helper can proceed - this is the desktop-app update path that avoids renaming a still-running exe."""
+    install_dir = Path(install_dir)
+    exe = install_dir / _ASSET_NAME
+    new = install_dir / (_ASSET_NAME + ".new")
+
+    try:
+        urllib.request.urlretrieve(url, str(new))  # noqa: S310 (release asset URL from latest_release)
+    except OSError as e:
+        return {"ok": False, "error": f"download failed: {e}"}
+    if new.stat().st_size < _MIN_EXE_BYTES:
+        _unlink_quietly(new)
+        return {"ok": False, "error": "the downloaded file is too small - aborting the update"}
+
+    helper = install_dir / "update-helper.bat"
+    helper.write_text(_HELPER_BAT.format(pid=int(app_pid), new=str(new), exe=str(exe)), encoding="utf-8")
+    detached = 0x00000008  # DETACHED_PROCESS
+    no_window = 0x08000000  # CREATE_NO_WINDOW
+    subprocess.Popen(  # noqa: S603 (fixed cmd + our own helper path)
+        ["cmd", "/c", str(helper)],
+        cwd=str(install_dir),
+        creationflags=detached | no_window,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return {"ok": True, "note": "the relay will close and reopen on the new version"}

--- a/localhost relay/tests/test_app.py
+++ b/localhost relay/tests/test_app.py
@@ -76,3 +76,31 @@ def test_api_shutdown_app_errors_when_not_in_app_mode(monkeypatch):
     r = ui.Api().shutdown_app()
     assert r["ok"] is False
     assert "desktop app" in r["error"]
+
+
+def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
+    from ucnexus_relay import updater
+
+    a = appmod.RelayApp()
+    shut = []
+    monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
+    monkeypatch.setattr(appmod, "_APP", a)
+    monkeypatch.setattr(ui, "_frozen", lambda: True)
+    monkeypatch.setattr(updater, "stage_update", lambda url, d, pid: {"ok": True, "note": "restarting"})
+    r = ui.Api().apply_update("https://x/e.exe")
+    assert r["ok"] is True
+    assert shut == [True]  # the app shut itself down so the helper can swap the unlocked exe
+
+
+def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
+    from ucnexus_relay import updater
+
+    a = appmod.RelayApp()
+    shut = []
+    monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
+    monkeypatch.setattr(appmod, "_APP", a)
+    monkeypatch.setattr(ui, "_frozen", lambda: True)
+    monkeypatch.setattr(updater, "stage_update", lambda url, d, pid: {"ok": False, "error": "download failed"})
+    r = ui.Api().apply_update("https://x/e.exe")
+    assert r["ok"] is False
+    assert shut == []  # a failed stage must NOT close the app

--- a/localhost relay/tests/test_channel_reconnect.py
+++ b/localhost relay/tests/test_channel_reconnect.py
@@ -41,3 +41,15 @@ def test_normal_close_is_generic_retry():
     # A plain server-side close (e.g. backend restart) is a transient drop, not a secret problem.
     exc = ConnectionClosedError(Close(1000, ""), None)
     assert channel._classify_connect_failure(exc)[0] == "dropped"
+
+
+def test_channel_state_snapshot_reflects_the_mark_helpers():
+    # the live state run_forever maintains + /health exposes (so the UI shows the REAL channel state)
+    channel._mark_connected()
+    assert channel.channel_state_snapshot() == {"connected": True, "state": "connected"}
+    channel._mark_disconnected("secret_rejected")
+    snap = channel.channel_state_snapshot()
+    assert snap["connected"] is False
+    assert snap["state"] == "secret_rejected"
+    channel._mark_disconnected()
+    assert channel.channel_state_snapshot()["state"] == "disconnected"

--- a/localhost relay/tests/test_ui.py
+++ b/localhost relay/tests/test_ui.py
@@ -146,3 +146,23 @@ def test_enroll_url_derived_from_baked_backend():
     url = ui._enroll_url_from_channel()
     assert url.startswith("https://")
     assert url.endswith("/graphql")
+
+
+def test_gather_status_channel_disconnected_when_serve_down(tmp_path, monkeypatch):
+    # a killed serve can't have a live channel, no matter what the log's last line says
+    p = _cfg(tmp_path, '[gp]\ndefault_company = "TUBC"\n[logging]\nfile = "relay.log"\n')
+    _log(tmp_path, {"asctime": "t1", "levelname": "INFO", "message": "channel connected"})
+    monkeypatch.setattr(ui, "relay_health", lambda host="127.0.0.1", port=7321: {"running": False})
+    monkeypatch.setattr(ui.autostart, "autostart_status", lambda: {"installed": True})
+    assert ui.gather_status(p)["channel"]["state"] == "disconnected"
+
+
+def test_gather_status_uses_live_channel_from_health(tmp_path, monkeypatch):
+    p = _cfg(tmp_path, '[gp]\ndefault_company = "TUBC"\n[logging]\nfile = "relay.log"\n')
+    _log(tmp_path, {"asctime": "t1", "levelname": "INFO", "message": "channel connected"})  # stale "connected"
+    monkeypatch.setattr(
+        ui, "relay_health", lambda host="127.0.0.1", port=7321: {"running": True, "channel": {"connected": False, "state": "secret_rejected"}}
+    )
+    monkeypatch.setattr(ui.autostart, "autostart_status", lambda: {"installed": True})
+    # the live /health channel wins over the stale log line
+    assert ui.gather_status(p)["channel"]["state"] == "secret_rejected"

--- a/localhost relay/tests/test_updater.py
+++ b/localhost relay/tests/test_updater.py
@@ -128,3 +128,30 @@ def test_apply_update_rejects_a_tiny_download(tmp_path, monkeypatch):
     assert r["ok"] is False
     assert "too small" in r["error"]
     assert exe.read_bytes() == b"OLD"  # left untouched on a bad download
+
+
+def test_stage_update_downloads_writes_helper_and_spawns_it(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+    calls = []
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
+    r = updater.stage_update("u", tmp_path, 4242)
+    assert r["ok"] is True
+    helper = tmp_path / "update-helper.bat"
+    assert helper.exists()
+    txt = helper.read_text(encoding="utf-8")
+    assert "4242" in txt  # waits for the app pid
+    assert "ucnexus-relay.exe" in txt  # relaunches the exe
+    assert (tmp_path / "ucnexus-relay.exe.new").exists()  # the new exe downloaded, not yet swapped
+    assert calls and calls[0][0][0] == ["cmd", "/c", str(helper)]  # helper spawned
+
+
+def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"tiny"))
+
+    def _no_spawn(*a, **k):
+        raise AssertionError("must not spawn the helper on a bad download")
+
+    monkeypatch.setattr(updater.subprocess, "Popen", _no_spawn)
+    r = updater.stage_update("u", tmp_path, 1)
+    assert r["ok"] is False
+    assert "too small" in r["error"]


### PR DESCRIPTION
fixes two issues from the last update attempt:
- "process not running but channel connected" contradiction
- WinError 5 access-denied swap failure

honest channel state: the serve process tracks its live channel-connected state (channel._STATE, updated by run_forever) and exposes it on /health. the Status tab reads /health, not relay.log's newest line - a killed serve never writes a clean disconnect line, so the log's last event went stale and the UI showed "channel connected" with the process not running.
- serve down -> channel disconnected (the channel lives inside serve, so it can't be up without it)
- serve up -> live /health.channel state
- log inference kept as a fallback for an older serve build.

self-terminating update: the desktop app no longer renames a still-running exe (a prior update's locked .old blocked the swap -> WinError 5). updater.stage_update downloads the new exe -> spawns a detached helper .bat -> waits for the app pid to exit -> moves the new exe over the unlocked exe (retrying while a bootloader child releases the image) -> relaunches app. Api.apply_update in app mode stages the update -> app.shutdown() (serve child, tray, window) -> the swap runs with nothing holding the exe. standalone serve keeps the in-process apply_update from PR B.

tests:
- channel state snapshot
- gather_status shows disconnected when serve down, prefers live /health channel over a stale log line
- stage_update writes helper + spawns it; rejects a tiny download without spawning
- Api.apply_update stages-then-shuts-down in app mode; no shutdown on a failed stage
119 pass, ruff clean.