### PR TITLE
fix(relay): pick latest release by build number, not GitHub list order

### DIFF
--- a/localhost relay/src/ucnexus_relay/updater.py
+++ b/localhost relay/src/ucnexus_relay/updater.py
@@ -12,6 +12,7 @@ compares unequal to any release tag (always "behind")."""
 
 import json
 import os
+import re
 import subprocess
 import urllib.request
 from pathlib import Path
@@ -31,19 +32,34 @@ def current_build() -> str:
         return "dev"
 
 
+def build_number(tag: str) -> int:
+    """The trailing build number of a `relay-v<ver>-build.<N>` tag (-1 if none, e.g. 'dev' or a plain
+    relay-v tag). Used to pick the newest release and to gate updates by version, not list order."""
+    m = re.search(r"build\.(\d+)$", tag or "")
+    return int(m.group(1)) if m else -1
+
+
 def latest_release() -> dict:
-    """The newest relay-v* release that carries the exe asset, from the public releases API. {} if none."""
+    """The relay-v* release with the HIGHEST build number that carries the exe asset. GitHub's /releases
+    list is not reliably newest-first (a newer build can appear mid-list), so pick by build number rather
+    than trusting list order. {} if none."""
     req = urllib.request.Request(_RELEASES_API, headers={"Accept": "application/vnd.github+json"})
     with urllib.request.urlopen(req, timeout=15) as r:  # noqa: S310 (fixed public GitHub API URL)
         releases = json.loads(r.read().decode())
-    for rel in releases:  # the API returns releases newest-first
+    best: dict = {}
+    best_n = -2
+    for rel in releases:
         tag = rel.get("tag_name", "")
         if not tag.startswith("relay-v"):
             continue
         asset = next((a for a in rel.get("assets", []) if a.get("name") == _ASSET_NAME), None)
-        if asset and asset.get("browser_download_url"):
-            return {"tag": tag, "url": asset["browser_download_url"], "published_at": rel.get("published_at")}
-    return {}
+        if not (asset and asset.get("browser_download_url")):
+            continue
+        n = build_number(tag)
+        if n > best_n:
+            best_n = n
+            best = {"tag": tag, "url": asset["browser_download_url"], "published_at": rel.get("published_at")}
+    return best
 
 
 def check_update() -> dict:
@@ -54,11 +70,14 @@ def check_update() -> dict:
         return {"ok": False, "error": f"could not reach GitHub releases: {e}"}
     if not latest:
         return {"ok": False, "error": "no relay release with an exe asset was found"}
+    # Only offer an update when the release is a HIGHER build than the installed one - never a downgrade.
+    # 'dev' has build number -1, so any real release is an update from a dev checkout.
+    update_available = build_number(latest["tag"]) > build_number(cur)
     return {
         "ok": True,
         "current": cur,
         "latest": latest["tag"],
-        "update_available": latest["tag"] != cur,
+        "update_available": update_available,
         "url": latest["url"],
     }
 

--- a/localhost relay/tests/test_updater.py
+++ b/localhost relay/tests/test_updater.py
@@ -26,23 +26,35 @@ def test_current_build_falls_back_to_dev():
     assert updater.current_build() == "dev"
 
 
-def test_latest_release_picks_newest_relay_asset(monkeypatch):
+def test_latest_release_picks_highest_build_not_list_order(monkeypatch):
+    # regression: GitHub's /releases list is NOT reliably newest-first - the real API returned
+    # build.9, build.8, build.7, build.10 in that order. Picking the first entry gives build.9 and
+    # would offer a DOWNGRADE to anyone on build.10. Pick by build number, not position.
     payload = [
         {"tag_name": "some-other-v1", "assets": []},
         {
             "tag_name": "relay-v0.1.0-build.9",
             "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build9.exe"}],
-            "published_at": "t9",
         },
         {
             "tag_name": "relay-v0.1.0-build.8",
             "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build8.exe"}],
         },
+        {
+            "tag_name": "relay-v0.1.0-build.10",  # newest, but appears AFTER the older ones in the list
+            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build10.exe"}],
+            "published_at": "t10",
+        },
     ]
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
     r = updater.latest_release()
-    assert r["tag"] == "relay-v0.1.0-build.9"
-    assert r["url"].endswith("build9.exe")
+    assert r["tag"] == "relay-v0.1.0-build.10"
+    assert r["url"].endswith("build10.exe")
+
+
+def test_latest_release_returns_empty_when_no_relay_release(monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp([{"tag_name": "some-other-v1", "assets": []}]))
+    assert updater.latest_release() == {}
 
 
 def test_latest_release_skips_releases_without_the_exe_asset(monkeypatch):
@@ -65,6 +77,20 @@ def test_check_update_up_to_date(monkeypatch):
     monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.9")
     monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "u"})
     assert updater.check_update()["update_available"] is False
+
+
+def test_check_update_never_offers_a_downgrade(monkeypatch):
+    # installed build is NEWER than what discovery returns (e.g. GitHub API lag) -> must NOT offer to
+    # "update" to the older build.
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.10")
+    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "u"})
+    assert updater.check_update()["update_available"] is False
+
+
+def test_check_update_from_dev_offers_any_release(monkeypatch):
+    monkeypatch.setattr(updater, "current_build", lambda: "dev")
+    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.1", "url": "u"})
+    assert updater.check_update()["update_available"] is True
 
 
 def test_check_update_no_release(monkeypatch):


### PR DESCRIPTION
Found while auditing whether the relay UI fields show real data (they do, except this one).

Updates tab reported wrong "latest" release.
latest_release() took first relay-v* entry; /releases is not newest-first. API returned tags in this order:
build.9
build.8
build.7
build.10 (newest, 4th in list)
build.6

on installed build.10, check_update() offered downgrade to build.9.

latest_release() now picks relay-v* with highest build.N (parsed from tag), not list order.
check_update() gates update_available on build number (latest > current).
dev treated as build -1.
added build_number(tag) helper.

test_latest_release_picks_highest_build_not_list_order - mirrors real API ordering (build.10 last), asserts build.10 wins.
test_check_update_never_offers_a_downgrade - installed newer than discovered -> no update.
test_check_update_from_dev_offers_any_release - dev checkout offered any release.

latest_release() returns build.10 against live GitHub API.
