### PR TITLE
Fix classification bulk-select toolbar hidden under MUI X v8

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -205,6 +205,9 @@ function LeafGrid({ rows, columns, options, onClassify, readOnly, siteShop }: Le
       disableRowSelectionOnClick
       rowSelectionModel={selectionModel}
       onRowSelectionModelChange={setSelectionModel}
+      // MUI X v8 hides the toolbar slot unless showToolbar is set - without it the bulk-classify
+      // toolbar below never rendered, so checkbox selection had no effect.
+      showToolbar={!readOnly && selectedCount > 0}
       sx={{
         '& .MuiDataGrid-cell.wrap-cell': {
           whiteSpace: 'normal',


### PR DESCRIPTION
found exercising the #216 site/shop bulk paths live: selecting rows in the classification leaf grid never showed the "N selected / Classify as X" toolbar.

MUI X v8 renders the DataGrid toolbar slot only when showToolbar is set - ClassificationGrid passed slots.toolbar without it, so the bulk-classify toolbar (both the original By UCSH/By Others buttons and the new Site/Shop ones) was dead. one prop added, shown only while rows are selected. group-level "X All" buttons were unaffected and already verified live.