### PR TITLE
Relay: single-instance app - focus/evict by version, promote newer exe, serve no-clobber guard

### DIFF
--- a/localhost relay/src/ucnexus_relay/app.py
+++ b/localhost relay/src/ucnexus_relay/app.py
@@ -8,13 +8,20 @@ unchanged, and only `serve` holds the single backend connection.
 UX: minimize hides the window to the tray (the relay keeps running); the window's X asks
 "Shut down the relay? GP will stop" and, if confirmed, stops the relay and quits; the tray 'Open' brings
 the window back, the tray 'Shut down' quits. Autostart launches this minimized to the tray (PR C).
+
+Single instance (packaged exe only; see ucnexus_relay.single_instance): before opening a window, run() runs
+a gate. A newer exe launched from anywhere promotes itself over the installed exe and relaunches from the
+install dir; otherwise the process either becomes the sole owner (writing app.lock + a loopback control
+server), focuses the already-running instance, or evicts an older one and takes over.
 """
 
+import os
 import sys
 import threading
 import time
+from pathlib import Path
 
-from . import setup
+from . import setup, single_instance
 from .config import DEFAULT_CONFIG_PATH
 from .logging_setup import get_logger
 from .ui import Api, _HTML, config_summary, relay_health
@@ -34,6 +41,8 @@ class RelayApp:
         self._window = None
         self._tray = None
         self._shutting_down = False
+        self._mutex = None  # single_instance.MutexResult while we own the app slot
+        self._control = None  # single_instance.ControlServer answering ping / show / quit_for_upgrade
 
     # --- serve child supervision ----------------------------------------------------------------------
 
@@ -65,11 +74,31 @@ class RelayApp:
             setup.stop_serve(self._install_dir())
         except Exception:
             logger.exception("error stopping the relay on shutdown")
+        self._release_single_instance()
         try:
             if self._tray is not None:
                 self._tray.stop()
         except Exception:
             logger.exception("error stopping the tray")
+
+    def _release_single_instance(self) -> None:
+        """Give up the app slot: drop app.lock, stop the control server, release the mutex. Runs on every
+        teardown path (X-close, tray 'Shut down', and the quit_for_upgrade handoff) so a newcomer sees the
+        slot freed."""
+        try:
+            single_instance.clear_lock(self._install_dir())
+        except Exception:
+            logger.exception("error clearing app.lock")
+        try:
+            if self._control is not None:
+                self._control.stop()
+        except Exception:
+            logger.exception("error stopping the control server")
+        try:
+            single_instance.release_mutex(self._mutex)
+        except Exception:
+            logger.exception("error releasing the single-instance mutex")
+        self._mutex = None
 
     def shutdown(self) -> None:
         """Stop the relay + tray and close the window (used by the tray/Status 'Shut down')."""
@@ -132,11 +161,124 @@ class RelayApp:
         )
         self._tray = pystray.Icon("ucnexus-relay", img, "UC Nexus Relay", menu)
 
-    def run(self, minimized: bool = False) -> int:
+    # --- single instance ------------------------------------------------------------------------------
+
+    def _ipc_show(self) -> None:
+        """A newcomer asked us to surface (it already granted us foreground rights). Restore the window and
+        pull it to the front."""
+        self._show_window()
+        single_instance.bring_to_front()
+
+    def _ipc_quit(self) -> None:
+        """A newer instance is taking over: tear down WITHOUT the shutdown-confirm dialog, then guarantee we
+        exit so our exe lock frees for the swap (mirrors the updater's hard-exit fallback)."""
+        logger.info("relay app evicted by a newer instance; shutting down for handoff")
+        self.shutdown()
+        timer = threading.Timer(2.0, lambda: os._exit(0))
+        timer.daemon = True
+        timer.start()
+
+    def _maybe_promote(self, force: bool) -> bool:
+        """If this frozen exe was launched from OUTSIDE the install dir, converge on the installed exe:
+        promote (swap self in + relaunch) when we're newer / forced / there's no install yet, otherwise
+        delegate to the installed exe. Returns True if the caller should exit (we handed off)."""
+        cfg_dir = self._install_dir()
+        me = Path(sys.executable)
+        installed = single_instance.installed_exe_path(cfg_dir)
+        # Short-circuit the common case (launched from the install dir) before probing the installed exe's
+        # build, so a normal startup never spawns a `print-build` subprocess.
+        if single_instance.same_path(me, installed):
+            return False
+        my_build = single_instance.current_build()
+        decision = single_instance.promote_decision(
+            frozen=True,
+            same_path=False,
+            installed_build=single_instance.installed_build(cfg_dir),
+            my_build=my_build,
+            force=force,
+        )
+        if decision == "skip":
+            return False
+        if decision == "delegate":
+            # the installed exe is same/newer: surface it if it's running, else launch it. Never run from here.
+            owner = single_instance.live_owner(cfg_dir)
+            if owner is not None:
+                single_instance.allow_foreground(owner["pid"])
+                single_instance.send_show(owner["port"], owner["nonce"])
+                logger.info("installed relay is current and running; focused it instead of running from %s", me)
+            else:
+                single_instance.launch_installed(cfg_dir)
+                logger.info("installed relay is current; launched it instead of running from %s", me)
+            return True
+        # promote: evict a running (installed) owner so its exe unlocks, swap, relaunch from the install dir
+        owner = single_instance.live_owner(cfg_dir)
+        if owner is not None:
+            single_instance.evict(owner, cfg_dir)
+        res = single_instance.promote_swap(me, cfg_dir)
+        if not res.get("ok"):
+            logger.error("promote failed (%s); running in place from %s", res.get("error"), me)
+            return False  # fall back to running from where we are rather than not running at all
+        single_instance.refresh_autostart_if_present(cfg_dir)
+        single_instance.launch_installed(cfg_dir)
+        logger.info("promoted %s -> %s (build %s) and relaunched", me, installed, my_build)
+        return True
+
+    def _acquire_single_instance(self, force: bool) -> bool:
+        """Become the single app owner, or signal an existing one and bow out. Returns True to proceed as
+        owner, False if the caller should exit (we focused / handed off to another instance)."""
+        cfg_dir = self._install_dir()
+        my_build = single_instance.current_build()
+
+        owner = single_instance.live_owner(cfg_dir)
+        evicted = False
+        if owner is not None:
+            if single_instance.decide_action(my_build, owner["build"], force) == "focus":
+                single_instance.allow_foreground(owner["pid"])
+                single_instance.send_show(owner["port"], owner["nonce"])
+                logger.info("relay already running (build %s); brought it to the front", owner["build"])
+                return False
+            logger.info("newer relay launched; evicting the running build %s", owner["build"])
+            single_instance.evict(owner, cfg_dir)
+            evicted = True
+
+        # serialise cold-start races: whoever creates the mutex first owns the slot. This only matters when
+        # we did NOT just evict an owner - after an eviction the mutex may still exist (the outgoing owner's
+        # handle closes a beat after its control server stops), and we're the rightful owner regardless.
+        self._mutex = single_instance.acquire_mutex()
+        if not evicted and not self._mutex.acquired and not force:
+            rival = single_instance.wait_for_owner(cfg_dir)
+            if rival is not None:
+                single_instance.allow_foreground(rival["pid"])
+                single_instance.send_show(rival["port"], rival["nonce"])
+                logger.info("lost the startup race; brought the winning instance to the front")
+                single_instance.release_mutex(self._mutex)
+                self._mutex = None
+                return False  # the rival is the owner
+
+        nonce = single_instance.new_nonce()
+        self._control = single_instance.ControlServer(
+            build=my_build, nonce=nonce, on_show=self._ipc_show, on_quit=self._ipc_quit
+        )
+        port = self._control.start()
+        single_instance.write_lock(
+            cfg_dir, pid=os.getpid(), build=my_build, exe_path=sys.executable, control_port=port, nonce=nonce
+        )
+        return True
+
+    # --- run ------------------------------------------------------------------------------------------
+
+    def run(self, minimized: bool = False, force: bool = False) -> int:
         import webview
 
         global _APP
         _APP = self
+        # Single-instance + promote gate. Only meaningful for the packaged exe: a dev run has
+        # sys.executable = python (no exe to promote/relaunch, build 'dev'), so keep today's behaviour there.
+        if getattr(sys, "frozen", False):
+            if self._maybe_promote(force):
+                return 0
+            if not self._acquire_single_instance(force):
+                return 0
         self.ensure_serve()
         self._window = webview.create_window(
             "UC Nexus Relay",
@@ -155,5 +297,5 @@ class RelayApp:
         return 0
 
 
-def run_app(minimized: bool = False) -> int:
-    return RelayApp().run(minimized=minimized)
+def run_app(minimized: bool = False, force: bool = False) -> int:
+    return RelayApp().run(minimized=minimized, force=force)

--- a/localhost relay/src/ucnexus_relay/cli.py
+++ b/localhost relay/src/ucnexus_relay/cli.py
@@ -1,11 +1,13 @@
 """Single entry point for the packaged relay exe (and `python -m ucnexus_relay`).
 
 Subcommands:
-  app (default)        the desktop app: window + system tray, supervising the relay (--minimized = start in tray)
+  app (default)        the desktop app: window + system tray, supervising the relay (--minimized = start in
+                       tray; --force = take over from a running instance even if same/older/dev)
   serve                run the relay (headless) - uvicorn on the configured [server] host/port
   enroll  ...          one-time enrollment (delegates to ucnexus_relay.enroll; pass its flags through)
   protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
   health               GET the local /health endpoint and print it (exit 0 if status ok)
+  print-build          print this exe's build tag (used by promote to compare against the installed exe)
   install-autostart    register a no-admin logon autostart (HKCU Run) so the relay starts at logon
   uninstall-autostart  remove that logon autostart entry
   autostart-status     print whether the logon autostart is installed (JSON)
@@ -45,6 +47,21 @@ def _reattach_console() -> None:
         sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
 
 
+def _relay_already_serving(host: str, port: int) -> bool:
+    """True if a relay is already answering /health on host:port. A second serve would fail the port bind
+    anyway, but the OLD flow wrote relay.pid before binding and deleted it on the way out - orphaning the
+    first serve (the app could no longer stop/restart it). Bailing here before touching relay.pid avoids
+    that."""
+    import json
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(f"http://{host}:{port}/health", timeout=2) as r:  # noqa: S310 (localhost)
+            return json.loads(r.read().decode()).get("status") == "ok"
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
 def _serve(argv: list[str]) -> int:
     import asyncio
     import os
@@ -56,6 +73,13 @@ def _serve(argv: list[str]) -> int:
     from .main import app
 
     s = get_settings()
+
+    # Single-instance: if a relay is already serving on this host/port, don't start a second one (and do NOT
+    # touch relay.pid - see _relay_already_serving). The app's ensure_serve/restart already gate on /health;
+    # this covers a stray manual `serve`, the scheduled-task deployment, and a double logon trigger.
+    if _relay_already_serving(s.server.host, s.server.port):
+        print(f"relay already serving on {s.server.host}:{s.server.port}; not starting a second one", file=sys.stderr)
+        return 0
 
     # Write a pid file next to config.toml so the UI's Stop/Restart can target THIS serve process. The ui
     # window and serve are both ucnexus-relay.exe, so a pid file is the reliable way to tell them apart.
@@ -176,7 +200,19 @@ def main(argv: list[str] | None = None) -> int:
         return _serve(rest)
     if cmd == "app":
         from .app import run_app
-        return run_app(minimized="--minimized" in rest)
+        return run_app(minimized="--minimized" in rest, force="--force" in rest)
+    if cmd == "print-build":
+        from .updater import current_build
+
+        # Write to fd 1 directly, NOT print(): the windowed build's _reattach_console rebinds sys.stdout to
+        # devnull when there's no console, which is exactly how promote's `installed_build` spawns us
+        # (detached, no window, output over a pipe). os.write(1) reaches that captured pipe regardless.
+        data = (current_build() + "\n").encode("utf-8")
+        try:
+            os.write(1, data)
+        except OSError:
+            sys.stdout.write(data.decode("utf-8"))
+        return 0
     if cmd == "enroll":
         from .enroll import main as enroll_main
         return enroll_main(rest)
@@ -193,7 +229,7 @@ def main(argv: list[str] | None = None) -> int:
         return _autostart_status(rest)
 
     print(
-        f"unknown command: {cmd!r} (expected: serve | app | enroll | protect-secret | health | "
+        f"unknown command: {cmd!r} (expected: serve | app | enroll | protect-secret | health | print-build | "
         "install-autostart | uninstall-autostart | autostart-status)",
         file=sys.stderr,
     )

--- a/localhost relay/src/ucnexus_relay/single_instance.py
+++ b/localhost relay/src/ucnexus_relay/single_instance.py
@@ -1,0 +1,459 @@
+"""Single-instance ownership for the desktop `app` process.
+
+The relay's top-level user-launched process is always `app` (double-click / shortcut / autostart); `serve`
+is only ever its child. Nothing stopped a second `app` from opening a second window + tray icon over the
+same serve. This module makes `app` single-instance and version-aware:
+
+  - the running owner writes app.lock (next to config.toml) with its pid, build, and a loopback control
+    port + nonce, and runs a tiny 127.0.0.1 control server (ping / show / quit_for_upgrade);
+  - a newcomer reads app.lock, pings the owner, and either focuses it, evicts + replaces it (a newer
+    build), or defers to it (older / dev), per decide_action();
+  - a session-local named mutex serialises two simultaneous cold starts so exactly one becomes owner.
+
+Promote-to-installed lives here too: a newer exe launched from anywhere (Downloads, a USB stick) swaps
+itself over the installed exe and relaunches from there, so the single-file distributable doubles as its
+own upgrader (see promote_decision / promote_swap).
+
+Everything is import-safe without a GUI backend - app.py wires the show / quit callbacks to the window -
+so the decision logic and the lockfile plumbing unit-test without opening a window.
+"""
+
+import json
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from . import updater
+from .logging_setup import get_logger
+
+logger = get_logger()
+
+LOCKFILE_NAME = "app.lock"
+MUTEX_NAME = "Local\\UCNexusRelay.App"
+ASSET_NAME = "ucnexus-relay.exe"
+WINDOW_TITLE = "UC Nexus Relay"
+_PING_TIMEOUT = 2.0
+
+_DETACHED = 0x00000008  # DETACHED_PROCESS
+_NO_WINDOW = 0x08000000  # CREATE_NO_WINDOW
+
+
+# --- build comparison ---------------------------------------------------------------------------------
+
+
+def current_build() -> str:
+    return updater.current_build()
+
+
+def new_nonce() -> str:
+    return secrets.token_hex(16)
+
+
+def build_is_newer(candidate: str, other: str) -> bool:
+    """True if `candidate` is a strictly higher build than `other`. 'dev' is build -1 (updater.build_number),
+    so a dev build is never newer than a real one - only --force overrides that (see decide_action)."""
+    return updater.build_number(candidate) > updater.build_number(other)
+
+
+def decide_action(new_build: str, running_build: str, force: bool = False) -> str:
+    """What a newcomer should do about a LIVE owner: 'replace' (evict + take over) or 'focus' (surface the
+    owner's window and exit). Newer -> replace; same / older / dev -> focus; --force always replaces."""
+    if force:
+        return "replace"
+    return "replace" if build_is_newer(new_build, running_build) else "focus"
+
+
+def promote_decision(*, frozen: bool, same_path: bool, installed_build: str | None, my_build: str, force: bool) -> str:
+    """Whether a launched exe should copy itself over the installed exe. Returns:
+    'skip'     - run in place (a dev run, or already the installed exe);
+    'promote'  - swap self in + relaunch from the install dir (newer, forced, or no install yet);
+    'delegate' - the installed exe is same/newer, so launch it instead of running from here."""
+    if not frozen or same_path:
+        return "skip"
+    if force or installed_build is None or build_is_newer(my_build, installed_build):
+        return "promote"
+    return "delegate"
+
+
+# --- lockfile -----------------------------------------------------------------------------------------
+
+
+def lockfile_path(config_dir) -> Path:
+    return Path(config_dir) / LOCKFILE_NAME
+
+
+def read_lock(config_dir) -> dict | None:
+    """Parse app.lock, or None if it's missing / unreadable / corrupt. Liveness is a separate ping (a lock
+    can outlive the process that wrote it if the app was killed) - see live_owner()."""
+    try:
+        return json.loads(lockfile_path(config_dir).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def write_lock(config_dir, *, pid: int, build: str, exe_path: str, control_port: int, nonce: str) -> None:
+    p = lockfile_path(config_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps({"pid": pid, "build": build, "exe_path": exe_path, "control_port": control_port, "nonce": nonce}),
+        encoding="utf-8",
+    )
+
+
+def clear_lock(config_dir) -> None:
+    try:
+        lockfile_path(config_dir).unlink()
+    except OSError:
+        pass
+
+
+# --- loopback control channel -------------------------------------------------------------------------
+
+
+def _recv_line(conn) -> bytes:
+    buf = bytearray()
+    while b"\n" not in buf:
+        try:
+            chunk = conn.recv(4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf.extend(chunk)
+        if len(buf) > 65536:  # a command line is tiny; cap to avoid an unbounded read
+            break
+    return bytes(buf)
+
+
+class ControlServer:
+    """The 127.0.0.1 line-JSON control server the owning app runs. Every command must carry the lock's
+    nonce (so only a local process that can read app.lock can drive it). Commands:
+      ping             -> {ok, build, pid}
+      show             -> on_show()  (surface the window)
+      quit_for_upgrade -> ok, then on_quit() off-thread (tear down for a newer instance's handoff)."""
+
+    def __init__(self, *, build: str, nonce: str, on_show, on_quit) -> None:
+        self._build = build
+        self._nonce = nonce
+        self._on_show = on_show
+        self._on_quit = on_quit
+        self._sock: socket.socket | None = None
+        self._port = 0
+        self._stop = False
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def start(self) -> int:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))  # ephemeral port; recorded in app.lock so the newcomer can find us
+        s.listen(8)
+        self._sock = s
+        self._port = s.getsockname()[1]
+        threading.Thread(target=self._accept_loop, name="relay-ctl", daemon=True).start()
+        return self._port
+
+    def stop(self) -> None:
+        self._stop = True
+        try:
+            if self._sock is not None:
+                self._sock.close()
+        except OSError:
+            pass
+
+    def _accept_loop(self) -> None:
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return  # socket closed by stop()
+            try:
+                self._handle(conn)
+            except Exception:
+                logger.exception("relay control connection failed")
+            finally:
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+
+    def _handle(self, conn) -> None:
+        conn.settimeout(3.0)
+        try:
+            req = json.loads(_recv_line(conn).decode("utf-8").strip() or "{}")
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._reply(conn, {"ok": False, "error": "bad request"})
+            return
+        if req.get("nonce") != self._nonce:
+            self._reply(conn, {"ok": False, "error": "bad nonce"})
+            return
+        cmd = req.get("cmd")
+        if cmd == "ping":
+            self._reply(conn, {"ok": True, "build": self._build, "pid": os.getpid()})
+        elif cmd == "show":
+            self._reply(conn, {"ok": True})
+            self._safe(self._on_show)
+        elif cmd == "quit_for_upgrade":
+            self._reply(conn, {"ok": True})
+            # run teardown off the accept thread so the reply flushes before the window is destroyed
+            threading.Thread(target=lambda: self._safe(self._on_quit), name="relay-quit", daemon=True).start()
+        else:
+            self._reply(conn, {"ok": False, "error": f"unknown cmd {cmd!r}"})
+
+    @staticmethod
+    def _safe(fn) -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("relay control handler failed")
+
+    @staticmethod
+    def _reply(conn, obj: dict) -> None:
+        try:
+            conn.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+        except OSError:
+            pass
+
+
+def _send(port, nonce: str, cmd: str, timeout: float = _PING_TIMEOUT) -> dict | None:
+    try:
+        with socket.create_connection(("127.0.0.1", int(port)), timeout=timeout) as conn:
+            conn.settimeout(timeout)
+            conn.sendall((json.dumps({"cmd": cmd, "nonce": nonce}) + "\n").encode("utf-8"))
+            raw = _recv_line(conn)
+        return json.loads(raw.decode("utf-8").strip() or "{}")
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def send_show(port, nonce) -> bool:
+    r = _send(port, nonce, "show")
+    return bool(r and r.get("ok"))
+
+
+def send_quit(port, nonce) -> bool:
+    r = _send(port, nonce, "quit_for_upgrade")
+    return bool(r and r.get("ok"))
+
+
+def live_owner(config_dir) -> dict | None:
+    """If app.lock points at an owner that answers ping, return {port, nonce, build, pid}; else None. The
+    ping (not the pid) is the authoritative liveness test, so a stale lock from a killed app reads as None."""
+    lock = read_lock(config_dir)
+    if not lock:
+        return None
+    port, nonce = lock.get("control_port"), lock.get("nonce")
+    if not port or not nonce:
+        return None
+    pong = _send(port, nonce, "ping")
+    if not (pong and pong.get("ok")):
+        return None
+    return {
+        "port": port,
+        "nonce": nonce,
+        "build": pong.get("build") or lock.get("build") or "dev",
+        "pid": pong.get("pid") or lock.get("pid"),
+    }
+
+
+def wait_for_release(config_dir, timeout: float = 15.0) -> bool:
+    """Poll until app.lock has no live owner (the evicted owner exited + freed its exe lock)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if live_owner(config_dir) is None:
+            return True
+        time.sleep(0.3)
+    return live_owner(config_dir) is None
+
+
+def wait_for_owner(config_dir, timeout: float = 5.0) -> dict | None:
+    """Poll until a live owner appears - used when we lost the cold-start mutex race and the winner's
+    control server hasn't come up yet. None on timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        owner = live_owner(config_dir)
+        if owner is not None:
+            return owner
+        time.sleep(0.2)
+    return live_owner(config_dir)
+
+
+def force_kill_pid(pid) -> None:
+    """Last-resort taskkill BY PID (never by image name - that would also kill us, same exe). Used only if a
+    graceful quit_for_upgrade didn't release the owner in time."""
+    if not pid:
+        return
+    try:
+        subprocess.run(["taskkill", "/PID", str(int(pid)), "/F"], capture_output=True, text=True)  # noqa: S607
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass
+
+
+def evict(owner: dict, config_dir) -> bool:
+    """Ask a live owner to quit for a handoff and wait for it to release. Graceful first (quit_for_upgrade);
+    force-kill its pid only if that times out. True once no live owner remains."""
+    send_quit(owner["port"], owner["nonce"])
+    if wait_for_release(config_dir):
+        return True
+    logger.warning("relay owner didn't quit gracefully; force-killing pid %s", owner.get("pid"))
+    force_kill_pid(owner.get("pid"))
+    return wait_for_release(config_dir, timeout=5.0)
+
+
+# --- session-local named mutex (Windows) --------------------------------------------------------------
+
+
+class MutexResult:
+    def __init__(self, handle, acquired: bool) -> None:
+        self.handle = handle
+        self.acquired = acquired  # True if WE created it first (it didn't already exist)
+
+
+def acquire_mutex(name: str = MUTEX_NAME) -> MutexResult:
+    """Create the session-local named mutex. `acquired` is False when the mutex already existed (another app
+    is starting / running). Off Windows (or if creation fails) `acquired` is True - the lockfile + ping
+    still serialise; the mutex only tightens the two-simultaneous-cold-start race."""
+    if sys.platform != "win32":
+        return MutexResult(None, True)
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    error_already_exists = 183
+    handle = kernel32.CreateMutexW(None, True, name)
+    existed = kernel32.GetLastError() == error_already_exists
+    if not handle:
+        return MutexResult(None, True)
+    return MutexResult(handle, not existed)
+
+
+def release_mutex(result: MutexResult | None) -> None:
+    if result is None or result.handle is None or sys.platform != "win32":
+        return
+    import ctypes
+
+    try:
+        ctypes.windll.kernel32.ReleaseMutex(result.handle)
+        ctypes.windll.kernel32.CloseHandle(result.handle)
+    except OSError:
+        pass
+
+
+# --- Win32 window activation --------------------------------------------------------------------------
+
+
+def allow_foreground(pid) -> None:
+    """Grant `pid` permission to steal foreground, so the owner's SetForegroundWindow actually raises the
+    window instead of just flashing the taskbar (Windows blocks a non-foreground process from doing that)."""
+    if sys.platform != "win32" or not pid:
+        return
+    import ctypes
+
+    try:
+        ctypes.windll.user32.AllowSetForegroundWindow(int(pid))
+    except (OSError, ValueError):
+        pass
+
+
+def bring_to_front(title: str = WINDOW_TITLE) -> bool:
+    """Restore + foreground the window with this title. The owner calls this for its OWN window on `show`,
+    after the newcomer granted it foreground rights via allow_foreground()."""
+    if sys.platform != "win32":
+        return False
+    import ctypes
+
+    user32 = ctypes.windll.user32
+    sw_restore = 9
+    hwnd = user32.FindWindowW(None, title)
+    if not hwnd:
+        return False
+    user32.ShowWindow(hwnd, sw_restore)
+    return bool(user32.SetForegroundWindow(hwnd))
+
+
+# --- promote-to-installed -----------------------------------------------------------------------------
+
+
+def installed_exe_path(config_dir) -> Path:
+    return Path(config_dir) / ASSET_NAME
+
+
+def same_path(a, b) -> bool:
+    try:
+        return Path(a).resolve() == Path(b).resolve()
+    except OSError:
+        return str(a).lower() == str(b).lower()
+
+
+def installed_build(config_dir, timeout: float = 8.0) -> str | None:
+    """The build of the installed exe, read by running `<installed> print-build`. None if there's no
+    installed exe or it didn't answer (the caller treats None as 'promote' - a fresh install)."""
+    exe = installed_exe_path(config_dir)
+    if not exe.exists():
+        return None
+    try:
+        out = subprocess.run(
+            [str(exe), "print-build"], capture_output=True, text=True, timeout=timeout, creationflags=_NO_WINDOW
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return (out.stdout or "").strip() or None
+
+
+def promote_swap(src_exe, config_dir, retries: int = 30) -> dict:
+    """Copy `src_exe` (this newer running exe, e.g. from Downloads) over the installed exe, renaming the
+    installed one aside first - Windows locks a running/held image but permits renaming it (the updater
+    relies on the same trick). Retries while the handle releases."""
+    install_dir = Path(config_dir)
+    install_dir.mkdir(parents=True, exist_ok=True)
+    exe = installed_exe_path(install_dir)
+    error = None
+    for _ in range(retries):
+        try:
+            if exe.exists():
+                os.replace(exe, updater._free_old_path(install_dir))  # move the installed exe aside
+            shutil.copy2(src_exe, exe)  # drop our newer exe into place
+            updater._cleanup_old(install_dir)
+            return {"ok": True, "path": str(exe)}
+        except OSError as e:
+            error = str(e)
+            time.sleep(0.5)
+    return {"ok": False, "error": f"promote swap failed: {error}"}
+
+
+def launch_installed(config_dir, minimized: bool = False) -> None:
+    """Spawn the installed exe as the desktop app, detached so it outlives this (promoting/delegating)
+    process. The relaunched exe runs the single-instance gate itself and becomes the owner."""
+    exe = installed_exe_path(config_dir)
+    args = [str(exe), "app"] + (["--minimized"] if minimized else [])
+    subprocess.Popen(  # noqa: S603 (our own installed exe path)
+        args,
+        cwd=str(config_dir),
+        creationflags=_DETACHED | _NO_WINDOW,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def refresh_autostart_if_present(config_dir) -> None:
+    """After a promote, repoint the HKCU Run entry at the (stable) installed exe path - a no-op if it
+    already points there. Only touches autostart when it's already installed, so a promote never silently
+    enables start-at-logon for someone who didn't ask for it. Shortcuts need no refresh: they already
+    target the fixed installed path, which a promote doesn't change."""
+    from . import autostart
+
+    if autostart.winreg is None:
+        return
+    try:
+        if autostart.autostart_status().get("installed"):
+            exe = installed_exe_path(config_dir)
+            autostart.install_autostart(command=f'"{exe}" app --minimized')
+    except OSError:
+        logger.exception("could not refresh autostart after promote")

--- a/localhost relay/tests/test_app.py
+++ b/localhost relay/tests/test_app.py
@@ -104,3 +104,126 @@ def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
     r = ui.Api().apply_update("https://x/e.exe")
     assert r["ok"] is False
     assert shut == []  # a failed stage must NOT close the app
+
+
+# --- single-instance gate ----------------------------------------------------------------------------
+
+from ucnexus_relay import single_instance as si  # noqa: E402
+
+BUILD5 = "relay-v0.1.0-build.5"
+BUILD6 = "relay-v0.1.0-build.6"
+
+
+def _fake_control(store):
+    class _Ctl:
+        def __init__(self, **kw):
+            store["kw"] = kw
+
+        def start(self):
+            return 5555
+
+    return _Ctl
+
+
+def test_acquire_focuses_a_running_same_build(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "current_build", lambda: BUILD5)
+    monkeypatch.setattr(si, "live_owner", lambda d: {"port": 1, "nonce": "n", "build": BUILD5, "pid": 123})
+    sent = []
+    monkeypatch.setattr(si, "allow_foreground", lambda pid: sent.append(("af", pid)))
+    monkeypatch.setattr(si, "send_show", lambda p, n: sent.append(("show", p, n)) or True)
+    assert a._acquire_single_instance(force=False) is False  # bowed out to the running instance
+    assert ("af", 123) in sent and ("show", 1, "n") in sent
+    assert a._control is None
+
+
+def test_acquire_becomes_owner_when_none_running(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "current_build", lambda: BUILD5)
+    monkeypatch.setattr(si, "live_owner", lambda d: None)
+    monkeypatch.setattr(si, "acquire_mutex", lambda: si.MutexResult(None, True))
+    store = {}
+    monkeypatch.setattr(si, "ControlServer", _fake_control(store))
+    monkeypatch.setattr(si, "new_nonce", lambda: "nonce")
+    locks = []
+    monkeypatch.setattr(si, "write_lock", lambda d, **kw: locks.append(kw))
+    assert a._acquire_single_instance(force=False) is True
+    assert locks[0]["control_port"] == 5555 and locks[0]["nonce"] == "nonce" and locks[0]["build"] == BUILD5
+    assert a._control is not None and a._mutex is not None
+
+
+def test_acquire_evicts_an_older_owner_then_takes_over(monkeypatch):
+    a = appmod.RelayApp()
+    owner = {"port": 1, "nonce": "n", "build": BUILD5, "pid": 123}
+    monkeypatch.setattr(si, "current_build", lambda: BUILD6)
+    monkeypatch.setattr(si, "live_owner", lambda d: owner)
+    evicted = []
+    monkeypatch.setattr(si, "evict", lambda o, d: evicted.append(o) or True)
+    monkeypatch.setattr(si, "acquire_mutex", lambda: si.MutexResult(None, True))
+    monkeypatch.setattr(si, "ControlServer", _fake_control({}))
+    monkeypatch.setattr(si, "new_nonce", lambda: "nonce")
+    monkeypatch.setattr(si, "write_lock", lambda d, **kw: None)
+    assert a._acquire_single_instance(force=False) is True
+    assert evicted == [owner]
+
+
+def test_acquire_defers_when_it_loses_the_cold_start_race(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "current_build", lambda: BUILD5)
+    monkeypatch.setattr(si, "live_owner", lambda d: None)
+    monkeypatch.setattr(si, "acquire_mutex", lambda: si.MutexResult(None, False))  # someone created it first
+    monkeypatch.setattr(si, "wait_for_owner", lambda d: {"port": 9, "nonce": "z", "build": BUILD5, "pid": 7})
+    sent = []
+    monkeypatch.setattr(si, "allow_foreground", lambda pid: sent.append(pid))
+    monkeypatch.setattr(si, "send_show", lambda p, n: sent.append((p, n)) or True)
+    monkeypatch.setattr(si, "release_mutex", lambda m: None)
+    assert a._acquire_single_instance(force=False) is False
+    assert 7 in sent and (9, "z") in sent
+
+
+def test_maybe_promote_skips_when_launched_from_install_dir(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "same_path", lambda x, y: True)
+    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
+    monkeypatch.setattr(si, "current_build", lambda: BUILD5)
+    assert a._maybe_promote(force=False) is False
+
+
+def test_maybe_promote_delegates_when_installed_is_current(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "same_path", lambda x, y: False)
+    monkeypatch.setattr(si, "installed_build", lambda d: BUILD6)
+    monkeypatch.setattr(si, "current_build", lambda: BUILD5)  # we're older -> delegate to installed
+    monkeypatch.setattr(si, "live_owner", lambda d: None)
+    launched = []
+    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
+    assert a._maybe_promote(force=False) is True
+    assert launched == [True]
+
+
+def test_maybe_promote_swaps_and_relaunches_when_newer(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "same_path", lambda x, y: False)
+    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
+    monkeypatch.setattr(si, "current_build", lambda: BUILD6)  # newer -> promote
+    monkeypatch.setattr(si, "live_owner", lambda d: None)
+    swapped = []
+    monkeypatch.setattr(si, "promote_swap", lambda src, d: swapped.append(src) or {"ok": True})
+    monkeypatch.setattr(si, "refresh_autostart_if_present", lambda d: None)
+    launched = []
+    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
+    assert a._maybe_promote(force=False) is True
+    assert swapped and launched == [True]
+
+
+def test_maybe_promote_runs_in_place_when_swap_fails(monkeypatch):
+    a = appmod.RelayApp()
+    monkeypatch.setattr(si, "same_path", lambda x, y: False)
+    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
+    monkeypatch.setattr(si, "current_build", lambda: BUILD6)
+    monkeypatch.setattr(si, "live_owner", lambda d: None)
+    monkeypatch.setattr(si, "promote_swap", lambda src, d: {"ok": False, "error": "locked"})
+    launched = []
+    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
+    assert a._maybe_promote(force=False) is False  # fall back to running in place
+    assert launched == []

--- a/localhost relay/tests/test_cli.py
+++ b/localhost relay/tests/test_cli.py
@@ -43,8 +43,9 @@ def test_main_dispatches_health(monkeypatch):
 
 
 def _fake_run_app(store):
-    def _run(minimized=False):
+    def _run(minimized=False, force=False):
         store["minimized"] = minimized
+        store["force"] = force
         return 0
 
     return _run
@@ -69,3 +70,52 @@ def test_flags_only_invocation_defaults_to_app_minimized(monkeypatch):
     monkeypatch.setattr(app_mod, "run_app", _fake_run_app(called))
     assert cli.main(["--minimized"]) == 0
     assert called["minimized"] is True
+
+
+def test_app_passes_force_through(monkeypatch):
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)
+    from ucnexus_relay import app as app_mod
+
+    called = {}
+    monkeypatch.setattr(app_mod, "run_app", _fake_run_app(called))
+    assert cli.main(["app", "--force"]) == 0
+    assert called["force"] is True and called["minimized"] is False
+
+
+def test_main_dispatches_print_build(monkeypatch, capfd):
+    # capfd (fd-level), not capsys: print-build writes to fd 1 directly so it survives the windowed build's
+    # devnull stdout when spawned over a pipe by promote's installed_build.
+    monkeypatch.setattr(cli, "_reattach_console", lambda: None)
+    from ucnexus_relay import updater
+
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.7")
+    assert cli.main(["print-build"]) == 0
+    assert "relay-v0.1.0-build.7" in capfd.readouterr().out
+
+
+def test_relay_already_serving_true(monkeypatch):
+    import json
+    import urllib.request
+
+    class _Resp:
+        def read(self):
+            return json.dumps({"status": "ok"}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert cli._relay_already_serving("127.0.0.1", 7321) is True
+
+
+def test_relay_already_serving_false_when_unreachable(monkeypatch):
+    import urllib.request
+
+    def _boom(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    assert cli._relay_already_serving("127.0.0.1", 7321) is False

--- a/localhost relay/tests/test_single_instance.py
+++ b/localhost relay/tests/test_single_instance.py
@@ -1,0 +1,189 @@
+"""Single-instance primitives: the version-decision logic, the app.lock plumbing, the loopback control
+channel (real sockets, no GUI), and the promote-to-installed swap. No window, no frozen exe."""
+
+import subprocess
+import time
+
+from ucnexus_relay import single_instance as si
+
+BUILD5 = "relay-v0.1.0-build.5"
+BUILD6 = "relay-v0.1.0-build.6"
+
+
+# --- version logic ------------------------------------------------------------------------------------
+
+
+def test_build_is_newer():
+    assert si.build_is_newer(BUILD6, BUILD5) is True
+    assert si.build_is_newer(BUILD5, BUILD6) is False
+    assert si.build_is_newer(BUILD5, BUILD5) is False
+    assert si.build_is_newer("dev", BUILD5) is False  # dev is build -1, never newer than a real build
+
+
+def test_decide_action_matrix():
+    assert si.decide_action(BUILD5, BUILD5) == "focus"  # same -> focus
+    assert si.decide_action(BUILD6, BUILD5) == "replace"  # newer -> replace
+    assert si.decide_action(BUILD5, BUILD6) == "focus"  # older -> focus
+    assert si.decide_action("dev", BUILD5) == "focus"  # dev over real -> focus
+    assert si.decide_action("dev", BUILD5, force=True) == "replace"  # --force always replaces
+
+
+def test_promote_decision_matrix():
+    d = si.promote_decision
+    assert d(frozen=False, same_path=False, installed_build=BUILD5, my_build=BUILD6, force=False) == "skip"
+    assert d(frozen=True, same_path=True, installed_build=BUILD5, my_build=BUILD6, force=False) == "skip"
+    assert d(frozen=True, same_path=False, installed_build=None, my_build=BUILD5, force=False) == "promote"
+    assert d(frozen=True, same_path=False, installed_build=BUILD5, my_build=BUILD6, force=False) == "promote"
+    assert d(frozen=True, same_path=False, installed_build=BUILD6, my_build=BUILD5, force=False) == "delegate"
+    assert d(frozen=True, same_path=False, installed_build=BUILD5, my_build=BUILD5, force=False) == "delegate"
+    assert d(frozen=True, same_path=False, installed_build=BUILD6, my_build=BUILD5, force=True) == "promote"
+
+
+# --- lockfile -----------------------------------------------------------------------------------------
+
+
+def test_lockfile_roundtrip_and_clear(tmp_path):
+    assert si.read_lock(tmp_path) is None  # nothing written yet
+    si.write_lock(tmp_path, pid=111, build=BUILD5, exe_path="C:/x.exe", control_port=5555, nonce="abc")
+    lock = si.read_lock(tmp_path)
+    assert lock == {"pid": 111, "build": BUILD5, "exe_path": "C:/x.exe", "control_port": 5555, "nonce": "abc"}
+    si.clear_lock(tmp_path)
+    assert si.read_lock(tmp_path) is None
+    si.clear_lock(tmp_path)  # idempotent - no error when already gone
+
+
+def test_read_lock_tolerates_corrupt(tmp_path):
+    si.lockfile_path(tmp_path).write_text("{ not json", encoding="utf-8")
+    assert si.read_lock(tmp_path) is None
+
+
+# --- loopback control channel -------------------------------------------------------------------------
+
+
+def _wait(pred, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(0.02)
+    return pred()
+
+
+def test_control_server_ping_show_quit_and_nonce(tmp_path):
+    events = {"show": 0, "quit": 0}
+    server = si.ControlServer(
+        build=BUILD5,
+        nonce="secret",
+        on_show=lambda: events.__setitem__("show", events["show"] + 1),
+        on_quit=lambda: events.__setitem__("quit", events["quit"] + 1),
+    )
+    port = server.start()
+    try:
+        pong = si._send(port, "secret", "ping")
+        assert pong["ok"] is True and pong["build"] == BUILD5 and pong["pid"] > 0
+
+        assert si._send(port, "WRONG", "ping") == {"ok": False, "error": "bad nonce"}
+
+        assert si.send_show(port, "secret") is True
+        assert _wait(lambda: events["show"] == 1)
+
+        assert si.send_quit(port, "secret") is True
+        assert _wait(lambda: events["quit"] == 1)
+    finally:
+        server.stop()
+
+
+def test_live_owner_and_wait_for_release(tmp_path):
+    server = si.ControlServer(build=BUILD5, nonce="n", on_show=lambda: None, on_quit=lambda: None)
+    port = server.start()
+    si.write_lock(tmp_path, pid=222, build=BUILD5, exe_path="x", control_port=port, nonce="n")
+    try:
+        owner = si.live_owner(tmp_path)
+        assert owner is not None and owner["build"] == BUILD5 and owner["port"] == port
+        assert si.wait_for_release(tmp_path, timeout=0.5) is False  # still live
+    finally:
+        server.stop()
+    assert _wait(lambda: si.live_owner(tmp_path) is None)  # ping fails once the socket is closed
+    assert si.wait_for_release(tmp_path, timeout=1.0) is True
+
+
+def test_live_owner_none_without_lock(tmp_path):
+    assert si.live_owner(tmp_path) is None
+
+
+# --- evict --------------------------------------------------------------------------------------------
+
+
+def test_evict_graceful(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(si, "send_quit", lambda p, n: calls.append("quit") or True)
+    monkeypatch.setattr(si, "wait_for_release", lambda d, **k: True)
+    killed = []
+    monkeypatch.setattr(si, "force_kill_pid", lambda pid: killed.append(pid))
+    assert si.evict({"port": 1, "nonce": "n", "pid": 9}, tmp_path) is True
+    assert calls == ["quit"] and killed == []  # graceful quit released it; no force-kill
+
+
+def test_evict_force_kills_when_graceful_times_out(monkeypatch, tmp_path):
+    monkeypatch.setattr(si, "send_quit", lambda p, n: True)
+    releases = iter([False, True])  # first wait times out, second (after kill) succeeds
+    monkeypatch.setattr(si, "wait_for_release", lambda d, **k: next(releases))
+    killed = []
+    monkeypatch.setattr(si, "force_kill_pid", lambda pid: killed.append(pid))
+    assert si.evict({"port": 1, "nonce": "n", "pid": 9}, tmp_path) is True
+    assert killed == [9]
+
+
+# --- promote-to-installed -----------------------------------------------------------------------------
+
+
+def test_promote_swap_replaces_installed(tmp_path):
+    installed = si.installed_exe_path(tmp_path)
+    installed.write_text("OLD", encoding="utf-8")
+    src = tmp_path / "Downloads" / "ucnexus-relay.exe"
+    src.parent.mkdir()
+    src.write_text("NEW", encoding="utf-8")
+
+    res = si.promote_swap(src, tmp_path)
+    assert res["ok"] is True
+    assert installed.read_text(encoding="utf-8") == "NEW"
+    assert not list(tmp_path.glob("ucnexus-relay.exe.old*"))  # the aside copy is cleaned up
+
+
+def test_promote_swap_fresh_install(tmp_path):
+    src = tmp_path / "src.exe"
+    src.write_text("NEW", encoding="utf-8")
+    res = si.promote_swap(src, tmp_path)
+    assert res["ok"] is True
+    assert si.installed_exe_path(tmp_path).read_text(encoding="utf-8") == "NEW"
+
+
+def test_installed_build_reads_print_build(monkeypatch, tmp_path):
+    si.installed_exe_path(tmp_path).write_text("exe", encoding="utf-8")
+
+    class _R:
+        stdout = BUILD6 + "\n"
+
+    monkeypatch.setattr(si.subprocess, "run", lambda *a, **k: _R())
+    assert si.installed_build(tmp_path) == BUILD6
+
+
+def test_installed_build_none_when_missing(tmp_path):
+    assert si.installed_build(tmp_path) is None  # no installed exe
+
+
+def test_installed_build_none_on_subprocess_error(monkeypatch, tmp_path):
+    si.installed_exe_path(tmp_path).write_text("exe", encoding="utf-8")
+
+    def _boom(*a, **k):
+        raise subprocess.SubprocessError("nope")
+
+    monkeypatch.setattr(si.subprocess, "run", _boom)
+    assert si.installed_build(tmp_path) is None
+
+
+def test_acquire_mutex_non_windows(monkeypatch):
+    monkeypatch.setattr(si.sys, "platform", "linux")
+    r = si.acquire_mutex()
+    assert r.acquired is True and r.handle is None
+    si.release_mutex(r)  # no-op, no error


### PR DESCRIPTION
Closes #246.

app = single-instance owner. before opening a window (packaged exe only), run() runs a gate:
- read app.lock (next to config.toml) -> ping recorded loopback control port
- live owner + same/older/dev build -> focus it -> exit
- live owner + newer build -> evict (graceful quit_for_upgrade -> force-kill by pid only on timeout) -> take over
- --force -> always take over
- no owner -> acquire session-local named mutex -> start control server -> write app.lock -> run

owner runs a 127.0.0.1 line-JSON control server:
ping -> {build, pid}
show -> restore + foreground
quit_for_upgrade -> tear down bypassing shutdown-confirm dialog -> hard-exit fallback
every command gated by a random nonce in app.lock.
newcomer calls AllowSetForegroundWindow(owner pid) before show.

promote-to-installed runs when a newer exe launches from OUTSIDE the install dir -> copies itself over %LOCALAPPDATA%\UCNexusRelay\ucnexus-relay.exe (rename-while-locked swap, reuses updater helpers) -> repoints autostart at installed path (only if autostart already on) -> relaunches from there
same/older exe from elsewhere -> delegates to the installed one
build comparison uses new print-build subcommand -> writes fd 1 directly (survives the windowed build's devnull stdout when read over a pipe).

serve exits 0 if /health already answers, WITHOUT writing or deleting relay.pid - fixes the bug where a second serve overwrote then deleted relay.pid and orphaned the first (app could no longer stop/restart it).

single_instance.py (new): mutex, app.lock, control server + client, Win32 activation, promote swap
app.py: gate + IPC callbacks + lock/mutex/control teardown on every shutdown path
cli.py: serve guard, --force for app, print-build
