### PR TITLE
Simplify README by removing unnecessary details

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,4 @@ monorepo layout
 - testing/ - simulated user testing knowledgebase
 - docs/ - design docs
 
-frontend and backend talk through a single /graphql endpoint. dev commands, conventions, and the
-architecture guide live in CLAUDE.md.
+frontend and backend talk through a single /graphql endpoint.


### PR DESCRIPTION
Removed redundant information about dev commands and architecture guide.