### PR TITLE
Fix #236: min-score floor on manufacturer->vendor fuzzy suggestions

### DIFF
--- a/backend/app/services/manufacturer_match.py
+++ b/backend/app/services/manufacturer_match.py
@@ -23,6 +23,13 @@ _WHITESPACE = re.compile(r"\s+")
 # collapse. Longest-first alternation matters: "OF CANADA" must be tried before bare "CANADA".
 _LEGAL_SUFFIX = re.compile(r"\s+(?:OF\s+CANADA|CANADA|LTEE|CORP|LTD|INC|CO)$")
 
+# Issue #236: minimum fuzzy score for a vendor to count as a candidate at all. Below this, a
+# manufacturer simply has no match - the dialog shows its "pick a vendor manually" note instead of
+# pre-selecting junk (a 44% match auto-confirmed a wrong vendor in prod). token_set_ratio scores
+# genuine partial matches (subset tokens like "SCHLAGE LOCK CO" vs "SCHLAGE") at or near 100, so a
+# floor of 70 keeps real candidates while dropping coincidental letter overlap.
+MIN_SCORE = 70.0
+
 
 def normalize(name: str | None) -> str:
     """Canonical manufacturer key: uppercase, punctuation->space, whitespace collapsed, trailing legal
@@ -53,11 +60,12 @@ def score(a: str, b: str) -> float:
     return SequenceMatcher(None, a, b).ratio() * 100.0
 
 
-def rank_vendors(manufacturer: str, vendors: list[dict], top_n: int = 5) -> list[dict]:
+def rank_vendors(manufacturer: str, vendors: list[dict], top_n: int = 5, min_score: float = MIN_SCORE) -> list[dict]:
     """Rank live GP vendors by fuzzy match of their name to `manufacturer`, best first, capped at
     top_n. Each vendor dict is expected to carry `vendor_id` + `vendor_name`. Returns a list of
     {"gp_vendor_id", "gp_vendor_name", "score"} dicts. An empty/blank manufacturer yields no
-    candidates (nothing to rank against)."""
+    candidates (nothing to rank against), and neither does one whose best match scores below
+    min_score (issue #236 - no candidate beats a junk candidate the dialog would pre-select)."""
     key = normalize(manufacturer)
     if not key:
         return []
@@ -69,6 +77,7 @@ def rank_vendors(manufacturer: str, vendors: list[dict], top_n: int = 5) -> list
         }
         for v in vendors
     ]
+    scored = [c for c in scored if c["score"] >= min_score]
     # Highest score first; break ties by name so the ordering is deterministic.
     scored.sort(key=lambda c: (-c["score"], c["gp_vendor_name"]))
     return scored[:top_n]

--- a/backend/tests/test_manufacturer_match.py
+++ b/backend/tests/test_manufacturer_match.py
@@ -50,19 +50,39 @@ def test_score_zero_for_empty_side():
 
 
 def test_rank_vendors_orders_best_first_and_caps():
+    # All three are token-subset matches (score 100 under token_set_ratio); ties break by name so
+    # the ordering is deterministic, and top_n caps the list.
     vendors = [
         {"vendor_id": "V1", "vendor_name": "Acme Inc"},
-        {"vendor_id": "V2", "vendor_name": "Schlage Lock Company"},
-        {"vendor_id": "V3", "vendor_name": "Best Access"},
+        {"vendor_id": "V2", "vendor_name": "Acme Hardware Group"},
+        {"vendor_id": "V3", "vendor_name": "Acme Hardware Group of Canada"},
     ]
     ranked = m.rank_vendors("ACME", vendors, top_n=2)
     assert len(ranked) == 2
-    assert ranked[0]["gp_vendor_id"] == "V1"
-    assert ranked[0]["score"] == 100.0
-    assert ranked[0]["score"] >= ranked[1]["score"]
+    assert ranked[0]["score"] >= ranked[1]["score"] >= m.MIN_SCORE
+    assert [c["gp_vendor_name"] for c in ranked] == sorted(c["gp_vendor_name"] for c in ranked)
 
 
 def test_rank_vendors_blank_manufacturer_returns_nothing():
     vendors = [{"vendor_id": "V1", "vendor_name": "Acme Inc"}]
     assert m.rank_vendors("", vendors) == []
     assert m.rank_vendors("   ", vendors) == []
+
+
+def test_rank_vendors_drops_weak_matches_below_the_floor():
+    # Issue #236: the 44%-style coincidental overlap must yield NO candidates, not a junk
+    # pre-select (seen on prod: ZZQX WIDGETWORKS INC -> BRIDGEPORT WORLDWIDE at 44).
+    vendors = [
+        {"vendor_id": "V1", "vendor_name": "Bridgeport Worldwide"},
+        {"vendor_id": "V2", "vendor_name": "Best Access"},
+    ]
+    assert m.rank_vendors("ZZQX WIDGETWORKS INC", vendors) == []
+
+
+def test_rank_vendors_keeps_genuine_partial_matches():
+    # token_set_ratio scores subset-token names at/near 100, so real partials survive the floor.
+    vendors = [{"vendor_id": "V1", "vendor_name": "Schlage Lock Company"}]
+    ranked = m.rank_vendors("SCHLAGE", vendors)
+    assert len(ranked) == 1
+    assert ranked[0]["gp_vendor_id"] == "V1"
+    assert ranked[0]["score"] >= m.MIN_SCORE


### PR DESCRIPTION
closes #236

rank_vendors now drops candidates below MIN_SCORE (70). a manufacturer with only coincidental overlap (the prod ZZQX -> BRIDGEPORT 44% case) yields no candidates, the hint reaches its previously-unreachable 'empty' kind, and the dialog shows "pick a vendor manually" with nothing pre-selected or auto-confirmed.

- token_set_ratio scores genuine subset-token partials (SCHLAGE vs Schlage Lock Company) at or near 100, so real matches and saved mappings are unaffected
- no frontend change needed - computeManufacturerVendorHint already returns 'empty' for zero candidates
- tests cover the floor drop, partial-match survival, and deterministic tie ordering