### PR TITLE
Relay single-file model: config from %LOCALAPPDATA%, double-click opens the UI

### DIFF
--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -1,8 +1,8 @@
 """Single entry point for the packaged relay exe (and `python -m ucnexus_relay`).
 
 Subcommands:
-  serve (default)      run the relay (headless) - uvicorn on the configured [server] host/port
-  app [--minimized]    the desktop app: window + system tray, supervising the relay (--minimized = start in tray)
+  app (default)        the desktop app: window + system tray, supervising the relay (--minimized = start in tray)
+  serve                run the relay (headless) - uvicorn on the configured [server] host/port
   enroll  ...          one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
   protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
   health               GET the local /health endpoint and print it (exit 0 if status ok)
@@ -78,18 +78,23 @@ def _serve(argv: list[str]) -> int:
         # [channel].backend_url makes channel.run_forever() a no-op, so this is safe on a relay that
         # hasn't been reconfigured for it yet.
         #
+        # Skip the channel entirely when unenrolled (no secret): the backend refuses it pre-accept, so
+        # running it would just spam secret-rejected retries. serve still binds the local HTTP server so
+        # /health answers and the app shows "running"; enrolling + restarting serve brings the channel up.
+        #
         # run_forever loops indefinitely (reconnect-with-backoff), so it must be cancelled on shutdown:
         # a plain gather() would keep awaiting it after uvicorn's server.serve() returns on SIGINT /
         # service stop, hanging the process. Run it as a task and cancel it once the server exits.
-        channel_task = asyncio.create_task(channel.run_forever())
+        channel_task = asyncio.create_task(channel.run_forever()) if s.auth.shared_secret else None
         try:
             await server.serve()
         finally:
-            channel_task.cancel()
-            try:
-                await channel_task
-            except asyncio.CancelledError:
-                pass
+            if channel_task is not None:
+                channel_task.cancel()
+                try:
+                    await channel_task
+                except asyncio.CancelledError:
+                    pass
 
     try:
         asyncio.run(_run())
@@ -163,7 +168,9 @@ def main(argv: list[str] | None = None) -> int:
     if argv and not argv[0].startswith("-"):
         cmd, rest = argv[0], argv[1:]
     else:
-        cmd, rest = "serve", argv  # bare invocation (or only flags) defaults to serving
+        # bare invocation (a double-clicked exe) opens the desktop app. The serve child (setup.start_serve)
+        # and the autostart entries pass an explicit command, so only a bare double-click is affected.
+        cmd, rest = "app", argv
 
     if cmd == "serve":
         return _serve(rest)

--- a/localhost relay/src/ucnexus_relay/config.py
+++ b/localhost relay/src/ucnexus_relay/config.py
@@ -1,5 +1,6 @@
 """Config loading from config.toml (Python 3.11 tomllib + pydantic validation)."""
 
+import os
 import sys
 import tomllib
 from functools import lru_cache
@@ -11,11 +12,13 @@ from . import dpapi
 
 
 def _default_config_path() -> Path:
-    # When packaged by PyInstaller, __file__ points into the temp extraction dir, so config.toml is
-    # resolved next to the .exe instead. In a dev checkout it sits at <root>/config.toml
+    # Packaged: a FIXED per-user path (%LOCALAPPDATA%\UCNexusRelay\config.toml), NOT next to the exe, so
+    # the exe can be run from anywhere (Downloads, a USB stick) and still find the enrolled config - the
+    # single-file-distributable model. In a dev checkout it sits at <root>/config.toml
     # (config.py is <root>/src/ucnexus_relay/config.py).
     if getattr(sys, "frozen", False):
-        return Path(sys.executable).resolve().parent / "config.toml"
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "UCNexusRelay" / "config.toml"
     return Path(__file__).resolve().parents[2] / "config.toml"
 
 
@@ -32,7 +35,9 @@ class ServerCfg(BaseModel):
 
 
 class AuthCfg(BaseModel):
-    shared_secret: str
+    # Empty until enrolled. When it's blank the desktop app boots to the Setup tab; serve brokers nothing
+    # (no outbound channel) until enrollment writes a real secret.
+    shared_secret: str = ""
 
 
 class CorsCfg(BaseModel):
@@ -97,7 +102,7 @@ class ChannelCfg(BaseModel):
 
 class Settings(BaseModel):
     server: ServerCfg = ServerCfg()
-    auth: AuthCfg
+    auth: AuthCfg = AuthCfg()
     cors: CorsCfg = CorsCfg()
     sql: SqlCfg = SqlCfg()
     gp: GpCfg = GpCfg()
@@ -109,9 +114,10 @@ class Settings(BaseModel):
 def get_settings(path: str | None = None) -> Settings:
     cfg_path = Path(path) if path else DEFAULT_CONFIG_PATH
     if not cfg_path.exists():
-        raise RuntimeError(
-            f"config file not found: {cfg_path} — copy config.example.toml to config.toml and set the shared_secret"
-        )
+        # First run / not yet enrolled: every setting except the secret is baked into the defaults above,
+        # so build from them with an empty secret rather than failing. The app opens Setup to enroll;
+        # serve runs its local HTTP server but brokers nothing until a config with a secret exists.
+        return Settings()
     with open(cfg_path, "rb") as f:
         data = tomllib.load(f)
     # the shared_secret is DPAPI-encrypted at rest (see ucnexus_relay.dpapi); decrypt on read so the

--- a/localhost relay/tests/test_cli.py
+++ b/localhost relay/tests/test_cli.py
@@ -40,3 +40,32 @@ def test_main_dispatches_health(monkeypatch):
     monkeypatch.setattr(cli, "_health", lambda rest: called.setdefault("rest", rest) or 0)
     assert cli.main(["health"]) == 0
     assert called["rest"] == []
+
+
+def _fake_run_app(store):
+    def _run(minimized=False):
+        store["minimized"] = minimized
+        return 0
+
+    return _run
+
+
+def test_bare_invocation_defaults_to_app(monkeypatch):
+    # single-file model: a double-clicked exe (no args) opens the desktop app, not headless serve.
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)
+    from ucnexus_relay import app as app_mod
+
+    called = {}
+    monkeypatch.setattr(app_mod, "run_app", _fake_run_app(called))
+    assert cli.main([]) == 0
+    assert called["minimized"] is False
+
+
+def test_flags_only_invocation_defaults_to_app_minimized(monkeypatch):
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)
+    from ucnexus_relay import app as app_mod
+
+    called = {}
+    monkeypatch.setattr(app_mod, "run_app", _fake_run_app(called))
+    assert cli.main(["--minimized"]) == 0
+    assert called["minimized"] is True

--- a/localhost relay/tests/test_config.py
+++ b/localhost relay/tests/test_config.py
@@ -1,0 +1,20 @@
+"""Tolerant config loading for the single-file model: a missing config.toml means "unenrolled" (build
+from the baked defaults with an empty secret), not a crash. get_settings takes an explicit path so each
+test uses a unique one - it's @lru_cache-d by path."""
+
+from ucnexus_relay.config import get_settings
+
+
+def test_missing_config_returns_unenrolled_defaults(tmp_path):
+    s = get_settings(str(tmp_path / "does-not-exist" / "config.toml"))
+    assert s.auth.shared_secret == ""              # unenrolled - no secret yet
+    assert s.sql.server == "10.0.0.246,1435"       # infra is baked into the defaults
+    assert s.gp.default_company == "TUBC"
+    assert s.channel.backend_url.startswith("wss://")
+
+
+def test_loads_a_real_config_with_secret(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[auth]\nshared_secret = "plain-dev-secret"\n', encoding="utf-8")
+    s = get_settings(str(cfg))
+    assert s.auth.shared_secret == "plain-dev-secret"  # plaintext (dev) passes dpapi.unprotect unchanged


### PR DESCRIPTION
everything but the enrollment secret is baked into the exe:
SQL server/driver
CORS
backend wss URL
GP companies

download exe -> run anywhere -> double-click opens UI -> enroll in Setup. no config.toml to hand-place, no admin.

- config resolves to FIXED %LOCALAPPDATA%\UCNexusRelay\config.toml, not next-to-exe -> any copy of the exe finds the enrolled config.
- get_settings tolerates missing config -> returns unenrolled defaults.
- bare invocation (double-click) defaults to app. serve child + autostart pass explicit commands. CI smoke test uses explicit unknown subcommand.
- serve skips outbound channel when unenrolled (backend refuses it) -> runs local HTTP server until enrollment.

already-enrolled machine unchanged; config already at %LOCALAPPDATA%\UCNexusRelay.

relay not in CI. verified locally - ruff clean, full relay suite passes (new config + cli tests). needs a new relay build.
