### PR TITLE
Add #256: manual PO creation lands as a draft

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -154,14 +154,14 @@ def create_po(
     buyer_id: str | None = None,
     shipping_cost: float | None = None,
     tariff_amount: float | None = None,
+    preferred_delivery_date=None,
 ) -> PurchaseOrder:
     """Create a manual PO with line items. No hardware items are created.
 
-    A manual PO is GP-first: the frontend pushes it to the GP relay and only calls this on success,
-    passing GP's returned po_number + gp_company. When those are present the PO is stamped and
-    advanced DRAFT -> GP_REGISTERED in this SAME commit, so there is no window where a created DRAFT
-    exists without its GP number (which would otherwise show "Register in GP" and let a retry create
-    a duplicate GP PO). Omitting them creates a plain DRAFT.
+    Issue #256: the manual path creates a plain DRAFT (no po_number/gp_company) - registering it
+    into GP is a separate, conscious user action (register_po_in_gp). The GP-first stamping branch
+    below (po_number + gp_company present, advancing DRAFT -> GP_REGISTERED in the same commit)
+    remains for callers that already hold a GP result.
 
     gp_vendor_id/vendor_name_snapshot are the GP vendor picked live from gpVendors at push time
     (issue #200 - there is no local vendor-to-GP mirror), frozen onto the PO for display."""
@@ -202,6 +202,8 @@ def create_po(
         buyer_id=buyer_id.strip() if buyer_id and buyer_id.strip() else None,
         shipping_cost=_coerce_order_cost(shipping_cost, "shipping_cost"),
         tariff_amount=_coerce_order_cost(tariff_amount, "tariff_amount"),
+        # Issue #216/#256: the PM's requested date, captured at request creation.
+        preferred_delivery_date=preferred_delivery_date,
     )
     session.add(po)
     session.flush()

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -179,35 +179,21 @@ class CreatePOLineItemInput:
 
 
 @strawberry.input
-class CreatePOInput:
-    """Issue #199: GP-first, server-side. The resolver pushes this to GP via relay_call (create_po)
-    BEFORE persisting anything, using GP's returned PONUMBER + company, so the PO is created already
-    GP-registered in one commit (no numberless DRAFT window)."""
+class CreateDraftPOInput:
+    """Issue #256: manual PO creation lands as a plain DRAFT - no relay, no GP fields. Registering
+    the draft into GP (register_po_in_gp) is a separate, conscious user action where the GP vendor,
+    buyer identity, and cost code are captured."""
 
     line_items: list[CreatePOLineItemInput]
-    # The GP vendor picked live from the gpVendors(company) list (issue #200 - there's no local
-    # vendor-to-GP mirror anymore). Snapshotted onto the PO for display.
-    gp_vendor_id: str
-    gp_vendor_name: str
-    gp_company: str
-    # GP buyer (POP00101), picked from the gpBuyers dropdown - always sent so the relay's own
-    # per-workstation buyer fallback never decides it for a server-brokered call.
-    buyer_id: str
     project_id: strawberry.ID | None = None
-    # Optional link to a UC Nexus vendor record (contact info), independent of the GP vendor above.
+    # Optional link to a UC Nexus vendor record (contact info).
     vendor_id: strawberry.ID | None = None
     notes: str | None = None
-    # GP cost code for a project-linked PO (the issue #121 dropdown, 'phase-step-element').
-    # Applied to every job-cost line when the PO is pushed to GP via the relay.
-    cost_code: str | None = None
+    # Issue #216: the PM's requested date, captured at request creation.
+    preferred_delivery_date: date | None = None
     # Issue #156: optional order-time dollar costs. Null means "not entered"; 0 is a valid value.
     shipping_cost: float | None = None
     tariff_amount: float | None = None
-    # Optional custom PO number to request from GP; the relay reserves GP's next number when omitted.
-    po_number: str | None = None
-    # Issue #202 #1: client-generated key (one per user action, re-sent on retry) that makes this
-    # GP-first write idempotent - a retry returns the already-created PO instead of a second GP PO.
-    idempotency_key: str = ""
 
 
 @strawberry.input

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -35,7 +35,7 @@ from .inputs import (
     AssignOpeningsInput,
     CompleteOpeningInput,
     ConfirmShipmentInput,
-    CreatePOInput,
+    CreateDraftPOInput,
     CreateReceiveInput,
     CreateShipmentReturnInput,
     CreateVendorInput,
@@ -190,52 +190,6 @@ def _resolve_line_manufacturers(session, project_id, line_items_data) -> list[st
     return resolved
 
 
-def _prepare_create_po(*, project_id, vendor_id, gp_vendor_id, buyer_id, cost_code, po_number, line_items_data) -> dict:
-    """Read-only: resolve the vendor contact + job number, pre-validate the fields, and build the relay
-    create_po payload. Raises before the GP write so a bad request never reaches the relay."""
-    from app.models.project import Project as ProjectModel
-    from app.models.vendor import Vendor as VendorModel
-
-    with SessionLocal() as session:
-        vendor_contact_name = None
-        if vendor_id is not None:
-            vendor = session.get(VendorModel, vendor_id)
-            if vendor is None:
-                raise NotFoundError(f"Vendor {vendor_id} not found")
-            vendor_contact_name = vendor.contact_name
-
-        job_number = None
-        if project_id is not None:
-            project = session.get(ProjectModel, project_id)
-            if project is None:
-                raise NotFoundError(f"Project {project_id} not found")
-            job_number = project.project_id
-
-        # Issue #216: a project PO requires the buyer to be assigned to the project with a
-        # designated cost code (strict - no assignment row means no project POs).
-        buyer_repository.validate_buyer_can_order(session, buyer_id, project_id, cost_code)
-
-        manufacturers = _resolve_line_manufacturers(session, project_id, line_items_data)
-
-    gp_po.validate_create_po_inputs(
-        job_number=job_number, cost_code=cost_code, po_number=po_number, line_items=line_items_data
-    )
-    payload = gp_po.build_create_po_payload(
-        vendor_gp_id=gp_vendor_id,
-        vendor_contact_name=vendor_contact_name,
-        buyer_id=buyer_id,
-        job_number=job_number,
-        cost_code=cost_code,
-        po_number=po_number,
-        line_items=line_items_data,
-    )
-    # build_create_po_payload emits one line per line_items_data entry, in order, so index-align the
-    # resolved manufacturers onto the relay payload lines (the relay caps/RTRIMs to USRDEFND1's char(50)).
-    for line, manufacturer in zip(payload["lines"], manufacturers):
-        line["manufacturer"] = manufacturer
-    return payload
-
-
 def _assert_buyer_identity(caller_gp_buyer_id: str | None, input_buyer_id: str) -> None:
     """Issue #216: a PO is pushed as the CALLER's GP buyer identity (Clerk publicMetadata.gpBuyerId),
     not a free pick - reject a missing identity or a mismatched buyer_id before anything hits GP."""
@@ -246,42 +200,6 @@ def _assert_buyer_identity(caller_gp_buyer_id: str | None, input_buyer_id: str) 
         )
     if (input_buyer_id or "").strip().upper() != caller_gp_buyer_id.strip().upper():
         raise ValidationError("POs can only be created as your own GP buyer", field="buyer_id")
-
-
-def _persist_create_po(
-    *,
-    key,
-    line_items_data,
-    project_id,
-    vendor_id,
-    notes,
-    cost_code,
-    gp_result,
-    gp_vendor_id,
-    vendor_name_snapshot,
-    buyer_id,
-    shipping_cost,
-    tariff_amount,
-) -> PurchaseOrder:
-    with SessionLocal() as session:
-        po = po_repository.create_po(
-            session,
-            line_items=line_items_data,
-            project_id=project_id,
-            vendor_id=vendor_id,
-            notes=notes,
-            cost_code=cost_code,
-            po_number=gp_result["po_number"],
-            gp_company=gp_result["company"],
-            gp_vendor_id=gp_vendor_id,
-            vendor_name_snapshot=vendor_name_snapshot,
-            buyer_id=buyer_id,
-            shipping_cost=shipping_cost,
-            tariff_amount=tariff_amount,
-        )
-        gp_idempotency.stamp_result_id(session, key, "create_po", gp_result, str(po.id))
-        session.commit()
-        return _load_po_within(session, po.id)
 
 
 def _prepare_register_po(*, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code, line_items_data) -> dict:
@@ -738,24 +656,12 @@ class Mutation:
 
     # PO
     @strawberry.mutation
-    async def create_po(self, info: strawberry.Info, input: CreatePOInput) -> PurchaseOrder:
-        """Issue #199: GP-first, server-side. Pushes the PO to GP via relay_call (create_po) BEFORE
-        persisting anything, then records it already carrying GP's returned PONUMBER + company in one
-        commit (it lands GP-Registered) - there is never a numberless DRAFT that could be re-registered
-        into a duplicate GP PO. Issue #200: the GP vendor is picked live (gpVendors) and sent as
-        gp_vendor_id/gp_vendor_name - there is no local vendor-to-GP mirror to look up anymore.
-
-        Issue #202 #1/#3: idempotency_key (client-generated, one per user action, re-sent on retry) makes
-        a retry a no-op in GP; fields are validated before the relay_call; the DB work is offloaded so no
-        Postgres connection is held across the relay round-trip."""
-        auth = require_user(info)
-        # Issue #216: the PO is pushed as the caller's own GP buyer identity, never a free pick.
-        caller_buyer = await asyncio.to_thread(user_repository.get_user_gp_buyer_id, auth["user_id"])
-        _assert_buyer_identity(caller_buyer, input.buyer_id)
-        key = gp_idempotency.validate_key(input.idempotency_key)
-
-        project_id = uuid.UUID(str(input.project_id)) if input.project_id else None
-        vendor_id = uuid.UUID(str(input.vendor_id)) if input.vendor_id else None
+    def create_draft_po(self, info: strawberry.Info, input: CreateDraftPOInput) -> PurchaseOrder:
+        """Issue #256: manual PO creation lands as a plain DRAFT - no relay round-trip, no GP fields,
+        no buyer involved. Registering the draft into GP (register_po_in_gp) is the separate,
+        conscious user action where GP vendor / buyer identity / cost code are captured and the
+        issue #216 assignment gating applies."""
+        require_user(info)
         line_items_data = [
             {
                 "hardware_category": li.hardware_category,
@@ -767,43 +673,19 @@ class Mutation:
             }
             for li in input.line_items
         ]
-
-        state = await asyncio.to_thread(gp_idempotency.load, key)
-        if state is not None and state.result_id is not None:
-            return await asyncio.to_thread(_load_po_type, uuid.UUID(state.result_id))
-
-        payload = await asyncio.to_thread(
-            _prepare_create_po,
-            project_id=project_id,
-            vendor_id=vendor_id,
-            gp_vendor_id=input.gp_vendor_id,
-            buyer_id=input.buyer_id,
-            cost_code=input.cost_code,
-            po_number=input.po_number,
-            line_items_data=line_items_data,
-        )
-
-        if state is not None and state.relay_result is not None:
-            gp_result = state.relay_result
-        else:
-            gp_result = await relay_gateway.relay_call(input.gp_company, "create_po", payload)
-            await asyncio.to_thread(gp_idempotency.record_relay_result, key, "create_po", gp_result)
-
-        return await asyncio.to_thread(
-            _persist_create_po,
-            key=key,
-            line_items_data=line_items_data,
-            project_id=project_id,
-            vendor_id=vendor_id,
-            notes=input.notes,
-            cost_code=input.cost_code,
-            gp_result=gp_result,
-            gp_vendor_id=input.gp_vendor_id,
-            vendor_name_snapshot=input.gp_vendor_name,
-            buyer_id=input.buyer_id,
-            shipping_cost=input.shipping_cost,
-            tariff_amount=input.tariff_amount,
-        )
+        with SessionLocal() as session:
+            po = po_repository.create_po(
+                session,
+                line_items=line_items_data,
+                project_id=uuid.UUID(str(input.project_id)) if input.project_id else None,
+                vendor_id=uuid.UUID(str(input.vendor_id)) if input.vendor_id else None,
+                notes=input.notes,
+                shipping_cost=input.shipping_cost,
+                tariff_amount=input.tariff_amount,
+                preferred_delivery_date=input.preferred_delivery_date,
+            )
+            session.commit()
+            return _load_po_within(session, po.id)
 
     @strawberry.mutation
     async def register_po_in_gp(self, info: strawberry.Info, input: RegisterPOInput) -> PurchaseOrder:

--- a/backend/tests/test_po_repository_create_po.py
+++ b/backend/tests/test_po_repository_create_po.py
@@ -9,14 +9,8 @@ from app.models.enums import HardwareItemState
 from app.models.hardware import HardwareItem
 from app.models.project import Opening, Project
 from app.models.vendor import Vendor
-from app.repositories import buyer_repository, po_repository
+from app.repositories import po_repository
 from app.schemas import mutations
-
-
-def _assign_buyer(session, buyer_id, project, cost_codes=("210-200",)):
-    """Issue #216: _prepare_create_po/_prepare_register_po enforce buyer->project/cost-code
-    assignments for project POs, so tests exercising them must seed one."""
-    return buyer_repository.save_assignment(session, buyer_id, [project.id], list(cost_codes))
 
 
 def _make_vendor(session, name: str = "Acme") -> Vendor:
@@ -24,25 +18,6 @@ def _make_vendor(session, name: str = "Acme") -> Vendor:
     session.add(v)
     session.flush()
     return v
-
-
-class _NoCloseSession:
-    """Wrap the test session as a context manager that does NOT close it (the db_session fixture owns
-    its lifecycle), so a monkeypatched _prepare_* runs against the test's uncommitted transaction
-    instead of opening a fresh, empty connection via the real SessionLocal()."""
-
-    def __init__(self, session):
-        self._session = session
-
-    def __enter__(self):
-        return self._session
-
-    def __exit__(self, *exc):
-        return False
-
-
-def _use_test_session(monkeypatch, db_session) -> None:
-    monkeypatch.setattr(mutations, "SessionLocal", lambda: _NoCloseSession(db_session))
 
 
 def _make_project(session) -> Project:
@@ -84,50 +59,32 @@ def _po_line(hardware_category, product_code, order_as="ML2010") -> dict:
     }
 
 
-# --- issue #233: _prepare_create_po resolves each line's manufacturer from matching HardwareItems ------
+# --- issue #233: _resolve_line_manufacturers resolves each line's manufacturer from HardwareItems ------
 
 
-def test_prepare_create_po_attaches_manufacturer_per_line(monkeypatch, db_session):
+def test_resolve_line_manufacturers_attaches_per_line(db_session):
     project = _make_project(db_session)
     _add_hardware_item(db_session, project, hardware_category="HINGE", product_code="HG-100", manufacturer="SCHLAGE")
     _add_hardware_item(db_session, project, hardware_category="LOCK", product_code="LK-200", manufacturer="SARGENT")
-    _assign_buyer(db_session, "mira", project)
-    _use_test_session(monkeypatch, db_session)
 
-    payload = mutations._prepare_create_po(
-        project_id=project.id,
-        vendor_id=None,
-        gp_vendor_id="GPV1",
-        buyer_id="mira",
-        cost_code="210-200-2",
-        po_number=None,
-        line_items_data=[_po_line("HINGE", "HG-100"), _po_line("LOCK", "LK-200")],
+    resolved = mutations._resolve_line_manufacturers(
+        db_session, project.id, [_po_line("HINGE", "HG-100"), _po_line("LOCK", "LK-200")]
     )
 
-    assert [line["manufacturer"] for line in payload["lines"]] == ["SCHLAGE", "SARGENT"]
+    assert resolved == ["SCHLAGE", "SARGENT"]
 
 
-def test_prepare_create_po_leaves_manufacturer_blank_without_a_hardware_match(monkeypatch, db_session):
+def test_resolve_line_manufacturers_blank_without_a_hardware_match(db_session):
     project = _make_project(db_session)
     # a hardware item exists, but not for this line's category + code
     _add_hardware_item(db_session, project, hardware_category="HINGE", product_code="HG-100", manufacturer="SCHLAGE")
-    _assign_buyer(db_session, "mira", project)
-    _use_test_session(monkeypatch, db_session)
 
-    payload = mutations._prepare_create_po(
-        project_id=project.id,
-        vendor_id=None,
-        gp_vendor_id="GPV1",
-        buyer_id="mira",
-        cost_code="210-200-2",
-        po_number=None,
-        line_items_data=[_po_line("LOCK", "LK-999")],
-    )
+    resolved = mutations._resolve_line_manufacturers(db_session, project.id, [_po_line("LOCK", "LK-999")])
 
-    assert payload["lines"][0]["manufacturer"] is None
+    assert resolved == [None]
 
 
-def test_prepare_create_po_disagreeing_items_take_first_non_null_and_log(monkeypatch, db_session, caplog):
+def test_resolve_line_manufacturers_disagreeing_items_take_first_non_null_and_log(db_session, caplog):
     project = _make_project(db_session)
     # same category + code across three openings: a null, then two conflicting manufacturers. created_at
     # is set explicitly so "first non-null" is deterministic (SCHLAGE precedes SARGENT).
@@ -155,38 +112,17 @@ def test_prepare_create_po_disagreeing_items_take_first_non_null_and_log(monkeyp
         manufacturer="SARGENT",
         created_at=datetime(2026, 1, 1, 0, 0, 2),
     )
-    _assign_buyer(db_session, "mira", project)
-    _use_test_session(monkeypatch, db_session)
 
     with caplog.at_level(logging.WARNING):
-        payload = mutations._prepare_create_po(
-            project_id=project.id,
-            vendor_id=None,
-            gp_vendor_id="GPV1",
-            buyer_id="mira",
-            cost_code="210-200-2",
-            po_number=None,
-            line_items_data=[_po_line("HINGE", "HG-100")],
-        )
+        resolved = mutations._resolve_line_manufacturers(db_session, project.id, [_po_line("HINGE", "HG-100")])
 
-    assert payload["lines"][0]["manufacturer"] == "SCHLAGE"
+    assert resolved == ["SCHLAGE"]
     assert any("manufacturer disagreement" in r.message for r in caplog.records)
 
 
-def test_prepare_create_po_without_a_project_sends_no_manufacturer(monkeypatch, db_session):
-    _use_test_session(monkeypatch, db_session)
-
-    payload = mutations._prepare_create_po(
-        project_id=None,
-        vendor_id=None,
-        gp_vendor_id="GPV1",
-        buyer_id="mira",
-        cost_code=None,
-        po_number=None,
-        line_items_data=[_po_line("HINGE", "HG-100")],
-    )
-
-    assert payload["lines"][0]["manufacturer"] is None
+def test_resolve_line_manufacturers_without_a_project_sends_none(db_session):
+    resolved = mutations._resolve_line_manufacturers(db_session, None, [_po_line("HINGE", "HG-100")])
+    assert resolved == [None]
 
 
 def _line_item(order_as: str | None) -> dict:

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -389,9 +389,9 @@ export const REGISTER_PO_IN_GP = gql`
   }
 `;
 
-export const CREATE_PO = gql`
-  mutation CreatePO($input: CreatePOInput!) {
-    createPo(input: $input) {
+export const CREATE_DRAFT_PO = gql`
+  mutation CreateDraftPO($input: CreateDraftPOInput!) {
+    createDraftPo(input: $input) {
       id
       poNumber
       requestNumber
@@ -408,6 +408,7 @@ export const CREATE_PO = gql`
         phone
       }
       notes
+      preferredDeliveryDate
       createdAt
       updatedAt
       lineItems {

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -17,7 +17,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
-import { CREATE_PO, REGISTER_PO_IN_GP } from '../../graphql/mutations';
+import { CREATE_DRAFT_PO, REGISTER_PO_IN_GP } from '../../graphql/mutations';
 import {
   GET_BUYER_ASSIGNMENTS,
   GET_GP_COST_CODES,
@@ -26,6 +26,7 @@ import {
   SUGGEST_VENDOR_FOR_MANUFACTURER,
 } from '../../graphql/queries';
 import { useIdentity } from '../../hooks/useIdentity';
+import VendorSelect from '../../components/VendorSelect';
 import type { Project } from '../../types/project';
 import type { PurchaseOrder } from './index';
 import RelayStatusChip from '../../relay/RelayStatusChip';
@@ -120,8 +121,8 @@ export default function GpPurchaseOrderDialog({
   registerPo,
 }: GpPurchaseOrderDialogProps) {
   const { showToast } = useToast();
-  // Issue #216: the PO is created as the CALLER's GP buyer identity (Clerk publicMetadata.gpBuyerId),
-  // not a free pick. Enforced again server-side.
+  // Issue #216: a PO is REGISTERED as the CALLER's GP buyer identity (Clerk publicMetadata.gpBuyerId),
+  // not a free pick - enforced again server-side. Drafting (issue #256) involves no buyer at all.
   const { gpBuyerId } = useIdentity();
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
   const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
@@ -139,6 +140,9 @@ export default function GpPurchaseOrderDialog({
   // Issue #156: optional order-time dollar costs. Kept as strings ('' = not entered, distinct from 0).
   const [shippingCost, setShippingCost] = useState('');
   const [tariffAmount, setTariffAmount] = useState('');
+  // Issue #256: create mode drafts carry an optional Nexus vendor link + the PM's preferred date.
+  const [vendorId, setVendorId] = useState<string | null>(null);
+  const [preferredDeliveryDate, setPreferredDeliveryDate] = useState('');
   const [costCode, setCostCode] = useState('');
   const [nextKey, setNextKey] = useState(2);
   const [lineItems, setLineItems] = useState<LineItemRow[]>([{ key: 1, ...EMPTY_LINE_ITEM }]);
@@ -148,7 +152,9 @@ export default function GpPurchaseOrderDialog({
   // user can screenshot it. Distinct from the field-level `errors` map.
   const [gpError, setGpError] = useState<GpError | null>(null);
 
-  const [createPO, { loading: createLoading }] = useMutation<{ createPo: { poNumber: string | null } }>(CREATE_PO);
+  const [createDraftPo, { loading: createLoading }] = useMutation<{ createDraftPo: { requestNumber: string } }>(
+    CREATE_DRAFT_PO,
+  );
   const [registerPoInGp, { loading: registerLoading }] = useMutation<{ registerPoInGp: { poNumber: string | null } }>(
     REGISTER_PO_IN_GP,
   );
@@ -161,7 +167,8 @@ export default function GpPurchaseOrderDialog({
   // GP relay status. The company comes from the connected relay (it's enrolled for exactly one), so it's
   // read from the hook here rather than picked by the user. The page still passes relayConnected in as
   // the single source of truth for the connected flag; standalone, the hook's own connected value is used.
-  const relay = useRelayStatus({ skip: !open });
+  // Issue #256: only register mode talks to GP - create mode is a plain draft and needs no relay.
+  const relay = useRelayStatus({ skip: !open || !isRegister });
   const company = relay.company ?? '';
   const relayStatus: boolean | null = relayConnectedProp !== undefined ? relayConnectedProp : relay.connected;
   const relayConnected = relayStatus === true;
@@ -170,16 +177,16 @@ export default function GpPurchaseOrderDialog({
   const isJob = !!projectId && !!selectedProject;
   const jobNumber = selectedProject?.projectId ?? null;
 
-  // Issue #216: the caller's buyer assignment (their projects + designated cost codes). Strict: no
-  // assignment means no project POs - the project dropdown offers only assigned projects and the
-  // cost-code dropdown only designated codes.
+  // Issue #216: the caller's buyer assignment (their projects + designated cost codes). Register-only
+  // (issue #256: drafting is open to everyone; the GP registration is where the buyer gating applies) -
+  // the caller must be assigned to the draft's project and only designated cost codes are offered.
   interface BuyerAssignmentData {
     buyerId: string;
     costCodes: string[];
     projects: { id: string; projectId: string; description: string | null }[];
   }
   const { data: assignmentsData } = useQuery<{ buyerAssignments: BuyerAssignmentData[] }>(GET_BUYER_ASSIGNMENTS, {
-    skip: !open,
+    skip: !open || !isRegister,
     fetchPolicy: 'cache-and-network',
   });
   const myAssignment = useMemo(() => {
@@ -192,26 +199,13 @@ export default function GpPurchaseOrderDialog({
   }, [assignmentsData, gpBuyerId]);
   const assignedProjectIds = useMemo(() => new Set((myAssignment?.projects ?? []).map((p) => p.id)), [myAssignment]);
   const designatedCostCodes = useMemo(() => new Set(myAssignment?.costCodes ?? []), [myAssignment]);
-  // Create mode offers only assigned projects (plus the stock-PO option); register mode's project is
-  // fixed by the draft, so instead the caller must be assigned to it.
-  const selectableProjects = useMemo(
-    () => projects.filter((p) => assignedProjectIds.has(p.id)),
-    [projects, assignedProjectIds],
-  );
   const registerProjectAllowed = !isRegister || !registerPo?.projectId || assignedProjectIds.has(registerPo.projectId);
-
-  // A preset project (opened from a project's PO page) the caller isn't assigned to falls back to
-  // no-project once assignments load, so the Select never holds a value outside its options.
-  useEffect(() => {
-    if (!open || isRegister || !projectId || !assignmentsData) return;
-    if (!assignedProjectIds.has(projectId)) setProjectId('');
-  }, [open, isRegister, projectId, assignmentsData, assignedProjectIds]);
 
   // Live GP vendor list (PM00200), per company - issue #200 replaces the locally-synced vendor mirror
   // with a direct pick from this list, snapshotted onto the PO.
   const { data: gpVendorsData, refetch: refetchVendors } = useQuery<{ gpVendors: GpVendorOption[] }>(GET_GP_VENDORS, {
     variables: { company },
-    skip: !open || !relayConnected || !company,
+    skip: !open || !isRegister || !relayConnected || !company,
     fetchPolicy: 'cache-first',
   });
   const gpVendors = gpVendorsData?.gpVendors ?? [];
@@ -238,7 +232,7 @@ export default function GpPurchaseOrderDialog({
   }, [open]);
 
   useEffect(() => {
-    if (!open || !relayConnected || !company || distinctManufacturers.length === 0) return;
+    if (!open || !isRegister || !relayConnected || !company || distinctManufacturers.length === 0) return;
     let cancelled = false;
     (async () => {
       // Fetch each manufacturer's suggestion concurrently, not one after another, so N distinct
@@ -264,7 +258,7 @@ export default function GpPurchaseOrderDialog({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, relayConnected, company, manufacturerKey, client]);
+  }, [open, isRegister, relayConnected, company, manufacturerKey, client]);
 
   const suggestionsLoaded =
     distinctManufacturers.length > 0 && distinctManufacturers.every((m) => mfrSuggestions[m] !== undefined);
@@ -283,7 +277,7 @@ export default function GpPurchaseOrderDialog({
     refetch: refetchCostCodes,
   } = useQuery<{ gpCostCodes: GpCostCode[] }>(GET_GP_COST_CODES, {
     variables: { company, job: jobNumber ?? '' },
-    skip: !open || !relayConnected || !company || !jobNumber,
+    skip: !open || !isRegister || !relayConnected || !company || !jobNumber,
     fetchPolicy: 'cache-first',
   });
   // Issue #216: only the caller's designated cost codes ('cc1-cc2') are offered for the job.
@@ -336,6 +330,8 @@ export default function GpPurchaseOrderDialog({
       setNotes('');
       setShippingCost('');
       setTariffAmount('');
+      setVendorId(null);
+      setPreferredDeliveryDate('');
       setLineItems([{ key: 1, ...EMPTY_LINE_ITEM }]);
       setNextKey(2);
     }
@@ -429,14 +425,17 @@ export default function GpPurchaseOrderDialog({
       if (isNaN(cost) || cost < 0) errs[`li_${i}_cost`] = 'Must be >= 0';
       if (!li.orderAs.trim()) errs[`li_${i}_orderAs`] = 'Required';
     }
-    // GP is mandatory: a PO that can't be created in GP isn't created/registered at all.
-    if (!relayConnected) errs.gp = 'GP relay not detected on this machine - it must be running to push a PO to GP';
-    if (!gpVendorId) errs.vendor = 'Select a GP vendor';
-    else if (isRegister && !vendorConfirmed) errs.vendor = 'Confirm the suggested GP vendor before registering';
-    // Issue #216: the PO is pushed as the caller's own GP buyer identity.
-    if (!gpBuyerId) errs.buyer = 'Your account has no GP buyer identity - ask an Admin to set it in User Management';
-    else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
-    if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
+    // Issue #256: only register mode talks to GP - draft creation has no relay/vendor/buyer/cost-code
+    // requirements at all.
+    if (isRegister) {
+      if (!relayConnected) errs.gp = 'GP relay not detected on this machine - it must be running to push a PO to GP';
+      if (!gpVendorId) errs.vendor = 'Select a GP vendor';
+      else if (!vendorConfirmed) errs.vendor = 'Confirm the suggested GP vendor before registering';
+      // Issue #216: the PO is pushed as the caller's own GP buyer identity.
+      if (!gpBuyerId) errs.buyer = 'Your account has no GP buyer identity - ask an Admin to set it in User Management';
+      else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
+      if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
+    }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
       errs.shippingCost = 'Must be >= 0';
@@ -495,24 +494,22 @@ export default function GpPurchaseOrderDialog({
         });
         showToast(`PO ${resp.data?.registerPoInGp?.poNumber} registered in GP`, 'success');
       } else {
-        const resp = await createPO({
+        // Issue #256: manual creation lands as a plain DRAFT - no relay, no GP fields. Registering
+        // it into GP is a separate, conscious action on the draft row.
+        const resp = await createDraftPo({
           variables: {
             input: {
               projectId: projectId || null,
-              gpVendorId,
-              gpVendorName,
-              buyerId: gpBuyerId,
+              vendorId: vendorId || null,
               notes: notes.trim() || null,
-              costCode: gpCostCode,
+              preferredDeliveryDate: preferredDeliveryDate || null,
               shippingCost: shippingCostValue,
               tariffAmount: tariffAmountValue,
-              gpCompany: company,
-              idempotencyKey,
               lineItems: lineItemsInput,
             },
           },
         });
-        showToast(`PO ${resp.data?.createPo?.poNumber} created in GP and UC Nexus`, 'success');
+        showToast(`PO request ${resp.data?.createDraftPo?.requestNumber} created as draft`, 'success');
       }
 
       // Succeeded: clear the key so a later reopen starts a new action.
@@ -523,8 +520,13 @@ export default function GpPurchaseOrderDialog({
       // the mutation reported failure, and reusing the key makes the retry safe.
       // Surface the full GP error persistently (issue #187) so the user can screenshot it; the toast
       // just points at the detail panel.
-      setGpError(extractGpError(err) ?? { message: 'Failed to push PO to GP' });
-      showToast("Could not complete the PO in GP - see the error detail below. A retry won't create a duplicate.", 'error');
+      setGpError(extractGpError(err) ?? { message: isRegister ? 'Failed to push PO to GP' : 'Failed to create the draft PO' });
+      showToast(
+        isRegister
+          ? "Could not complete the PO in GP - see the error detail below. A retry won't create a duplicate."
+          : 'Could not create the draft PO - see the error detail below.',
+        'error',
+      );
     } finally {
       setGpBusy(false);
     }
@@ -536,13 +538,16 @@ export default function GpPurchaseOrderDialog({
     gpBuyerId,
     lineItems,
     projectId,
+    vendorId,
+    preferredDeliveryDate,
     gpVendorId,
     gpVendorName,
     notes,
     shippingCost,
     tariffAmount,
     registerPo,
-    createPO,
+    isRegister,
+    createDraftPo,
     registerPoInGp,
     showToast,
     onSubmitted,
@@ -551,9 +556,9 @@ export default function GpPurchaseOrderDialog({
   // --- Render ---
 
   const busy = createLoading || registerLoading || gpBusy;
-  const title = isRegister ? 'Register Purchase Order in GP' : 'Create Purchase Order in GP';
-  const submitIdleLabel = isRegister ? 'Register in GP' : 'Create PO';
-  const submitBusyLabel = gpBusy ? 'Pushing to GP…' : isRegister ? 'Registering…' : 'Saving…';
+  const title = isRegister ? 'Register Purchase Order in GP' : 'Create PO Request (Draft)';
+  const submitIdleLabel = isRegister ? 'Register in GP' : 'Create Draft';
+  const submitBusyLabel = isRegister ? (gpBusy ? 'Pushing to GP…' : 'Registering…') : 'Saving…';
 
   // Status line under the cost-code dropdown (an explicit validation error takes precedence).
   const costCodeHelper =
@@ -617,11 +622,12 @@ export default function GpPurchaseOrderDialog({
           <GpErrorAlert error={gpError} onClose={() => setGpError(null)} />
         </Box>
       )}
-      {/* Issue #216: POs are created as YOUR GP buyer identity, against your assigned projects. */}
-      {!gpBuyerId ? (
+      {/* Issue #216: GP registration happens as YOUR buyer identity, against your assigned projects.
+          Drafting (issue #256) is open to everyone, so these gate register mode only. */}
+      {isRegister && !gpBuyerId ? (
         <Alert severity="error" sx={{ mb: 2 }}>
           Your account has no GP buyer identity - an Admin must set it in User Management before you can
-          create purchase orders.
+          register purchase orders.
         </Alert>
       ) : isRegister && !registerProjectAllowed ? (
         <Alert severity="error" sx={{ mb: 2 }}>
@@ -639,60 +645,74 @@ export default function GpPurchaseOrderDialog({
           size="small"
           fullWidth
           disabled={isRegister}
-          helperText={
-            !isRegister && gpBuyerId && selectableProjects.length === 0
-              ? `Buyer ${gpBuyerId} has no assigned projects - only a stock PO is possible`
-              : ''
-          }
         >
           <MenuItem value="">No Project (stock PO)</MenuItem>
-          {(isRegister ? projects : selectableProjects).map((p) => (
+          {projects.map((p) => (
             <MenuItem key={p.id} value={p.id}>
               {p.description || p.projectId}
             </MenuItem>
           ))}
         </TextField>
 
-        <Box>
-          <Stack direction="row" spacing={0.5} alignItems="flex-start">
+        {isRegister ? (
+          <Box>
+            <Stack direction="row" spacing={0.5} alignItems="flex-start">
+              <TextField
+                select
+                label="GP Vendor"
+                value={gpVendorId ?? ''}
+                onChange={(e) => handleGpVendorChange(e.target.value)}
+                size="small"
+                sx={{ flex: 1 }}
+                disabled={!relayConnected || gpVendors.length === 0}
+                error={!!errors.vendor}
+                helperText={vendorHelper}
+              >
+                {gpVendors.map((v) => (
+                  <MenuItem key={v.vendorId} value={v.vendorId}>
+                    {v.vendorName}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <IconButton
+                size="small"
+                aria-label="Refresh GP vendors"
+                onClick={() => refetchVendors()}
+                disabled={!relayConnected}
+                sx={{ mt: 0.5 }}
+              >
+                <RefreshIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+            {gpVendorId && !vendorConfirmed && (
+              <FormControlLabel
+                sx={{ mt: 0.5 }}
+                control={
+                  <Checkbox size="small" checked={vendorConfirmed} onChange={(e) => setVendorConfirmed(e.target.checked)} />
+                }
+                label={`This is the correct GP vendor${gpVendorName ? ` (${gpVendorName})` : ''}`}
+              />
+            )}
+            {manufacturerHintNode}
+          </Box>
+        ) : (
+          /* Issue #256: a draft carries an optional Nexus vendor link + the PM's preferred date; the
+             GP vendor is picked later, at register time. */
+          <Stack direction="row" spacing={2}>
+            <Box sx={{ flex: 1 }}>
+              <VendorSelect value={vendorId} onChange={setVendorId} />
+            </Box>
             <TextField
-              select
-              label="GP Vendor"
-              value={gpVendorId ?? ''}
-              onChange={(e) => handleGpVendorChange(e.target.value)}
+              label="Preferred delivery date"
+              type="date"
+              value={preferredDeliveryDate}
+              onChange={(e) => setPreferredDeliveryDate(e.target.value)}
               size="small"
-              sx={{ flex: 1 }}
-              disabled={!relayConnected || gpVendors.length === 0}
-              error={!!errors.vendor}
-              helperText={vendorHelper}
-            >
-              {gpVendors.map((v) => (
-                <MenuItem key={v.vendorId} value={v.vendorId}>
-                  {v.vendorName}
-                </MenuItem>
-              ))}
-            </TextField>
-            <IconButton
-              size="small"
-              aria-label="Refresh GP vendors"
-              onClick={() => refetchVendors()}
-              disabled={!relayConnected}
-              sx={{ mt: 0.5 }}
-            >
-              <RefreshIcon fontSize="small" />
-            </IconButton>
-          </Stack>
-          {isRegister && gpVendorId && !vendorConfirmed && (
-            <FormControlLabel
-              sx={{ mt: 0.5 }}
-              control={
-                <Checkbox size="small" checked={vendorConfirmed} onChange={(e) => setVendorConfirmed(e.target.checked)} />
-              }
-              label={`This is the correct GP vendor${gpVendorName ? ` (${gpVendorName})` : ''}`}
+              sx={{ width: 190 }}
+              slotProps={{ inputLabel: { shrink: true } }}
             />
-          )}
-          {manufacturerHintNode}
-        </Box>
+          </Stack>
+        )}
         <Stack direction="row" spacing={2}>
           <TextField
             label="Shipping costs (optional)"
@@ -730,7 +750,9 @@ export default function GpPurchaseOrderDialog({
         />
       </Stack>
 
-      {/* GP purchase order (every PO lives in GP - it's the source of truth) */}
+      {/* GP purchase order - register mode only (issue #256: a draft doesn't touch GP; company,
+          buyer identity, and cost code are captured when the draft is consciously registered). */}
+      {isRegister && (
       <Box sx={{ mb: 3, p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
         <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
           <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
@@ -790,6 +812,7 @@ export default function GpPurchaseOrderDialog({
           </Alert>
         )}
       </Box>
+      )}
 
       {/* Line Items */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -785,22 +785,16 @@ function POListPage() {
             Document Settings
           </Button>
         )}
-        <Tooltip
-          title={relayConnected ? '' : 'GP relay not detected on this machine - it must be running to create a PO'}
-          arrow
+        {/* Issue #256: creating a PO lands as a DRAFT (no GP involved), so no relay gating here -
+            the relay is only needed later, to register the draft into GP. */}
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setCreateOpen(true)}
         >
-          <span>
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<AddIcon />}
-              onClick={() => setCreateOpen(true)}
-              disabled={!relayConnected}
-            >
-              Create PO
-            </Button>
-          </span>
-        </Tooltip>
+          Create PO
+        </Button>
       </Box>
 
       {/* Statistics Cards (display-only) */}

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -111,12 +111,14 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
 - **Expand all** targets only the currently-visible (filtered + sorted) rows — not the raw fetch.
 - The Status multi-select uses underlying enum values (DRAFT, PARTIALLY_RECEIVED, etc.) but displays formatted labels. When driving via JS, the option's a11y `value` attribute reflects the display label, but the actual MUI state holds the enum value — so test by observing filtered rows, not by reading the option's a11y value.
 
-**Create PO Dialog** (manual PO creation):
-- Project selector (optional — can create POs without a project)
-- Vendor Name, Vendor Contact fields
-- Line items grid: Hardware Category, Product Code, Qty, Unit Cost, Classification (optional), Order As (optional — vendor alias/alternate product name)
+**Create PO Dialog** (manual PO creation, issue #256 - draft-first, NO relay needed):
+- Title "Create PO Request (Draft)"; the Create PO button works with the relay offline
+- Project selector (optional, all projects — buyer assignments only gate the register step)
+- Vendor (Nexus vendor strict-select, optional) + Preferred delivery date
+- Shipping costs / Tariffs (optional), Notes
+- Line items grid: Hardware Category, Product Code, Qty, Unit Cost, Order As (REQUIRED per line; no Classification column - the PM sets site/shop at import)
 - "Add Item" button to add rows, delete button per row (minimum 1 item)
-- Submit creates a DRAFT PO with auto-generated request number (PO-REQ-XXX)
+- Submit ("Create Draft") creates a DRAFT PO with auto-generated request number (PO-REQ-XXX); no GP push. Registering into GP is the separate "Register in GP" action on the draft (relay + buyer identity required there)
 
 **PO Detail Modal**:
 - Shows: status chip, PO number, vendor info, quote #, dates, "No Project" label if project-less
@@ -305,7 +307,7 @@ Inventory quantity corrections are NOT here — they live in the Warehouse modul
 - Verifying a generated PDF (issue #230 PO document): the doc is text-based react-pdf, not an image, so `pdftotext` works. Fastest path for content assertions: use the dialog's "Save to PO documents" to upload it, query the PO's `documents { downloadUrl }` (presigned S3 URL) via GraphQL, `curl` the URL to a file, then `pdftotext -layout` (or `-raw` for the totals column, which `-layout` misaligns since Subtotal/Freight/Miscellaneous/Tax/Order-Total are right-aligned). "Generate & preview" opens a blob in a new tab that's hard to read via MCP - prefer save-then-fetch.
 - pdftotext/poppler is NOT installed on the dev machine, and naive stream-inflation can't read the text (react-pdf subsets fonts to custom glyph IDs). Working alternative: open the presigned `downloadUrl` directly in a browser tab (Chrome renders PDFs natively) and `take_screenshot` - the full totals column is readable in the image. Verified this way for issue #156 (Tariffs line + Order Total math).
 - Issue #156 fields: PO detail modal shows "Shipping Costs" / "Tariffs" info rows ('-' when null) and edit-mode number fields; the generate-document dialog's Freight prefills from the PO's shippingCost (saved documentData override wins) and its new Tariffs field from the PO's tariffAmount; the PDF prints a Tariffs totals line only when > 0.
-- Issue #216 buyer identity: creating/registering POs REQUIRES the signed-in user to have a GP buyer identity (Clerk publicMetadata.gpBuyerId, set in Admin -> User Management) AND, for project POs, a buyer assignment (Admin -> Buyers: assigned projects + designated 'cc1-cc2' cost codes). Without them the dialog blocks and the backend rejects. The test user (Jay Puzon) is linked to GP buyer "mira" with project 80003 + cost codes 210-200/310-000 assigned. The dialog's Buyer field is read-only (your identity); the project dropdown offers only assigned projects; the cost-code dropdown only designated codes. Stock POs (no project) skip the assignment check but still need the identity.
+- Issue #216 buyer identity (scoped to REGISTERING by issue #256 - drafting needs neither): registering a PO into GP REQUIRES the signed-in user to have a GP buyer identity (Clerk publicMetadata.gpBuyerId, set in Admin -> User Management) AND, for project POs, a buyer assignment (Admin -> Buyers: assigned projects + designated 'cc1-cc2' cost codes). Without them the register dialog blocks and the backend rejects. The test user (Jay Puzon) is linked to GP buyer "mira" with project 80003 + cost codes 210-200/310-000 assigned. The register dialog's Buyer field is read-only (your identity); its cost-code dropdown offers only designated codes. Stock POs (no project) skip the assignment check but still need the identity.
 - Issue #216 delivery dates: PO Requests capture "Preferred delivery date" per vendor card in the import wizard's PO step; the detail modal edits Preferred only while DRAFT and Expected only when GP-Registered/Vendor-Confirmed (server-enforced).
 - Import-created PO drafts have EMPTY Order As values unless set in the wizard's PO step - the register dialog then blocks submit with per-line 'Required' errors until each line's Order As is filled.
 - The generate dialog + admin PO-settings text fields APPEND when driven by `fill`/`fill_form` if they already hold a value (same MUI controlled-input quirk as spinbuttons). For a pre-filled field, set the value via `evaluate_script` using the native value setter + an `input` event (match the label's `for` attr to the input id), or drive the mutation directly. Empty fields fill fine.


### PR DESCRIPTION
closes #256

manual PO creation now lands as a plain DRAFT; pushing it into GP is a separate, conscious "Register in GP" action (which stays fully GP-driven - relay push, GP assigns the number).

- createDraftPo replaces the GP-first createPo mutation: persists project (any - buyer gating applies at register, per the #216 flow), optional nexus vendor, preferred delivery date, shipping/tariffs, notes, line items. no relay round-trip, no idempotency key, no buyer
- the create dialog drops the GP box, GP vendor picker, manufacturer suggestion, and identity alerts - all register-mode only now; create gains VendorSelect + preferred date and works with the relay offline
- the Create PO button is un-gated from the relay; the row-level Register in GP button stays gated
- _prepare_create_po/_persist_create_po removed; their manufacturer-resolution tests now target _resolve_line_manufacturers directly
- testing/CLAUDE.md updated for the draft-first flow