### PR TITLE
Add #216 pt1: preferred delivery date + PM-set site/shop at import

### DIFF
--- a/backend/alembic/versions/052_po_preferred_delivery_date.py
+++ b/backend/alembic/versions/052_po_preferred_delivery_date.py
@@ -1,0 +1,27 @@
+"""PO preferred_delivery_date (issue #216)
+
+The PM's requested date, captured at PO-request creation in the import wizard and editable only
+while DRAFT. Distinct from expected_delivery_date, which is the vendor's answer and only enterable
+after GP registration.
+
+Revision ID: 052
+Revises: 051
+Create Date: 2026-07-16
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "052"
+down_revision = "051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("purchase_orders", sa.Column("preferred_delivery_date", sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("purchase_orders", "preferred_delivery_date")

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -74,6 +74,10 @@ class PurchaseOrder(Base):
     # dialog), editable on the PO afterward. Null means "not entered"; 0 is a valid entered value.
     shipping_cost: Mapped[Decimal | None] = mapped_column(Numeric(12, 2), nullable=True)
     tariff_amount: Mapped[Decimal | None] = mapped_column(Numeric(12, 2), nullable=True)
+    # Issue #216: the PM's requested date, captured at PO-request creation (import wizard) and
+    # editable only while DRAFT. expected_delivery_date is the vendor's answer - it can only be
+    # entered after the PO is GP-Registered (and before receiving starts).
+    preferred_delivery_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     expected_delivery_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     ordered_at: Mapped[datetime | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -497,6 +497,8 @@ def finalize_import_session(
                 status=POStatus.DRAFT,
                 vendor_id=vendor_id,
                 notes=po_draft.get("notes"),
+                # Issue #216: the PM's requested date, captured at PO-request creation.
+                preferred_delivery_date=po_draft.get("preferred_delivery_date"),
             )
             session.add(po)
             session.flush()

--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -512,6 +512,7 @@ def update_po(
     po_id: uuid.UUID,
     vendor_id=_UNSET,
     expected_delivery_date=None,
+    preferred_delivery_date=None,
     po_number: str | None = None,
     vendor_quote_number: str | None = None,
     project_id=_UNSET,
@@ -569,7 +570,16 @@ def update_po(
         else:
             po.po_number = None
 
+    # Issue #216: the two delivery dates are status-gated. Preferred is the PM's ask, captured on the
+    # DRAFT request; expected is the vendor's answer, only enterable once the PO exists in GP (the
+    # DRAFT/GP_REGISTERED/VENDOR_CONFIRMED guard above already blocks both after receiving starts).
+    if preferred_delivery_date is not None:
+        if po.status != POStatus.DRAFT:
+            raise InvalidStateTransitionError("Preferred delivery date can only be set on a Draft PO request")
+        po.preferred_delivery_date = preferred_delivery_date
     if expected_delivery_date is not None:
+        if po.status == POStatus.DRAFT:
+            raise InvalidStateTransitionError("Expected delivery date can only be set after the PO is GP-Registered")
         po.expected_delivery_date = expected_delivery_date
     if vendor_quote_number is not None:
         po.vendor_quote_number = vendor_quote_number if vendor_quote_number.strip() else None

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -100,6 +100,8 @@ class PODraftInput:
     po_number: str | None = None
     vendor_id: strawberry.ID | None = None
     notes: str | None = None
+    # Issue #216: the PM's requested date, captured at PO-request creation.
+    preferred_delivery_date: date | None = None
     hardware_item_refs: list[HardwareItemRef] = strawberry.field(default_factory=list)
     line_item_aliases: list[POLineItemOrderAsInput] = strawberry.field(default_factory=list)
 

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -534,6 +534,7 @@ class Mutation:
                     "po_number": po.po_number,
                     "vendor_id": str(po.vendor_id) if po.vendor_id else None,
                     "notes": po.notes,
+                    "preferred_delivery_date": po.preferred_delivery_date,
                     "hardware_item_refs": [
                         {
                             "opening_number": ref.opening_number,
@@ -850,6 +851,7 @@ class Mutation:
         id: strawberry.ID,
         vendor_id: strawberry.ID | None = None,
         expected_delivery_date: date | None = None,
+        preferred_delivery_date: date | None = None,
         po_number: str | None = None,
         vendor_quote_number: str | None = None,
         project_id: strawberry.ID | None = None,
@@ -871,6 +873,7 @@ class Mutation:
                 uuid.UUID(str(id)),
                 vendor_id=vid,
                 expected_delivery_date=expected_delivery_date,
+                preferred_delivery_date=preferred_delivery_date,
                 po_number=po_number,
                 vendor_quote_number=vendor_quote_number,
                 project_id=pid,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -311,6 +311,7 @@ def _po_to_type(po, receive_records=None) -> PurchaseOrder:
         shipping_cost=float(po.shipping_cost) if po.shipping_cost is not None else None,
         tariff_amount=float(po.tariff_amount) if po.tariff_amount is not None else None,
         notes=po.notes,
+        preferred_delivery_date=po.preferred_delivery_date,
         expected_delivery_date=po.expected_delivery_date,
         ordered_at=po.ordered_at,
         created_at=po.created_at,

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -325,6 +325,7 @@ class PurchaseOrder:
     shipping_cost: float | None
     tariff_amount: float | None
     notes: str | None
+    preferred_delivery_date: date | None
     expected_delivery_date: date | None
     ordered_at: datetime | None
     created_at: datetime

--- a/backend/tests/test_po_repository_create_po.py
+++ b/backend/tests/test_po_repository_create_po.py
@@ -258,6 +258,35 @@ def test_create_po_rejects_when_any_line_item_missing_order_as(db_session):
     assert exc.value.field == "order_as"
 
 
+# --- issue #216: status-gated delivery dates ------------------------------------------------------
+
+
+def test_update_po_preferred_date_only_on_draft(db_session):
+    from datetime import date as date_cls
+
+    from app.errors import InvalidStateTransitionError
+    from app.models.enums import POStatus
+
+    vendor = _make_vendor(db_session)
+    po = po_repository.create_po(db_session, line_items=[_line_item("ML2010")], vendor_id=vendor.id)
+    db_session.flush()
+
+    po_repository.update_po(db_session, po.id, preferred_delivery_date=date_cls(2026, 8, 1))
+    assert po.preferred_delivery_date == date_cls(2026, 8, 1)
+
+    # Expected is rejected while DRAFT
+    with pytest.raises(InvalidStateTransitionError):
+        po_repository.update_po(db_session, po.id, expected_delivery_date=date_cls(2026, 8, 15))
+
+    # After GP registration, expected is allowed and preferred is locked
+    po.status = POStatus.GP_REGISTERED
+    db_session.flush()
+    po_repository.update_po(db_session, po.id, expected_delivery_date=date_cls(2026, 8, 15))
+    assert po.expected_delivery_date == date_cls(2026, 8, 15)
+    with pytest.raises(InvalidStateTransitionError):
+        po_repository.update_po(db_session, po.id, preferred_delivery_date=date_cls(2026, 8, 2))
+
+
 # --- issue #156: optional order-time shipping cost + tariff -------------------------------------
 
 

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client/core';
 
 export const UPDATE_PO = gql`
-  mutation UpdatePO($id: ID!, $vendorId: ID, $expectedDeliveryDate: Date, $poNumber: String, $vendorQuoteNumber: String, $notes: String, $shippingCost: Float, $tariffAmount: Float) {
-    updatePo(id: $id, vendorId: $vendorId, expectedDeliveryDate: $expectedDeliveryDate, poNumber: $poNumber, vendorQuoteNumber: $vendorQuoteNumber, notes: $notes, shippingCost: $shippingCost, tariffAmount: $tariffAmount) {
+  mutation UpdatePO($id: ID!, $vendorId: ID, $expectedDeliveryDate: Date, $preferredDeliveryDate: Date, $poNumber: String, $vendorQuoteNumber: String, $notes: String, $shippingCost: Float, $tariffAmount: Float) {
+    updatePo(id: $id, vendorId: $vendorId, expectedDeliveryDate: $expectedDeliveryDate, preferredDeliveryDate: $preferredDeliveryDate, poNumber: $poNumber, vendorQuoteNumber: $vendorQuoteNumber, notes: $notes, shippingCost: $shippingCost, tariffAmount: $tariffAmount) {
       id
       poNumber
       requestNumber
@@ -20,6 +20,7 @@ export const UPDATE_PO = gql`
       shippingCost
       tariffAmount
       notes
+      preferredDeliveryDate
       expectedDeliveryDate
       orderedAt
       updatedAt

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -89,6 +89,7 @@ export const GET_PURCHASE_ORDERS = gql`
       shippingCost
       tariffAmount
       notes
+      preferredDeliveryDate
       expectedDeliveryDate
       orderedAt
       createdAt

--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -36,6 +36,8 @@ export interface ClassificationRow {
   itemQuantity: number;
   classificationKey: string;
   classification: string;
+  // Issue #216: second axis (Site/Shop) for PO-purpose imports; '' = not yet classified.
+  siteShop?: string;
 }
 
 export type GroupByField = 'hardwareCategory' | 'vendorNo' | 'productCode' | 'openingNumber'
@@ -57,12 +59,28 @@ interface ClassificationGridProps {
   options: ClassificationOption[];
   onClassify: (classificationKeys: string[], value: string) => void;
   readOnly?: boolean;
+  // Issue #216: optional second axis (Site/Shop). Rows whose primary classification equals
+  // siteShopExemptValue (By Others) don't need it and render an em-dash.
+  siteShopOptions?: ClassificationOption[];
+  onClassifySiteShop?: (classificationKeys: string[], value: string) => void;
+  siteShopExemptValue?: string;
 }
 
 interface GroupNode {
   label: string;
   rows: ClassificationRow[];
   children: Map<string, GroupNode> | null;
+}
+
+// Issue #216: the optional Site/Shop axis, bundled so it threads through the group tree in one prop.
+interface SiteShopAxis {
+  options: ClassificationOption[];
+  onClassify: (classificationKeys: string[], value: string) => void;
+  exemptValue?: string;
+}
+
+function siteShopEligibleKeys(rows: ClassificationRow[], exemptValue?: string): string[] {
+  return uniqueClassificationKeys(rows.filter((r) => !exemptValue || r.classification !== exemptValue));
 }
 
 function formatGroupKey(field: GroupByField, value: unknown): string {
@@ -146,9 +164,10 @@ interface LeafGridProps {
   options: ClassificationOption[];
   onClassify: ClassificationGridProps['onClassify'];
   readOnly?: boolean;
+  siteShop?: SiteShopAxis;
 }
 
-function LeafGrid({ rows, columns, options, onClassify, readOnly }: LeafGridProps) {
+function LeafGrid({ rows, columns, options, onClassify, readOnly, siteShop }: LeafGridProps) {
   const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>({
     type: 'include',
     ids: new Set(),
@@ -163,6 +182,16 @@ function LeafGrid({ rows, columns, options, onClassify, readOnly }: LeafGridProp
       setSelectionModel({ type: 'include', ids: new Set() });
     },
     [selectionModel, rows, onClassify],
+  );
+
+  const handleBulkSiteShop = useCallback(
+    (value: string) => {
+      if (!siteShop) return;
+      const selectedRows = rows.filter((r) => selectionModel.ids.has(r.id));
+      siteShop.onClassify(siteShopEligibleKeys(selectedRows, siteShop.exemptValue), value);
+      setSelectionModel({ type: 'include', ids: new Set() });
+    },
+    [selectionModel, rows, siteShop],
   );
 
   return (
@@ -187,10 +216,15 @@ function LeafGrid({ rows, columns, options, onClassify, readOnly }: LeafGridProp
       slots={{
         toolbar: !readOnly && selectedCount > 0
           ? () => (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5, flexWrap: 'wrap' }}>
                 <Typography variant="body2">{selectedCount} selected</Typography>
                 {options.map((opt) => (
                   <Button key={opt.value} size="small" color={opt.color} onClick={() => handleBulkClassify(opt.value)}>
+                    Classify as {opt.label}
+                  </Button>
+                ))}
+                {siteShop?.options.map((opt) => (
+                  <Button key={opt.value} size="small" color={opt.color} onClick={() => handleBulkSiteShop(opt.value)}>
                     Classify as {opt.label}
                   </Button>
                 ))}
@@ -209,9 +243,10 @@ interface GroupAccordionProps {
   onClassify: ClassificationGridProps['onClassify'];
   readOnly?: boolean;
   depth: number;
+  siteShop?: SiteShopAxis;
 }
 
-function GroupAccordion({ node, columns, options, onClassify, readOnly, depth }: GroupAccordionProps) {
+function GroupAccordion({ node, columns, options, onClassify, readOnly, depth, siteShop }: GroupAccordionProps) {
   const { labelMap, colorMap } = useMemo(() => buildOptionLookups(options), [options]);
 
   const classifiedCount = node.rows.filter((r) => r.classification !== '').length;
@@ -224,6 +259,15 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth }:
       onClassify(uniqueClassificationKeys(node.rows), value);
     },
     [node.rows, onClassify],
+  );
+
+  const handleGroupAllSiteShop = useCallback(
+    (value: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!siteShop) return;
+      siteShop.onClassify(siteShopEligibleKeys(node.rows, siteShop.exemptValue), value);
+    },
+    [node.rows, siteShop],
   );
 
   const singleValue = allSameClassification ? [...uniqueClassifications][0] : null;
@@ -254,7 +298,7 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth }:
             ({node.rows.length} items)
           </Typography>
           {!readOnly && (
-            <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5 }}>
+            <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
               {options.map((opt) => (
                 <Button
                   key={opt.value}
@@ -262,6 +306,17 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth }:
                   variant="outlined"
                   color={opt.color}
                   onClick={(e) => handleGroupAll(opt.value, e)}
+                >
+                  {opt.label} All
+                </Button>
+              ))}
+              {siteShop?.options.map((opt) => (
+                <Button
+                  key={opt.value}
+                  size="small"
+                  variant="outlined"
+                  color={opt.color}
+                  onClick={(e) => handleGroupAllSiteShop(opt.value, e)}
                 >
                   {opt.label} All
                 </Button>
@@ -281,18 +336,42 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth }:
               onClassify={onClassify}
               readOnly={readOnly}
               depth={depth + 1}
+              siteShop={siteShop}
             />
           ))
         ) : (
-          <LeafGrid rows={node.rows} columns={columns} options={options} onClassify={onClassify} readOnly={readOnly} />
+          <LeafGrid
+            rows={node.rows}
+            columns={columns}
+            options={options}
+            onClassify={onClassify}
+            readOnly={readOnly}
+            siteShop={siteShop}
+          />
         )}
       </AccordionDetails>
     </Accordion>
   );
 }
 
-export default function ClassificationGrid({ rows, options, onClassify, readOnly }: ClassificationGridProps) {
+export default function ClassificationGrid({
+  rows,
+  options,
+  onClassify,
+  readOnly,
+  siteShopOptions,
+  onClassifySiteShop,
+  siteShopExemptValue,
+}: ClassificationGridProps) {
   const { labelMap, colorMap } = useMemo(() => buildOptionLookups(options), [options]);
+
+  const siteShop = useMemo<SiteShopAxis | undefined>(
+    () =>
+      siteShopOptions && onClassifySiteShop
+        ? { options: siteShopOptions, onClassify: onClassifySiteShop, exemptValue: siteShopExemptValue }
+        : undefined,
+    [siteShopOptions, onClassifySiteShop, siteShopExemptValue],
+  );
 
   const [groupByFields, setGroupByFields] = useState<GroupByField[]>([]);
 
@@ -321,7 +400,40 @@ export default function ClassificationGrid({ rows, options, onClassify, readOnly
   const columns: GridColDef[] = useMemo(() => {
     const hiddenFields = new Set(groupByFields);
     const visible = ALL_COLUMNS.filter((col) => !hiddenFields.has(col.field as GroupByField));
-    return [
+    const toggleCell = (
+      value: string,
+      cellOptions: ClassificationOption[],
+      onChange: (newValue: string) => void,
+    ) => (
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        value={value || null}
+        onChange={(_, newValue) => {
+          if (newValue !== null) onChange(newValue);
+        }}
+        sx={{ height: 28 }}
+      >
+        {cellOptions.map((opt) => (
+          <ToggleButton
+            key={opt.value}
+            value={opt.value}
+            sx={{
+              px: 1, fontSize: '0.75rem',
+              '&.Mui-selected': {
+                backgroundColor: `${opt.color}.main`,
+                color: `${opt.color}.contrastText`,
+                '&:hover': { backgroundColor: `${opt.color}.dark` },
+              },
+            }}
+          >
+            {opt.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    );
+
+    const cols: GridColDef[] = [
       ...visible,
       {
         field: 'classification',
@@ -341,40 +453,38 @@ export default function ClassificationGrid({ rows, options, onClassify, readOnly
               />
             );
           }
-          return (
-            <ToggleButtonGroup
-              size="small"
-              exclusive
-              value={value || null}
-              onChange={(_, newValue) => {
-                if (newValue !== null) {
-                  onClassify([params.row.classificationKey], newValue);
-                }
-              }}
-              sx={{ height: 28 }}
-            >
-              {options.map((opt) => (
-                <ToggleButton
-                  key={opt.value}
-                  value={opt.value}
-                  sx={{
-                    px: 1, fontSize: '0.75rem',
-                    '&.Mui-selected': {
-                      backgroundColor: `${opt.color}.main`,
-                      color: `${opt.color}.contrastText`,
-                      '&:hover': { backgroundColor: `${opt.color}.dark` },
-                    },
-                  }}
-                >
-                  {opt.label}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
-          );
+          return toggleCell(value, options, (newValue) => onClassify([params.row.classificationKey], newValue));
         },
       },
     ];
-  }, [groupByFields, onClassify, readOnly, options, labelMap, colorMap]);
+
+    if (siteShop) {
+      cols.push({
+        field: 'siteShop',
+        headerName: 'Site/Shop',
+        flex: 0.8,
+        minWidth: 120,
+        sortable: false,
+        renderCell: (params: GridRenderCellParams) => {
+          // A By-Others item is out of scope, so it carries no site/shop classification.
+          if (siteShop.exemptValue && params.row.classification === siteShop.exemptValue) {
+            return <Chip size="small" label="—" />;
+          }
+          const value = params.row.siteShop ?? '';
+          if (readOnly) {
+            if (!value) return <Chip size="small" label="—" />;
+            const opt = siteShop.options.find((o) => o.value === value);
+            return <Chip size="small" label={opt?.label ?? value} color={opt?.color ?? 'default'} />;
+          }
+          return toggleCell(value, siteShop.options, (newValue) =>
+            siteShop.onClassify([params.row.classificationKey], newValue),
+          );
+        },
+      });
+    }
+
+    return cols;
+  }, [groupByFields, onClassify, readOnly, options, labelMap, colorMap, siteShop]);
 
   return (
     <Box>
@@ -424,10 +534,18 @@ export default function ClassificationGrid({ rows, options, onClassify, readOnly
             onClassify={onClassify}
             readOnly={readOnly}
             depth={0}
+            siteShop={siteShop}
           />
         ))
       ) : (
-        <LeafGrid rows={rows} columns={columns} options={options} onClassify={onClassify} readOnly={readOnly} />
+        <LeafGrid
+          rows={rows}
+          columns={columns}
+          options={options}
+          onClassify={onClassify}
+          readOnly={readOnly}
+          siteShop={siteShop}
+        />
       )}
     </Box>
   );

--- a/frontend/src/modules/import/ClassificationStep.tsx
+++ b/frontend/src/modules/import/ClassificationStep.tsx
@@ -7,6 +7,8 @@ import type { ImportPurpose } from './types';
 interface ClassificationStepProps {
   classificationRows: ClassificationRow[];
   onClassify: (keys: string[], value: string) => void;
+  // Issue #216: PO-purpose second axis - the PM sets Site/Shop here, not the PO user at register time.
+  onClassifySiteShop: (keys: string[], value: string) => void;
   purpose: ImportPurpose;
   itemCount: number;
   openingCount: number;
@@ -18,6 +20,7 @@ interface ClassificationStepProps {
 export default function ClassificationStep({
   classificationRows,
   onClassify,
+  onClassifySiteShop,
   purpose,
   itemCount,
   openingCount,
@@ -32,10 +35,19 @@ export default function ClassificationStep({
 
   const options = purpose === 'po' ? SCOPE_OPTIONS : ASSEMBLY_OPTIONS;
 
+  // Issue #216: for PO purpose, every in-scope (non-By-Others) item also needs a Site/Shop pick.
+  const inScopeRows = useMemo(
+    () => (purpose === 'po' ? classificationRows.filter((r) => r.classification !== 'BY_OTHERS') : []),
+    [purpose, classificationRows],
+  );
+  const siteShopCount = inScopeRows.filter((r) => (r.siteShop ?? '') !== '').length;
+  const allSiteShopClassified = siteShopCount === inScopeRows.length;
+
   const canProceed = useMemo(() => {
     if (isReadOnly) return true;
+    if (purpose === 'po') return allClassified && allSiteShopClassified;
     return allClassified;
-  }, [isReadOnly, allClassified]);
+  }, [isReadOnly, purpose, allClassified, allSiteShopClassified]);
 
   return (
     <Box>
@@ -56,16 +68,25 @@ export default function ClassificationStep({
         <>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
             {purpose === 'po'
-              ? 'Classify each item as By UCSH (in scope) or By Others (excluded from scope).'
+              ? 'Classify each item as By UCSH (in scope) or By Others (excluded from scope), and each in-scope item as Site or Shop hardware.'
               : 'Classify each item group as Site Hardware or Shop Hardware.'}
           </Typography>
           <Typography
             variant="body2"
-            sx={{ mb: 2 }}
+            sx={{ mb: purpose === 'po' ? 0.5 : 2 }}
             color={allClassified ? 'success.main' : 'text.secondary'}
           >
             {classifiedCount} of {classificationRows.length} items classified
           </Typography>
+          {purpose === 'po' && (
+            <Typography
+              variant="body2"
+              sx={{ mb: 2 }}
+              color={allSiteShopClassified ? 'success.main' : 'text.secondary'}
+            >
+              {siteShopCount} of {inScopeRows.length} in-scope items site/shop classified
+            </Typography>
+          )}
         </>
       )}
 
@@ -74,6 +95,9 @@ export default function ClassificationStep({
         options={options}
         onClassify={onClassify}
         readOnly={isReadOnly}
+        siteShopOptions={purpose === 'po' ? ASSEMBLY_OPTIONS : undefined}
+        onClassifySiteShop={purpose === 'po' ? onClassifySiteShop : undefined}
+        siteShopExemptValue={purpose === 'po' ? 'BY_OTHERS' : undefined}
       />
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -106,9 +106,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // Action step state
   const [selectedVendors, setSelectedVendors] = useState<Set<string>>(new Set());
-  const [vendorPOInfo, setVendorPOInfo] = useState<Map<string, { vendorId: string | null; notes: string }>>(new Map());
+  const [vendorPOInfo, setVendorPOInfo] = useState<
+    Map<string, { vendorId: string | null; notes: string; preferredDeliveryDate: string }>
+  >(new Map());
   const [unitCostOverrides, setUnitCostOverrides] = useState<Map<string, number>>(new Map());
   const [classifications, setClassifications] = useState<Map<string, string>>(new Map());
+  // Issue #216: PO-purpose second axis (SITE_HARDWARE/SHOP_HARDWARE), set by the PM at request
+  // creation. Same classificationKey keying as `classifications` (which holds scope for PO purpose).
+  const [siteShopClassifications, setSiteShopClassifications] = useState<Map<string, string>>(new Map());
   const [orderAsValues, setOrderAsValues] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
@@ -331,9 +336,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         itemQuantity: hi.item_quantity,
         classificationKey: ck,
         classification: classifications.get(ck) ?? '',
+        siteShop: siteShopClassifications.get(ck) ?? '',
       };
     });
-  }, [aggregatedHardwareItems, classifications]);
+  }, [aggregatedHardwareItems, classifications, siteShopClassifications]);
 
   // Items grouped by vendor for auto PO segregation (excludes BY_OTHERS items)
   const vendorGroups = useMemo(() => {
@@ -398,6 +404,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     setUnitCostOverrides(new Map());
     setOrderAsValues(new Map());
     setClassifications(new Map());
+    setSiteShopClassifications(new Map());
     setSarRequestNumber('');
     setShippingPRDrafts([]);
     setSelectedReconItems(new Set());
@@ -472,14 +479,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // Manufacturer-group PO info
   const updateVendorPO = useCallback(
-    (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => {
+    (manufacturerKey: string, field: 'vendorId' | 'notes' | 'preferredDeliveryDate', value: string | null) => {
       setVendorPOInfo((prev) => {
         const next = new Map(prev);
-        const existing = next.get(manufacturerKey) ?? { vendorId: null, notes: '' };
+        const existing = next.get(manufacturerKey) ?? { vendorId: null, notes: '', preferredDeliveryDate: '' };
         if (field === 'vendorId') {
           next.set(manufacturerKey, { ...existing, vendorId: value });
         } else {
-          next.set(manufacturerKey, { ...existing, notes: value ?? '' });
+          next.set(manufacturerKey, { ...existing, [field]: value ?? '' });
         }
         return next;
       });
@@ -499,6 +506,15 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   // Classification (batch-capable)
   const classifyBatch = useCallback((keys: string[], value: string) => {
     setClassifications((prev) => {
+      const next = new Map(prev);
+      for (const key of keys) next.set(key, value);
+      return next;
+    });
+  }, []);
+
+  // Issue #216: PO-purpose Site/Shop axis (batch-capable)
+  const classifySiteShopBatch = useCallback((keys: string[], value: string) => {
+    setSiteShopClassifications((prev) => {
       const next = new Map(prev);
       for (const key of keys) next.set(key, value);
       return next;
@@ -646,7 +662,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               // Filter out BY_OTHERS items from this vendor's PO draft
               const inScopeItems = items.filter((hi) => !isByOthers(hi));
               if (inScopeItems.length === 0) return null;
-              const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '' };
+              const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '', preferredDeliveryDate: '' };
               // Collect aliases for this manufacturer group's aggregated line items
               const seenKeys = new Set<string>();
               const lineItemAliases: Array<{ hardwareCategory: string; productCode: string; orderAs: string }> = [];
@@ -668,6 +684,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
                 poNumber: null,
                 vendorId: info.vendorId,
                 notes: info.notes || null,
+                preferredDeliveryDate: info.preferredDeliveryDate || null,
                 hardwareItemRefs: inScopeItems.map((hi) => ({
                   openingNumber: hi.opening_number,
                   productCode: hi.product_code,
@@ -684,7 +701,16 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             const [hardwareCategory, productCode, unitCost] = key.split('|');
             return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };
           })
-        : null,
+        : purpose === 'po'
+          // Issue #216: the PM's Site/Shop picks from the Classification step's second axis.
+          // By-Others items are out of scope and carry none.
+          ? Array.from(siteShopClassifications.entries())
+              .filter(([key, cls]) => cls !== '' && !byOthersKeys.has(key))
+              .map(([key, cls]) => {
+                const [hardwareCategory, productCode, unitCost] = key.split('|');
+                return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };
+              })
+          : null,
       shippingOutPrDrafts: purpose === 'shipping'
         ? shippingPRDrafts.map((pr) => ({
             requestNumber: pr.requestNumber,
@@ -738,7 +764,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             .filter(Boolean)
         : null,
     };
-  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, shippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
+  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, shippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1107,6 +1133,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             <ClassificationStep
               classificationRows={classificationRows}
               onClassify={classifyBatch}
+              onClassifySiteShop={classifySiteShopBatch}
               purpose={purpose!}
               itemCount={aggregatedHardwareItems.length}
               openingCount={selectedOpenings.size}

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -29,12 +29,16 @@ interface PriorOrderAsQueryData {
 
 interface PurchaseOrdersStepProps {
   vendorGroups: Map<string, AggregatedHardwareItem[]>;
-  vendorPOInfo: Map<string, { vendorId: string | null; notes: string }>;
+  vendorPOInfo: Map<string, { vendorId: string | null; notes: string; preferredDeliveryDate: string }>;
   selectedVendors: Set<string>;
   unitCostOverrides: Map<string, number>;
   orderAsValues: Map<string, string>;
   onToggleVendor: (vendor: string) => void;
-  onUpdateVendorPO: (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => void;
+  onUpdateVendorPO: (
+    manufacturerKey: string,
+    field: 'vendorId' | 'notes' | 'preferredDeliveryDate',
+    value: string | null,
+  ) => void;
   onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
   onUpdateOrderAs: (key: string, value: string) => void;
   onNext: () => void;
@@ -81,12 +85,16 @@ function aggregateLineItems(
 interface VendorGroupCardProps {
   vendor: string;
   items: AggregatedHardwareItem[];
-  info: { vendorId: string | null; notes: string };
+  info: { vendorId: string | null; notes: string; preferredDeliveryDate: string };
   isSelected: boolean;
   unitCostOverrides: Map<string, number>;
   orderAsValues: Map<string, string>;
   onToggleVendor: (vendor: string) => void;
-  onUpdateVendorPO: (manufacturerKey: string, field: 'vendorId' | 'notes', value: string | null) => void;
+  onUpdateVendorPO: (
+    manufacturerKey: string,
+    field: 'vendorId' | 'notes' | 'preferredDeliveryDate',
+    value: string | null,
+  ) => void;
   onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
   onUpdateOrderAs: (key: string, value: string) => void;
 }
@@ -150,7 +158,7 @@ function VendorGroupCard({
         </Typography>
       </Box>
 
-      {/* Vendor select + Notes fields */}
+      {/* Vendor select + Preferred delivery date + Notes fields */}
       <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
         <Box sx={{ flex: 1 }}>
           <VendorSelect
@@ -159,6 +167,16 @@ function VendorGroupCard({
             disabled={!isSelected}
           />
         </Box>
+        <TextField
+          label="Preferred delivery date"
+          size="small"
+          type="date"
+          disabled={!isSelected}
+          value={info.preferredDeliveryDate}
+          onChange={(e) => onUpdateVendorPO(vendor, 'preferredDeliveryDate', e.target.value)}
+          sx={{ width: 190 }}
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
         <TextField
           label="Notes"
           size="small"
@@ -303,7 +321,7 @@ export default function PurchaseOrdersStep({
       </Typography>
 
       {sortedVendors.map(([vendor, items]) => {
-        const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '' };
+        const info = vendorPOInfo.get(vendor) ?? { vendorId: null, notes: '', preferredDeliveryDate: '' };
         const isSelected = selectedVendors.has(vendor);
         return (
           <VendorGroupCard

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -73,12 +73,6 @@ const EMPTY_LINE_ITEM: Omit<LineItemRow, 'key' | 'id'> = {
   orderAs: '',
 };
 
-const CLASSIFICATIONS = [
-  { value: '', label: 'None' },
-  { value: 'SITE_HARDWARE', label: 'Site Hardware' },
-  { value: 'SHOP_HARDWARE', label: 'Shop Hardware' },
-];
-
 // Pick the live GP vendor that best matches an imported draft's vendor name (issue #175, reworked for
 // #200 now that the picker reads gpVendors live instead of a locally-synced mirror). Returns the match
 // plus whether it is CONFIDENT - an exact name match - versus a loose substring guess the user must
@@ -784,11 +778,12 @@ export default function GpPurchaseOrderDialog({
         </Typography>
       )}
 
-      {/* Column headers */}
+      {/* Column headers. Site/shop classification is set by the PM at request creation (issue #216),
+          so there is no Classification column here - register mode passes the draft's values through. */}
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: '1.2fr 1.2fr 0.6fr 0.7fr 1fr 1fr auto',
+          gridTemplateColumns: '1.3fr 1.3fr 0.6fr 0.7fr 1.2fr auto',
           gap: 1,
           mb: 0.5,
         }}
@@ -797,7 +792,6 @@ export default function GpPurchaseOrderDialog({
         <Typography variant="caption" sx={{ fontWeight: 'bold' }}>Product Code</Typography>
         <Typography variant="caption" sx={{ fontWeight: 'bold' }}>Qty</Typography>
         <Typography variant="caption" sx={{ fontWeight: 'bold' }}>Unit Cost</Typography>
-        <Typography variant="caption" sx={{ fontWeight: 'bold' }}>Classification</Typography>
         <Typography variant="caption" sx={{ fontWeight: 'bold' }}>Order As</Typography>
         <Box />
       </Box>
@@ -808,7 +802,7 @@ export default function GpPurchaseOrderDialog({
           key={li.key}
           sx={{
             display: 'grid',
-            gridTemplateColumns: '1.2fr 1.2fr 0.6fr 0.7fr 1fr 1fr auto',
+            gridTemplateColumns: '1.3fr 1.3fr 0.6fr 0.7fr 1.2fr auto',
             gap: 1,
             mb: 1,
             alignItems: 'start',
@@ -848,18 +842,6 @@ export default function GpPurchaseOrderDialog({
             helperText={errors[`li_${idx}_cost`]}
             slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
           />
-          <TextField
-            select
-            size="small"
-            value={li.classification}
-            onChange={(e) => updateLineItem(li.key, 'classification', e.target.value)}
-          >
-            {CLASSIFICATIONS.map((c) => (
-              <MenuItem key={c.value} value={c.value}>
-                {c.label}
-              </MenuItem>
-            ))}
-          </TextField>
           <TextField
             size="small"
             required

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -102,6 +102,7 @@ export default function PODetailModal({
   const [vendorId, setVendorId] = useState<string | null>(po.vendor?.id ?? null);
   const [vendorQuoteNumber, setVendorQuoteNumber] = useState(po.vendorQuoteNumber ?? '');
   const [expectedDeliveryDate, setExpectedDeliveryDate] = useState(po.expectedDeliveryDate ?? '');
+  const [preferredDeliveryDate, setPreferredDeliveryDate] = useState(po.preferredDeliveryDate ?? '');
   const [notes, setNotes] = useState(po.notes ?? '');
   // Issue #156: optional order-time dollar costs, kept as strings ('' = not entered, distinct from 0).
   const [shippingCost, setShippingCost] = useState(po.shippingCost != null ? String(po.shippingCost) : '');
@@ -198,6 +199,7 @@ export default function PODetailModal({
     setVendorId(po.vendor?.id ?? null);
     setVendorQuoteNumber(po.vendorQuoteNumber ?? '');
     setExpectedDeliveryDate(po.expectedDeliveryDate ?? '');
+    setPreferredDeliveryDate(po.preferredDeliveryDate ?? '');
     setNotes(po.notes ?? '');
     setShippingCost(po.shippingCost != null ? String(po.shippingCost) : '');
     setTariffAmount(po.tariffAmount != null ? String(po.tariffAmount) : '');
@@ -258,11 +260,16 @@ export default function PODetailModal({
       return;
     }
 
+    // Issue #216: the delivery dates are status-gated - preferred is the PM's ask on the DRAFT
+    // request, expected is the vendor's answer once GP-Registered. Send only the one editable now
+    // (null = "not provided" for these).
+    const isDraft = po.status === 'DRAFT';
     updatePo({
       variables: {
         id: po.id,
         vendorId: vendorId || null,
-        expectedDeliveryDate: expectedDeliveryDate || null,
+        preferredDeliveryDate: isDraft ? preferredDeliveryDate || null : null,
+        expectedDeliveryDate: !isDraft ? expectedDeliveryDate || null : null,
         poNumber: poNumber || null,
         vendorQuoteNumber: vendorQuoteNumber || null,
         notes: notes || null,
@@ -572,15 +579,29 @@ export default function PODetailModal({
               fullWidth
               size="small"
             />
-            <TextField
-              label="Expected Delivery Date"
-              type="date"
-              value={expectedDeliveryDate}
-              onChange={(e) => setExpectedDeliveryDate(e.target.value)}
-              fullWidth
-              size="small"
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
+            {/* Issue #216: preferred is the PM's ask, editable only on the DRAFT request; expected is
+                the vendor's answer, only enterable once GP-Registered (and before receiving). */}
+            {po.status === 'DRAFT' ? (
+              <TextField
+                label="Preferred Delivery Date"
+                type="date"
+                value={preferredDeliveryDate}
+                onChange={(e) => setPreferredDeliveryDate(e.target.value)}
+                fullWidth
+                size="small"
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            ) : (
+              <TextField
+                label="Expected Delivery Date"
+                type="date"
+                value={expectedDeliveryDate}
+                onChange={(e) => setExpectedDeliveryDate(e.target.value)}
+                fullWidth
+                size="small"
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
             <Stack direction="row" spacing={2}>
               <TextField
                 label="Shipping Costs"
@@ -620,6 +641,7 @@ export default function PODetailModal({
             <InfoRow label="Vendor Quote #" value={po.vendorQuoteNumber || '-'} />
             <InfoRow label="Shipping Costs" value={po.shippingCost != null ? `$${po.shippingCost.toFixed(2)}` : '-'} />
             <InfoRow label="Tariffs" value={po.tariffAmount != null ? `$${po.tariffAmount.toFixed(2)}` : '-'} />
+            <InfoRow label="Preferred Delivery Date" value={formatDate(po.preferredDeliveryDate)} />
             <InfoRow label="Expected Delivery Date" value={formatDate(po.expectedDeliveryDate)} />
             <InfoRow label="Order Date" value={formatDate(po.orderedAt)} />
             {po.notes && (

--- a/frontend/src/modules/po/POGenerateDialog.tsx
+++ b/frontend/src/modules/po/POGenerateDialog.tsx
@@ -129,7 +129,11 @@ function GenerateForm({ po, settings, buyers, gpTotals, projectNumber, onClose, 
   const [shipTo, setShipTo] = useState(dd?.shipTo ?? '');
   const [shippingMethod, setShippingMethod] = useState(dd?.shippingMethod ?? '');
   const [proposalNumber, setProposalNumber] = useState(dd?.proposalNumber ?? '');
-  const [requiredBy, setRequiredBy] = useState(dd?.requiredByOverride ?? po.expectedDeliveryDate ?? '');
+  // Required-by: saved override, else the vendor's expected date, else the PM's preferred date
+  // (issue #216 - pre-send, expected doesn't exist yet, so the doc asks for the preferred date).
+  const [requiredBy, setRequiredBy] = useState(
+    dd?.requiredByOverride ?? po.expectedDeliveryDate ?? po.preferredDeliveryDate ?? '',
+  );
   // Totals: saved override if this PO was generated before, else the PO's own order-time value
   // (issue #156), else the GP-read values, else 0.
   const [freight, setFreight] = useState(String(dd?.freight ?? po.shippingCost ?? gpTotals?.freight ?? 0));

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -137,6 +137,7 @@ export interface PurchaseOrder {
   shippingCost: number | null;
   tariffAmount: number | null;
   notes: string | null;
+  preferredDeliveryDate: string | null;
   expectedDeliveryDate: string | null;
   orderedAt: string | null;
   createdAt: string;

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -8,28 +8,29 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
 
 ## Environment
 
-Two runtimes. **Local is the default** for simulated user testing (no deploy wait); Railway is the fallback.
+**Railway is the default** for simulated user testing (issue #182 pivot - the localdev runtime was dropped for UC Nexus e2e; zero local setup needed).
 
-- **Local (default)**: frontend `http://localhost:5173`, backend `http://localhost:8000`. Run the backend with `poetry run uvicorn main:app --reload` (from `backend/`) and the frontend with `npm run dev` (from `frontend/`).
-- **Railway (fallback)**: frontend `https://frontend-production-34fc.up.railway.app/`, backend `https://backend-production-7866.up.railway.app/`.
+- **Railway production (default)**: frontend `https://frontend-production-34fc.up.railway.app/`, backend `https://backend-production-7866.up.railway.app/`. Deploys from master after CI passes.
+- **Railway PR environments** (once enabled in Project Settings → Environments): every PR gets a full ephemeral replica (frontend + backend + fresh empty Postgres, migrated on boot). The Railway GitHub bot comments the environment's URLs on the PR - test there BEFORE merge, substituting those URLs into the sign-in flow below. Data starts empty; seed via the import fixture. `VITE_GRAPHQL_URL` is a reference variable (`https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/graphql`) so each environment self-wires; `TESTING_ENABLED` and Clerk keys inherit from production.
+- **Local (manual fallback)**: frontend `http://localhost:5173`, backend `http://localhost:8000`. Run the backend with `poetry run uvicorn main:app --reload` (from `backend/`) and the frontend with `npm run dev` (from `frontend/`). Needs a local Postgres (not provided; the worktree-localdev adoption was dropped).
 - **Auth**: Clerk sign-in, automated via one-time sign-in tokens (no manual password/verification needed).
   - Backend endpoint `GET /testing/clerk-sign-in` generates the token (requires `TESTING_ENABLED=true`).
   - Navigate to the frontend URL with `?__clerk_ticket=TOKEN` to auto-authenticate.
-  - Clerk dev instances already allow `localhost`, so the same flow works against the local runtime unchanged.
+  - Tokens are one-time use; fetch a fresh one each session. Works on any runtime with the same Clerk dev instance.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
 
 ## Getting Started (Every Session)
 
-1. **Sign in**: Use `evaluate_script` to fetch a sign-in token and navigate with it. Local (default):
+1. **Sign in**: Use `evaluate_script` to fetch a sign-in token and navigate with it. Railway production (default):
    ```js
    (async () => {
-     const resp = await fetch('http://localhost:8000/testing/clerk-sign-in');
+     const resp = await fetch('https://backend-production-7866.up.railway.app/testing/clerk-sign-in');
      const { token } = await resp.json();
-     window.location.href = 'http://localhost:5173/?__clerk_ticket=' + token;
+     window.location.href = 'https://frontend-production-34fc.up.railway.app/?__clerk_ticket=' + token + '&cb=' + Date.now();
      return 'Navigating with sign-in token...';
    })()
    ```
-   For the Railway fallback, swap in the `backend-production-7866` / `frontend-production-34fc` URLs.
+   For a PR environment, swap in the URLs from the Railway bot's PR comment. For the local fallback, use `http://localhost:8000` / `http://localhost:5173`.
    - Clerk auto-authenticates — no email, password, or verification code needed.
    - You land on `/app` (Module Selector) fully signed in.
 2. **Reset data** (if needed): Click the "DevAction: drop and rebuild schema" button in the app bar.
@@ -269,7 +270,7 @@ Inventory quantity corrections are NOT here — they live in the Warehouse modul
 
 - `fill_form` is much more reliable than sequential `fill` calls for forms with many fields.
 - After "DevAction: drop and rebuild schema", there are TWO dialogs: a MUI confirm dialog, then a `window.alert()`. Must handle both.
-- Clerk sign-in tokens: Fetch from `GET /testing/clerk-sign-in` on the backend, then navigate to the frontend with `?__clerk_ticket=TOKEN`. Local default is `http://localhost:8000` (backend) + `http://localhost:5173` (frontend); Railway is the fallback. Clerk auto-authenticates - no form fill, no verification code. Tokens are one-time use; fetch a fresh one each session.
+- Clerk sign-in tokens: Fetch from `GET /testing/clerk-sign-in` on the backend, then navigate to the frontend with `?__clerk_ticket=TOKEN`. Railway production is the default runtime (issue #182); PR environments and localhost use the same flow with their own URLs. Clerk auto-authenticates - no form fill, no verification code. Tokens are one-time use; fetch a fresh one each session.
 - When viewing "All Projects", `projectId` is undefined/null in queries — this returns all POs across projects.
 - To test the Warehouse Receiving wizard's "Enter Quantities" step, you need at least one PO in ORDERED (or higher) status. DRAFT POs do not appear in the receiving wizard's PO selection list.
 - The line item field formerly called "Vendor Alias" is now called "Order As" in pre-order screens (Create PO dialog, PO detail modal) and "Ordered As" in post-order screens (Warehouse receiving wizard).
@@ -302,6 +303,8 @@ Inventory quantity corrections are NOT here — they live in the Warehouse modul
 - Transfer dialog Aisle/Bay/Bin: these are comboboxes with autocomplete="list". Use `evaluate_script` to set the underlying input value (native value setter + `input` event). This reliably sets the values without triggering dropdown selection. The Transfer button enables once all three fields are filled.
 - Locations page (Warden filter, panel open): when a single warehouse filter is active, the left rail single-column shows just the bin name + qty (no warehouse chip in that column, since filter is already scoped). The right panel header still shows the warehouse chip (e.g. "WRD").
 - Verifying a generated PDF (issue #230 PO document): the doc is text-based react-pdf, not an image, so `pdftotext` works. Fastest path for content assertions: use the dialog's "Save to PO documents" to upload it, query the PO's `documents { downloadUrl }` (presigned S3 URL) via GraphQL, `curl` the URL to a file, then `pdftotext -layout` (or `-raw` for the totals column, which `-layout` misaligns since Subtotal/Freight/Miscellaneous/Tax/Order-Total are right-aligned). "Generate & preview" opens a blob in a new tab that's hard to read via MCP - prefer save-then-fetch.
+- pdftotext/poppler is NOT installed on the dev machine, and naive stream-inflation can't read the text (react-pdf subsets fonts to custom glyph IDs). Working alternative: open the presigned `downloadUrl` directly in a browser tab (Chrome renders PDFs natively) and `take_screenshot` - the full totals column is readable in the image. Verified this way for issue #156 (Tariffs line + Order Total math).
+- Issue #156 fields: PO detail modal shows "Shipping Costs" / "Tariffs" info rows ('-' when null) and edit-mode number fields; the generate-document dialog's Freight prefills from the PO's shippingCost (saved documentData override wins) and its new Tariffs field from the PO's tariffAmount; the PDF prints a Tariffs totals line only when > 0.
 - The generate dialog + admin PO-settings text fields APPEND when driven by `fill`/`fill_form` if they already hold a value (same MUI controlled-input quirk as spinbuttons). For a pre-filled field, set the value via `evaluate_script` using the native value setter + an `input` event (match the label's `for` attr to the input id), or drive the mutation directly. Empty fields fill fine.
 - Date-only fields: a `<TextField type="date">` renders as Month/Day/Year spinbuttons in the a11y tree. Set it via `evaluate_script` native setter with a `YYYY-MM-DD` string on the underlying input (dispatch `input` + `change`). Note: formatting a `YYYY-MM-DD` string with `new Date(str)` is UTC and prints the previous calendar day in a behind-UTC tz - the PO-document code parses date-only strings as local (fixed in #238), so the printed required-by should match what was entered.
 - To seed a project's job-site address for the PO document's "Use project site" ship-to option (most test projects have null address fields), call `updateProject(id, {jobSiteName, address, city, state, zip})` via `evaluate_script` (Admin/Manager gated). Then the dialog's "Use project site" button builds a real "UC Hardware Inc. - Deliver to site / ..." block.


### PR DESCRIPTION
part 1 of #216 (Greg Sutton PO creation feedback) - the request-creation changes. buyer->project/cost-code mappings follow separately; GP-side items split to #257.

preferred vs expected delivery date are now distinct, status-gated fields:
- preferred_delivery_date (migration 052) is the PM's ask - input per vendor card in the import wizard's PO step, editable in the detail modal only while DRAFT
- expected_delivery_date is the vendor's answer - only enterable after GP-Registered (server-enforced; the existing guard already blocks both once receiving starts)
- generated document required-by prefill: saved override, else expected, else preferred

site/shop classification moves to the PM at request creation:
- PO-purpose Classification step gains a Site/Shop second axis (By Others items exempt), with per-group and bulk-selection actions; Next requires scope + site/shop complete
- picks flow through finalize onto HardwareItem + POLineItem (existing classifications pipe)
- the create/register GP dialog drops its Classification column - register passes the draft's values through untouched

also carries the #182 testing/CLAUDE.md railway-first rewrite (uncommitted from that issue).

repo tests cover the date gating; verified the import wizard second axis and dialog column removal compile + lint + vitest clean.