### PR TITLE
Fix #227 shop-assembly review follow-ups

### DIFF
--- a/backend/alembic/versions/042_shop_assembly_opening_pull_request.py
+++ b/backend/alembic/versions/042_shop_assembly_opening_pull_request.py
@@ -46,6 +46,19 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # PR-parented openings (Start a Task, #222) have shop_assembly_request_id NULL, so
+    # re-tightening it to NOT NULL would abort. Refuse rather than silently drop or orphan
+    # them - the operator must remove them before downgrading past 042.
+    bind = op.get_bind()
+    orphans = bind.execute(
+        sa.text("SELECT count(*) FROM shop_assembly_openings WHERE shop_assembly_request_id IS NULL")
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"Cannot downgrade past migration 042: {orphans} shop_assembly_openings row(s) are "
+            "PR-parented (shop_assembly_request_id IS NULL). Delete them before downgrading."
+        )
+
     op.drop_index("ix_shop_assembly_openings_pull_request", table_name="shop_assembly_openings")
     op.drop_column("shop_assembly_openings", "pull_request_id")
     op.alter_column(

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -198,7 +198,18 @@ def complete_opening(
                 field="item_results",
             )
         if not res.installed:
-            deficient_reason_by_id[res.shop_assembly_opening_item_id] = res.deficient_reason
+            reason = (res.deficient_reason or "").strip()
+            if not reason:
+                raise ValidationError(
+                    "A deficiency reason is required for items not installed",
+                    field="deficient_reason",
+                )
+            if len(reason) > 500:
+                raise ValidationError(
+                    "Deficiency reason must be 500 characters or fewer",
+                    field="deficient_reason",
+                )
+            deficient_reason_by_id[res.shop_assembly_opening_item_id] = reason
 
     # 5. Create OpeningItem (snapshot opening identity from the ShopAssemblyOpening row)
     now = datetime.utcnow()

--- a/backend/app/repositories/stock_repository.py
+++ b/backend/app/repositories/stock_repository.py
@@ -798,10 +798,36 @@ def report_deficiency_at_assembly(
     )
     il = session.scalars(il_stmt).first()
     if il is None:
-        raise NotFoundError(
-            f"No inventory location for {sa_oi.hardware_category}/{sa_oi.product_code} "
-            f"in project {project_id} to return the deficient unit to"
+        # Row was hard-deleted (e.g. replace-schedule re-upload) after the unit was pulled.
+        # Re-materialize a project inventory row so the returned deficient unit has somewhere to
+        # land. Origin is a stock row (find-or-create) to satisfy ck_inventory_locations_has_origin;
+        # no stock quantity is decremented - this unit came from the project's own deleted inventory.
+        from app.repositories import warehouse_admin_repository
+
+        now = datetime.utcnow()
+        warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+        stock_row = _find_or_create_stock_row(
+            session,
+            warehouse_id=warehouse_id,
+            hardware_category=sa_oi.hardware_category,
+            product_code=sa_oi.product_code,
+            aisle=None,
+            bay=None,
+            bin=None,
+            received_at=now,
         )
+        il = InventoryLocationModel(
+            project_id=project_id,
+            stock_item_id=stock_row.id,
+            warehouse_id=warehouse_id,
+            hardware_category=sa_oi.hardware_category,
+            product_code=sa_oi.product_code,
+            quantity=0,
+            deficient_quantity=0,
+            received_at=now,
+        )
+        session.add(il)
+        session.flush()  # populate il.id for the audit log's entity_id
 
     il.quantity += quantity
     il.deficient_quantity = (il.deficient_quantity or 0) + quantity

--- a/backend/tests/test_completion_deficiency_checklist.py
+++ b/backend/tests/test_completion_deficiency_checklist.py
@@ -242,3 +242,111 @@ def test_checklist_item_must_belong_to_opening(db_session):
                 shop_assembly_repository.OpeningItemResult(uuid.uuid4(), installed=False, deficient_reason="x")
             ],
         )
+
+
+def test_completion_creates_inventory_row_when_deleted(db_session):
+    """#227(2): a deficient flag still completes when the source inventory row was hard-deleted.
+
+    Simulates a replace-schedule re-upload that removed the InventoryLocation row after the unit
+    was pulled. report_deficiency_at_assembly re-materializes the row instead of aborting, so the
+    installed items' snapshots are preserved.
+    """
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=DEFICIENT[0], code=DEFICIENT[1], quantity=0)
+    db_session.delete(il)
+    db_session.flush()
+
+    _, opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-CHK4",
+        items=[(*INSTALLED, 1), (*DEFICIENT, 1)],
+    )
+
+    result = shop_assembly_repository.complete_opening(
+        db_session,
+        opening.id,
+        "A",
+        "2",
+        "3",
+        item_results=[
+            shop_assembly_repository.OpeningItemResult(sao[INSTALLED[1]].id, installed=True),
+            shop_assembly_repository.OpeningItemResult(
+                sao[DEFICIENT[1]].id, installed=False, deficient_reason="bent tab"
+            ),
+        ],
+        completed_by="assembler",
+    )
+    db_session.flush()
+
+    # Installed item is still snapshotted despite the missing deficient-product row.
+    hw = _installed_hardware(db_session, result.id)
+    assert {h.product_code for h in hw} == {INSTALLED[1]}
+
+    # A fresh inventory row was materialized for the returned deficient unit (available 0).
+    def_il = db_session.scalars(
+        select(InventoryLocation).where(
+            InventoryLocation.project_id == project.id,
+            InventoryLocation.product_code == DEFICIENT[1],
+        )
+    ).first()
+    assert def_il is not None
+    assert def_il.quantity == 1
+    assert def_il.deficient_quantity == 1
+    assert def_il.stock_item_id is not None
+
+    # Replacement pull is still appended.
+    repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-CHK4")).first()
+    assert repl is not None
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+
+def test_deficient_item_requires_reason(db_session):
+    """#227(3): complete_opening rejects a not-installed item with a missing/blank reason."""
+    project = _make_project(db_session)
+    _, opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-CHK5",
+        items=[(*DEFICIENT, 1)],
+    )
+
+    for bad_reason in (None, "   "):
+        with pytest.raises(ValidationError):
+            shop_assembly_repository.complete_opening(
+                db_session,
+                opening.id,
+                None,
+                None,
+                None,
+                item_results=[
+                    shop_assembly_repository.OpeningItemResult(
+                        sao[DEFICIENT[1]].id, installed=False, deficient_reason=bad_reason
+                    )
+                ],
+            )
+
+
+def test_deficient_reason_length_capped(db_session):
+    """#227(3): complete_opening rejects a deficiency reason over 500 characters."""
+    project = _make_project(db_session)
+    _, opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-CHK6",
+        items=[(*DEFICIENT, 1)],
+    )
+
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.complete_opening(
+            db_session,
+            opening.id,
+            None,
+            None,
+            None,
+            item_results=[
+                shop_assembly_repository.OpeningItemResult(
+                    sao[DEFICIENT[1]].id, installed=False, deficient_reason="x" * 501
+                )
+            ],
+        )


### PR DESCRIPTION
closes #227 (three unfixed #226-review judgment calls).

042 downgrade guard (item 1, option C)
- downgrade aborted on SET NOT NULL because Start-a-Task openings have shop_assembly_request_id NULL
- now counts PR-parented openings first, raises a clear error if any exist, deletes/orphans nothing
- empty-DB down->up->check cycle unchanged, CI migration-integrity unaffected

report_deficiency_at_assembly create-if-missing (item 2)
- flagging a deficient item aborted complete_opening when its InventoryLocation row was hard-deleted (replace-schedule re-upload), rolling back installed snapshots
- now re-materializes the row (stock-item origin to satisfy ck_inventory_locations_has_origin) then bumps deficient, no stock qty decremented
- test: hard-deleted row still completes and recreates the row

complete_opening reason validation (item 3)
- direct GraphQL could flag installed=false with a null/empty reason and no length bound
- now rejects blank deficient_reason, caps at 500 chars server-side (matches frontend maxLength)
- tests: null + whitespace reason rejected, 501-char reason rejected