### PR TITLE
Fix off-by-one date on the generated PO document (#230 follow-up)

### DIFF
--- a/frontend/src/modules/po/POGenerateDialog.tsx
+++ b/frontend/src/modules/po/POGenerateDialog.tsx
@@ -71,7 +71,10 @@ function projectBlock(p: ProjectShipTo): string {
 
 function formatDocDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '';
-  const d = new Date(dateStr);
+  // Parse a date-only string (YYYY-MM-DD, from a date input or a GraphQL Date) as LOCAL midnight, not
+  // UTC - `new Date("2026-08-15")` is UTC, which renders as the previous day in a behind-UTC timezone.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : new Date(dateStr);
   return isNaN(d.getTime()) ? '' : d.toLocaleDateString();
 }
 


### PR DESCRIPTION
formatDocDate parsed date-only YYYY-MM-DD via new Date() (UTC midnight). follow-up to #237.
2026-08-15 printed 8/14/2026 on the PO; tariff effective-until label off by one.
now parses date-only strings as local midnight.

found during simulated user testing of #237.
