### PR TITLE
Generate PO document: GP-sourced totals + buyer, plain ship-to, PO-module settings (#230)

### DIFF
--- a/backend/alembic/versions/050_add_shipping_methods_setting.py
+++ b/backend/alembic/versions/050_add_shipping_methods_setting.py
@@ -1,0 +1,31 @@
+"""Add shipping_methods to po_document_settings (issue #230 follow-up)
+
+The generate dialog's Shipping Method is now a dropdown fed by an admin-configurable list, so the
+boilerplate row gains a shipping_methods JSON column. The column is NOT NULL; the already-seeded row
+is backfilled with the default option set before the constraint is applied.
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-07-14
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "050"
+down_revision = "049"
+branch_labels = None
+depends_on = None
+
+_DEFAULT = '["LOCAL DELIVERY", "Supply by your freight company", "Supply by our freight company", "Pick up"]'
+
+
+def upgrade() -> None:
+    op.add_column("po_document_settings", sa.Column("shipping_methods", sa.JSON(), nullable=True))
+    op.execute(f"UPDATE po_document_settings SET shipping_methods = '{_DEFAULT}' WHERE shipping_methods IS NULL")
+    op.alter_column("po_document_settings", "shipping_methods", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("po_document_settings", "shipping_methods")

--- a/backend/app/models/po_document_settings.py
+++ b/backend/app/models/po_document_settings.py
@@ -26,6 +26,8 @@ class PODocumentSettings(Base):
     mandatory_bullets: Mapped[list] = mapped_column(JSON, nullable=False)
     # Courier / freight account numbers (informational block).
     shipping_accounts: Mapped[list] = mapped_column(JSON, nullable=False)
+    # The selectable shipping-method options for the generate dialog's dropdown.
+    shipping_methods: Mapped[list] = mapped_column(JSON, nullable=False)
     # The customs-broker + business-number block, included on international shipments.
     customs_broker_block: Mapped[str] = mapped_column(Text, nullable=False)
     # Wood-door FSC certification note (conditional, toggled per PO).

--- a/backend/app/repositories/po_document_settings_repository.py
+++ b/backend/app/repositories/po_document_settings_repository.py
@@ -29,6 +29,13 @@ DEFAULT_SHIPPING_ACCOUNTS = [
     "UPS acct# 1167F1",
 ]
 
+DEFAULT_SHIPPING_METHODS = [
+    "LOCAL DELIVERY",
+    "Supply by your freight company",
+    "Supply by our freight company",
+    "Pick up",
+]
+
 DEFAULT_CUSTOMS_BROKER_BLOCK = (
     "UC Hardware Inc. (UCH) Business Number 728227356 RT0001\n"
     "UCH Customs Broker:\n"
@@ -82,6 +89,7 @@ def get_settings(session: Session) -> PODocumentSettings:
         tax_numbers=DEFAULT_TAX_NUMBERS,
         mandatory_bullets=list(DEFAULT_MANDATORY_BULLETS),
         shipping_accounts=list(DEFAULT_SHIPPING_ACCOUNTS),
+        shipping_methods=list(DEFAULT_SHIPPING_METHODS),
         customs_broker_block=DEFAULT_CUSTOMS_BROKER_BLOCK,
         fsc_note=DEFAULT_FSC_NOTE,
         usa_tariff_note=DEFAULT_USA_TARIFF_NOTE,
@@ -106,6 +114,7 @@ def update_settings(
     tax_numbers=_UNSET,
     mandatory_bullets=_UNSET,
     shipping_accounts=_UNSET,
+    shipping_methods=_UNSET,
     customs_broker_block=_UNSET,
     fsc_note=_UNSET,
     usa_tariff_note=_UNSET,
@@ -127,6 +136,8 @@ def update_settings(
         settings.mandatory_bullets = [b.strip() for b in (mandatory_bullets or []) if b and b.strip()]
     if shipping_accounts is not _UNSET:
         settings.shipping_accounts = [a.strip() for a in (shipping_accounts or []) if a and a.strip()]
+    if shipping_methods is not _UNSET:
+        settings.shipping_methods = [m.strip() for m in (shipping_methods or []) if m and m.strip()]
     if customs_broker_block is not _UNSET:
         settings.customs_broker_block = customs_broker_block or ""
     if fsc_note is not _UNSET:

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -300,6 +300,7 @@ class UpdatePODocumentSettingsInput:
     tax_numbers: str | None = strawberry.UNSET
     mandatory_bullets: list[str] | None = strawberry.UNSET
     shipping_accounts: list[str] | None = strawberry.UNSET
+    shipping_methods: list[str] | None = strawberry.UNSET
     customs_broker_block: str | None = strawberry.UNSET
     fsc_note: str | None = strawberry.UNSET
     usa_tariff_note: str | None = strawberry.UNSET

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -1426,6 +1426,7 @@ class Mutation:
                 "tax_numbers",
                 "mandatory_bullets",
                 "shipping_accounts",
+                "shipping_methods",
                 "customs_broker_block",
                 "fsc_note",
                 "usa_tariff_note",

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -42,6 +42,7 @@ from .types import (
     DeficientItemRow,
     GpCostCode,
     GpJob,
+    GpPoTotals,
     GpVendor,
     HomeDashboardStats,
     InventoryHierarchyNode,
@@ -270,6 +271,7 @@ def _po_document_settings_to_type(s) -> PODocumentSettings:
         tax_numbers=s.tax_numbers,
         mandatory_bullets=list(s.mandatory_bullets or []),
         shipping_accounts=list(s.shipping_accounts or []),
+        shipping_methods=list(s.shipping_methods or []),
         customs_broker_block=s.customs_broker_block,
         fsc_note=s.fsc_note,
         usa_tariff_note=s.usa_tariff_note,
@@ -1150,6 +1152,23 @@ class Query:
         require_user(info)
         result = await relay_gateway.relay_call(company, "list_cost_codes", {"job": job})
         return [_gp_cost_code_to_type(c) for c in result["cost_codes"]]
+
+    @strawberry.field
+    async def gp_po_totals(self, info: strawberry.Info, company: str, po_number: str) -> GpPoTotals | None:
+        """GP-computed header totals (POP10100) for a PO, read live via the connected relay - auto-fills
+        the generated PO document (issue #230). Returns null if the PO isn't found in GP."""
+        require_user(info)
+        result = await relay_gateway.relay_call(company, "read_po_totals", {"po_number": po_number})
+        if result is None or result.get("totals") is None:
+            return None
+        t = result["totals"]
+        return GpPoTotals(
+            po_number=t["po_number"],
+            subtotal=float(t["subtotal"]),
+            freight=float(t["freight"]),
+            miscellaneous=float(t["miscellaneous"]),
+            tax_amount=float(t["tax_amount"]),
+        )
 
     @strawberry.field
     async def suggest_vendor_for_manufacturer(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -268,6 +268,7 @@ class PODocumentSettings:
     tax_numbers: str
     mandatory_bullets: list[str]
     shipping_accounts: list[str]
+    shipping_methods: list[str]
     customs_broker_block: str
     fsc_note: str
     usa_tariff_note: str
@@ -278,6 +279,18 @@ class PODocumentSettings:
     footer_notes: str
     signature_note: str
     updated_at: datetime
+
+
+@strawberry.type
+class GpPoTotals:
+    """GP-computed PO header totals (POP10100) read live via the relay, to auto-fill the generated
+    supplier PO document (issue #230). Only available for a PO that exists in GP."""
+
+    po_number: str
+    subtotal: float
+    freight: float
+    miscellaneous: float
+    tax_amount: float
 
 
 @strawberry.type

--- a/backend/tests/test_po_document_settings_repository.py
+++ b/backend/tests/test_po_document_settings_repository.py
@@ -12,6 +12,7 @@ def test_get_settings_creates_default_on_first_read(db_session):
     assert settings.tax_numbers == repo.DEFAULT_TAX_NUMBERS
     assert settings.mandatory_bullets == repo.DEFAULT_MANDATORY_BULLETS
     assert settings.shipping_accounts == repo.DEFAULT_SHIPPING_ACCOUNTS
+    assert settings.shipping_methods == repo.DEFAULT_SHIPPING_METHODS
     assert settings.customs_broker_block == repo.DEFAULT_CUSTOMS_BROKER_BLOCK
     assert settings.usa_tariff_effective_until == repo.DEFAULT_USA_TARIFF_EFFECTIVE_UNTIL
     assert settings.company_from_address == repo.DEFAULT_COMPANY_FROM_ADDRESS
@@ -45,9 +46,11 @@ def test_update_settings_drops_blank_list_entries(db_session):
         db_session,
         mandatory_bullets=["  keep me  ", "", "   ", "second"],
         shipping_accounts=["acct", None, ""],
+        shipping_methods=["  LOCAL DELIVERY ", "", "Pick up"],
     )
     assert updated.mandatory_bullets == ["keep me", "second"]
     assert updated.shipping_accounts == ["acct"]
+    assert updated.shipping_methods == ["LOCAL DELIVERY", "Pick up"]
 
 
 def test_update_settings_can_clear_the_tariff_date(db_session):

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -684,6 +684,7 @@ export const UPDATE_PO_DOCUMENT_SETTINGS = gql`
       taxNumbers
       mandatoryBullets
       shippingAccounts
+      shippingMethods
       customsBrokerBlock
       fscNote
       usaTariffNote

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -74,6 +74,7 @@ export const GET_PURCHASE_ORDERS = gql`
       requestNumber
       projectId
       status
+      gpCompany
       gpVendorId
       vendorNameSnapshot
       buyerId
@@ -644,6 +645,18 @@ export const GET_GP_BUYERS = gql`
   }
 `;
 
+export const GET_GP_PO_TOTALS = gql`
+  query GetGpPoTotals($company: String!, $poNumber: String!) {
+    gpPoTotals(company: $company, poNumber: $poNumber) {
+      poNumber
+      subtotal
+      freight
+      miscellaneous
+      taxAmount
+    }
+  }
+`;
+
 export const GET_GP_COST_CODES = gql`
   query GetGpCostCodes($company: String!, $job: String!) {
     gpCostCodes(company: $company, job: $job) {
@@ -687,6 +700,7 @@ export const PO_DOCUMENT_SETTINGS_FIELDS = `
   taxNumbers
   mandatoryBullets
   shippingAccounts
+  shippingMethods
   customsBrokerBlock
   fscNote
   usaTariffNote

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -8,7 +8,6 @@ import FolderIcon from '@mui/icons-material/Folder';
 import GroupIcon from '@mui/icons-material/Group';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import RouterIcon from '@mui/icons-material/Router';
-import DescriptionIcon from '@mui/icons-material/Description';
 import PeopleIcon from '@mui/icons-material/People';
 import BusinessIcon from '@mui/icons-material/Business';
 import CategoryIcon from '@mui/icons-material/Category';
@@ -54,7 +53,6 @@ const SUB_ROUTES = [
   { label: 'Projects', path: '/app/admin/projects', icon: <FolderIcon fontSize="large" /> },
   { label: 'User Management', path: '/app/admin/users', icon: <GroupIcon fontSize="large" /> },
   { label: 'Relay Installs', path: '/app/admin/relay-installs', icon: <RouterIcon fontSize="large" /> },
-  { label: 'PO Document Settings', path: '/app/admin/po-document-settings', icon: <DescriptionIcon fontSize="large" /> },
   { label: 'Location Cleanup', path: '/app/admin/location-cleanup', icon: <CleaningServicesIcon fontSize="large" /> },
 ];
 

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -9,7 +9,6 @@ import WarehousesPage from './WarehousesPage';
 import ProjectsPage from './ProjectsPage';
 import LocationCleanupPage from './LocationCleanupPage';
 import RelayInstallsPage from './RelayInstallsPage';
-import PODocumentSettingsPage from './PODocumentSettingsPage';
 import AdminLanding from './AdminLanding';
 import BackToModule from '../../components/BackToModule';
 
@@ -33,7 +32,6 @@ export default function AdminModule() {
       <Route path="projects" element={<AdminSubLayout><ProjectsPage /></AdminSubLayout>} />
       <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />
       <Route path="relay-installs" element={<AdminSubLayout><RelayInstallsPage /></AdminSubLayout>} />
-      <Route path="po-document-settings" element={<AdminSubLayout><PODocumentSettingsPage /></AdminSubLayout>} />
       <Route path="location-cleanup" element={<AdminSubLayout><LocationCleanupPage /></AdminSubLayout>} />
       <Route path="*" element={<Navigate to="/app/admin" replace />} />
     </Routes>

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -429,8 +429,9 @@ export default function PODetailModal({
 
   const canCancel = po.status === 'DRAFT' || po.status === 'GP_REGISTERED' || po.status === 'VENDOR_CONFIRMED';
 
-  // The supplier PO document can be generated for any live PO (not a cancelled one).
-  const canGenerate = po.status !== 'CANCELLED';
+  // The supplier PO document reads the buyer list + GP totals live, so it's only for a PO that
+  // exists in GP (has a GP company + number) and needs the relay connected.
+  const canGenerate = !!po.gpCompany && !!po.poNumber && po.status !== 'CANCELLED';
 
   const displayTitle = po.poNumber ? `PO: ${po.poNumber}` : `Request: ${po.requestNumber}`;
 
@@ -459,13 +460,21 @@ export default function PODetailModal({
             </Button>
           )}
           {canGenerate && (
-            <Button
-              variant="outlined"
-              startIcon={<DescriptionIcon />}
-              onClick={() => setGenerateOpen(true)}
+            <Tooltip
+              title={relayConnected ? '' : 'GP relay not detected on this machine - it must be running to generate a PO document (buyer + GP totals are read live)'}
+              arrow
             >
-              Generate PO Document
-            </Button>
+              <span>
+                <Button
+                  variant="outlined"
+                  startIcon={<DescriptionIcon />}
+                  onClick={() => setGenerateOpen(true)}
+                  disabled={!relayConnected}
+                >
+                  Generate PO Document
+                </Button>
+              </span>
+            </Tooltip>
           )}
           {canRegisterInGp && (
             <Tooltip

--- a/frontend/src/modules/po/PODocumentSettingsPage.tsx
+++ b/frontend/src/modules/po/PODocumentSettingsPage.tsx
@@ -7,11 +7,13 @@ import { GET_PO_DOCUMENT_SETTINGS } from '../../graphql/queries';
 import { UPDATE_PO_DOCUMENT_SETTINGS } from '../../graphql/mutations';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
+import BackToModule from '../../components/BackToModule';
 
 interface PODocumentSettings {
   taxNumbers: string;
   mandatoryBullets: string[];
   shippingAccounts: string[];
+  shippingMethods: string[];
   customsBrokerBlock: string;
   fscNote: string;
   usaTariffNote: string;
@@ -35,19 +37,20 @@ export default function PODocumentSettingsPage() {
   const { isAdmin } = useIdentity();
   const { data, loading } = useQuery<{ poDocumentSettings: PODocumentSettings }>(GET_PO_DOCUMENT_SETTINGS);
 
-  if (!isAdmin) {
-    return <Alert severity="warning">You need the Admin/Manager role to edit PO document settings.</Alert>;
-  }
-  if (loading && !data) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-  if (!data) return null;
-  // key on the loaded values so the form re-initializes if the settings ever change underneath it.
-  return <SettingsForm settings={data.poDocumentSettings} />;
+  return (
+    <Box>
+      <BackToModule to="/app/po" label="Purchase Orders" />
+      {!isAdmin ? (
+        <Alert severity="warning">You need the Admin/Manager role to edit PO document settings.</Alert>
+      ) : loading && !data ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : data ? (
+        <SettingsForm settings={data.poDocumentSettings} />
+      ) : null}
+    </Box>
+  );
 }
 
 function SettingsForm({ settings }: { settings: PODocumentSettings }) {
@@ -56,6 +59,7 @@ function SettingsForm({ settings }: { settings: PODocumentSettings }) {
   const [taxNumbers, setTaxNumbers] = useState(settings.taxNumbers);
   const [mandatoryBullets, setMandatoryBullets] = useState(toLines(settings.mandatoryBullets));
   const [shippingAccounts, setShippingAccounts] = useState(toLines(settings.shippingAccounts));
+  const [shippingMethods, setShippingMethods] = useState(toLines(settings.shippingMethods));
   const [customsBrokerBlock, setCustomsBrokerBlock] = useState(settings.customsBrokerBlock);
   const [fscNote, setFscNote] = useState(settings.fscNote);
   const [usaTariffNote, setUsaTariffNote] = useState(settings.usaTariffNote);
@@ -78,6 +82,7 @@ function SettingsForm({ settings }: { settings: PODocumentSettings }) {
           taxNumbers,
           mandatoryBullets: fromLines(mandatoryBullets),
           shippingAccounts: fromLines(shippingAccounts),
+          shippingMethods: fromLines(shippingMethods),
           customsBrokerBlock,
           fscNote,
           usaTariffNote,
@@ -117,6 +122,12 @@ function SettingsForm({ settings }: { settings: PODocumentSettings }) {
             fullWidth
           />
         </Stack>
+        <TextField
+          label="Shipping methods" value={shippingMethods}
+          onChange={(e) => setShippingMethods(e.target.value)}
+          fullWidth multiline minRows={3}
+          helperText="Dropdown options for the generate dialog's Shipping Method, one per line."
+        />
 
         <Divider />
         <TextField

--- a/frontend/src/modules/po/POGenerateDialog.tsx
+++ b/frontend/src/modules/po/POGenerateDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
   Typography, Box, Stack, MenuItem, Select, FormControl, InputLabel,
@@ -6,7 +6,7 @@ import {
 } from '@mui/material';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { pdf } from '@react-pdf/renderer';
-import { GET_PO_DOCUMENT_SETTINGS, GET_WAREHOUSES, GET_PROJECT_SHIP_TO } from '../../graphql/queries';
+import { GET_PO_DOCUMENT_SETTINGS, GET_GP_BUYERS, GET_GP_PO_TOTALS, GET_PROJECT_SHIP_TO } from '../../graphql/queries';
 import { SAVE_PO_DOCUMENT_DATA, UPLOAD_PO_DOCUMENT } from '../../graphql/mutations';
 import { useToast } from '../../components/Toast';
 import { poVendorName } from './poVendorName';
@@ -24,6 +24,7 @@ interface PODocumentSettings {
   taxNumbers: string;
   mandatoryBullets: string[];
   shippingAccounts: string[];
+  shippingMethods: string[];
   customsBrokerBlock: string;
   fscNote: string;
   usaTariffNote: string;
@@ -35,50 +36,22 @@ interface PODocumentSettings {
   signatureNote: string;
 }
 
-interface Warehouse {
-  id: string;
-  name: string;
-  code: string;
-  address: string | null;
-  city: string | null;
-  province: string | null;
-  postalCode: string | null;
-}
-
-interface ProjectShipTo {
-  id: string;
-  projectId: string;
-  jobSiteName: string | null;
-  address: string | null;
-  city: string | null;
-  state: string | null;
-  zip: string | null;
-}
-
-function joinLines(parts: (string | null | undefined)[]): string {
-  return parts.map((p) => (p ?? '').trim()).filter((p) => p.length > 0).join('\n');
-}
-
-function warehouseBlock(w: Warehouse): string {
-  const cityLine = [w.city, w.province, w.postalCode].filter(Boolean).join('  ');
-  return joinLines([w.name, w.address, cityLine]);
-}
-
-function projectBlock(p: ProjectShipTo): string {
-  const cityLine = [p.city, p.state, p.zip].filter(Boolean).join('  ');
-  return joinLines(['UC Hardware Inc. - Deliver to site', p.jobSiteName, p.address, cityLine]);
+interface GpPoTotals {
+  poNumber: string;
+  subtotal: number;
+  freight: number;
+  miscellaneous: number;
+  taxAmount: number;
 }
 
 function formatDocDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '';
-  // Parse a date-only string (YYYY-MM-DD, from a date input or a GraphQL Date) as LOCAL midnight, not
-  // UTC - `new Date("2026-08-15")` is UTC, which renders as the previous day in a behind-UTC timezone.
+  // Parse a date-only string (YYYY-MM-DD) as LOCAL midnight, not UTC, so it prints as entered.
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
   const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : new Date(dateStr);
   return isNaN(d.getTime()) ? '' : d.toLocaleDateString();
 }
 
-// Read a Blob as a base64 payload (strips the data: URL prefix), matching the PO upload path.
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -88,65 +61,99 @@ function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
+// Outer loader: the dialog hard-requires the relay (the Generate button is gated on it + a GP-
+// registered PO), so it fetches the boilerplate, the live GP buyers, and the PO's GP totals, then
+// renders the form once. The inner form initializes its state from those props (no effect-sync).
 export default function POGenerateDialog({ open, po, onClose, onRefetch }: POGenerateDialogProps) {
-  const { showToast } = useToast();
+  const company = po.gpCompany ?? '';
+  const poNumber = po.poNumber ?? '';
 
-  const { data: settingsData, loading: settingsLoading } = useQuery<{ poDocumentSettings: PODocumentSettings }>(
-    GET_PO_DOCUMENT_SETTINGS,
-    { skip: !open },
+  const { data: settingsData, loading: sLoading } = useQuery<{ poDocumentSettings: PODocumentSettings }>(
+    GET_PO_DOCUMENT_SETTINGS, { skip: !open },
   );
-  const { data: warehousesData } = useQuery<{ warehouses: Warehouse[] }>(GET_WAREHOUSES, {
-    variables: { includeInactive: false },
-    skip: !open,
+  const { data: buyersData, loading: bLoading } = useQuery<{ gpBuyers: string[] }>(GET_GP_BUYERS, {
+    variables: { company }, skip: !open || !company,
   });
-  const { data: projectData } = useQuery<{ projectShipTo: ProjectShipTo | null }>(GET_PROJECT_SHIP_TO, {
-    variables: { projectId: po.projectId },
-    skip: !open || !po.projectId,
+  const { data: totalsData, loading: tLoading } = useQuery<{ gpPoTotals: GpPoTotals | null }>(GET_GP_PO_TOTALS, {
+    variables: { company, poNumber }, skip: !open || !company || !poNumber,
   });
+  // Only for the document's Project Number field (the job number); ship-to is now free text.
+  const { data: projectData, loading: pLoading } = useQuery<{ projectShipTo: { projectId: string } | null }>(
+    GET_PROJECT_SHIP_TO, { variables: { projectId: po.projectId }, skip: !open || !po.projectId },
+  );
 
   const settings = settingsData?.poDocumentSettings;
-  const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
-  const projectShipTo = projectData?.projectShipTo ?? null;
+  const loading = sLoading || bLoading || tLoading || pLoading;
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Generate PO Document - {poNumber || po.requestNumber}</DialogTitle>
+      {open && settings && !loading ? (
+        <GenerateForm
+          po={po}
+          settings={settings}
+          buyers={buyersData?.gpBuyers ?? []}
+          gpTotals={totalsData?.gpPoTotals ?? null}
+          projectNumber={projectData?.projectShipTo?.projectId ?? null}
+          onClose={onClose}
+          onRefetch={onRefetch}
+        />
+      ) : (
+        <DialogContent dividers>
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}
+
+interface GenerateFormProps {
+  po: PurchaseOrder;
+  settings: PODocumentSettings;
+  buyers: string[];
+  gpTotals: GpPoTotals | null;
+  projectNumber: string | null;
+  onClose: () => void;
+  onRefetch: () => void;
+}
+
+function GenerateForm({ po, settings, buyers, gpTotals, projectNumber, onClose, onRefetch }: GenerateFormProps) {
+  const { showToast } = useToast();
+  const dd = po.documentData;
+
+  const [vendorAddress, setVendorAddress] = useState(dd?.vendorAddress ?? '');
+  const [buyerName, setBuyerName] = useState(dd?.buyerName ?? po.buyerId ?? '');
+  const [currency, setCurrency] = useState(dd?.currency ?? 'CAD');
+  const [shipTo, setShipTo] = useState(dd?.shipTo ?? '');
+  const [shippingMethod, setShippingMethod] = useState(dd?.shippingMethod ?? '');
+  const [proposalNumber, setProposalNumber] = useState(dd?.proposalNumber ?? '');
+  const [requiredBy, setRequiredBy] = useState(dd?.requiredByOverride ?? po.expectedDeliveryDate ?? '');
+  // Totals: saved override if this PO was generated before, else the GP-read values, else 0.
+  const [freight, setFreight] = useState(String(dd?.freight ?? gpTotals?.freight ?? 0));
+  const [miscellaneous, setMiscellaneous] = useState(String(dd?.miscellaneous ?? gpTotals?.miscellaneous ?? 0));
+  const [taxAmount, setTaxAmount] = useState(String(dd?.taxAmount ?? gpTotals?.taxAmount ?? 0));
+  const [taxLabel, setTaxLabel] = useState(dd?.taxLabel ?? 'Taxes');
+  const [includeFsc, setIncludeFsc] = useState(dd?.includeFsc ?? false);
+  const [includeUsaTariff, setIncludeUsaTariff] = useState(dd?.includeUsaTariff ?? false);
+  const [includeCustoms, setIncludeCustoms] = useState(dd?.includeCustoms ?? false);
 
   const [saveDocData, { loading: saving }] = useMutation(SAVE_PO_DOCUMENT_DATA);
   const [uploadDocument, { loading: uploading }] = useMutation(UPLOAD_PO_DOCUMENT);
   const [busy, setBusy] = useState(false);
+  const working = busy || saving || uploading;
 
-  // --- Form state ---
-  const [vendorAddress, setVendorAddress] = useState('');
-  const [buyerName, setBuyerName] = useState('');
-  const [currency, setCurrency] = useState('CAD');
-  const [shipTo, setShipTo] = useState('');
-  const [shippingMethod, setShippingMethod] = useState('');
-  const [proposalNumber, setProposalNumber] = useState('');
-  const [requiredBy, setRequiredBy] = useState('');
-  const [freight, setFreight] = useState('0');
-  const [miscellaneous, setMiscellaneous] = useState('0');
-  const [taxAmount, setTaxAmount] = useState('0');
-  const [taxLabel, setTaxLabel] = useState('Taxes');
-  const [includeFsc, setIncludeFsc] = useState(false);
-  const [includeUsaTariff, setIncludeUsaTariff] = useState(false);
-  const [includeCustoms, setIncludeCustoms] = useState(false);
-
-  // Initialize the form each time the dialog opens, from the saved PODocumentData (if any) else defaults.
-  useEffect(() => {
-    if (!open) return;
-    const dd = po.documentData;
-    setVendorAddress(dd?.vendorAddress ?? '');
-    setBuyerName(dd?.buyerName ?? po.buyerId ?? '');
-    setCurrency(dd?.currency ?? 'CAD');
-    setShipTo(dd?.shipTo ?? '');
-    setShippingMethod(dd?.shippingMethod ?? '');
-    setProposalNumber(dd?.proposalNumber ?? '');
-    setRequiredBy(dd?.requiredByOverride ?? po.expectedDeliveryDate ?? '');
-    setFreight(String(dd?.freight ?? 0));
-    setMiscellaneous(String(dd?.miscellaneous ?? 0));
-    setTaxAmount(String(dd?.taxAmount ?? 0));
-    setTaxLabel(dd?.taxLabel ?? 'Taxes');
-    setIncludeFsc(dd?.includeFsc ?? false);
-    setIncludeUsaTariff(dd?.includeUsaTariff ?? false);
-    setIncludeCustoms(dd?.includeCustoms ?? false);
-  }, [open, po]);
+  // Include the current value in the option list even if the live list doesn't have it (a saved
+  // free-text buyer, or a shipping method that was later removed from settings), so it still shows.
+  const buyerOptions = useMemo(
+    () => Array.from(new Set([...buyers, ...(buyerName ? [buyerName] : [])])),
+    [buyers, buyerName],
+  );
+  const shippingMethodOptions = useMemo(
+    () => Array.from(new Set([...settings.shippingMethods, ...(shippingMethod ? [shippingMethod] : [])])),
+    [settings.shippingMethods, shippingMethod],
+  );
 
   const num = (s: string): number => {
     const n = parseFloat(s);
@@ -174,52 +181,49 @@ export default function POGenerateDialog({ open, po, onClose, onRefetch }: POGen
       miscellaneous, taxAmount, taxLabel, requiredBy, includeFsc, includeUsaTariff, includeCustoms],
   );
 
-  const buildDocProps = useCallback(
-    (s: PODocumentSettings): PurchaseOrderDocumentProps => {
-      const requiredByLabel = formatDocDate(requiredBy);
-      return {
-        poNumber: po.poNumber ?? po.requestNumber,
-        date: formatDocDate(po.orderedAt) || new Date().toLocaleDateString(),
-        requiredBy: requiredByLabel,
-        proposalNumber: proposalNumber || null,
-        companyFromAddress: s.companyFromAddress,
-        vendorName: poVendorName(po) || '-',
-        vendorAddress: vendorAddress || null,
-        shipTo,
-        projectNumber: projectShipTo?.projectId ?? null,
-        shippingMethod: shippingMethod || null,
-        paymentTerms: s.paymentTerms,
-        confirmWith: s.confirmWith,
-        buyerName: buyerName || null,
-        currency,
-        lineItems: po.lineItems.map((li) => ({
-          itemNumber: li.hardwareCategory,
-          reference: li.orderAs,
-          date: requiredByLabel,
-          uom: 'Each',
-          ordered: li.orderedQuantity,
-          unitPrice: li.unitCost,
-        })),
-        freight: num(freight),
-        miscellaneous: num(miscellaneous),
-        taxAmount: num(taxAmount),
-        taxLabel: taxLabel || 'Taxes',
-        taxNumbers: s.taxNumbers,
-        mandatoryBullets: s.mandatoryBullets,
-        shippingAccounts: s.shippingAccounts,
-        customsBrokerBlock: s.customsBrokerBlock,
-        fscNote: s.fscNote,
-        usaTariffNote: s.usaTariffNote,
-        footerNotes: s.footerNotes,
-        signatureNote: s.signatureNote,
-        includeFsc,
-        includeUsaTariff,
-        includeCustoms,
-      };
-    },
-    [po, proposalNumber, vendorAddress, shipTo, projectShipTo, shippingMethod, buyerName, currency,
-      requiredBy, freight, miscellaneous, taxAmount, taxLabel, includeFsc, includeUsaTariff, includeCustoms],
-  );
+  const buildDocProps = useCallback((): PurchaseOrderDocumentProps => {
+    const requiredByLabel = formatDocDate(requiredBy);
+    return {
+      poNumber: po.poNumber ?? po.requestNumber,
+      date: formatDocDate(po.orderedAt) || new Date().toLocaleDateString(),
+      requiredBy: requiredByLabel,
+      proposalNumber: proposalNumber || null,
+      companyFromAddress: settings.companyFromAddress,
+      vendorName: poVendorName(po) || '-',
+      vendorAddress: vendorAddress || null,
+      shipTo,
+      projectNumber,
+      shippingMethod: shippingMethod || null,
+      paymentTerms: settings.paymentTerms,
+      confirmWith: settings.confirmWith,
+      buyerName: buyerName || null,
+      currency,
+      lineItems: po.lineItems.map((li) => ({
+        itemNumber: li.hardwareCategory,
+        reference: li.orderAs,
+        date: requiredByLabel,
+        uom: 'Each',
+        ordered: li.orderedQuantity,
+        unitPrice: li.unitCost,
+      })),
+      freight: num(freight),
+      miscellaneous: num(miscellaneous),
+      taxAmount: num(taxAmount),
+      taxLabel: taxLabel || 'Taxes',
+      taxNumbers: settings.taxNumbers,
+      mandatoryBullets: settings.mandatoryBullets,
+      shippingAccounts: settings.shippingAccounts,
+      customsBrokerBlock: settings.customsBrokerBlock,
+      fscNote: settings.fscNote,
+      usaTariffNote: settings.usaTariffNote,
+      footerNotes: settings.footerNotes,
+      signatureNote: settings.signatureNote,
+      includeFsc,
+      includeUsaTariff,
+      includeCustoms,
+    };
+  }, [po, proposalNumber, settings, vendorAddress, shipTo, shippingMethod, buyerName, currency, projectNumber,
+    requiredBy, freight, miscellaneous, taxAmount, taxLabel, includeFsc, includeUsaTariff, includeCustoms]);
 
   const persist = useCallback(async () => {
     await saveDocData({ variables: { poId: po.id, input: docInput() } });
@@ -227,31 +231,28 @@ export default function POGenerateDialog({ open, po, onClose, onRefetch }: POGen
   }, [saveDocData, po.id, docInput, onRefetch]);
 
   const handlePreview = useCallback(async () => {
-    if (!settings) return;
     setBusy(true);
     try {
       await persist();
-      const blob = await pdf(<PurchaseOrderDocument {...buildDocProps(settings)} />).toBlob();
+      const blob = await pdf(<PurchaseOrderDocument {...buildDocProps()} />).toBlob();
       window.open(URL.createObjectURL(blob), '_blank');
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed to generate document', 'error');
     } finally {
       setBusy(false);
     }
-  }, [settings, persist, buildDocProps, showToast]);
+  }, [persist, buildDocProps, showToast]);
 
   const handleSaveToPO = useCallback(async () => {
-    if (!settings) return;
     setBusy(true);
     try {
       await persist();
-      const blob = await pdf(<PurchaseOrderDocument {...buildDocProps(settings)} />).toBlob();
+      const blob = await pdf(<PurchaseOrderDocument {...buildDocProps()} />).toBlob();
       const base64 = await blobToBase64(blob);
-      const fileName = `PO-${po.poNumber ?? po.requestNumber}.pdf`;
       await uploadDocument({
         variables: {
           poId: po.id,
-          fileName,
+          fileName: `PO-${po.poNumber ?? po.requestNumber}.pdf`,
           contentType: 'application/pdf',
           documentType: 'GENERATED_PO',
           fileDataBase64: base64,
@@ -265,158 +266,138 @@ export default function POGenerateDialog({ open, po, onClose, onRefetch }: POGen
     } finally {
       setBusy(false);
     }
-  }, [settings, persist, buildDocProps, uploadDocument, po, onRefetch, showToast, onClose]);
+  }, [persist, buildDocProps, uploadDocument, po, onRefetch, showToast, onClose]);
 
-  const working = busy || saving || uploading;
-
-  const tariffHint = settings?.usaTariffEffectiveUntil
+  const tariffHint = settings.usaTariffEffectiveUntil
     ? `Health-care tariff SA-code note (effective until ${formatDocDate(settings.usaTariffEffectiveUntil)})`
     : 'USA health-care tariff SA-code note';
 
   return (
-    <Dialog open={open} onClose={working ? undefined : onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Generate PO Document - {po.poNumber ?? po.requestNumber}</DialogTitle>
+    <>
       <DialogContent dividers>
-        {settingsLoading && !settings ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <CircularProgress />
-          </Box>
-        ) : (
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            <Typography variant="subtitle2" color="text.secondary">Vendor & buyer</Typography>
-            <TextField
-              label="Vendor mailing address"
-              value={vendorAddress}
-              onChange={(e) => setVendorAddress(e.target.value)}
-              fullWidth size="small" multiline minRows={2}
-              placeholder={`${poVendorName(po)}\nStreet\nCity, Prov  Postal`}
-            />
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Buyer" value={buyerName} onChange={(e) => setBuyerName(e.target.value)}
-                fullWidth size="small"
-              />
-              <FormControl size="small" sx={{ minWidth: 140 }}>
-                <InputLabel>Currency</InputLabel>
-                <Select label="Currency" value={currency} onChange={(e) => setCurrency(e.target.value)}>
-                  <MenuItem value="CAD">CAD ($)</MenuItem>
-                  <MenuItem value="USD">USD ($US)</MenuItem>
-                </Select>
-              </FormControl>
-            </Stack>
-
-            <Divider />
-            <Typography variant="subtitle2" color="text.secondary">Ship to</Typography>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-              <FormControl size="small" sx={{ minWidth: 220 }}>
-                <InputLabel>Use a warehouse</InputLabel>
-                <Select
-                  label="Use a warehouse"
-                  value=""
-                  onChange={(e) => {
-                    const w = warehouses.find((x) => x.id === e.target.value);
-                    if (w) setShipTo(warehouseBlock(w));
-                  }}
-                >
-                  {warehouses.map((w) => (
-                    <MenuItem key={w.id} value={w.id}>{w.name} ({w.code})</MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-              <Button
-                size="small" variant="outlined"
-                disabled={!projectShipTo}
-                onClick={() => projectShipTo && setShipTo(projectBlock(projectShipTo))}
-              >
-                Use project site
-              </Button>
-            </Stack>
-            <TextField
-              label="Ship-to block"
-              value={shipTo}
-              onChange={(e) => setShipTo(e.target.value)}
-              fullWidth size="small" multiline minRows={3}
-              helperText="Pick a source above, or type a custom block. Leave empty to print 'Affix SHIP TO label'."
-            />
-            <TextField
-              label="Shipping method" value={shippingMethod} onChange={(e) => setShippingMethod(e.target.value)}
-              fullWidth size="small" placeholder="e.g. LOCAL DELIVERY, Supply by your freight company"
-            />
-
-            <Divider />
-            <Typography variant="subtitle2" color="text.secondary">Header details</Typography>
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Proposal #" value={proposalNumber} onChange={(e) => setProposalNumber(e.target.value)}
-                fullWidth size="small"
-              />
-              <TextField
-                label="Required by date" type="date" value={requiredBy}
-                onChange={(e) => setRequiredBy(e.target.value)}
-                fullWidth size="small" slotProps={{ inputLabel: { shrink: true } }}
-              />
-            </Stack>
-
-            <Divider />
-            <Typography variant="subtitle2" color="text.secondary">Totals (GP-computed - enter to match)</Typography>
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Freight" type="number" value={freight} onChange={(e) => setFreight(e.target.value)}
-                fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
-              />
-              <TextField
-                label="Miscellaneous" type="number" value={miscellaneous}
-                onChange={(e) => setMiscellaneous(e.target.value)}
-                fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
-              />
-            </Stack>
-            <Stack direction="row" spacing={2}>
-              <TextField
-                label="Tax amount" type="number" value={taxAmount} onChange={(e) => setTaxAmount(e.target.value)}
-                fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
-              />
-              <TextField
-                label="Tax label" value={taxLabel} onChange={(e) => setTaxLabel(e.target.value)}
-                fullWidth size="small" placeholder="Taxes / HST"
-              />
-            </Stack>
-
-            <Divider />
-            <Typography variant="subtitle2" color="text.secondary">Conditional notes</Typography>
-            <FormControl>
-              <FormControlLabel
-                control={<Switch checked={includeFsc} onChange={(e) => setIncludeFsc(e.target.checked)} />}
-                label="Wood-door FSC note"
-              />
-              <FormControlLabel
-                control={<Switch checked={includeUsaTariff} onChange={(e) => setIncludeUsaTariff(e.target.checked)} />}
-                label={tariffHint}
-              />
-              <FormControlLabel
-                control={<Switch checked={includeCustoms} onChange={(e) => setIncludeCustoms(e.target.checked)} />}
-                label="International customs broker + shipping accounts"
-              />
-              <FormHelperText>These append the matching boilerplate blocks below the totals.</FormHelperText>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="subtitle2" color="text.secondary">Vendor & buyer</Typography>
+          <TextField
+            label="Vendor mailing address" value={vendorAddress}
+            onChange={(e) => setVendorAddress(e.target.value)}
+            fullWidth size="small" multiline minRows={2}
+            placeholder={`${poVendorName(po)}\nStreet\nCity, Prov  Postal`}
+          />
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Buyer</InputLabel>
+              <Select label="Buyer" value={buyerName} onChange={(e) => setBuyerName(e.target.value)} displayEmpty>
+                <MenuItem value=""><em>None</em></MenuItem>
+                {buyerOptions.map((b) => (
+                  <MenuItem key={b} value={b}>{b}</MenuItem>
+                ))}
+              </Select>
+              <FormHelperText>Registered GP buyer for this PO.</FormHelperText>
             </FormControl>
-
-            {po.lineItems.length === 0 && (
-              <Alert severity="warning">This PO has no line items - the document will show an empty table.</Alert>
-            )}
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>Currency</InputLabel>
+              <Select label="Currency" value={currency} onChange={(e) => setCurrency(e.target.value)}>
+                <MenuItem value="CAD">CAD ($)</MenuItem>
+                <MenuItem value="USD">USD ($US)</MenuItem>
+              </Select>
+            </FormControl>
           </Stack>
-        )}
+
+          <Divider />
+          <Typography variant="subtitle2" color="text.secondary">Ship to</Typography>
+          <TextField
+            label="Ship-to block" value={shipTo} onChange={(e) => setShipTo(e.target.value)}
+            fullWidth size="small" multiline minRows={3}
+            helperText="Free text. Leave empty to print nothing under Ship To."
+          />
+          <FormControl fullWidth size="small">
+            <InputLabel>Shipping method</InputLabel>
+            <Select
+              label="Shipping method" value={shippingMethod}
+              onChange={(e) => setShippingMethod(e.target.value)} displayEmpty
+            >
+              <MenuItem value=""><em>None</em></MenuItem>
+              {shippingMethodOptions.map((m) => (
+                <MenuItem key={m} value={m}>{m}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Divider />
+          <Typography variant="subtitle2" color="text.secondary">Header details</Typography>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="Proposal #" value={proposalNumber} onChange={(e) => setProposalNumber(e.target.value)}
+              fullWidth size="small"
+            />
+            <TextField
+              label="Required by date" type="date" value={requiredBy}
+              onChange={(e) => setRequiredBy(e.target.value)}
+              fullWidth size="small" slotProps={{ inputLabel: { shrink: true } }}
+            />
+          </Stack>
+
+          <Divider />
+          <Typography variant="subtitle2" color="text.secondary">
+            Totals (pre-filled from GP - override if needed)
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="Freight" type="number" value={freight} onChange={(e) => setFreight(e.target.value)}
+              fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+            />
+            <TextField
+              label="Miscellaneous" type="number" value={miscellaneous}
+              onChange={(e) => setMiscellaneous(e.target.value)}
+              fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="Tax amount" type="number" value={taxAmount} onChange={(e) => setTaxAmount(e.target.value)}
+              fullWidth size="small" slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+            />
+            <TextField
+              label="Tax label" value={taxLabel} onChange={(e) => setTaxLabel(e.target.value)}
+              fullWidth size="small" placeholder="Taxes / HST"
+            />
+          </Stack>
+
+          <Divider />
+          <Typography variant="subtitle2" color="text.secondary">Conditional notes</Typography>
+          <FormControl>
+            <FormControlLabel
+              control={<Switch checked={includeFsc} onChange={(e) => setIncludeFsc(e.target.checked)} />}
+              label="Wood-door FSC note"
+            />
+            <FormControlLabel
+              control={<Switch checked={includeUsaTariff} onChange={(e) => setIncludeUsaTariff(e.target.checked)} />}
+              label={tariffHint}
+            />
+            <FormControlLabel
+              control={<Switch checked={includeCustoms} onChange={(e) => setIncludeCustoms(e.target.checked)} />}
+              label="International customs broker + shipping accounts"
+            />
+            <FormHelperText>These append the matching boilerplate blocks below the totals.</FormHelperText>
+          </FormControl>
+
+          {po.lineItems.length === 0 && (
+            <Alert severity="warning">This PO has no line items - the document will show an empty table.</Alert>
+          )}
+        </Stack>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={working}>Cancel</Button>
-        <Button onClick={handleSaveToPO} disabled={working || !settings}>
+        <Button onClick={handleSaveToPO} disabled={working}>
           {working ? 'Working...' : 'Save to PO documents'}
         </Button>
         <Button
-          variant="contained" onClick={handlePreview} disabled={working || !settings}
+          variant="contained" onClick={handlePreview} disabled={working}
           startIcon={working ? <CircularProgress size={16} /> : undefined}
         >
           {working ? 'Generating...' : 'Generate & preview'}
         </Button>
       </DialogActions>
-    </Dialog>
+    </>
   );
 }

--- a/frontend/src/modules/po/PurchaseOrderDocument.tsx
+++ b/frontend/src/modules/po/PurchaseOrderDocument.tsx
@@ -172,9 +172,7 @@ export default function PurchaseOrderDocument(props: PurchaseOrderDocumentProps)
           </View>
           <View style={styles.party}>
             <Text style={styles.partyLabel}>Ship To</Text>
-            {lines(shipTo).length > 0
-              ? lines(shipTo).map((l, i) => <Text key={i} style={styles.partyLine}>{l}</Text>)
-              : <Text style={styles.partyLine}>Affix SHIP TO label</Text>}
+            {lines(shipTo).map((l, i) => <Text key={i} style={styles.partyLine}>{l}</Text>)}
           </View>
         </View>
 

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -41,6 +41,10 @@ import RelayStatusChip from '../../relay/RelayStatusChip';
 import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from './poVendorName';
 import { PO_STATUS_VALUES, formatPoStatus, poStatusChipColor } from './poStatus';
+import { Routes, Route, useNavigate } from 'react-router-dom';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { useIdentity } from '../../hooks/useIdentity';
+import PODocumentSettingsPage from './PODocumentSettingsPage';
 
 // --- Types ---
 
@@ -123,6 +127,7 @@ export interface PurchaseOrder {
   requestNumber: string;
   projectId: string | null;
   status: string;
+  gpCompany: string | null;
   gpVendorId: string | null;
   vendorNameSnapshot: string | null;
   buyerId: string | null;
@@ -546,7 +551,9 @@ function POTableRow({ po, expanded, onToggle, onOpen, onRegister, relayConnected
 
 // --- Component ---
 
-export default function POModule() {
+function POListPage() {
+  const navigate = useNavigate();
+  const { isAdmin } = useIdentity();
   const [selectedProject, setSelectedProject] = useState<Project | 'all' | null>(null);
   const [selectedPOId, setSelectedPOId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -681,6 +688,15 @@ export default function POModule() {
           Purchase Orders — {projectLabel}
         </Typography>
         <RelayStatusChip connected={relayConnected} />
+        {isAdmin && (
+          <Button
+            size="small"
+            startIcon={<SettingsIcon />}
+            onClick={() => navigate('/app/po/document-settings')}
+          >
+            Document Settings
+          </Button>
+        )}
         <Tooltip
           title={relayConnected ? '' : 'GP relay not detected on this machine - it must be running to create a PO'}
           arrow
@@ -850,5 +866,14 @@ export default function POModule() {
         relayConnected={relayConnected}
       />
     </Box>
+  );
+}
+
+export default function POModule() {
+  return (
+    <Routes>
+      <Route index element={<POListPage />} />
+      <Route path="document-settings" element={<PODocumentSettingsPage />} />
+    </Routes>
   );
 }

--- a/localhost relay/src/ucnexus_relay/channel.py
+++ b/localhost relay/src/ucnexus_relay/channel.py
@@ -110,6 +110,16 @@ def _run_list_jobs(company: str, payload: dict) -> dict:
     return {"company": company, "jobs": rows}
 
 
+def _run_read_po_totals(company: str, payload: dict) -> dict:
+    ops.check_company_allowed(company)
+    po_number = (payload.get("po_number") or "").strip()
+    if not po_number:
+        raise ops.RelayOpError("missing_po_number", "po_number is required")
+    with db.get_read_connection(company) as conn:
+        totals = econnect.read_po_totals(conn, po_number)
+    return {"company": company, "totals": totals}
+
+
 def _run_create_po(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     request = models.CreatePoRequest(company=company, **payload)
@@ -141,6 +151,7 @@ _OPS = {
     "list_buyers": _run_list_buyers,
     "list_cost_codes": _run_list_cost_codes,
     "list_jobs": _run_list_jobs,
+    "read_po_totals": _run_read_po_totals,
     "create_po": _run_create_po,
     "create_receipt": _run_create_receipt,
 }

--- a/localhost relay/src/ucnexus_relay/econnect.py
+++ b/localhost relay/src/ucnexus_relay/econnect.py
@@ -455,6 +455,34 @@ def list_jobs(conn) -> list[dict]:
     return [{"job_number": r.job_number, "job_name": r.job_name or None} for r in rows]
 
 
+def read_po_totals(conn, po_number: str) -> dict | None:
+    """Read-only: a PO's GP-computed header totals, to auto-fill the generated PO document (issue
+    #230). Reads the open-PO work table POP10100 first, then the history table POP30100 (a fully
+    processed PO moves there). Columns: SUBTOTAL, FRTAMNT (freight), MSCCHRG (misc charges), TAXAMNT
+    (tax). Returns None if the PO number isn't in GP.
+
+    NOTE: MSCCHRG is the physical POP10100 column for misc charges (eConnect's element for it is
+    MSCCHAMT); verify it against the live table on the first relay run - it's the only column name
+    here that isn't already read/written elsewhere in this file, so if GP rejects it, that one alias
+    is the fix."""
+    cur = conn.cursor()
+    for table in ("POP10100", "POP30100"):
+        row = cur.execute(
+            f"SELECT RTRIM(PONUMBER) AS po, SUBTOTAL AS subtotal, FRTAMNT AS freight, "
+            f"MSCCHRG AS misc, TAXAMNT AS tax FROM dbo.{table} WHERE PONUMBER = ?",
+            po_number,
+        ).fetchone()
+        if row is not None:
+            return {
+                "po_number": row.po,
+                "subtotal": float(row.subtotal or 0),
+                "freight": float(row.freight or 0),
+                "miscellaneous": float(row.misc or 0),
+                "tax_amount": float(row.tax or 0),
+            }
+    return None
+
+
 def list_cost_codes(conn, job_number: str) -> list[dict]:
     """Read-only: the active cost codes defined for ONE job in JC00701 (WennSoft Job Cost).
     Cost codes are per-job, and the real Cost_Element varies by code (210-200 is element 2,

--- a/localhost relay/tests/test_channel.py
+++ b/localhost relay/tests/test_channel.py
@@ -79,6 +79,31 @@ def test_list_jobs_routes_to_econnect(monkeypatch):
     }
 
 
+def test_read_po_totals_requires_po_number():
+    reply = channel._dispatch("read_po_totals", "TUBC", {})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "missing_po_number"
+
+
+def test_read_po_totals_routes_to_econnect_and_strips_number(monkeypatch):
+    seen = {}
+
+    def _fake(conn, po_number):
+        seen["po"] = po_number
+        return {"po_number": po_number, "subtotal": 20.0, "freight": 0.0, "miscellaneous": 0.0, "tax_amount": 0.0}
+
+    monkeypatch.setattr(econnect, "read_po_totals", _fake)
+    reply = channel._dispatch("read_po_totals", "TUBC", {"po_number": "  PO0000056  "})
+    assert seen["po"] == "PO0000056"
+    assert reply["result"]["totals"]["subtotal"] == 20.0
+
+
+def test_read_po_totals_passes_through_none_when_not_found(monkeypatch):
+    monkeypatch.setattr(econnect, "read_po_totals", lambda conn, po_number: None)
+    reply = channel._dispatch("read_po_totals", "TUBC", {"po_number": "PO-NOPE"})
+    assert reply == {"ok": True, "result": {"company": "TUBC", "totals": None}}
+
+
 def test_unknown_op_returns_a_clean_error():
     reply = channel._dispatch("not_a_real_op", "TUBC", {})
     assert reply == {"ok": False, "error": {"error": "unknown_op", "message": "unknown op 'not_a_real_op'", "context": {}}}

--- a/localhost relay/tests/test_read_po_totals.py
+++ b/localhost relay/tests/test_read_po_totals.py
@@ -1,0 +1,68 @@
+"""econnect.read_po_totals: coercion of the POP10100 amounts and the work -> history (POP30100)
+fallback, driven by a fake pyodbc cursor so no test touches GP."""
+
+from ucnexus_relay import econnect
+
+
+class _Row:
+    def __init__(self, po, subtotal, freight, misc, tax):
+        self.po = po
+        self.subtotal = subtotal
+        self.freight = freight
+        self.misc = misc
+        self.tax = tax
+
+
+class _Cursor:
+    """Returns rows_by_table[table] for each execute(), where table is inferred from the SQL text."""
+
+    def __init__(self, rows_by_table):
+        self._rows = rows_by_table
+        self._table = None
+
+    def execute(self, sql, po_number):
+        self._table = "POP10100" if "POP10100" in sql else "POP30100"
+        return self
+
+    def fetchone(self):
+        return self._rows.get(self._table)
+
+
+class _Conn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_reads_work_table_and_coerces_amounts():
+    row = _Row("PO0000056", 20, 100, 50, 75)
+    conn = _Conn(_Cursor({"POP10100": row}))
+    out = econnect.read_po_totals(conn, "PO0000056")
+    assert out == {
+        "po_number": "PO0000056",
+        "subtotal": 20.0,
+        "freight": 100.0,
+        "miscellaneous": 50.0,
+        "tax_amount": 75.0,
+    }
+
+
+def test_null_amounts_coerce_to_zero():
+    row = _Row("PO1", None, None, None, None)
+    conn = _Conn(_Cursor({"POP10100": row}))
+    out = econnect.read_po_totals(conn, "PO1")
+    assert out["subtotal"] == 0.0 and out["freight"] == 0.0 and out["tax_amount"] == 0.0
+
+
+def test_falls_back_to_history_table():
+    row = _Row("PO-HIST", 5, 0, 0, 0)
+    conn = _Conn(_Cursor({"POP10100": None, "POP30100": row}))
+    out = econnect.read_po_totals(conn, "PO-HIST")
+    assert out["po_number"] == "PO-HIST" and out["subtotal"] == 5.0
+
+
+def test_returns_none_when_not_in_either_table():
+    conn = _Conn(_Cursor({"POP10100": None, "POP30100": None}))
+    assert econnect.read_po_totals(conn, "PO-NOPE") is None


### PR DESCRIPTION
follow-up to #237/#238, generate-PO-document form.

dialog + generate button gated to a GP-registered PO (GP company + number) with relay connected - it reads live GP data.

read_po_totals - new relay op, reads POP10100, work table -> history POP30100:
SUBTOTAL
FRTAMNT
MSCCHRG
TAXAMNT

gpPoTotals(company, poNumber) backend query.
dialog pre-fills freight/misc/tax from GP, overridable.
tax label stays a setting.

buyer field - live GP Buyers dropdown (reuses gpBuyers), defaults to PO's stored buyer.

shipping method - admin-configurable dropdown from new shipping_methods list on po_document_settings. migration 050 seeds:
LOCAL DELIVERY
Supply by your freight company
...

ship-to - free text, empty prints nothing.

PO Document Settings page moved from Admin into PO module -> nested route + Document Settings header button.

new relay build required to test totals end to end; buyer dropdown works with current relay.
read_po_totals uses physical POP10100 misc column MSCCHRG (eConnect element is MSCCHAMT); verify on first relay run.

alembic head 050, 14 settings/data tests, relay 138 tests.
