### PR TITLE
fix(relay): build the exe windowed so no console window pops for the tray app

### DIFF
--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -13,7 +13,36 @@ Subcommands:
 The packaged exe bundles all of these so a workstation needs only the .exe + config.toml (no Poetry).
 """
 
+import os
 import sys
+
+
+def _reattach_console() -> None:
+    """The exe is built windowed (console=False) so the tray app and the detached `serve` child never pop
+    a console window. The cost of a windowed build is that a CLI subcommand run from a terminal would be
+    silent, and PyInstaller leaves sys.stdout/stderr as None there, so a plain print() would crash. On
+    Windows, attach to the launching terminal's console if there is one - there ISN'T for the tray app
+    (launched from a shortcut) or the detached serve child, so those stay windowless - and guarantee
+    stdout/stderr are always writable."""
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            attach_parent = ctypes.c_uint(-1).value  # ATTACH_PARENT_PROCESS (DWORD (DWORD)-1)
+            if ctypes.windll.kernel32.AttachConsole(attach_parent):
+                sys.stdout = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
+                sys.stderr = open("CONOUT$", "w", encoding="utf-8", buffering=1)  # noqa: SIM115
+                try:
+                    sys.stdin = open("CONIN$", encoding="utf-8")  # noqa: SIM115
+                except OSError:
+                    pass
+        except OSError:
+            pass
+    # a windowed PyInstaller build can leave these None; keep print()/logging from crashing if no console
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+    if sys.stderr is None:
+        sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
 
 
 def _serve(argv: list[str]) -> int:
@@ -129,6 +158,7 @@ def _autostart_status(argv: list[str]) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _reattach_console()  # windowed build: attach to the launching terminal (if any) so CLI output shows
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and not argv[0].startswith("-"):
         cmd, rest = argv[0], argv[1:]

--- a/localhost relay/tests/test_cli.py
+++ b/localhost relay/tests/test_cli.py
@@ -1,0 +1,42 @@
+"""CLI dispatch + the windowed-build console-reattach shim. The exe is built windowed (console=False) so
+no console window pops for the tray app / detached serve; the shim's job is to keep CLI subcommands
+printable and to never leave stdout/stderr as None (a windowed PyInstaller build can), which would crash
+print()/logging."""
+
+import sys
+
+from ucnexus_relay import cli
+
+
+def test_reattach_console_never_leaves_streams_none(monkeypatch):
+    # the crash-safety net: a windowed build with no console leaves stdout/stderr None. Force the
+    # non-win32 path so no real console API is touched, then prove the streams are backfilled + writable.
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.setattr(cli.sys, "stdout", None)
+    monkeypatch.setattr(cli.sys, "stderr", None)
+    cli._reattach_console()
+    assert cli.sys.stdout is not None
+    assert cli.sys.stderr is not None
+    cli.sys.stdout.write("")  # writable - does not raise
+    cli.sys.stderr.write("")
+
+
+def test_reattach_console_leaves_present_streams_untouched(monkeypatch):
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    out, err = sys.stdout, sys.stderr
+    cli._reattach_console()
+    assert cli.sys.stdout is out
+    assert cli.sys.stderr is err
+
+
+def test_main_unknown_command_returns_2(monkeypatch):
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)  # don't touch the real console under pytest
+    assert cli.main(["definitely-not-a-command"]) == 2
+
+
+def test_main_dispatches_health(monkeypatch):
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)
+    called = {}
+    monkeypatch.setattr(cli, "_health", lambda rest: called.setdefault("rest", rest) or 0)
+    assert cli.main(["health"]) == 0
+    assert called["rest"] == []

--- a/localhost relay/ucnexus-relay.spec
+++ b/localhost relay/ucnexus-relay.spec
@@ -53,7 +53,11 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=False,
-    console=True,
+    # Windowed (GUI) subsystem: a console-subsystem exe pops a console window every time the tray app is
+    # launched (titled with the exe path), which stays for the app's whole life. Building windowed means
+    # neither the tray app nor the detached `serve` child ever shows a console. cli.py reattaches to the
+    # launching terminal's console (AttachConsole) so CLI subcommands still print when run by hand.
+    console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,


### PR DESCRIPTION
console window pops open on relay tray app launch. cause is console=True in ucnexus-relay.spec.

a console-subsystem exe gets a console window on interactive launch (the shortcut runs `ucnexus-relay.exe app`), titled with the exe path, staying for the app's whole life. the serve child was already windowless (DETACHED_PROCESS | CREATE_NO_WINDOW), so the stray window is the GUI app itself.

console=False in ucnexus-relay.spec. neither tray app nor serve shows console.

a windowed build detaches from the terminal and PyInstaller leaves stdout/stderr None, so hand-run CLI subcommands would be silent and print() would crash. cli.main calls _reattach_console(): hand-run CLI subcommands (ucnexus-relay.exe health, enroll) attach to the launching terminal via AttachConsole(ATTACH_PARENT_PROCESS). no-op for shortcut tray app + detached serve child. stdout/stderr never None.

test_reattach_console_never_leaves_streams_none
test_reattach_console_leaves_present_streams_untouched
test_main_unknown_command_returns_2
test_main_dispatches_health

full relay suite 126 passed. lint clean.
