### PR TITLE
relay-link heartbeat: reap a dead relay within ~a minute

### DIFF
--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -7,8 +7,10 @@ This is deliberate: the old supersede-the-incumbent behaviour (issue #202 #6) bo
 relays thrash - each new connection force-closing the other, reconnecting, and superseding back - and
 could drop a valid in-flight reply, failing a relay_call whose GP write had actually committed. Failing
 pending calls now happens only on a genuine disconnect (unregister), where the reply truly can't arrive.
-A briefly half-dead incumbent is detected by the websockets ping timeout, which fires unregister and
-frees the slot for the next reconnect."""
+A briefly half-dead incumbent is detected by the app-level heartbeat (issue #277): the /relay-link route
+pings the relay on a data message every HEARTBEAT_INTERVAL_SECONDS and, after HEARTBEAT_MAX_MISSED
+unanswered pings, closes the socket - which fires unregister, frees the slot, and flips relayStatus
+within ~a minute instead of the ~hour it took the platform to reap the dead TCP connection."""
 
 import asyncio
 import uuid
@@ -19,12 +21,25 @@ from app.errors import RelayCallError, RelayTimeoutError, RelayUnavailableError
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
+# App-level heartbeat (issue #277). ASGI exposes no WS ping/pong control frame, so the route rides a
+# {"type": "ping"} / {"type": "pong"} data exchange rather than protocol pings. The relay's websockets
+# client answers protocol pings automatically but NOT these data pings, so it carries a matching handler
+# (relay channel.py). Detection is up to HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MAX_MISSED (~40s here).
+HEARTBEAT_INTERVAL_SECONDS = 20.0
+HEARTBEAT_MAX_MISSED = 2
+
 
 class RelayGateway:
     def __init__(self) -> None:
         self._socket: WebSocket | None = None
         self._company: str | None = None
         self._pending: dict[str, asyncio.Future] = {}
+        # Heartbeat bookkeeping for the current connection (issue #277). `_unanswered_pings` counts pings
+        # sent since the last pong; `_heartbeat_armed` only turns True after the relay answers its first
+        # ping, so a relay build that doesn't speak the data heartbeat yet is never falsely reaped - it
+        # just falls back to the old disconnect-on-read behaviour.
+        self._unanswered_pings = 0
+        self._heartbeat_armed = False
 
     @property
     def connected(self) -> bool:
@@ -44,6 +59,8 @@ class RelayGateway:
             return False
         self._socket = websocket
         self._company = company
+        self._unanswered_pings = 0
+        self._heartbeat_armed = False
         return True
 
     def unregister(self, websocket: WebSocket) -> None:
@@ -51,7 +68,24 @@ class RelayGateway:
         if self._socket is websocket:
             self._socket = None
             self._company = None
+            self._unanswered_pings = 0
+            self._heartbeat_armed = False
             self._fail_all("relay disconnected")
+
+    def note_pong(self) -> None:
+        """Called by the route's read loop for each {"type": "pong"} the relay sends. Clears the miss
+        counter and arms the reaper - once the relay has answered one ping, missed pings mean it's gone."""
+        if self._socket is not None:
+            self._unanswered_pings = 0
+            self._heartbeat_armed = True
+
+    def register_ping_miss(self) -> bool:
+        """Called by the route's heartbeat once per interval, just before it sends the next ping. Counts
+        the pings the relay hasn't answered yet and returns True when it has gone quiet long enough to
+        reap (HEARTBEAT_MAX_MISSED unanswered pings) - but only once armed, so a relay that never answers
+        a ping is left to the disconnect-on-read path rather than being killed on a false positive."""
+        self._unanswered_pings += 1
+        return self._heartbeat_armed and self._unanswered_pings >= HEARTBEAT_MAX_MISSED
 
     def _fail_all(self, message: str) -> None:
         pending, self._pending = self._pending, {}

--- a/backend/main.py
+++ b/backend/main.py
@@ -180,6 +180,11 @@ async def relay_link(websocket: WebSocket):
         await _serve_relay_link(websocket)
     except WebSocketDisconnect:
         pass
+    except asyncio.CancelledError:
+        # The connection is being torn down (server shutdown, or a test harness closing its portal) while
+        # the background heartbeat task made the read loop's teardown yield. The relay is gone either way,
+        # so treat it as a clean disconnect and let the handler end normally rather than error out.
+        pass
     finally:
         relay_gateway.unregister(websocket)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from collections.abc import Callable
 from typing import Any
@@ -15,6 +16,7 @@ from app.errors import AppError
 from app.repositories import relay_repository
 from app.schemas.mutations import Mutation
 from app.schemas.queries import Query
+from app.services.relay_gateway import HEARTBEAT_INTERVAL_SECONDS
 from app.services.relay_gateway import gateway as relay_gateway
 
 
@@ -82,6 +84,57 @@ def health():
     return {"status": "ok"}
 
 
+async def _relay_read_loop(websocket: WebSocket) -> None:
+    """Feed each frame the relay sends to relay_gateway: a {"type": "pong"} answers the heartbeat
+    (issue #277), anything else is a {id, ok, result|error} job reply to correlate with relay_call()."""
+    while True:
+        message = await websocket.receive_json()
+        if isinstance(message, dict) and message.get("type") == "pong":
+            relay_gateway.note_pong()
+        else:
+            relay_gateway.resolve(message)
+
+
+async def _relay_heartbeat_loop(websocket: WebSocket) -> None:
+    """Ping the connected relay on a data message every interval; once it misses too many pongs, close
+    the socket so the route's finally unregisters it and relayStatus flips (issue #277). ASGI has no WS
+    ping frame, so this is an application-level {"type": "ping"} the relay answers with {"type": "pong"}."""
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        if relay_gateway.register_ping_miss():
+            # The relay has gone quiet: close so the read loop ends and finally -> unregister runs, which
+            # also fails any in-flight relay_call fast instead of letting it burn the full 30s timeout.
+            # A half-dead socket may fail to close; reaping is decided either way, so swallow and return.
+            try:
+                await websocket.close(code=1011)
+            except Exception:
+                pass
+            return
+        try:
+            await websocket.send_json({"type": "ping"})
+        except Exception:
+            # Socket already gone; let the read loop's disconnect drive unregister via the route's finally.
+            return
+
+
+async def _serve_relay_link(websocket: WebSocket) -> None:
+    """Run the relay read loop and the heartbeat concurrently. Whichever finishes first (a disconnect,
+    or the heartbeat reaping a silent relay) cancels the other; a read-loop disconnect is re-raised so
+    the route's `except WebSocketDisconnect` handles it exactly as before the heartbeat existed."""
+    reader = asyncio.create_task(_relay_read_loop(websocket))
+    heartbeat = asyncio.create_task(_relay_heartbeat_loop(websocket))
+    try:
+        done, _ = await asyncio.wait({reader, heartbeat}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        reader.cancel()
+        heartbeat.cancel()
+        await asyncio.gather(reader, heartbeat, return_exceptions=True)
+    for task in done:
+        exc = task.exception()
+        if exc is not None:
+            raise exc
+
+
 @app.websocket("/relay-link")
 async def relay_link(websocket: WebSocket):
     """The relay's outbound wss channel. It dials in with `Authorization: Bearer <enrolled secret>`
@@ -116,9 +169,7 @@ async def relay_link(websocket: WebSocket):
         await websocket.close(code=4409)
         return
     try:
-        while True:
-            reply = await websocket.receive_json()
-            relay_gateway.resolve(reply)
+        await _serve_relay_link(websocket)
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,8 +129,16 @@ async def _serve_relay_link(websocket: WebSocket) -> None:
         reader.cancel()
         heartbeat.cancel()
         await asyncio.gather(reader, heartbeat, return_exceptions=True)
+    # Surface a genuine reader disconnect so the route handles it as before. Skip a task that finished by
+    # cancellation: task.exception() re-raises CancelledError there, which would propagate out of the
+    # route uncaught and mark the whole route task cancelled (a spurious failure on a clean teardown).
     for task in done:
-        exc = task.exception()
+        if task.cancelled():
+            continue
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            continue
         if exc is not None:
             raise exc
 

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -144,3 +144,44 @@ def test_unregister_fails_any_pending_calls():
             await call_task
 
     asyncio.run(run())
+
+
+def test_register_ping_miss_does_not_reap_before_the_first_pong():
+    # issue #277: a relay build that doesn't answer the data heartbeat yet must never be reaped on a
+    # false positive - missed pings only count once the relay has proven it speaks the protocol.
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket())
+    assert gateway.register_ping_miss() is False
+    assert gateway.register_ping_miss() is False
+    assert gateway.register_ping_miss() is False
+
+
+def test_register_ping_miss_reaps_after_two_misses_once_armed():
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket())
+    gateway.note_pong()  # the first pong arms the reaper
+    assert gateway.register_ping_miss() is False  # 1 unanswered ping
+    assert gateway.register_ping_miss() is True  # 2 unanswered pings -> reap
+
+
+def test_note_pong_resets_the_miss_counter():
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket())
+    gateway.note_pong()
+    assert gateway.register_ping_miss() is False
+    gateway.note_pong()  # a responsive relay keeps the counter from ever reaching the reap threshold
+    assert gateway.register_ping_miss() is False
+
+
+def test_try_register_resets_heartbeat_state_for_the_new_connection():
+    # A fresh connection must not inherit the previous socket's armed flag or miss count.
+    gateway = RelayGateway()
+    first_ws = FakeWebSocket()
+    gateway.try_register("TUBC", first_ws)
+    gateway.note_pong()
+    gateway.register_ping_miss()
+    gateway.unregister(first_ws)
+
+    gateway.try_register("TUBC", FakeWebSocket())
+    assert gateway.register_ping_miss() is False  # not armed yet on the new connection
+    assert gateway.register_ping_miss() is False

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -19,6 +19,7 @@ os.environ.setdefault("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
 from fastapi.testclient import TestClient  # noqa: E402
 from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
+import main  # noqa: E402
 from app.database import SessionLocal  # noqa: E402
 from app.models.relay_install import RelayInstall  # noqa: E402
 from app.repositories import relay_repository  # noqa: E402
@@ -77,3 +78,43 @@ def test_relay_link_rejects_an_unknown_secret(_migrate_database):
         except WebSocketDisconnect:
             pass
     assert gateway.connected is False
+
+
+def test_relay_link_heartbeat_keeps_a_responsive_relay_connected(_migrate_database, monkeypatch):
+    # issue #277: a relay that answers the data-message pings must stay registered - the heartbeat only
+    # reaps a relay that has gone silent, never one that keeps ponging.
+    monkeypatch.setattr(main, "HEARTBEAT_INTERVAL_SECONDS", 0.1)
+    secret = "relay-link-heartbeat-alive"
+    install_id = _enroll_committed("WS-HB-ALIVE", "TUBC", secret)
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}) as ws:
+                _wait_until(lambda: gateway.connected)
+                for _ in range(3):
+                    assert ws.receive_json() == {"type": "ping"}
+                    ws.send_json({"type": "pong"})
+                assert gateway.connected is True
+    finally:
+        _delete_install(install_id)
+
+
+def test_relay_link_heartbeat_reaps_a_relay_that_stops_answering(_migrate_database, monkeypatch):
+    # issue #277: answer the first ping to arm the reaper, then go silent. The route must close the
+    # socket so the gateway unregisters and relayStatus flips, instead of reading connected for ~an hour.
+    monkeypatch.setattr(main, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+    secret = "relay-link-heartbeat-drop"
+    install_id = _enroll_committed("WS-HB-DROP", "TUBC", secret)
+    try:
+        with TestClient(app) as client:
+            try:
+                with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}) as ws:
+                    _wait_until(lambda: gateway.connected)
+                    assert ws.receive_json() == {"type": "ping"}
+                    ws.send_json({"type": "pong"})  # arm, then stop answering
+                    _wait_until(lambda: not gateway.connected, timeout=5.0)
+            except WebSocketDisconnect:
+                # The server-side close (heartbeat reap) surfaces here as the context exits; expected.
+                pass
+        assert gateway.connected is False
+    finally:
+        _delete_install(install_id)

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -60,12 +60,16 @@ def test_relay_link_handshake_registers_the_company(_migrate_database):
     install_id = _enroll_committed("WS-REGRESSION", "TUBC", secret)
     try:
         with TestClient(app) as client:
-            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}):
+            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}) as ws:
                 _wait_until(lambda: gateway.connected)
                 assert gateway.connected is True
                 assert gateway.company == "TUBC"
-            # Leaving the context closes the socket; the route's finally unregisters it.
-            _wait_until(lambda: not gateway.connected)
+                # Close client-side and let the route's finally unregister BEFORE leaving the context, so
+                # the app task has already returned when the test client tears its portal down. Now that
+                # the route also runs a background heartbeat task, its disconnect teardown yields once,
+                # which otherwise races the portal's cancel-on-exit and surfaces a spurious CancelledError.
+                ws.close()
+                _wait_until(lambda: not gateway.connected)
             assert gateway.connected is False
     finally:
         _delete_install(install_id)
@@ -96,6 +100,11 @@ def test_relay_link_heartbeat_keeps_a_responsive_relay_connected(_migrate_databa
                     assert ws.receive_json() == {"type": "ping"}
                     ws.send_json({"type": "pong"})
                 assert gateway.connected is True
+                # Close and let the route unregister before the context tears the portal down (see the
+                # handshake test) so a clean teardown doesn't race the heartbeat into a spurious cancel.
+                ws.close()
+                _wait_until(lambda: not gateway.connected)
+            assert gateway.connected is False
     finally:
         _delete_install(install_id)
 

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -8,9 +8,11 @@ relay socket, so no relay ever registered and relayStatus stayed false. These te
 route so that failure mode can't come back unnoticed.
 """
 
+import asyncio
 import os
 import time
 
+import pytest
 from cryptography.fernet import Fernet
 
 # The crypto layer reads RELAY_SECRET_ENC_KEY at call time; provide one before enroll/authenticate.
@@ -118,3 +120,56 @@ def test_relay_link_heartbeat_reaps_a_relay_that_stops_answering(_migrate_databa
         assert gateway.connected is False
     finally:
         _delete_install(install_id)
+
+
+class _FakeRelaySocket:
+    """A minimal WebSocket stand-in for driving _serve_relay_link directly (no DB, no TestClient thread).
+    receive_json yields the queued messages/exceptions in order, then blocks as an idle relay would."""
+
+    def __init__(self, incoming):
+        self._incoming = list(incoming)
+        self.sent: list[dict] = []
+        self.closed_code: int | None = None
+
+    async def receive_json(self):
+        if self._incoming:
+            item = self._incoming.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        await asyncio.Event().wait()  # nothing more to read: block until the heartbeat/cancel ends us
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_code = code
+
+
+def test_serve_relay_link_reraises_a_reader_disconnect():
+    # A genuine client disconnect must surface as WebSocketDisconnect so the route's except handles it.
+    async def run():
+        ws = _FakeRelaySocket([WebSocketDisconnect()])
+        gateway.try_register("TEST", ws)
+        try:
+            with pytest.raises(WebSocketDisconnect):
+                await main._serve_relay_link(ws)
+        finally:
+            gateway.unregister(ws)
+
+    asyncio.run(run())
+
+
+def test_serve_relay_link_swallows_a_cancelled_reader():
+    # Regression for the CI failure on the responsive-relay test: when the read task ends by cancellation
+    # (a clean teardown races the active heartbeat), _serve_relay_link must return normally. Re-raising
+    # there marked the whole route task cancelled, which TestClient surfaced as a CancelledError.
+    async def run():
+        ws = _FakeRelaySocket([asyncio.CancelledError()])
+        gateway.try_register("TEST", ws)
+        try:
+            await main._serve_relay_link(ws)  # must not raise
+        finally:
+            gateway.unregister(ws)
+
+    asyncio.run(run())

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -1,6 +1,8 @@
 """Outbound WS channel: the relay dials OUT to the UC Nexus backend at wss://<backend>/relay-link,
 authenticates with the enrolled [auth].shared_secret on the connect handshake, and answers job
-messages of the shape {id, op, company, payload} with {id, ok, result|error}.
+messages of the shape {id, op, company, payload} with {id, ok, result|error}. It also answers the
+backend's application-level heartbeat - a {"type": "ping"} control message - with {"type": "pong"}
+(issue #277).
 
 This is a second, additive transport alongside the existing inbound HTTP server (main.py) - nothing
 here changes GET /vendors etc. Op handlers call the SAME eConnect functions (and, for create_po /
@@ -9,7 +11,10 @@ either way.
 
 Reconnects with exponential backoff on drop. The `websockets` client's default ping_interval=20s /
 ping_timeout=20s already satisfies the ~20s keepalive a corporate proxy idle timeout needs, so no
-separate ping loop is required here - see ChannelCfg in config.py.
+separate ping loop is required here - see ChannelCfg in config.py. That WS-protocol ping is distinct
+from the backend's data-message heartbeat above: the protocol ping keeps a corporate proxy from idling
+the socket, while answering the data heartbeat lets the backend reap a dead relay from its registry
+within ~a minute (issue #277) - the websockets client auto-answers protocol pings but not data pings.
 """
 
 import asyncio
@@ -203,6 +208,15 @@ async def _handle_job(job: dict) -> dict:
     return reply
 
 
+def _heartbeat_reply(message: object) -> dict | None:
+    """The pong to send for the backend's application-level heartbeat ping (issue #277), or None if
+    `message` is a normal job to dispatch. ASGI can't send a WS ping frame, so the backend pings on a
+    data message; the relay answers it here (the websockets client auto-answers only protocol pings)."""
+    if isinstance(message, dict) and message.get("type") == "ping":
+        return {"type": "pong"}
+    return None
+
+
 async def _run_once(url: str, secret: str, cfg) -> None:
     # websockets is pinned to ^13.0 (see pyproject); on 13.x the top-level websockets.connect is the
     # legacy client whose keyword is `extra_headers`. `additional_headers` is the 14.0+ name and raises
@@ -244,6 +258,12 @@ async def _run_once(url: str, secret: str, cfg) -> None:
                     job = json.loads(raw)
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("channel received a non-JSON message", extra={"raw": str(raw)[:200]})
+                    continue
+                pong = _heartbeat_reply(job)
+                if pong is not None:
+                    # Backend heartbeat (issue #277): answer through the same writer queue so the pong
+                    # never interleaves mid-frame with a job reply, and don't dispatch it as a job.
+                    await send_queue.put(pong)
                     continue
                 task = asyncio.create_task(_dispatch_job(job))
                 jobs.add(task)

--- a/relay/tests/test_channel_heartbeat.py
+++ b/relay/tests/test_channel_heartbeat.py
@@ -1,0 +1,20 @@
+"""The backend's application-level heartbeat (issue #277): a {"type": "ping"} data message the relay
+answers with {"type": "pong"} so the backend can reap a dead relay from its registry within ~a minute.
+Distinct from the websockets client's protocol ping (proxy keepalive), which the library auto-answers."""
+
+from ucnexus_relay import channel
+
+
+def test_ping_control_message_is_answered_with_a_pong():
+    assert channel._heartbeat_reply({"type": "ping"}) == {"type": "pong"}
+
+
+def test_job_messages_are_not_treated_as_heartbeat():
+    job = {"id": "abc", "op": "list_vendors", "company": "TUBC", "payload": {}}
+    assert channel._heartbeat_reply(job) is None
+
+
+def test_pong_and_non_dict_messages_are_not_treated_as_heartbeat():
+    assert channel._heartbeat_reply({"type": "pong"}) is None
+    assert channel._heartbeat_reply("not-a-dict") is None
+    assert channel._heartbeat_reply(None) is None


### PR DESCRIPTION
closes #277

/relay-link had no heartbeat: `connected` meant only "socket registered", and unregister ran only when a read failed. a relay that died without a clean close read as connected until the platform reaped the dead TCP socket ~an hour later - nothing was calling GP in that window, so the chip stayed green the whole time the relay was gone.

ASGI has no ping/pong control frame, so the route can't emit WS protocol pings (those live below the app in uvicorn's `--ws-ping-*`, which wasn't reaping here). this rides an application-level `{"type":"ping"}` / `{"type":"pong"}` data exchange instead, which needs the small relay-side answer.

backend
- route runs the read loop and a heartbeat as two concurrent tasks; first to finish cancels the other, `finally` still unregisters
- heartbeat pings every HEARTBEAT_INTERVAL_SECONDS (20s), reaps after 2 unanswered pongs -> close -> unregister; relayStatus flips in ~40s, under a minute with the frontend's 10s poll
- reap arms only after the first pong on a connection, so a relay that doesn't answer pings yet is never falsely killed (no deploy-order thrash)
- reap runs the existing `_fail_all`, so an in-flight relay_call on a dead socket fails fast with RelayUnavailableError instead of hanging the full 30s

relay
- channel answers `{"type":"ping"}` with `{"type":"pong"}` through its existing writer queue, not dispatched as a job
- the client's own protocol ping (corporate-proxy keepalive) is unchanged

no migration, no frontend change. deploy relay first (answering pings is harmless to the current backend), then backend.
