### PR TITLE
Add #216 pt2: buyer identity + per-buyer project/cost-code assignments

### DIFF
--- a/backend/alembic/versions/053_buyer_assignments.py
+++ b/backend/alembic/versions/053_buyer_assignments.py
@@ -1,0 +1,48 @@
+"""Buyer assignments (issue #216)
+
+Per-GP-buyer authorization: the projects a buyer may create POs for (M2M) and the GP cost codes
+they may use (JSON list of 'cc1-cc2'). Strict enforcement - an unassigned buyer cannot create
+project POs. The user->buyer link lives in Clerk publicMetadata.gpBuyerId, not here.
+
+Revision ID: 053
+Revises: 052
+Create Date: 2026-07-16
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "053"
+down_revision = "052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "buyer_assignments",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("buyer_id", sa.String(15), nullable=False),
+        sa.Column("cost_codes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("buyer_id", name="uq_buyer_assignments_buyer_id"),
+    )
+    op.create_table(
+        "buyer_assignment_projects",
+        sa.Column(
+            "buyer_assignment_id",
+            sa.Uuid(),
+            sa.ForeignKey("buyer_assignments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("project_id", sa.Uuid(), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.PrimaryKeyConstraint("buyer_assignment_id", "project_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("buyer_assignment_projects")
+    op.drop_table("buyer_assignments")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ class Base(DeclarativeBase):
 
 # Import all models so Alembic can detect them
 from .audit_log import InventoryAuditLog  # noqa: E402, F401
+from .buyer_assignment import BuyerAssignment  # noqa: E402, F401
 from .deficiency_review import DeficiencyReview  # noqa: E402, F401
 from .gp_write import GpWriteIdempotency  # noqa: E402, F401
 from .hardware import HardwareItem  # noqa: E402, F401

--- a/backend/app/models/buyer_assignment.py
+++ b/backend/app/models/buyer_assignment.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON, Column, ForeignKey, String, Table, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+from .project import Project
+
+# M2M: the projects a buyer may create POs for (issue #216).
+buyer_assignment_projects = Table(
+    "buyer_assignment_projects",
+    Base.metadata,
+    Column("buyer_assignment_id", ForeignKey("buyer_assignments.id", ondelete="CASCADE"), primary_key=True),
+    Column("project_id", ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class BuyerAssignment(Base):
+    """Issue #216: per-GP-buyer authorization - which projects a buyer creates POs for and which GP
+    cost codes they may use. STRICT: a buyer with no row (or a project/cost code outside their
+    assignment) cannot create a project PO. buyer_id is the GP BUYERID (char 15); a UC Nexus account
+    is linked to it via the user's Clerk publicMetadata.gpBuyerId (set in Admin -> User Management).
+    """
+
+    __tablename__ = "buyer_assignments"
+    __table_args__ = (UniqueConstraint("buyer_id", name="uq_buyer_assignments_buyer_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    buyer_id: Mapped[str] = mapped_column(String(15), nullable=False)
+    # Designated GP cost codes as 'cc1-cc2' strings (e.g. '310-000'); the dialog offers only the
+    # job's live cost codes whose code part matches one of these.
+    cost_codes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    projects: Mapped[list[Project]] = relationship(secondary=buyer_assignment_projects)

--- a/backend/app/repositories/buyer_repository.py
+++ b/backend/app/repositories/buyer_repository.py
@@ -1,0 +1,98 @@
+"""Repository for buyer assignments (issue #216): which projects a GP buyer may create POs for and
+which GP cost codes they may use. Enforcement is STRICT - a buyer with no assignment row cannot
+create project POs at all; stock POs (no project) are not gated here."""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.errors import NotFoundError, ValidationError
+from app.models.buyer_assignment import BuyerAssignment
+from app.models.project import Project
+
+
+def _clean_buyer_id(buyer_id: str) -> str:
+    cleaned = (buyer_id or "").strip()
+    if not cleaned:
+        raise ValidationError("Buyer id is required", field="buyer_id")
+    return cleaned
+
+
+def _clean_cost_codes(cost_codes: list[str] | None) -> list[str]:
+    """Normalize to a deduped list of non-empty 'cc1-cc2' strings, preserving order."""
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for code in cost_codes or []:
+        c = (code or "").strip()
+        if c and c not in seen:
+            seen.add(c)
+            cleaned.append(c)
+    return cleaned
+
+
+def list_assignments(session: Session) -> list[BuyerAssignment]:
+    stmt = select(BuyerAssignment).options(selectinload(BuyerAssignment.projects)).order_by(BuyerAssignment.buyer_id)
+    return list(session.scalars(stmt).unique().all())
+
+
+def get_assignment(session: Session, buyer_id: str) -> BuyerAssignment | None:
+    stmt = (
+        select(BuyerAssignment)
+        .options(selectinload(BuyerAssignment.projects))
+        .where(BuyerAssignment.buyer_id == _clean_buyer_id(buyer_id))
+    )
+    return session.scalars(stmt).unique().first()
+
+
+def save_assignment(
+    session: Session, buyer_id: str, project_ids: list[uuid.UUID], cost_codes: list[str]
+) -> BuyerAssignment:
+    """Upsert the one assignment row for a buyer (the admin dialog sends the whole state each save)."""
+    cleaned_id = _clean_buyer_id(buyer_id)
+    projects = []
+    for pid in project_ids:
+        project = session.get(Project, pid)
+        if project is None:
+            raise NotFoundError(f"Project {pid} not found")
+        projects.append(project)
+
+    assignment = get_assignment(session, cleaned_id)
+    if assignment is None:
+        assignment = BuyerAssignment(id=uuid.uuid4(), buyer_id=cleaned_id, cost_codes=[])
+        session.add(assignment)
+    assignment.cost_codes = _clean_cost_codes(cost_codes)
+    assignment.projects = projects
+    session.flush()
+    return assignment
+
+
+def delete_assignment(session: Session, buyer_id: str) -> None:
+    assignment = get_assignment(session, buyer_id)
+    if assignment is None:
+        raise NotFoundError(f"No assignment for buyer '{buyer_id}'")
+    session.delete(assignment)
+
+
+def validate_buyer_can_order(
+    session: Session, buyer_id: str, project_id: uuid.UUID | None, cost_code: str | None
+) -> None:
+    """Enforce issue #216 for a PROJECT PO push: the buyer must be assigned to the project and the
+    cost code's 'cc1-cc2' part must be one of their designated codes. A stock PO (project_id None)
+    is not gated. Raises a clean field error the dialog can show."""
+    if project_id is None:
+        return
+
+    assignment = get_assignment(session, buyer_id)
+    if assignment is None:
+        raise ValidationError(
+            f"Buyer '{buyer_id}' has no project assignments; an Admin must configure them under Admin -> Buyers",
+            field="buyer_id",
+        )
+    if not any(p.id == project_id for p in assignment.projects):
+        raise ValidationError(f"Buyer '{buyer_id}' is not assigned to this project", field="project_id")
+
+    # cost_code arrives as 'cc1-cc2-element' (the dialog's pick); designations are 'cc1-cc2'.
+    code_part = (cost_code or "").strip().rsplit("-", 1)[0]
+    if not code_part or code_part not in (assignment.cost_codes or []):
+        raise ValidationError(f"Cost code '{cost_code}' is not designated to buyer '{buyer_id}'", field="cost_code")

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -41,6 +41,20 @@ def _display_email(u: dict) -> str:
     return ""
 
 
+def _user_summary(u: dict) -> dict:
+    """The shape the users query / user mutations return, from a raw Clerk user payload."""
+    metadata = u.get("public_metadata") or {}
+    return {
+        "id": u["id"],
+        "first_name": u.get("first_name") or "",
+        "last_name": u.get("last_name") or "",
+        "email": _primary_email(u),
+        "roles": metadata.get("roles", []),
+        "gp_buyer_id": metadata.get("gpBuyerId") or None,
+        "image_url": u.get("image_url") or "",
+    }
+
+
 def list_users() -> list[dict]:
     """List all Clerk users with their roles from publicMetadata."""
     users = []
@@ -57,17 +71,7 @@ def list_users() -> list[dict]:
         data = resp.json()
 
         for u in data:
-            metadata = u.get("public_metadata") or {}
-            users.append(
-                {
-                    "id": u["id"],
-                    "first_name": u.get("first_name") or "",
-                    "last_name": u.get("last_name") or "",
-                    "email": _primary_email(u),
-                    "roles": metadata.get("roles", []),
-                    "image_url": u.get("image_url") or "",
-                }
-            )
+            users.append(_user_summary(u))
 
         if len(data) < limit:
             break
@@ -107,21 +111,40 @@ def get_user_roles(user_id: str) -> list[str]:
     return metadata.get("roles") or []
 
 
-def update_user_roles(user_id: str, roles: list[str]) -> dict:
-    """Update a Clerk user's roles in publicMetadata."""
+def _merge_public_metadata(user_id: str, patch: dict) -> dict:
+    """Merge keys into a Clerk user's publicMetadata via the /metadata endpoint (deep merge), so
+    writing one key (roles) never wipes another (gpBuyerId) - PATCH /users/{id} would replace the
+    whole object. Returns the updated user summary."""
     resp = _client.patch(
-        f"/users/{user_id}",
+        f"/users/{user_id}/metadata",
         headers=_headers(),
-        json={"public_metadata": {"roles": roles}},
+        json={"public_metadata": patch},
     )
     resp.raise_for_status()
-    u = resp.json()
+    return _user_summary(resp.json())
+
+
+def update_user_roles(user_id: str, roles: list[str]) -> dict:
+    """Update a Clerk user's roles in publicMetadata."""
+    return _merge_public_metadata(user_id, {"roles": roles})
+
+
+def update_user_gp_buyer_id(user_id: str, gp_buyer_id: str | None) -> dict:
+    """Issue #216: set (or clear, with None) the GP BUYERID this UC Nexus account acts as. The PO
+    dialog auto-uses it and the create/register mutations enforce it server-side."""
+    cleaned = (gp_buyer_id or "").strip() or None
+    return _merge_public_metadata(user_id, {"gpBuyerId": cleaned})
+
+
+def get_user_gp_buyer_id(user_id: str) -> str | None:
+    """Issue #216: the caller's GP buyer identity from Clerk publicMetadata, or None if unset."""
+    try:
+        resp = _client.get(f"/users/{user_id}", headers=_headers())
+        resp.raise_for_status()
+        u = resp.json()
+    except httpx.HTTPError as e:
+        raise AppError(
+            "Could not load your user profile from Clerk; please try again.", code="CLERK_UNAVAILABLE"
+        ) from e
     metadata = u.get("public_metadata") or {}
-    return {
-        "id": u["id"],
-        "first_name": u.get("first_name") or "",
-        "last_name": u.get("last_name") or "",
-        "email": _primary_email(u),
-        "roles": metadata.get("roles", []),
-        "image_url": u.get("image_url") or "",
-    }
+    return metadata.get("gpBuyerId") or None

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -8,8 +8,9 @@ from sqlalchemy import select
 
 from app.auth import require_admin, require_user, resolve_display_name
 from app.database import SessionLocal
-from app.errors import InvalidStateTransitionError, InventoryShortfallError, NotFoundError
+from app.errors import InvalidStateTransitionError, InventoryShortfallError, NotFoundError, ValidationError
 from app.repositories import (
+    buyer_repository,
     notification_repository,
     po_document_settings_repository,
     po_repository,
@@ -58,6 +59,8 @@ from .inputs import (
     UpdateWarehouseInput,
 )
 from .queries import (
+    _buyer_assignment_to_type,
+    _clerk_user_to_type,
     _deficiency_review_to_type,
     _inventory_location_to_type,
     _notification_to_type,
@@ -80,6 +83,7 @@ from .queries import (
 )
 from .types import (
     ApproveResult,
+    BuyerAssignment,
     ClerkUser,
     DeficiencyReview,
     FinalizeImportResult,
@@ -207,6 +211,10 @@ def _prepare_create_po(*, project_id, vendor_id, gp_vendor_id, buyer_id, cost_co
                 raise NotFoundError(f"Project {project_id} not found")
             job_number = project.project_id
 
+        # Issue #216: a project PO requires the buyer to be assigned to the project with a
+        # designated cost code (strict - no assignment row means no project POs).
+        buyer_repository.validate_buyer_can_order(session, buyer_id, project_id, cost_code)
+
         manufacturers = _resolve_line_manufacturers(session, project_id, line_items_data)
 
     gp_po.validate_create_po_inputs(
@@ -226,6 +234,18 @@ def _prepare_create_po(*, project_id, vendor_id, gp_vendor_id, buyer_id, cost_co
     for line, manufacturer in zip(payload["lines"], manufacturers):
         line["manufacturer"] = manufacturer
     return payload
+
+
+def _assert_buyer_identity(caller_gp_buyer_id: str | None, input_buyer_id: str) -> None:
+    """Issue #216: a PO is pushed as the CALLER's GP buyer identity (Clerk publicMetadata.gpBuyerId),
+    not a free pick - reject a missing identity or a mismatched buyer_id before anything hits GP."""
+    if not caller_gp_buyer_id:
+        raise ValidationError(
+            "Your account has no GP buyer identity; an Admin must set it in User Management",
+            field="buyer_id",
+        )
+    if (input_buyer_id or "").strip().upper() != caller_gp_buyer_id.strip().upper():
+        raise ValidationError("POs can only be created as your own GP buyer", field="buyer_id")
 
 
 def _persist_create_po(
@@ -291,6 +311,9 @@ def _prepare_register_po(*, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code,
             if project is None:
                 raise NotFoundError(f"Project {po.project_id} not found")
             job_number = project.project_id
+
+        # Issue #216: registering a draft is the ordering action - same strict buyer gating.
+        buyer_repository.validate_buyer_can_order(session, buyer_id, po.project_id, cost_code)
 
         manufacturers = _resolve_line_manufacturers(session, po.project_id, line_items_data)
 
@@ -725,7 +748,10 @@ class Mutation:
         Issue #202 #1/#3: idempotency_key (client-generated, one per user action, re-sent on retry) makes
         a retry a no-op in GP; fields are validated before the relay_call; the DB work is offloaded so no
         Postgres connection is held across the relay round-trip."""
-        require_user(info)
+        auth = require_user(info)
+        # Issue #216: the PO is pushed as the caller's own GP buyer identity, never a free pick.
+        caller_buyer = await asyncio.to_thread(user_repository.get_user_gp_buyer_id, auth["user_id"])
+        _assert_buyer_identity(caller_buyer, input.buyer_id)
         key = gp_idempotency.validate_key(input.idempotency_key)
 
         project_id = uuid.UUID(str(input.project_id)) if input.project_id else None
@@ -792,7 +818,10 @@ class Mutation:
         Issue #202 #1/#3: idempotency_key makes a retry a no-op in GP; the DRAFT-state guard and fields
         are checked before the relay_call so a double-submit never reaches GP; the DB work is offloaded
         so no Postgres connection is held across the relay round-trip."""
-        require_user(info)
+        auth = require_user(info)
+        # Issue #216: the PO is registered as the caller's own GP buyer identity, never a free pick.
+        caller_buyer = await asyncio.to_thread(user_repository.get_user_gp_buyer_id, auth["user_id"])
+        _assert_buyer_identity(caller_buyer, input.buyer_id)
         key = gp_idempotency.validate_key(input.idempotency_key)
 
         pid = uuid.UUID(str(input.po_id))
@@ -1509,15 +1538,38 @@ class Mutation:
 
     @strawberry.mutation
     def update_user_roles(self, user_id: str, roles: list[str]) -> ClerkUser:
-        result = user_repository.update_user_roles(user_id, roles)
-        return ClerkUser(
-            id=result["id"],
-            first_name=result["first_name"],
-            last_name=result["last_name"],
-            email=result["email"],
-            roles=result["roles"],
-            image_url=result["image_url"],
-        )
+        return _clerk_user_to_type(user_repository.update_user_roles(user_id, roles))
+
+    @strawberry.mutation
+    def update_user_gp_buyer_id(self, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:
+        """Issue #216: link a UC Nexus account to the GP BUYERID it acts as (null clears). The PO
+        dialog auto-uses the caller's identity and createPo/registerPoInGp enforce it."""
+        return _clerk_user_to_type(user_repository.update_user_gp_buyer_id(user_id, gp_buyer_id))
+
+    @strawberry.mutation
+    def save_buyer_assignment(
+        self, info: strawberry.Info, buyer_id: str, project_ids: list[strawberry.ID], cost_codes: list[str]
+    ) -> BuyerAssignment:
+        """Issue #216: upsert a buyer's whole assignment (projects + designated cost codes). Admin."""
+        require_admin(info)
+        with SessionLocal() as session:
+            assignment = buyer_repository.save_assignment(
+                session,
+                buyer_id,
+                [uuid.UUID(str(pid)) for pid in project_ids],
+                cost_codes,
+            )
+            session.commit()
+            refreshed = buyer_repository.get_assignment(session, assignment.buyer_id)
+            return _buyer_assignment_to_type(refreshed)
+
+    @strawberry.mutation
+    def delete_buyer_assignment(self, info: strawberry.Info, buyer_id: str) -> bool:
+        require_admin(info)
+        with SessionLocal() as session:
+            buyer_repository.delete_assignment(session, buyer_id)
+            session.commit()
+            return True
 
     # ---------------------------------------------------------------------------
     # Stock pool + deficiency mutations

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -38,6 +38,8 @@ from .types import (
     AdminStats,
     AuditLogEntry,
     BackOrderedItem,
+    BuyerAssignment,
+    BuyerAssignmentProject,
     ClerkUser,
     DeficientItemRow,
     GpCostCode,
@@ -283,6 +285,33 @@ def _po_document_settings_to_type(s) -> PODocumentSettings:
         footer_notes=s.footer_notes,
         signature_note=s.signature_note,
         updated_at=s.updated_at,
+    )
+
+
+def _clerk_user_to_type(u: dict) -> ClerkUser:
+    return ClerkUser(
+        id=u["id"],
+        first_name=u["first_name"],
+        last_name=u["last_name"],
+        email=u["email"],
+        roles=u["roles"],
+        gp_buyer_id=u.get("gp_buyer_id"),
+        image_url=u["image_url"],
+    )
+
+
+def _buyer_assignment_to_type(a) -> BuyerAssignment:
+    return BuyerAssignment(
+        buyer_id=a.buyer_id,
+        cost_codes=list(a.cost_codes or []),
+        projects=[
+            BuyerAssignmentProject(
+                id=strawberry.ID(str(p.id)),
+                project_id=p.project_id,
+                description=p.description,
+            )
+            for p in a.projects
+        ],
     )
 
 
@@ -1091,17 +1120,16 @@ class Query:
     @strawberry.field
     def users(self) -> list[ClerkUser]:
         results = user_repository.list_users()
-        return [
-            ClerkUser(
-                id=u["id"],
-                first_name=u["first_name"],
-                last_name=u["last_name"],
-                email=u["email"],
-                roles=u["roles"],
-                image_url=u["image_url"],
-            )
-            for u in results
-        ]
+        return [_clerk_user_to_type(u) for u in results]
+
+    @strawberry.field
+    def buyer_assignments(self) -> list[BuyerAssignment]:
+        """Issue #216: per-buyer project + cost-code authorization. The PO dialog reads this to
+        filter its options; the create/register mutations re-enforce it server-side."""
+        from app.repositories import buyer_repository
+
+        with SessionLocal() as session:
+            return [_buyer_assignment_to_type(a) for a in buyer_repository.list_assignments(session)]
 
     @strawberry.field
     def vendors(self) -> list[Vendor]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -900,7 +900,27 @@ class ClerkUser:
     last_name: str
     email: str
     roles: list[str]
+    # Issue #216: the GP BUYERID this account acts as (Clerk publicMetadata.gpBuyerId), or null.
+    gp_buyer_id: str | None
     image_url: str
+
+
+@strawberry.type
+class BuyerAssignmentProject:
+    """Slim project ref for buyer assignments (the full Project type carries openings)."""
+
+    id: strawberry.ID
+    project_id: str
+    description: str | None
+
+
+@strawberry.type
+class BuyerAssignment:
+    """Issue #216: the projects a GP buyer may create POs for + their designated cost codes."""
+
+    buyer_id: str
+    cost_codes: list[str]
+    projects: list[BuyerAssignmentProject]
 
 
 @strawberry.type

--- a/backend/tests/test_buyer_assignments.py
+++ b/backend/tests/test_buyer_assignments.py
@@ -1,0 +1,93 @@
+"""Buyer assignments (issue #216): CRUD + strict project/cost-code enforcement for project POs."""
+
+import uuid
+
+import pytest
+
+from app.errors import NotFoundError, ValidationError
+from app.models.project import Project
+from app.repositories import buyer_repository
+from app.schemas.mutations import _assert_buyer_identity
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:6]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def test_save_assignment_upserts_one_row_per_buyer(db_session):
+    p1 = _make_project(db_session)
+    p2 = _make_project(db_session)
+
+    first = buyer_repository.save_assignment(db_session, "  mira ", [p1.id], ["310-000", " 310-000", ""])
+    assert first.buyer_id == "mira"
+    assert first.cost_codes == ["310-000"]  # trimmed + deduped + blanks dropped
+    assert [p.id for p in first.projects] == [p1.id]
+
+    second = buyer_repository.save_assignment(db_session, "mira", [p1.id, p2.id], ["210-200"])
+    assert second.id == first.id  # updated in place, not duplicated
+    assert {p.id for p in second.projects} == {p1.id, p2.id}
+    assert second.cost_codes == ["210-200"]
+
+
+def test_save_assignment_rejects_unknown_project(db_session):
+    with pytest.raises(NotFoundError):
+        buyer_repository.save_assignment(db_session, "mira", [uuid.uuid4()], [])
+
+
+def test_delete_assignment(db_session):
+    p = _make_project(db_session)
+    buyer_repository.save_assignment(db_session, "mira", [p.id], [])
+    buyer_repository.delete_assignment(db_session, "mira")
+    assert buyer_repository.get_assignment(db_session, "mira") is None
+    with pytest.raises(NotFoundError):
+        buyer_repository.delete_assignment(db_session, "mira")
+
+
+def test_validate_stock_po_is_not_gated(db_session):
+    # No assignment rows at all - a stock PO (no project) is still allowed.
+    buyer_repository.validate_buyer_can_order(db_session, "mira", None, None)
+
+
+def test_validate_rejects_unassigned_buyer(db_session):
+    p = _make_project(db_session)
+    with pytest.raises(ValidationError) as exc:
+        buyer_repository.validate_buyer_can_order(db_session, "mira", p.id, "210-200-2")
+    assert exc.value.field == "buyer_id"
+
+
+def test_validate_rejects_project_outside_assignment(db_session):
+    assigned = _make_project(db_session)
+    other = _make_project(db_session)
+    buyer_repository.save_assignment(db_session, "mira", [assigned.id], ["210-200"])
+    with pytest.raises(ValidationError) as exc:
+        buyer_repository.validate_buyer_can_order(db_session, "mira", other.id, "210-200-2")
+    assert exc.value.field == "project_id"
+
+
+def test_validate_rejects_undesignated_cost_code(db_session):
+    p = _make_project(db_session)
+    buyer_repository.save_assignment(db_session, "mira", [p.id], ["310-000"])
+    with pytest.raises(ValidationError) as exc:
+        # '210-200-2' -> code part '210-200', not in the designated list
+        buyer_repository.validate_buyer_can_order(db_session, "mira", p.id, "210-200-2")
+    assert exc.value.field == "cost_code"
+
+
+def test_validate_happy_path(db_session):
+    p = _make_project(db_session)
+    buyer_repository.save_assignment(db_session, "mira", [p.id], ["210-200", "310-000"])
+    buyer_repository.validate_buyer_can_order(db_session, "mira", p.id, "210-200-2")
+
+
+def test_assert_buyer_identity():
+    with pytest.raises(ValidationError):
+        _assert_buyer_identity(None, "mira")
+    with pytest.raises(ValidationError):
+        _assert_buyer_identity("", "mira")
+    with pytest.raises(ValidationError):
+        _assert_buyer_identity("mira", "steve")
+    # case-insensitive, whitespace-tolerant match (GP BUYERID is char-padded uppercase)
+    _assert_buyer_identity("MIRA", " mira ")

--- a/backend/tests/test_po_repository_create_po.py
+++ b/backend/tests/test_po_repository_create_po.py
@@ -9,8 +9,14 @@ from app.models.enums import HardwareItemState
 from app.models.hardware import HardwareItem
 from app.models.project import Opening, Project
 from app.models.vendor import Vendor
-from app.repositories import po_repository
+from app.repositories import buyer_repository, po_repository
 from app.schemas import mutations
+
+
+def _assign_buyer(session, buyer_id, project, cost_codes=("210-200",)):
+    """Issue #216: _prepare_create_po/_prepare_register_po enforce buyer->project/cost-code
+    assignments for project POs, so tests exercising them must seed one."""
+    return buyer_repository.save_assignment(session, buyer_id, [project.id], list(cost_codes))
 
 
 def _make_vendor(session, name: str = "Acme") -> Vendor:
@@ -85,6 +91,7 @@ def test_prepare_create_po_attaches_manufacturer_per_line(monkeypatch, db_sessio
     project = _make_project(db_session)
     _add_hardware_item(db_session, project, hardware_category="HINGE", product_code="HG-100", manufacturer="SCHLAGE")
     _add_hardware_item(db_session, project, hardware_category="LOCK", product_code="LK-200", manufacturer="SARGENT")
+    _assign_buyer(db_session, "mira", project)
     _use_test_session(monkeypatch, db_session)
 
     payload = mutations._prepare_create_po(
@@ -104,6 +111,7 @@ def test_prepare_create_po_leaves_manufacturer_blank_without_a_hardware_match(mo
     project = _make_project(db_session)
     # a hardware item exists, but not for this line's category + code
     _add_hardware_item(db_session, project, hardware_category="HINGE", product_code="HG-100", manufacturer="SCHLAGE")
+    _assign_buyer(db_session, "mira", project)
     _use_test_session(monkeypatch, db_session)
 
     payload = mutations._prepare_create_po(
@@ -147,6 +155,7 @@ def test_prepare_create_po_disagreeing_items_take_first_non_null_and_log(monkeyp
         manufacturer="SARGENT",
         created_at=datetime(2026, 1, 1, 0, 0, 2),
     )
+    _assign_buyer(db_session, "mira", project)
     _use_test_session(monkeypatch, db_session)
 
     with caplog.at_level(logging.WARNING):

--- a/backend/tests/test_register_po_in_gp.py
+++ b/backend/tests/test_register_po_in_gp.py
@@ -13,8 +13,13 @@ from app.models.hardware import HardwareItem
 from app.models.project import Opening, Project
 from app.models.purchase_order import POLineItem, PurchaseOrder
 from app.models.vendor import Vendor
-from app.repositories import import_repository, po_repository
+from app.repositories import buyer_repository, import_repository, po_repository
 from app.schemas import mutations
+
+
+def _assign_buyer(session, buyer_id, project, cost_codes=("210-200",)):
+    """Issue #216: _prepare_register_po enforces buyer->project/cost-code assignments."""
+    return buyer_repository.save_assignment(session, buyer_id, [project.id], list(cost_codes))
 
 
 def _make_project(session) -> Project:
@@ -459,6 +464,7 @@ def test_prepare_register_po_attaches_manufacturer_per_line(monkeypatch, db_sess
         vendor_id=gp_vendor.id,
     )
     assert draft.status == POStatus.DRAFT
+    _assign_buyer(db_session, "mira", project)
     _use_test_session(monkeypatch, db_session)
 
     payload = mutations._prepare_register_po(
@@ -500,6 +506,7 @@ def test_prepare_register_po_disagreeing_items_take_first_non_null_and_log(monke
         project_id=project.id,
         vendor_id=gp_vendor.id,
     )
+    _assign_buyer(db_session, "mira", project)
     _use_test_session(monkeypatch, db_session)
 
     with caplog.at_level(logging.WARNING):

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -92,6 +92,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
       { label: 'Opening Status', path: '/app/admin/opening-status' },
       { label: 'Vendors', path: '/app/admin/vendors' },
       { label: 'User Management', path: '/app/admin/users' },
+      { label: 'Buyers', path: '/app/admin/buyers' },
       { label: 'Relay Installs', path: '/app/admin/relay-installs' },
     ],
   },

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -578,8 +578,43 @@ export const UPDATE_USER_ROLES = gql`
       lastName
       email
       roles
+      gpBuyerId
       imageUrl
     }
+  }
+`;
+
+export const UPDATE_USER_GP_BUYER_ID = gql`
+  mutation UpdateUserGpBuyerId($userId: String!, $gpBuyerId: String) {
+    updateUserGpBuyerId(userId: $userId, gpBuyerId: $gpBuyerId) {
+      id
+      firstName
+      lastName
+      email
+      roles
+      gpBuyerId
+      imageUrl
+    }
+  }
+`;
+
+export const SAVE_BUYER_ASSIGNMENT = gql`
+  mutation SaveBuyerAssignment($buyerId: String!, $projectIds: [ID!]!, $costCodes: [String!]!) {
+    saveBuyerAssignment(buyerId: $buyerId, projectIds: $projectIds, costCodes: $costCodes) {
+      buyerId
+      costCodes
+      projects {
+        id
+        projectId
+        description
+      }
+    }
+  }
+`;
+
+export const DELETE_BUYER_ASSIGNMENT = gql`
+  mutation DeleteBuyerAssignment($buyerId: String!) {
+    deleteBuyerAssignment(buyerId: $buyerId)
   }
 `;
 

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -590,7 +590,22 @@ export const GET_USERS = gql`
       lastName
       email
       roles
+      gpBuyerId
       imageUrl
+    }
+  }
+`;
+
+export const GET_BUYER_ASSIGNMENTS = gql`
+  query GetBuyerAssignments {
+    buyerAssignments {
+      buyerId
+      costCodes
+      projects {
+        id
+        projectId
+        description
+      }
     }
   }
 `;

--- a/frontend/src/hooks/useIdentity.ts
+++ b/frontend/src/hooks/useIdentity.ts
@@ -2,6 +2,8 @@ import { useUser } from '@clerk/clerk-react';
 
 interface PublicMetadata {
   roles?: string[];
+  // Issue #216: the GP BUYERID this account acts as (set by an Admin in User Management).
+  gpBuyerId?: string | null;
 }
 
 export function useIdentity() {
@@ -11,5 +13,6 @@ export function useIdentity() {
   const roles = metadata.roles ?? [];
   const hasRole = (role: string) => roles.includes(role);
   const isAdmin = hasRole('Admin/Manager');
-  return { displayName, roles, hasRole, isAdmin, user };
+  const gpBuyerId = metadata.gpBuyerId || null;
+  return { displayName, roles, hasRole, isAdmin, gpBuyerId, user };
 }

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -8,6 +8,7 @@ import FolderIcon from '@mui/icons-material/Folder';
 import GroupIcon from '@mui/icons-material/Group';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import RouterIcon from '@mui/icons-material/Router';
+import BadgeIcon from '@mui/icons-material/Badge';
 import PeopleIcon from '@mui/icons-material/People';
 import BusinessIcon from '@mui/icons-material/Business';
 import CategoryIcon from '@mui/icons-material/Category';
@@ -52,6 +53,7 @@ const SUB_ROUTES = [
   { label: 'Warehouses', path: '/app/admin/warehouses', icon: <WarehouseIcon fontSize="large" /> },
   { label: 'Projects', path: '/app/admin/projects', icon: <FolderIcon fontSize="large" /> },
   { label: 'User Management', path: '/app/admin/users', icon: <GroupIcon fontSize="large" /> },
+  { label: 'Buyers', path: '/app/admin/buyers', icon: <BadgeIcon fontSize="large" /> },
   { label: 'Relay Installs', path: '/app/admin/relay-installs', icon: <RouterIcon fontSize="large" /> },
   { label: 'Location Cleanup', path: '/app/admin/location-cleanup', icon: <CleaningServicesIcon fontSize="large" /> },
 ];

--- a/frontend/src/modules/admin/BuyersPage.tsx
+++ b/frontend/src/modules/admin/BuyersPage.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
+import { useMutation, useQuery } from '@apollo/client/react';
+import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/queries';
+import { DELETE_BUYER_ASSIGNMENT, SAVE_BUYER_ASSIGNMENT } from '../../graphql/mutations';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import type { Project } from '../../types/project';
+
+interface AssignmentProject {
+  id: string;
+  projectId: string;
+  description: string | null;
+}
+
+interface BuyerAssignmentRow {
+  buyerId: string;
+  costCodes: string[];
+  projects: AssignmentProject[];
+}
+
+function projectLabel(p: { projectId: string; description: string | null }): string {
+  return p.description ? `${p.projectId} · ${p.description}` : p.projectId;
+}
+
+export default function BuyersPage() {
+  const { isAdmin } = useIdentity();
+  const { showToast } = useToast();
+
+  const { data, loading } = useQuery<{ buyerAssignments: BuyerAssignmentRow[] }>(GET_BUYER_ASSIGNMENTS, {
+    skip: !isAdmin,
+    fetchPolicy: 'cache-and-network',
+  });
+  const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS, { skip: !isAdmin });
+  const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
+  const rows = useMemo(() => data?.buyerAssignments ?? [], [data]);
+
+  // Edit dialog state. isNew drives whether the buyer id is editable (it's the row key).
+  const [editOpen, setEditOpen] = useState(false);
+  const [isNew, setIsNew] = useState(false);
+  const [buyerId, setBuyerId] = useState('');
+  const [selectedProjects, setSelectedProjects] = useState<Project[]>([]);
+  const [costCodesText, setCostCodesText] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+
+  const [saveAssignment, { loading: saving }] = useMutation(SAVE_BUYER_ASSIGNMENT, {
+    refetchQueries: [{ query: GET_BUYER_ASSIGNMENTS }],
+    onCompleted: () => {
+      showToast('Buyer assignment saved', 'success');
+      setEditOpen(false);
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const [deleteAssignment] = useMutation(DELETE_BUYER_ASSIGNMENT, {
+    refetchQueries: [{ query: GET_BUYER_ASSIGNMENTS }],
+    onCompleted: () => {
+      showToast('Buyer assignment deleted', 'success');
+      setDeleteTarget(null);
+    },
+    onError: (err) => {
+      showToast(err.message, 'error');
+      setDeleteTarget(null);
+    },
+  });
+
+  const openNew = useCallback(() => {
+    setIsNew(true);
+    setBuyerId('');
+    setSelectedProjects([]);
+    setCostCodesText('');
+    setEditOpen(true);
+  }, []);
+
+  const openEdit = useCallback(
+    (row: BuyerAssignmentRow) => {
+      setIsNew(false);
+      setBuyerId(row.buyerId);
+      const assignedIds = new Set(row.projects.map((p) => p.id));
+      setSelectedProjects(projects.filter((p) => assignedIds.has(p.id)));
+      setCostCodesText(row.costCodes.join('\n'));
+      setEditOpen(true);
+    },
+    [projects],
+  );
+
+  const handleSave = useCallback(() => {
+    saveAssignment({
+      variables: {
+        buyerId: buyerId.trim(),
+        projectIds: selectedProjects.map((p) => p.id),
+        costCodes: costCodesText
+          .split('\n')
+          .map((c) => c.trim())
+          .filter(Boolean),
+      },
+    });
+  }, [saveAssignment, buyerId, selectedProjects, costCodesText]);
+
+  const columns = useMemo<GridColDef[]>(
+    () => [
+      { field: 'buyerId', headerName: 'GP Buyer', width: 160 },
+      {
+        field: 'projects',
+        headerName: 'Assigned Projects',
+        flex: 2,
+        sortable: false,
+        renderCell: (params) => (
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', py: 0.5 }}>
+            {(params.row.projects as AssignmentProject[]).length > 0
+              ? (params.row.projects as AssignmentProject[]).map((p) => (
+                  <Chip key={p.id} size="small" label={projectLabel(p)} />
+                ))
+              : '—'}
+          </Box>
+        ),
+      },
+      {
+        field: 'costCodes',
+        headerName: 'Designated Cost Codes',
+        flex: 1,
+        sortable: false,
+        valueGetter: (_value: unknown, row: BuyerAssignmentRow) =>
+          row.costCodes.length > 0 ? row.costCodes.join(', ') : '—',
+      },
+      {
+        field: 'actions',
+        headerName: '',
+        width: 60,
+        sortable: false,
+        filterable: false,
+        renderCell: (params) => (
+          <IconButton
+            size="small"
+            color="error"
+            aria-label={`Delete assignment for ${params.row.buyerId}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              setDeleteTarget(params.row.buyerId);
+            }}
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        ),
+      },
+    ],
+    [],
+  );
+
+  if (!isAdmin) {
+    return (
+      <Alert severity="error" sx={{ mt: 2 }}>
+        You do not have permission to manage buyers. The Admin/Manager role is required.
+      </Alert>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="h5">Buyers</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Which projects each GP buyer may create POs for, and their designated cost codes. A buyer
+            with no assignment cannot create project POs. Link accounts to buyers in User Management.
+          </Typography>
+        </Box>
+        <Button variant="contained" size="small" startIcon={<AddIcon />} onClick={openNew}>
+          Add Buyer
+        </Button>
+      </Box>
+
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        getRowId={(row) => row.buyerId}
+        loading={loading}
+        density="compact"
+        getRowHeight={() => 'auto'}
+        disableRowSelectionOnClick
+        onRowClick={(params: GridRowParams<BuyerAssignmentRow>) => openEdit(params.row)}
+        hideFooter={rows.length <= 25}
+        autoHeight
+      />
+
+      <Dialog open={editOpen} onClose={() => setEditOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{isNew ? 'Add Buyer Assignment' : `Edit Buyer: ${buyerId}`}</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="GP Buyer ID"
+            value={buyerId}
+            onChange={(e) => setBuyerId(e.target.value)}
+            size="small"
+            fullWidth
+            disabled={!isNew}
+            sx={{ mt: 1, mb: 2 }}
+            helperText={isNew ? 'The GP BUYERID exactly as it appears in GP (POP00101)' : ''}
+          />
+          <Autocomplete
+            multiple
+            options={projects}
+            value={selectedProjects}
+            onChange={(_, next) => setSelectedProjects(next)}
+            getOptionLabel={(p) => projectLabel(p)}
+            isOptionEqualToValue={(a, b) => a.id === b.id}
+            renderInput={(params) => <TextField {...params} label="Assigned projects" size="small" />}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            label="Designated cost codes"
+            value={costCodesText}
+            onChange={(e) => setCostCodesText(e.target.value)}
+            size="small"
+            fullWidth
+            multiline
+            minRows={3}
+            maxRows={8}
+            placeholder={'310-000\n210-200'}
+            helperText="One per line, as 'cc1-cc2' (the code without the element digit)"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleSave} disabled={saving || !buyerId.trim()}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Delete buyer assignment?"
+        message={`Buyer '${deleteTarget}' will no longer be able to create project POs.`}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={() => deleteAssignment({ variables: { buyerId: deleteTarget } })}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/UserManagementPage.tsx
+++ b/frontend/src/modules/admin/UserManagementPage.tsx
@@ -13,11 +13,12 @@ import {
   Checkbox,
   Avatar,
   Stack,
+  TextField,
 } from '@mui/material';
 import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_USERS } from '../../graphql/queries';
-import { UPDATE_USER_ROLES } from '../../graphql/mutations';
+import { UPDATE_USER_GP_BUYER_ID, UPDATE_USER_ROLES } from '../../graphql/mutations';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 
@@ -37,6 +38,8 @@ interface ClerkUser {
   lastName: string;
   email: string;
   roles: string[];
+  // Issue #216: the GP BUYERID this account acts as when creating POs, or null.
+  gpBuyerId: string | null;
   imageUrl: string;
 }
 
@@ -71,6 +74,12 @@ const columns: GridColDef[] = [
     valueGetter: (_value: unknown, row: ClerkUser) =>
       row.roles.length > 0 ? row.roles.join(', ') : 'No roles',
   },
+  {
+    field: 'gpBuyerId',
+    headerName: 'GP Buyer',
+    width: 120,
+    valueGetter: (_value: unknown, row: ClerkUser) => row.gpBuyerId || '—',
+  },
 ];
 
 export default function UserManagementPage() {
@@ -78,22 +87,21 @@ export default function UserManagementPage() {
   const { showToast } = useToast();
   const [selectedUser, setSelectedUser] = useState<ClerkUser | null>(null);
   const [editRoles, setEditRoles] = useState<string[]>([]);
+  const [editGpBuyerId, setEditGpBuyerId] = useState('');
+  const [saving, setSaving] = useState(false);
 
   const { data, loading } = useQuery<{ users: ClerkUser[] }>(GET_USERS);
   const users = useMemo(() => data?.users ?? [], [data]);
 
-  const [updateRoles, { loading: saving }] = useMutation(UPDATE_USER_ROLES, {
+  const [updateRoles] = useMutation(UPDATE_USER_ROLES);
+  const [updateGpBuyerId] = useMutation(UPDATE_USER_GP_BUYER_ID, {
     refetchQueries: [{ query: GET_USERS }],
-    onCompleted: () => {
-      showToast('Roles updated successfully', 'success');
-      setSelectedUser(null);
-    },
-    onError: (err) => showToast(err.message, 'error'),
   });
 
   const handleRowClick = useCallback((params: GridRowParams<ClerkUser>) => {
     setSelectedUser(params.row);
     setEditRoles(params.row.roles);
+    setEditGpBuyerId(params.row.gpBuyerId ?? '');
   }, []);
 
   const handleToggleRole = useCallback((role: string) => {
@@ -102,10 +110,20 @@ export default function UserManagementPage() {
     );
   }, []);
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     if (!selectedUser) return;
-    updateRoles({ variables: { userId: selectedUser.id, roles: editRoles } });
-  }, [selectedUser, editRoles, updateRoles]);
+    setSaving(true);
+    try {
+      await updateRoles({ variables: { userId: selectedUser.id, roles: editRoles } });
+      await updateGpBuyerId({ variables: { userId: selectedUser.id, gpBuyerId: editGpBuyerId.trim() || null } });
+      showToast('User updated successfully', 'success');
+      setSelectedUser(null);
+    } catch (err: unknown) {
+      showToast(err instanceof Error ? err.message : 'Failed to update user', 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [selectedUser, editRoles, editGpBuyerId, updateRoles, updateGpBuyerId, showToast]);
 
   if (!isAdmin) {
     return (
@@ -121,7 +139,7 @@ export default function UserManagementPage() {
         User Management
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Click a user to manage their roles.
+        Click a user to manage their roles and GP buyer identity.
       </Typography>
 
       <DataGrid
@@ -143,7 +161,7 @@ export default function UserManagementPage() {
         fullWidth
       >
         <DialogTitle>
-          Edit Roles: {selectedUser ? [selectedUser.firstName, selectedUser.lastName].filter(Boolean).join(' ') || selectedUser.email : ''}
+          Edit User: {selectedUser ? [selectedUser.firstName, selectedUser.lastName].filter(Boolean).join(' ') || selectedUser.email : ''}
         </DialogTitle>
         <DialogContent>
           <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
@@ -177,6 +195,14 @@ export default function UserManagementPage() {
               />
             ))}
           </FormGroup>
+          <TextField
+            label="GP Buyer ID"
+            value={editGpBuyerId}
+            onChange={(e) => setEditGpBuyerId(e.target.value)}
+            size="small"
+            sx={{ mt: 2, width: 240 }}
+            helperText="The GP BUYERID this account creates POs as (issue #216). Blank = cannot create POs."
+          />
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelectedUser(null)}>Cancel</Button>

--- a/frontend/src/modules/admin/index.tsx
+++ b/frontend/src/modules/admin/index.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import ProjectPurchasingProgressPage from './ProjectPurchasingProgressPage';
 import OpeningStatusTab from './OpeningStatusTab';
 import UserManagementPage from './UserManagementPage';
+import BuyersPage from './BuyersPage';
 import VendorsPage from './VendorsPage';
 import WarehousesPage from './WarehousesPage';
 import ProjectsPage from './ProjectsPage';
@@ -31,6 +32,7 @@ export default function AdminModule() {
       <Route path="warehouses" element={<AdminSubLayout><WarehousesPage /></AdminSubLayout>} />
       <Route path="projects" element={<AdminSubLayout><ProjectsPage /></AdminSubLayout>} />
       <Route path="users" element={<AdminSubLayout><UserManagementPage /></AdminSubLayout>} />
+      <Route path="buyers" element={<AdminSubLayout><BuyersPage /></AdminSubLayout>} />
       <Route path="relay-installs" element={<AdminSubLayout><RelayInstallsPage /></AdminSubLayout>} />
       <Route path="location-cleanup" element={<AdminSubLayout><LocationCleanupPage /></AdminSubLayout>} />
       <Route path="*" element={<Navigate to="/app/admin" replace />} />

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -19,12 +19,13 @@ import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
 import { CREATE_PO, REGISTER_PO_IN_GP } from '../../graphql/mutations';
 import {
-  GET_GP_BUYERS,
+  GET_BUYER_ASSIGNMENTS,
   GET_GP_COST_CODES,
   GET_GP_VENDORS,
   GET_PROJECTS,
   SUGGEST_VENDOR_FOR_MANUFACTURER,
 } from '../../graphql/queries';
+import { useIdentity } from '../../hooks/useIdentity';
 import type { Project } from '../../types/project';
 import type { PurchaseOrder } from './index';
 import RelayStatusChip from '../../relay/RelayStatusChip';
@@ -119,8 +120,11 @@ export default function GpPurchaseOrderDialog({
   registerPo,
 }: GpPurchaseOrderDialogProps) {
   const { showToast } = useToast();
+  // Issue #216: the PO is created as the CALLER's GP buyer identity (Clerk publicMetadata.gpBuyerId),
+  // not a free pick. Enforced again server-side.
+  const { gpBuyerId } = useIdentity();
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
-  const projects = projectsData?.projects ?? [];
+  const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
 
   const isRegister = !!registerPo;
 
@@ -135,7 +139,6 @@ export default function GpPurchaseOrderDialog({
   // Issue #156: optional order-time dollar costs. Kept as strings ('' = not entered, distinct from 0).
   const [shippingCost, setShippingCost] = useState('');
   const [tariffAmount, setTariffAmount] = useState('');
-  const [buyerId, setBuyerId] = useState('');
   const [costCode, setCostCode] = useState('');
   const [nextKey, setNextKey] = useState(2);
   const [lineItems, setLineItems] = useState<LineItemRow[]>([{ key: 1, ...EMPTY_LINE_ITEM }]);
@@ -167,15 +170,42 @@ export default function GpPurchaseOrderDialog({
   const isJob = !!projectId && !!selectedProject;
   const jobNumber = selectedProject?.projectId ?? null;
 
-  // Registered buyers for the chosen company (POP00101), live from GP via the backend relay channel.
-  // cache-first so reopening the dialog reuses the loaded list instead of re-pulling it browser -> backend
-  // -> WS -> relay -> GP; the refresh control forces a re-pull when the master data changed.
-  const { data: buyersData, refetch: refetchBuyers } = useQuery<{ gpBuyers: string[] }>(GET_GP_BUYERS, {
-    variables: { company },
-    skip: !open || !relayConnected || !company,
-    fetchPolicy: 'cache-first',
+  // Issue #216: the caller's buyer assignment (their projects + designated cost codes). Strict: no
+  // assignment means no project POs - the project dropdown offers only assigned projects and the
+  // cost-code dropdown only designated codes.
+  interface BuyerAssignmentData {
+    buyerId: string;
+    costCodes: string[];
+    projects: { id: string; projectId: string; description: string | null }[];
+  }
+  const { data: assignmentsData } = useQuery<{ buyerAssignments: BuyerAssignmentData[] }>(GET_BUYER_ASSIGNMENTS, {
+    skip: !open,
+    fetchPolicy: 'cache-and-network',
   });
-  const buyers = buyersData?.gpBuyers ?? [];
+  const myAssignment = useMemo(() => {
+    if (!gpBuyerId) return null;
+    return (
+      (assignmentsData?.buyerAssignments ?? []).find(
+        (a) => a.buyerId.trim().toUpperCase() === gpBuyerId.trim().toUpperCase(),
+      ) ?? null
+    );
+  }, [assignmentsData, gpBuyerId]);
+  const assignedProjectIds = useMemo(() => new Set((myAssignment?.projects ?? []).map((p) => p.id)), [myAssignment]);
+  const designatedCostCodes = useMemo(() => new Set(myAssignment?.costCodes ?? []), [myAssignment]);
+  // Create mode offers only assigned projects (plus the stock-PO option); register mode's project is
+  // fixed by the draft, so instead the caller must be assigned to it.
+  const selectableProjects = useMemo(
+    () => projects.filter((p) => assignedProjectIds.has(p.id)),
+    [projects, assignedProjectIds],
+  );
+  const registerProjectAllowed = !isRegister || !registerPo?.projectId || assignedProjectIds.has(registerPo.projectId);
+
+  // A preset project (opened from a project's PO page) the caller isn't assigned to falls back to
+  // no-project once assignments load, so the Select never holds a value outside its options.
+  useEffect(() => {
+    if (!open || isRegister || !projectId || !assignmentsData) return;
+    if (!assignedProjectIds.has(projectId)) setProjectId('');
+  }, [open, isRegister, projectId, assignmentsData, assignedProjectIds]);
 
   // Live GP vendor list (PM00200), per company - issue #200 replaces the locally-synced vendor mirror
   // with a direct pick from this list, snapshotted onto the PO.
@@ -256,7 +286,8 @@ export default function GpPurchaseOrderDialog({
     skip: !open || !relayConnected || !company || !jobNumber,
     fetchPolicy: 'cache-first',
   });
-  const costCodes = costCodesData?.gpCostCodes ?? [];
+  // Issue #216: only the caller's designated cost codes ('cc1-cc2') are offered for the job.
+  const costCodes = (costCodesData?.gpCostCodes ?? []).filter((c) => designatedCostCodes.has(c.costCode));
 
   // Seed the form when the dialog opens. Create mode -> empty; register mode -> the draft's values
   // (project locked, line items carrying their ids so edits map back). The vendor is seeded separately
@@ -280,7 +311,6 @@ export default function GpPurchaseOrderDialog({
     seededRef.current = true;
     // Fresh open = fresh user action, so start a new idempotency key on the next submit.
     idempotencyKeyRef.current = null;
-    setBuyerId('');
     setCostCode('');
     setErrors({});
     if (registerPo) {
@@ -403,7 +433,9 @@ export default function GpPurchaseOrderDialog({
     if (!relayConnected) errs.gp = 'GP relay not detected on this machine - it must be running to push a PO to GP';
     if (!gpVendorId) errs.vendor = 'Select a GP vendor';
     else if (isRegister && !vendorConfirmed) errs.vendor = 'Confirm the suggested GP vendor before registering';
-    if (!buyerId) errs.buyer = 'Select a buyer';
+    // Issue #216: the PO is pushed as the caller's own GP buyer identity.
+    if (!gpBuyerId) errs.buyer = 'Your account has no GP buyer identity - ask an Admin to set it in User Management';
+    else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
     if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
@@ -412,7 +444,7 @@ export default function GpPurchaseOrderDialog({
       errs.tariffAmount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, buyerId, isJob, costCode, shippingCost, tariffAmount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -448,7 +480,7 @@ export default function GpPurchaseOrderDialog({
               poId: registerPo.id,
               gpVendorId,
               gpVendorName,
-              buyerId,
+              buyerId: gpBuyerId,
               gpCompany: company,
               costCode: gpCostCode,
               shippingCost: shippingCostValue,
@@ -469,7 +501,7 @@ export default function GpPurchaseOrderDialog({
               projectId: projectId || null,
               gpVendorId,
               gpVendorName,
-              buyerId,
+              buyerId: gpBuyerId,
               notes: notes.trim() || null,
               costCode: gpCostCode,
               shippingCost: shippingCostValue,
@@ -501,7 +533,7 @@ export default function GpPurchaseOrderDialog({
     isJob,
     costCode,
     company,
-    buyerId,
+    gpBuyerId,
     lineItems,
     projectId,
     gpVendorId,
@@ -585,6 +617,18 @@ export default function GpPurchaseOrderDialog({
           <GpErrorAlert error={gpError} onClose={() => setGpError(null)} />
         </Box>
       )}
+      {/* Issue #216: POs are created as YOUR GP buyer identity, against your assigned projects. */}
+      {!gpBuyerId ? (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Your account has no GP buyer identity - an Admin must set it in User Management before you can
+          create purchase orders.
+        </Alert>
+      ) : isRegister && !registerProjectAllowed ? (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Buyer {gpBuyerId} is not assigned to this project - an Admin can change assignments under
+          Admin → Buyers.
+        </Alert>
+      ) : null}
       {/* Header Fields */}
       <Stack spacing={2} sx={{ mb: 3 }}>
         <TextField
@@ -595,9 +639,14 @@ export default function GpPurchaseOrderDialog({
           size="small"
           fullWidth
           disabled={isRegister}
+          helperText={
+            !isRegister && gpBuyerId && selectableProjects.length === 0
+              ? `Buyer ${gpBuyerId} has no assigned projects - only a stock PO is possible`
+              : ''
+          }
         >
           <MenuItem value="">No Project (stock PO)</MenuItem>
-          {projects.map((p) => (
+          {(isRegister ? projects : selectableProjects).map((p) => (
             <MenuItem key={p.id} value={p.id}>
               {p.description || p.projectId}
             </MenuItem>
@@ -698,34 +747,14 @@ export default function GpPurchaseOrderDialog({
             sx={{ minWidth: 140 }}
             disabled
           />
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
-            <TextField
-              select
-              label="Buyer"
-              value={buyerId}
-              onChange={(e) => setBuyerId(e.target.value)}
-              size="small"
-              sx={{ minWidth: 180 }}
-              disabled={!relayConnected || buyers.length === 0}
-              error={!!errors.buyer}
-              helperText={errors.buyer}
-            >
-              {buyers.map((b) => (
-                <MenuItem key={b} value={b}>
-                  {b}
-                </MenuItem>
-              ))}
-            </TextField>
-            <IconButton
-              size="small"
-              aria-label="Refresh buyers"
-              onClick={() => refetchBuyers()}
-              disabled={!relayConnected}
-              sx={{ mt: 0.5 }}
-            >
-              <RefreshIcon fontSize="small" />
-            </IconButton>
-          </Box>
+          {/* Issue #216: the buyer IS the caller's GP identity - display only, never a pick. */}
+          <TextField
+            label="Buyer (you)"
+            value={gpBuyerId ?? '—'}
+            size="small"
+            sx={{ minWidth: 180 }}
+            disabled
+          />
           <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
             <TextField
               select


### PR DESCRIPTION
closes #216 (final part - pt1 was #258, GP-side items split to #257)

buyers are now identities, not free picks. a UC Nexus account links to its GP BUYERID via Clerk publicMetadata.gpBuyerId, set per user in User Management (metadata writes switched to Clerk's merge endpoint - the old PATCH replaced the whole object, so saving roles would have wiped the buyer id).

new Admin -> Buyers page (buyer_assignments + M2M projects, migration 053):
- assigned projects per buyer
- designated cost codes per buyer ('cc1-cc2', one per line)
- STRICT: a buyer with no assignment cannot create project POs; stock POs stay ungated

create/register PO dialog:
- buyer field is read-only = your identity; blocking alert when the account has none
- create mode: project dropdown offers only your assigned projects, cost-code dropdown only your designated codes; a preset project you aren't assigned to falls back to stock PO
- register mode: the draft's project is fixed, so you must be assigned to it or submit blocks

server-side enforcement on both GP push paths: input buyer_id must equal the caller's identity, and validate_buyer_can_order checks project + cost code before anything reaches the relay.

repo tests cover assignment CRUD, strict validation paths, and the identity assertion; existing _prepare_* tests seed assignments.