### PR TITLE
Fix PO generate dialog: Buyer/Shipping-method label overlaps empty select

### DIFF
--- a/frontend/src/modules/po/POGenerateDialog.tsx
+++ b/frontend/src/modules/po/POGenerateDialog.tsx
@@ -286,7 +286,7 @@ function GenerateForm({ po, settings, buyers, gpTotals, projectNumber, onClose, 
           <Stack direction="row" spacing={2}>
             <FormControl fullWidth size="small">
               <InputLabel>Buyer</InputLabel>
-              <Select label="Buyer" value={buyerName} onChange={(e) => setBuyerName(e.target.value)} displayEmpty>
+              <Select label="Buyer" value={buyerName} onChange={(e) => setBuyerName(e.target.value)}>
                 <MenuItem value=""><em>None</em></MenuItem>
                 {buyerOptions.map((b) => (
                   <MenuItem key={b} value={b}>{b}</MenuItem>
@@ -314,7 +314,7 @@ function GenerateForm({ po, settings, buyers, gpTotals, projectNumber, onClose, 
             <InputLabel>Shipping method</InputLabel>
             <Select
               label="Shipping method" value={shippingMethod}
-              onChange={(e) => setShippingMethod(e.target.value)} displayEmpty
+              onChange={(e) => setShippingMethod(e.target.value)}
             >
               <MenuItem value=""><em>None</em></MenuItem>
               {shippingMethodOptions.map((m) => (


### PR DESCRIPTION
closes #248

Buyer field label overlapped the entry area when Buyer was None/empty (screenshot in issue).

Buyer + Shipping-method selects used displayEmpty -> the closed field renders the None placeholder while the InputLabel stays un-shrunk and centered, so the label lands on top of the value.

dropped displayEmpty from both selects. empty state now shows the label as a placeholder, matching every other field in the dialog; the None option stays in the dropdown to clear a selection.