### PR TITLE
tune dependabot: backend+frontend only, ignore majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,20 @@
 version: 2
+
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: pip
+    directory: /backend
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     groups:
-      github-actions:
+      backend:
         patterns:
           - "*"
-
-  - package-ecosystem: pip
-    directories:
-      - /backend
-      - /relay
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    groups:
-      pip-minor-patch:
-        update-types:
-          - minor
-          - patch
 
   - package-ecosystem: npm
     directory: /frontend
@@ -31,21 +22,11 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    groups:
-      npm-minor-patch:
+    ignore:
+      - dependency-name: "*"
         update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: docker
-    directories:
-      - /backend
-      - /frontend
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
+          - version-update:semver-major
     groups:
-      docker:
+      frontend:
         patterns:
           - "*"


### PR DESCRIPTION
narrows dependabot after the first-run flush opened 12 PRs, most of them noise.

scope is now backend (pip /backend) + frontend (npm /frontend) only. majors ignored on both via version-update:semver-major, so no more isolated major PRs like mui-icons 7->9, eslint 9->10, or node 20->26.

removed pip /relay (relay isn't covered by CI), docker base-image bumps (CI never builds the images so they're unvalidated), and github-actions.

weekly schedule, 7-day cooldown, one grouped PR per ecosystem. next run should be 1-2 clean minor/patch PRs instead of 12.

#281 is unaffected by this - it's a dependabot security update from a repo-level alert on the vendored System.Text.Json, not a version update from this file. close it and dismiss that alert separately.
