### PR TITLE
Add #240: admin display-name editing in User Management

### DIFF
--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -129,6 +129,19 @@ def update_user_roles(user_id: str, roles: list[str]) -> dict:
     return _merge_public_metadata(user_id, {"roles": roles})
 
 
+def update_user_name(user_id: str, first_name: str, last_name: str) -> dict:
+    """Issue #240: admin-driven display-name change. first_name/last_name are top-level Clerk user
+    fields (not metadata), so this never touches roles/gpBuyerId. Everything that shows a display
+    name (useIdentity fullName, resolve_display_name for received_by) derives from these."""
+    resp = _client.patch(
+        f"/users/{user_id}",
+        headers=_headers(),
+        json={"first_name": (first_name or "").strip(), "last_name": (last_name or "").strip()},
+    )
+    resp.raise_for_status()
+    return _user_summary(resp.json())
+
+
 def update_user_gp_buyer_id(user_id: str, gp_buyer_id: str | None) -> dict:
     """Issue #216: set (or clear, with None) the GP BUYERID this UC Nexus account acts as. The PO
     dialog auto-uses it and the create/register mutations enforce it server-side."""

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -1541,6 +1541,11 @@ class Mutation:
         return _clerk_user_to_type(user_repository.update_user_roles(user_id, roles))
 
     @strawberry.mutation
+    def update_user_name(self, user_id: str, first_name: str, last_name: str) -> ClerkUser:
+        """Issue #240: admin-driven display-name change (Clerk first/last name)."""
+        return _clerk_user_to_type(user_repository.update_user_name(user_id, first_name, last_name))
+
+    @strawberry.mutation
     def update_user_gp_buyer_id(self, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:
         """Issue #216: link a UC Nexus account to the GP BUYERID it acts as (null clears). The PO
         dialog auto-uses the caller's identity and createPo/registerPoInGp enforce it."""

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -584,6 +584,20 @@ export const UPDATE_USER_ROLES = gql`
   }
 `;
 
+export const UPDATE_USER_NAME = gql`
+  mutation UpdateUserName($userId: String!, $firstName: String!, $lastName: String!) {
+    updateUserName(userId: $userId, firstName: $firstName, lastName: $lastName) {
+      id
+      firstName
+      lastName
+      email
+      roles
+      gpBuyerId
+      imageUrl
+    }
+  }
+`;
+
 export const UPDATE_USER_GP_BUYER_ID = gql`
   mutation UpdateUserGpBuyerId($userId: String!, $gpBuyerId: String) {
     updateUserGpBuyerId(userId: $userId, gpBuyerId: $gpBuyerId) {

--- a/frontend/src/modules/admin/UserManagementPage.tsx
+++ b/frontend/src/modules/admin/UserManagementPage.tsx
@@ -18,7 +18,7 @@ import {
 import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_USERS } from '../../graphql/queries';
-import { UPDATE_USER_GP_BUYER_ID, UPDATE_USER_ROLES } from '../../graphql/mutations';
+import { UPDATE_USER_GP_BUYER_ID, UPDATE_USER_NAME, UPDATE_USER_ROLES } from '../../graphql/mutations';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 
@@ -88,12 +88,16 @@ export default function UserManagementPage() {
   const [selectedUser, setSelectedUser] = useState<ClerkUser | null>(null);
   const [editRoles, setEditRoles] = useState<string[]>([]);
   const [editGpBuyerId, setEditGpBuyerId] = useState('');
+  // Issue #240: admin-editable display name (Clerk first/last name).
+  const [editFirstName, setEditFirstName] = useState('');
+  const [editLastName, setEditLastName] = useState('');
   const [saving, setSaving] = useState(false);
 
   const { data, loading } = useQuery<{ users: ClerkUser[] }>(GET_USERS);
   const users = useMemo(() => data?.users ?? [], [data]);
 
   const [updateRoles] = useMutation(UPDATE_USER_ROLES);
+  const [updateName] = useMutation(UPDATE_USER_NAME);
   const [updateGpBuyerId] = useMutation(UPDATE_USER_GP_BUYER_ID, {
     refetchQueries: [{ query: GET_USERS }],
   });
@@ -102,6 +106,8 @@ export default function UserManagementPage() {
     setSelectedUser(params.row);
     setEditRoles(params.row.roles);
     setEditGpBuyerId(params.row.gpBuyerId ?? '');
+    setEditFirstName(params.row.firstName ?? '');
+    setEditLastName(params.row.lastName ?? '');
   }, []);
 
   const handleToggleRole = useCallback((role: string) => {
@@ -115,6 +121,15 @@ export default function UserManagementPage() {
     setSaving(true);
     try {
       await updateRoles({ variables: { userId: selectedUser.id, roles: editRoles } });
+      // Issue #240: only write the name when it actually changed (Clerk PATCH is not a no-op).
+      if (
+        editFirstName.trim() !== (selectedUser.firstName ?? '') ||
+        editLastName.trim() !== (selectedUser.lastName ?? '')
+      ) {
+        await updateName({
+          variables: { userId: selectedUser.id, firstName: editFirstName.trim(), lastName: editLastName.trim() },
+        });
+      }
       await updateGpBuyerId({ variables: { userId: selectedUser.id, gpBuyerId: editGpBuyerId.trim() || null } });
       showToast('User updated successfully', 'success');
       setSelectedUser(null);
@@ -123,7 +138,7 @@ export default function UserManagementPage() {
     } finally {
       setSaving(false);
     }
-  }, [selectedUser, editRoles, editGpBuyerId, updateRoles, updateGpBuyerId, showToast]);
+  }, [selectedUser, editRoles, editFirstName, editLastName, editGpBuyerId, updateRoles, updateName, updateGpBuyerId, showToast]);
 
   if (!isAdmin) {
     return (
@@ -180,6 +195,23 @@ export default function UserManagementPage() {
                 </Box>
               </>
             )}
+          </Stack>
+          {/* Issue #240: admin-editable display name (Clerk first/last name). */}
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <TextField
+              label="First name"
+              value={editFirstName}
+              onChange={(e) => setEditFirstName(e.target.value)}
+              size="small"
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              label="Last name"
+              value={editLastName}
+              onChange={(e) => setEditLastName(e.target.value)}
+              size="small"
+              sx={{ flex: 1 }}
+            />
           </Stack>
           <FormGroup>
             {ALL_ROLES.map((role) => (


### PR DESCRIPTION
closes #240

User Management's edit dialog gains First/Last name fields. updateUserName patches Clerk's top-level first_name/last_name - roles and gpBuyerId metadata are untouched, and everything that renders a display name (useIdentity fullName, resolve_display_name for received_by) derives from these fields. the name write is skipped when unchanged.