### PR TITLE
Fix date-only display in PO detail modal (UTC off-by-one)

### DIFF
--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -59,7 +59,11 @@ const DOC_TYPE_LABELS: Record<string, string> = {
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString();
+  // Parse a date-only string (YYYY-MM-DD) as LOCAL midnight, not UTC, so it displays as entered
+  // (same #238 fix as the PO-document code - `new Date('2026-08-01')` renders 7/31 behind UTC).
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : new Date(dateStr);
+  return isNaN(d.getTime()) ? '-' : d.toLocaleDateString();
 }
 
 function formatDateTime(dateStr: string | null | undefined): string {


### PR DESCRIPTION
found during #216 pt1 e2e: the detail modal rendered a stored 2026-08-01 preferred date as 7/31/2026.

formatDate parsed YYYY-MM-DD with new Date(str) - UTC midnight, one day early behind UTC. affects preferred + expected delivery dates. now parses date-only strings as local midnight, same fix #238 applied to the PO-document code.