### PR TITLE
fix(relay): stop the self-update loop, migrate onefile -> onedir so relaunch survives Defender

### DIFF
--- a/.github/workflows/relay-release.yml
+++ b/.github/workflows/relay-release.yml
@@ -1,12 +1,14 @@
 name: Relay Release
 
-# builds the relay into a single ucnexus-relay.exe on a Windows runner and publishes it.
+# builds the relay ONEDIR bundle on a Windows runner and publishes it as ucnexus-relay.zip.
 # - push to master touching "relay/**" -> builds + publishes an auto-versioned Release
-# - push a tag like `relay-v0.1.0`               -> builds + attaches the exe to that GitHub Release
-# - run manually (workflow_dispatch)             -> builds + uploads the exe as a workflow artifact
+# - push a tag like `relay-v0.1.0`               -> builds + attaches the zip to that GitHub Release
+# - run manually (workflow_dispatch)             -> builds + uploads the zip as a workflow artifact
 # path filters are not applied to tag pushes, so a `relay-v*` tag always builds regardless of what it touched.
-# DPAPI happens on the workstation at enroll time, so the CI-built exe carries no secret - safe to build
-# in the cloud. see "relay/docs/relay-deployment.md".
+# Onedir (not onefile) so the C-extension .pyd are permanent files, not re-extracted to %TEMP% on every
+# launch - that per-launch extraction collides with Windows Defender on a fresh self-update and crashes the
+# relaunched relay. DPAPI happens on the workstation at enroll time, so the CI build carries no secret -
+# safe to build in the cloud. see "relay/docs/relay-deployment.md".
 
 on:
   push:
@@ -63,18 +65,24 @@ jobs:
         # PowerShell does NOT block on a bare call and $LASTEXITCODE stays empty - Start-Process -Wait
         # -PassThru actually waits for it and reads the real exit code.
         run: |
-          $exe = Resolve-Path ./dist/ucnexus-relay.exe
+          $exe = Resolve-Path ./dist/ucnexus-relay/ucnexus-relay.exe
           $p = Start-Process -FilePath $exe -ArgumentList '__smoke__' -Wait -PassThru
           if ($p.ExitCode -ne 2) { Write-Error "expected exit 2 from unknown subcommand, got $($p.ExitCode)"; exit 1 }
           exit 0
+        shell: pwsh
+
+      - name: Package the onedir bundle as a zip
+        # zip the CONTENTS of the onedir (ucnexus-relay.exe + _internal\ at the archive root) so the
+        # installer/updater extract it straight into a versioned app-<build>\ folder.
+        run: Compress-Archive -Path dist/ucnexus-relay/* -DestinationPath dist/ucnexus-relay.zip -Force
         shell: pwsh
 
       - name: Upload artifact (manual runs)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: ucnexus-relay-exe
-          path: "relay/dist/ucnexus-relay.exe"
+          name: ucnexus-relay-zip
+          path: "relay/dist/ucnexus-relay.zip"
 
       - name: Publish to Release (tag pushes)
         if: startsWith(github.ref, 'refs/tags/')
@@ -84,7 +92,7 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           gh release create "$TAG" --title "relay $TAG" --notes "UC Nexus relay build $TAG. install steps: relay/docs/relay-deployment.md" --verify-tag || true
-          gh release upload "$TAG" dist/ucnexus-relay.exe --clobber
+          gh release upload "$TAG" dist/ucnexus-relay.zip --clobber
 
       # A push to master that touched "relay/**" auto-publishes a build-numbered Release.
       # The tag is created by GITHUB_TOKEN, which never re-triggers this workflow, so there's no loop.
@@ -97,4 +105,4 @@ jobs:
           version=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
           tag="relay-v${version}-build.${{ github.run_number }}"
           gh release create "$tag" --target "${{ github.sha }}" --title "relay $tag" --notes "Auto-built from ${{ github.sha }} (relay change on master). install steps: relay/docs/relay-deployment.md" || true
-          gh release upload "$tag" dist/ucnexus-relay.exe --clobber
+          gh release upload "$tag" dist/ucnexus-relay.zip --clobber

--- a/relay/build.ps1
+++ b/relay/build.ps1
@@ -1,19 +1,28 @@
-# Build dist/ucnexus-relay.exe locally via PyInstaller. CI (relay-release.yml) does the same on a
-# windows-latest runner for releases; this is for local builds / spec iteration.
+# Build the ucnexus-relay ONEDIR bundle locally via PyInstaller and zip it. CI (relay-release.yml) does the
+# same on a windows-latest runner for releases; this is for local builds / spec iteration.
 #
 #   .\build.ps1
 #
-# Requires the dev deps installed (poetry install --with dev). The exe lands in .\dist\.
+# Requires the dev deps installed (poetry install --with dev). Produces:
+#   .\dist\ucnexus-relay\            the onedir bundle (ucnexus-relay.exe + _internal\)
+#   .\dist\ucnexus-relay.zip         that bundle zipped (what the installer/updater extract into app-<build>\)
 $ErrorActionPreference = "Stop"
 Set-Location -Path $PSScriptRoot
 
-Write-Host "building ucnexus-relay.exe via PyInstaller..."
+Write-Host "building the ucnexus-relay onedir bundle via PyInstaller..."
 poetry run pyinstaller --clean --noconfirm ucnexus-relay.spec
 
-$exe = Join-Path $PSScriptRoot "dist\ucnexus-relay.exe"
-if (Test-Path $exe) {
-    Write-Host "built: $exe"
-} else {
+$appDir = Join-Path $PSScriptRoot "dist\ucnexus-relay"
+$exe = Join-Path $appDir "ucnexus-relay.exe"
+if (-not (Test-Path $exe)) {
     Write-Error "build did not produce $exe"
     exit 1
 }
+
+$zip = Join-Path $PSScriptRoot "dist\ucnexus-relay.zip"
+if (Test-Path $zip) { Remove-Item $zip -Force }
+# zip the CONTENTS of the onedir (exe + _internal at the archive root) so extracting into app-<build>\ lands
+# ucnexus-relay.exe directly there.
+Compress-Archive -Path (Join-Path $appDir "*") -DestinationPath $zip
+Write-Host "built onedir: $appDir"
+Write-Host "packaged zip: $zip"

--- a/relay/docs/relay-deployment.md
+++ b/relay/docs/relay-deployment.md
@@ -77,6 +77,19 @@ how the secret is protected, and the one gotcha
 updating to a new build
 - download the new `ucnexus-relay.exe` and re-run `install-relay.ps1 -ExePath <new exe>`. it re-stages the
   exe and re-registers the task, and leaves the existing `config.toml` (and its encrypted secret) in place.
+- or use the desktop app's Updates tab: it checks the public GitHub releases, downloads the exe, and
+  applies it in place. The app stages the download, exits, and a detached windowless helper
+  (`ucnexus-relay update-apply`) waits for the app to close, force-kills any remaining relay process BY PID
+  (never by image name), swaps the exe (rename-aside + drop-in), and relaunches - exactly once. The whole
+  sequence is bounded by a ~90s deadline and an attempt cap, so a failed update leaves the relay running on
+  the CURRENT build rather than looping or hanging.
+- update artifacts in the install dir (`%LOCALAPPDATA%\UCNexusRelay`):
+  - `update.log` - the helper's step-by-step log (wait -> kill -> swap -> relaunch); read this first if an
+    update misbehaves.
+  - `update-state.json` - the attempt ledger the Updates tab surfaces ("installed build N" / "update to
+    build N failed: <reason>"). status is one of staging/applying/success/failed/cancelled.
+  - `ucnexus-relay.exe.new` (in-flight download) and `ucnexus-relay.exe.old*` (the swapped-out exe, cleaned
+    up after a successful swap) are transient.
 
 uninstall
 - `install\uninstall-relay.ps1` removes the scheduled task and leaves the install dir. add `-RemoveFiles`

--- a/relay/docs/relay-deployment.md
+++ b/relay/docs/relay-deployment.md
@@ -4,9 +4,19 @@ at rest. the Chrome enterprise LNA pre-grant for the UC Nexus origin and flippin
 production company are IT / sign-off steps handled separately (per issue #178), not part of this.
 
 the shape of it
-- the relay ships as a single `ucnexus-relay.exe` (PyInstaller, built in CI on a windows runner and
-  attached to a GitHub Release - see `.github/workflows/relay-release.yml`). a workstation needs only the
-  exe plus a `config.toml` next to it; no Python or Poetry install.
+- the relay ships as a `ucnexus-relay.zip` PyInstaller ONEDIR bundle (`ucnexus-relay.exe` + an `_internal\`
+  folder), built in CI on a windows runner and attached to a GitHub Release - see
+  `.github/workflows/relay-release.yml`. a workstation needs only that bundle plus a `config.toml`; no
+  Python or Poetry install.
+- onedir, not onefile: a onefile exe re-extracts its bundle (including the C-extension `.pyd`) to `%TEMP%`
+  on EVERY launch, and on a Windows Defender box a freshly-written exe's extraction is scanned as it loads
+  and the relaunched relay crashes (`_multiprocessing` / `PIL._imaging`). onedir keeps the `.pyd` as
+  permanent files scanned once at install/update time, so launches load pre-scanned files.
+- install layout under `%LOCALAPPDATA%\UCNexusRelay\`: data (`config.toml`, `relay.log`, `relay.pid`,
+  `update.log`, `update-state.json`) lives in that dir; each version lives in its own `app-<...>\` folder;
+  a `current` directory junction points at the active version. shortcuts + autostart target the stable
+  `current\ucnexus-relay.exe` path, so a version update (which only repoints the junction) needs no change
+  to them.
 - a per-user scheduled task launches the exe AT LOGON and restarts it on failure. it runs as the logged-in
   domain user, NOT as a service account. that is deliberate: the relay authenticates to GP via Windows
   SSPI as that user (the one in DYNGRP), so it must run in that user's session. a boot-time service under
@@ -20,25 +30,30 @@ prerequisites on the workstation
 - the machine is domain-joined and the logged-in user can reach the GP SQL server and is in DYNGRP. on a
   domain box that's just Windows SSPI - no password stored anywhere.
 
-get the exe
-- grab `ucnexus-relay.exe` from the latest GitHub Release (tag `relay-v*`). releases are produced by the
+get the bundle
+- grab `ucnexus-relay.zip` from the latest GitHub Release (tag `relay-v*`). releases are produced by the
   Relay Release workflow when a `relay-v<version>` tag is pushed.
 - to cut a release: `git tag relay-v0.1.0 && git push origin relay-v0.1.0`. the workflow builds on
-  windows-latest and uploads the exe to the release for that tag.
+  windows-latest and uploads the zip to the release for that tag.
 - for a local build instead (spec iteration / offline): `poetry install --with dev` then `.\build.ps1`,
-  which runs PyInstaller against `ucnexus-relay.spec` and drops the exe in `dist\`.
+  which runs PyInstaller against `ucnexus-relay.spec` and drops the onedir bundle in `dist\ucnexus-relay\`
+  plus a zipped `dist\ucnexus-relay.zip`.
 
-install (elevated PowerShell, once per workstation)
-- registering a scheduled task writes to Task Scheduler, so the install needs admin. the relay itself then
-  runs un-elevated.
-- `install\install-relay.ps1 -ExePath <path to downloaded ucnexus-relay.exe>`
-- what it does:
-  - stages the exe into `%LOCALAPPDATA%\UCNexusRelay\` (override with `-InstallDir`)
-  - seeds a `config.toml` there from `config.example.toml` if one isn't already present (it never
-    overwrites an existing config - that would clobber an enrolled secret)
-  - registers the `UC Nexus Relay` scheduled task: at-logon trigger for the current user, runs
-    `ucnexus-relay.exe serve` with the install dir as the working directory, restart-on-failure (3 tries,
-    1 min apart), no execution time limit
+install - no-admin, self-service (the default for a non-admin workstation user)
+- `install\install-relay-user.ps1 -ZipPath <path to ucnexus-relay.zip> [-StartNow]`
+- what it does: extracts the bundle into `%LOCALAPPDATA%\UCNexusRelay\app-installed\`, points the `current`
+  junction at it, seeds `config.toml` (never overwriting an existing one), registers a no-admin HKCU Run
+  autostart (`current\ucnexus-relay.exe app --minimized` at logon, into the tray), and creates Desktop +
+  Start-menu shortcuts. no elevation needed.
+
+install - admin, scheduled task (IT / fleet alternative)
+- registering a scheduled task writes to Task Scheduler, so this needs admin; the relay itself runs
+  un-elevated.
+- `install\install-relay.ps1 -ZipPath <path to ucnexus-relay.zip>`
+- what it does: extracts the bundle + sets the `current` junction as above, seeds `config.toml`, and
+  registers the `UC Nexus Relay` scheduled task: at-logon trigger for the current user, runs
+  `current\ucnexus-relay.exe serve` with the install dir as the working directory, restart-on-failure (3
+  tries, 1 min apart), no execution time limit
 
 configure config.toml
 - edit `%LOCALAPPDATA%\UCNexusRelay\config.toml`:
@@ -51,18 +66,18 @@ configure config.toml
 enroll - sets the secret, DPAPI-encrypted (the normal path)
 - in UC Nexus an admin runs "provision relay install" and gets a one-time enrollment token. then on the
   workstation, from the install dir:
-  - `.\ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend-host>/graphql`
+  - `.\current\ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend-host>/graphql`
 - the relay generates its own long-lived secret, registers it with the backend using the one-time token
   (the backend can't reach the relay, but the relay can reach the backend), and writes the secret into
   `config.toml` DPAPI-ENCRYPTED. the backend keeps the plaintext (it's what the frontend presents as the
   Bearer token); the workstation keeps only the encrypted blob. nothing long-lived is ever hand-copied.
 - the by-hand alternative: set `[auth] shared_secret = "<your secret>"` as plaintext, then run
-  `.\ucnexus-relay.exe protect-secret` to encrypt it in place. this is idempotent - a value that's already
+  `.\current\ucnexus-relay.exe protect-secret` to encrypt it in place. this is idempotent - a value that's already
   `enc:dpapi:` is left alone. use `enroll --no-encrypt` only for throwaway dev configs.
 
 start and verify
 - `Start-ScheduledTask -TaskName "UC Nexus Relay"` (or just log off and back on)
-- `.\ucnexus-relay.exe health` - hits `http://127.0.0.1:7321/health` and prints the status
+- `.\current\ucnexus-relay.exe health` - hits `http://127.0.0.1:7321/health` and prints the status
 - for a fuller check (read-only GP identity probe): `curl -H "Authorization: Bearer <secret>"
   http://localhost:7321/info`. the secret there is the plaintext one the frontend uses, not the encrypted
   blob in config.
@@ -75,22 +90,28 @@ how the secret is protected, and the one gotcha
   with a clear error - just re-run `enroll` (or `protect-secret`) under the account the relay runs as.
 
 updating to a new build
-- download the new `ucnexus-relay.exe` and re-run `install-relay.ps1 -ExePath <new exe>`. it re-stages the
-  exe and re-registers the task, and leaves the existing `config.toml` (and its encrypted secret) in place.
-- or use the desktop app's Updates tab: it checks the public GitHub releases, downloads the exe, and
-  applies it in place. The app stages the download, exits, and a detached windowless helper
-  (`ucnexus-relay update-apply`) waits for the app to close, force-kills any remaining relay process BY PID
-  (never by image name), swaps the exe (rename-aside + drop-in), and relaunches - exactly once. The whole
-  sequence is bounded by a ~90s deadline and an attempt cap, so a failed update leaves the relay running on
-  the CURRENT build rather than looping or hanging.
+- download the new `ucnexus-relay.zip` and re-run the same installer (`install-relay-user.ps1 -ZipPath
+  <new zip>` or `install-relay.ps1 -ZipPath <new zip>`). it re-extracts the bundle, repoints `current`, and
+  leaves the existing `config.toml` (and its encrypted secret) in place.
+- or use the desktop app's Updates tab: it checks the public GitHub releases, downloads the zip, and applies
+  it in place. The app extracts the new version into a fresh `app-<build>\` folder, exits, and a detached
+  windowless helper (`ucnexus-relay update-apply`) - running from the OLD, already-scanned version - waits
+  for the app to close, force-kills any remaining relay process BY PID (never by image name), repoints the
+  `current` junction to the new version, and relaunches it, health-gated. Nothing renames or copies a
+  running folder, and the new version's `.pyd` were written at extract time (Defender scans them before
+  launch). The whole sequence is bounded by a ~90s deadline + an attempt cap; if the new version doesn't
+  come up healthy the junction rolls back to the previous one, so a failed update leaves the relay running
+  on the CURRENT build rather than looping or hanging. Stale `app-<build>\` folders are cleaned up on the
+  next start.
 - update artifacts in the install dir (`%LOCALAPPDATA%\UCNexusRelay`):
-  - `update.log` - the helper's step-by-step log (wait -> kill -> swap -> relaunch); read this first if an
-    update misbehaves.
+  - `update.log` - the helper's step-by-step log (wait -> kill -> repoint -> relaunch); read this first if
+    an update misbehaves.
   - `update-state.json` - the attempt ledger the Updates tab surfaces ("installed build N" / "update to
     build N failed: <reason>"). status is one of staging/applying/success/failed/cancelled.
-  - `ucnexus-relay.exe.new` (in-flight download) and `ucnexus-relay.exe.old*` (the swapped-out exe, cleaned
-    up after a successful swap) are transient.
+  - `ucnexus-relay-download.zip` (the in-flight download) and superseded `app-<build>\` folders are
+    transient; the download is deleted after extraction and old versions are cleaned on the next start.
 
 uninstall
-- `install\uninstall-relay.ps1` removes the scheduled task and leaves the install dir. add `-RemoveFiles`
-  to also delete the exe and config.
+- `install\uninstall-relay.ps1` removes the autostart (the HKCU Run entry and/or the scheduled task) and the
+  `current` junction, and leaves the install dir. add `-RemoveFiles` to also delete the versioned app
+  folders and config. (a scheduled-task removal needs an elevated PowerShell; the Run-entry removal does not.)

--- a/relay/install/install-relay-user.ps1
+++ b/relay/install/install-relay-user.ps1
@@ -80,10 +80,13 @@ if (-not (Test-Path $destCfg)) {
     Write-Host "kept existing config.toml at $destCfg"
 }
 
-# no-admin logon autostart via the HKCU Run key (the exe registers itself, targeting the stable `current`
-# path). The Run entry launches `app --minimized` at logon, so the relay comes up in the system tray.
-& $curExe install-autostart
-if ($LASTEXITCODE -ne 0) { Write-Error "install-autostart failed (exit $LASTEXITCODE)"; exit 1 }
+# no-admin logon autostart via the HKCU Run key, set directly (the exe is GUI-subsystem, so `& exe
+# install-autostart` returns immediately without a usable $LASTEXITCODE). This targets the stable `current`
+# path and matches the key/value the relay's own autostart-status / uninstall-autostart use, so the UI
+# "start at logon" toggle stays in sync.
+$runKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
+New-ItemProperty -Path $runKey -Name "UC Nexus Relay" -Value "`"$curExe`" app --minimized" -PropertyType String -Force | Out-Null
+Write-Host "registered HKCU Run autostart -> `"$curExe`" app --minimized"
 
 # Desktop + Start-menu shortcuts that open the app (window + tray), via the stable `current` path.
 $wsh = New-Object -ComObject WScript.Shell

--- a/relay/install/install-relay-user.ps1
+++ b/relay/install/install-relay-user.ps1
@@ -3,48 +3,67 @@
   Install the UC Nexus relay for the CURRENT USER with no admin rights.
 
 .DESCRIPTION
-  Stages ucnexus-relay.exe + a config.toml into a per-user install dir, registers a no-admin logon
-  autostart via the HKCU Run key (the exe's `install-autostart` subcommand, which launches the desktop
-  app minimized to the tray), and creates Desktop + Start-menu shortcuts. Nothing here needs elevation -
-  use this on a workstation whose user is not a local admin. For an IT/fleet install that prefers a
-  headless Scheduled Task, use install-relay.ps1 instead (needs admin).
+  Extracts the ucnexus-relay onedir bundle (ucnexus-relay.zip) into a per-user install dir under a
+  versioned app-<...>/ folder, points a stable `current` directory junction at it, seeds config.toml,
+  registers a no-admin logon autostart via the HKCU Run key (the exe's `install-autostart` subcommand,
+  which targets the stable `current` path), and creates Desktop + Start-menu shortcuts. Nothing here needs
+  elevation - use this on a workstation whose user is not a local admin. For an IT/fleet install that
+  prefers a headless Scheduled Task, use install-relay.ps1 instead (needs admin).
+
+  Onedir (not onefile): the C-extension .pyd live as permanent files in the app folder, so a launch loads
+  pre-scanned files instead of re-extracting to %TEMP% every time - that per-launch extraction collides
+  with Windows Defender on a fresh self-update and crashes the relaunched relay. Updates swap versions by
+  repointing the `current` junction, so shortcuts + autostart (which target `current`) never change.
 
   The relay runs as the current interactive user on purpose: it authenticates to GP via Windows SSPI as
   that domain user (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user.
 
-  The relay runs as the current interactive user on purpose: it authenticates to GP via Windows SSPI as
-  that domain user (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user.
-
-.PARAMETER ExePath
-  Path to ucnexus-relay.exe. Defaults to ..\dist\ucnexus-relay.exe (a local build). For a real install,
-  pass the exe downloaded from the GitHub Release.
+.PARAMETER ZipPath
+  Path to ucnexus-relay.zip. Defaults to ..\dist\ucnexus-relay.zip (a local build). For a real install,
+  pass the zip downloaded from the GitHub Release.
 
 .PARAMETER InstallDir
-  Where to stage the exe + config.toml. Defaults to %LOCALAPPDATA%\UCNexusRelay.
+  The per-user data dir (holds config.toml, logs, and the versioned app folders). Defaults to
+  %LOCALAPPDATA%\UCNexusRelay.
 
 .PARAMETER StartNow
   Also open the relay app immediately after install, so you can run Setup -> Enroll from its window.
 
 .EXAMPLE
-  .\install-relay-user.ps1 -ExePath C:\Users\me\Downloads\ucnexus-relay.exe -StartNow
+  .\install-relay-user.ps1 -ZipPath C:\Users\me\Downloads\ucnexus-relay.zip -StartNow
 #>
 [CmdletBinding()]
 param(
-    [string]$ExePath = (Join-Path $PSScriptRoot "..\dist\ucnexus-relay.exe"),
+    [string]$ZipPath = (Join-Path $PSScriptRoot "..\dist\ucnexus-relay.zip"),
     [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "UCNexusRelay"),
     [switch]$StartNow
 )
 $ErrorActionPreference = "Stop"
 
-if (-not (Test-Path $ExePath)) {
-    Write-Error "exe not found at $ExePath - download ucnexus-relay.exe from the GitHub Release (or build it with build.ps1) and pass -ExePath."
+if (-not (Test-Path $ZipPath)) {
+    Write-Error "bundle not found at $ZipPath - download ucnexus-relay.zip from the GitHub Release (or build it with build.ps1) and pass -ZipPath."
     exit 1
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-$destExe = Join-Path $InstallDir "ucnexus-relay.exe"
-Copy-Item -Path $ExePath -Destination $destExe -Force
-Write-Host "staged exe -> $destExe"
+
+# Extract the onedir bundle into a versioned app folder. Updates create their own app-<build>/ folders and
+# repoint `current`; this initial one is named generically and is cleaned up once an update supersedes it.
+$appDir = Join-Path $InstallDir "app-installed"
+if (Test-Path $appDir) { Remove-Item $appDir -Recurse -Force }
+Expand-Archive -Path $ZipPath -DestinationPath $appDir -Force
+$exe = Join-Path $appDir "ucnexus-relay.exe"
+if (-not (Test-Path $exe)) {
+    Write-Error "the bundle at $ZipPath did not contain ucnexus-relay.exe"
+    exit 1
+}
+
+# Stable `current` junction -> the active version. Shortcuts + autostart target this, never a versioned path.
+$cur = Join-Path $InstallDir "current"
+if (Test-Path $cur) { (Get-Item $cur).Delete() }
+New-Item -ItemType Junction -Path $cur -Target $appDir | Out-Null
+$curExe = Join-Path $cur "ucnexus-relay.exe"
+Write-Host "installed onedir bundle -> $appDir  (current -> $appDir)"
 
 # seed config.toml from the example if this workstation doesn't have one yet (never overwrite a real one -
 # it may hold the enrolled DPAPI secret)
@@ -61,17 +80,17 @@ if (-not (Test-Path $destCfg)) {
     Write-Host "kept existing config.toml at $destCfg"
 }
 
-# no-admin logon autostart via the HKCU Run key (the exe registers itself). The Run entry launches
-# `app --minimized` at logon, so the relay comes up in the system tray. No Task Scheduler, no elevation.
-& $destExe install-autostart
+# no-admin logon autostart via the HKCU Run key (the exe registers itself, targeting the stable `current`
+# path). The Run entry launches `app --minimized` at logon, so the relay comes up in the system tray.
+& $curExe install-autostart
 if ($LASTEXITCODE -ne 0) { Write-Error "install-autostart failed (exit $LASTEXITCODE)"; exit 1 }
 
-# Desktop + Start-menu shortcuts that open the app (window + tray).
+# Desktop + Start-menu shortcuts that open the app (window + tray), via the stable `current` path.
 $wsh = New-Object -ComObject WScript.Shell
 $startMenu = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
 foreach ($lnkDir in @([Environment]::GetFolderPath("Desktop"), $startMenu)) {
     $lnk = $wsh.CreateShortcut((Join-Path $lnkDir "UC Nexus Relay.lnk"))
-    $lnk.TargetPath = $destExe
+    $lnk.TargetPath = $curExe
     $lnk.Arguments = "app"
     $lnk.WorkingDirectory = $InstallDir
     $lnk.Description = "UC Nexus Relay"
@@ -80,7 +99,7 @@ foreach ($lnkDir in @([Environment]::GetFolderPath("Desktop"), $startMenu)) {
 Write-Host "created Desktop + Start-menu shortcuts (UC Nexus Relay)."
 
 if ($StartNow) {
-    Start-Process -FilePath $destExe -ArgumentList "app" -WorkingDirectory $InstallDir
+    Start-Process -FilePath $curExe -ArgumentList "app" -WorkingDirectory $InstallDir
     Write-Host "launched the UC Nexus Relay app."
 }
 

--- a/relay/install/install-relay.ps1
+++ b/relay/install/install-relay.ps1
@@ -1,21 +1,23 @@
 <#
 .SYNOPSIS
-  Install the UC Nexus relay on a workstation: stage the exe + config, register a logon scheduled task.
+  Install the UC Nexus relay on a workstation: extract the onedir bundle, register a logon scheduled task.
 
 .DESCRIPTION
-  Copies ucnexus-relay.exe (downloaded from the GitHub Release) and a config.toml into a per-user install
-  dir, then registers a Scheduled Task that launches the relay AT LOGON as the current user. Running as the
-  interactive user is deliberate: the relay authenticates to GP via Windows SSPI as that domain user (the
-  one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user (CurrentUser scope).
+  Extracts the ucnexus-relay onedir bundle (ucnexus-relay.zip, downloaded from the GitHub Release) into a
+  per-user install dir under a versioned app-<...>/ folder fronted by a stable `current` junction, seeds a
+  config.toml, then registers a Scheduled Task that launches the relay AT LOGON as the current user. Running
+  as the interactive user is deliberate: the relay authenticates to GP via Windows SSPI as that domain user
+  (the one in DYNGRP), and the DPAPI-encrypted shared_secret is bound to that same user (CurrentUser scope).
 
   Registering the task writes to Task Scheduler, so this must run from an elevated PowerShell (admin once).
-  The relay itself runs un-elevated (RunLevel Limited).
+  The relay itself runs un-elevated (RunLevel Limited). For a no-admin self-service install (HKCU Run key +
+  tray app), use install-relay-user.ps1 instead.
 
-.PARAMETER ExePath
-  Path to the downloaded ucnexus-relay.exe. Defaults to ..\dist\ucnexus-relay.exe (a local build).
+.PARAMETER ZipPath
+  Path to the downloaded ucnexus-relay.zip. Defaults to ..\dist\ucnexus-relay.zip (a local build).
 
 .PARAMETER InstallDir
-  Where to stage the exe + config.toml. Defaults to %LOCALAPPDATA%\UCNexusRelay.
+  The per-user data dir (config.toml, logs, versioned app folders). Defaults to %LOCALAPPDATA%\UCNexusRelay.
 
 .PARAMETER TaskName
   Scheduled task name. Defaults to "UC Nexus Relay".
@@ -24,11 +26,11 @@
   Also start the task immediately after install. Only do this once config.toml is enrolled.
 
 .EXAMPLE
-  .\install-relay.ps1 -ExePath C:\Users\me\Downloads\ucnexus-relay.exe
+  .\install-relay.ps1 -ZipPath C:\Users\me\Downloads\ucnexus-relay.zip
 #>
 [CmdletBinding()]
 param(
-    [string]$ExePath = (Join-Path $PSScriptRoot "..\dist\ucnexus-relay.exe"),
+    [string]$ZipPath = (Join-Path $PSScriptRoot "..\dist\ucnexus-relay.zip"),
     [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "UCNexusRelay"),
     [string]$TaskName = "UC Nexus Relay",
     [switch]$StartNow
@@ -43,15 +45,26 @@ if (-not $isAdmin) {
     exit 1
 }
 
-if (-not (Test-Path $ExePath)) {
-    Write-Error "exe not found at $ExePath - download ucnexus-relay.exe from the GitHub Release (or build it with build.ps1) and pass -ExePath."
+if (-not (Test-Path $ZipPath)) {
+    Write-Error "bundle not found at $ZipPath - download ucnexus-relay.zip from the GitHub Release (or build it with build.ps1) and pass -ZipPath."
     exit 1
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-$destExe = Join-Path $InstallDir "ucnexus-relay.exe"
-Copy-Item -Path $ExePath -Destination $destExe -Force
-Write-Host "staged exe -> $destExe"
+
+# extract the onedir bundle into a versioned app folder + point the stable `current` junction at it
+$appDir = Join-Path $InstallDir "app-installed"
+if (Test-Path $appDir) { Remove-Item $appDir -Recurse -Force }
+Expand-Archive -Path $ZipPath -DestinationPath $appDir -Force
+if (-not (Test-Path (Join-Path $appDir "ucnexus-relay.exe"))) {
+    Write-Error "the bundle at $ZipPath did not contain ucnexus-relay.exe"
+    exit 1
+}
+$cur = Join-Path $InstallDir "current"
+if (Test-Path $cur) { (Get-Item $cur).Delete() }
+New-Item -ItemType Junction -Path $cur -Target $appDir | Out-Null
+$curExe = Join-Path $cur "ucnexus-relay.exe"
+Write-Host "installed onedir bundle -> $appDir  (current -> $appDir)"
 
 # seed config.toml from the example if the workstation doesn't have one yet (never overwrite a real one -
 # it may hold the enrolled DPAPI secret)
@@ -68,9 +81,10 @@ if (-not (Test-Path $destCfg)) {
     Write-Host "kept existing config.toml at $destCfg"
 }
 
-# logon trigger + restart-on-failure, running as the current interactive user, un-elevated
+# logon trigger + restart-on-failure, running as the current interactive user, un-elevated, via the stable
+# `current` junction path (so a version update - which only repoints the junction - needs no task change)
 $user = "$env:USERDOMAIN\$env:USERNAME"
-$action = New-ScheduledTaskAction -Execute $destExe -Argument "serve" -WorkingDirectory $InstallDir
+$action = New-ScheduledTaskAction -Execute $curExe -Argument "serve" -WorkingDirectory $InstallDir
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
 $settings = New-ScheduledTaskSettingsSet `
@@ -96,7 +110,7 @@ Write-Host ""
 Write-Host "next steps:"
 Write-Host "  1. edit $destCfg  ([sql] server/driver, [gp] companies, [cors] origins)"
 Write-Host "  2. enroll (writes the DPAPI-encrypted secret):"
-Write-Host "       cd `"$InstallDir`"; .\ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend>/graphql"
-Write-Host "     (or set [auth] shared_secret by hand, then: .\ucnexus-relay.exe protect-secret)"
+Write-Host "       cd `"$InstallDir`"; & `"$curExe`" enroll --token <TOKEN> --backend-url https://<backend>/graphql"
+Write-Host "     (or set [auth] shared_secret by hand, then: & `"$curExe`" protect-secret)"
 Write-Host "  3. start it:  Start-ScheduledTask -TaskName `"$TaskName`"   (or just log off and back on)"
-Write-Host "  4. verify:    .\ucnexus-relay.exe health"
+Write-Host "  4. verify:    & `"$curExe`" health"

--- a/relay/install/uninstall-relay.ps1
+++ b/relay/install/uninstall-relay.ps1
@@ -1,16 +1,17 @@
 <#
 .SYNOPSIS
-  Remove the UC Nexus relay scheduled task (and optionally the install dir).
+  Remove the UC Nexus relay: the logon scheduled task and/or the HKCU Run autostart entry, the `current`
+  junction, and optionally the install dir.
 
 .PARAMETER TaskName
-  Scheduled task name. Defaults to "UC Nexus Relay".
+  Scheduled task name (admin install). Defaults to "UC Nexus Relay".
 
 .PARAMETER InstallDir
-  Install dir to delete when -RemoveFiles is given. Defaults to %LOCALAPPDATA%\UCNexusRelay.
+  Install dir. Defaults to %LOCALAPPDATA%\UCNexusRelay.
 
 .PARAMETER RemoveFiles
-  Also delete the install dir (exe + config.toml). The config holds the enrolled DPAPI secret, so this is
-  off by default.
+  Also delete the install dir (versioned app folders + config.toml). The config holds the enrolled DPAPI
+  secret, so this is off by default.
 
 .EXAMPLE
   .\uninstall-relay.ps1
@@ -24,20 +25,36 @@ param(
 )
 $ErrorActionPreference = "Stop"
 
-$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
-    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-    Write-Error "run this from an elevated PowerShell - unregistering the scheduled task requires it."
-    exit 1
+# stop any running relay so its files unlock before we remove them
+Get-Process ucnexus-relay -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+# remove the no-admin HKCU Run autostart entry (user install), if present
+$run = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
+if (Get-ItemProperty -Path $run -Name "UC Nexus Relay" -ErrorAction SilentlyContinue) {
+    Remove-ItemProperty -Path $run -Name "UC Nexus Relay" -Force
+    Write-Host "removed HKCU Run autostart entry."
 }
 
+# remove the scheduled task (admin install), if present - unregistering needs admin
 $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
 if ($task) {
-    try { Stop-ScheduledTask -TaskName $TaskName -ErrorAction Stop } catch {}
-    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
-    Write-Host "removed scheduled task '$TaskName'."
-} else {
-    Write-Host "no scheduled task '$TaskName' found."
+    $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+        ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $isAdmin) {
+        Write-Warning "scheduled task '$TaskName' exists but removing it needs an elevated PowerShell; skipped."
+    } else {
+        try { Stop-ScheduledTask -TaskName $TaskName -ErrorAction Stop } catch {}
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Host "removed scheduled task '$TaskName'."
+    }
+}
+
+# remove the `current` junction (just the reparse point) before any file deletion, so a recursive delete
+# can't follow it into the target
+$cur = Join-Path $InstallDir "current"
+if (Test-Path $cur) {
+    (Get-Item $cur).Delete()
+    Write-Host "removed the current junction."
 }
 
 if ($RemoveFiles) {

--- a/relay/src/ucnexus_relay/app.py
+++ b/relay/src/ucnexus_relay/app.py
@@ -19,7 +19,6 @@ import os
 import sys
 import threading
 import time
-from pathlib import Path
 
 from . import setup, single_instance
 from .config import DEFAULT_CONFIG_PATH
@@ -199,50 +198,18 @@ class RelayApp:
         timer.daemon = True
         timer.start()
 
-    def _maybe_promote(self, force: bool) -> bool:
-        """If this frozen exe was launched from OUTSIDE the install dir, converge on the installed exe:
-        promote (swap self in + relaunch) when we're newer / forced / there's no install yet, otherwise
-        delegate to the installed exe. Returns True if the caller should exit (we handed off)."""
-        cfg_dir = self._install_dir()
-        me = Path(sys.executable)
-        installed = single_instance.installed_exe_path(cfg_dir)
-        # Short-circuit the common case (launched from the install dir) before probing the installed exe's
-        # build, so a normal startup never spawns a `print-build` subprocess.
-        if single_instance.same_path(me, installed):
-            return False
-        my_build = single_instance.current_build()
-        decision = single_instance.promote_decision(
-            frozen=True,
-            same_path=False,
-            installed_build=single_instance.installed_build(cfg_dir),
-            my_build=my_build,
-            force=force,
-        )
-        if decision == "skip":
-            return False
-        if decision == "delegate":
-            # the installed exe is same/newer: surface it if it's running, else launch it. Never run from here.
-            owner = single_instance.live_owner(cfg_dir)
-            if owner is not None:
-                single_instance.allow_foreground(owner["pid"])
-                single_instance.send_show(owner["port"], owner["nonce"])
-                logger.info("installed relay is current and running; focused it instead of running from %s", me)
-            else:
-                single_instance.launch_installed(cfg_dir)
-                logger.info("installed relay is current; launched it instead of running from %s", me)
-            return True
-        # promote: evict a running (installed) owner so its exe unlocks, swap, relaunch from the install dir
-        owner = single_instance.live_owner(cfg_dir)
-        if owner is not None:
-            single_instance.evict(owner, cfg_dir)
-        res = single_instance.promote_swap(me, cfg_dir)
-        if not res.get("ok"):
-            logger.error("promote failed (%s); running in place from %s", res.get("error"), me)
-            return False  # fall back to running from where we are rather than not running at all
-        single_instance.refresh_autostart_if_present(cfg_dir)
-        single_instance.launch_installed(cfg_dir)
-        logger.info("promoted %s -> %s (build %s) and relaunched", me, installed, my_build)
-        return True
+    def _cleanup_old_versions(self) -> None:
+        """Delete stale app-<build>/ version folders a past update left behind, keeping the one we run
+        from. Best-effort - a folder still held by an exiting update helper is skipped and cleaned on a
+        later start (see layout.cleanup_old_versions)."""
+        from . import layout
+
+        try:
+            running = layout.running_version_dir()
+            keep = {running.name} if running is not None else set()
+            layout.cleanup_old_versions(self._install_dir(), keep)
+        except Exception:
+            logger.exception("error cleaning up old relay versions")
 
     def _acquire_single_instance(self, force: bool) -> bool:
         """Become the single app owner, or signal an existing one and bow out. Returns True to proceed as
@@ -293,13 +260,13 @@ class RelayApp:
 
         global _APP
         _APP = self
-        # Single-instance + promote gate. Only meaningful for the packaged exe: a dev run has
-        # sys.executable = python (no exe to promote/relaunch, build 'dev'), so keep today's behaviour there.
+        # Single-instance gate. Only meaningful for the packaged exe: a dev run has sys.executable = python
+        # (build 'dev'), so keep today's behaviour there. Onedir installs run via the `current` junction;
+        # there is no promote-from-Downloads step anymore (see single_instance / layout).
         if getattr(sys, "frozen", False):
-            if self._maybe_promote(force):
-                return 0
             if not self._acquire_single_instance(force):
                 return 0
+            self._cleanup_old_versions()
         self.ensure_serve()
         self._window = webview.create_window(
             "UC Nexus Relay",

--- a/relay/src/ucnexus_relay/app.py
+++ b/relay/src/ucnexus_relay/app.py
@@ -41,6 +41,7 @@ class RelayApp:
         self._window = None
         self._tray = None
         self._shutting_down = False
+        self._updating = False  # set while an update handoff is in progress, so user_shutdown doesn't cancel it
         self._mutex = None  # single_instance.MutexResult while we own the app slot
         self._control = None  # single_instance.ControlServer answering ping / show / quit_for_upgrade
 
@@ -101,7 +102,8 @@ class RelayApp:
         self._mutex = None
 
     def shutdown(self) -> None:
-        """Stop the relay + tray and close the window (used by the tray/Status 'Shut down')."""
+        """Stop the relay + tray and close the window. Used by the update handoff (apply_update) and,
+        via user_shutdown(), by the tray/Status 'Shut down'."""
         if self._shutting_down:
             return
         self._shutting_down = True
@@ -111,6 +113,24 @@ class RelayApp:
                 self._window.destroy()
         except Exception:
             logger.exception("error destroying the window")
+
+    def user_shutdown(self) -> None:
+        """A shutdown the USER asked for (tray/Status 'Shut down'). Distinct from the update handoff
+        (apply_update sets _updating): if an update is staged/applying, tell the helper to abort instead
+        of relaunching, so closing the relay mid-update is respected."""
+        self._cancel_update_if_pending()
+        self.shutdown()
+
+    def _cancel_update_if_pending(self) -> None:
+        if self._updating:
+            return  # this teardown IS the update handoff, not a user cancel
+        try:
+            from . import updater
+
+            if updater.read_ledger(self._install_dir()).get("status") in ("staging", "applying"):
+                updater.request_cancel(self._install_dir())
+        except Exception:
+            logger.exception("error requesting update cancel on shutdown")
 
     def _confirm_shutdown(self) -> bool:
         try:
@@ -137,6 +157,7 @@ class RelayApp:
         if self._shutting_down:
             return True
         if self._confirm_shutdown():
+            self._cancel_update_if_pending()  # a user-initiated close aborts an in-flight update
             self._shutting_down = True
             self._stop_relay_and_tray()  # the window closes naturally via the returned True
             return True
@@ -157,7 +178,7 @@ class RelayApp:
         ImageDraw.Draw(img).ellipse((16, 16, 48, 48), fill=(46, 204, 113))
         menu = pystray.Menu(
             pystray.MenuItem("Open", lambda: self._show_window(), default=True),
-            pystray.MenuItem("Shut down", lambda: self.shutdown()),
+            pystray.MenuItem("Shut down", lambda: self.user_shutdown()),
         )
         self._tray = pystray.Icon("ucnexus-relay", img, "UC Nexus Relay", menu)
 

--- a/relay/src/ucnexus_relay/autostart.py
+++ b/relay/src/ucnexus_relay/autostart.py
@@ -28,11 +28,22 @@ def _require_winreg() -> None:
 
 
 def default_command() -> str:
-    """The command the Run entry launches at logon: the packaged exe as the desktop app, started minimized
-    to the tray (the app supervises the relay). Quoted so a path with spaces survives. In a dev checkout
-    sys.executable is python, so this is only meaningful for the frozen exe - the installer and the UI
-    always run the packaged exe."""
-    return f'"{sys.executable}" app --minimized'
+    """The command the Run entry launches at logon: the packaged app, started minimized to the tray. For an
+    onedir install it targets the STABLE `current` junction path, so a version update (which only repoints
+    the junction) needs no autostart change; it falls back to sys.executable for a dev run. Quoted so a
+    path with spaces survives."""
+    exe = sys.executable
+    if getattr(sys, "frozen", False):
+        try:
+            from . import layout
+            from .config import DEFAULT_CONFIG_PATH
+
+            cur = layout.current_link(DEFAULT_CONFIG_PATH.parent) / layout.ASSET_NAME
+            if cur.exists():
+                exe = str(cur)
+        except Exception:  # noqa: BLE001 - fall back to sys.executable if the layout can't be resolved
+            pass
+    return f'"{exe}" app --minimized'
 
 
 def install_autostart(command: str | None = None, subkey: str = RUN_SUBKEY) -> str:

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -19,6 +19,7 @@ within ~a minute (issue #277) - the websockets client auto-answers protocol ping
 
 import asyncio
 import json
+import logging
 
 import pyodbc
 import websockets
@@ -285,16 +286,28 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
 
     secret = get_settings().auth.shared_secret
     backoff = cfg.reconnect_min_seconds
+    prev_category: str | None = None
     while stop_event is None or not stop_event.is_set():
         try:
             await _run_once(cfg.backend_url, secret, cfg)
             backoff = cfg.reconnect_min_seconds  # clean run - reset backoff before the next attempt
+            prev_category = None
             _mark_disconnected()  # _run_once returned -> the socket closed; reconnecting on the next loop
         except asyncio.CancelledError:
             raise
         except Exception as e:
             category, message = _classify_connect_failure(e)
-            logger.warning(message, extra={"category": category, "error": str(e), "backoff": backoff})
+            # A rejected/orphaned secret can't self-heal until re-enrollment (which restarts serve), so a
+            # de-enrolled relay would otherwise log the same WARNING every ~30s forever. Log it loudly once
+            # on the transition into that state, then at DEBUG. Transient drops and slot-busy stay at
+            # WARNING - each is a real, distinct reconnect event.
+            quiet_repeat = category == "secret_rejected" and prev_category == "secret_rejected"
+            logger.log(
+                logging.DEBUG if quiet_repeat else logging.WARNING,
+                message,
+                extra={"category": category, "error": str(e), "backoff": backoff},
+            )
             _mark_disconnected(category if category in ("secret_rejected", "slot_busy") else "disconnected")
             backoff = min(backoff * 2, cfg.reconnect_max_seconds)
+            prev_category = category
         await asyncio.sleep(backoff)

--- a/relay/src/ucnexus_relay/cli.py
+++ b/relay/src/ucnexus_relay/cli.py
@@ -21,13 +21,23 @@ import os
 import sys
 
 
+def _ensure_std_streams() -> None:
+    """A windowed PyInstaller build leaves sys.stdout/stderr as None; point them at devnull so print() /
+    logging never crash. Does NOT touch any console."""
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+    if sys.stderr is None:
+        sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+
+
 def _reattach_console() -> None:
-    """The exe is built windowed (console=False) so the tray app and the detached `serve` child never pop
-    a console window. The cost of a windowed build is that a CLI subcommand run from a terminal would be
-    silent, and PyInstaller leaves sys.stdout/stderr as None there, so a plain print() would crash. On
-    Windows, attach to the launching terminal's console if there is one - there ISN'T for the tray app
-    (launched from a shortcut) or the detached serve child, so those stay windowless - and guarantee
-    stdout/stderr are always writable."""
+    """For a HAND-RUN CLI subcommand: the exe is built windowed (console=False), so PyInstaller leaves
+    stdout/stderr None and a plain print() would be silent (or crash). Attach to the launching terminal's
+    console so the output shows, then guarantee the streams are writable.
+
+    Do NOT call this for `serve` / `app` / `update-apply`: they are background/GUI processes, and attaching
+    a `serve` child to whatever console spawned it leaks uvicorn's access logs (INFO: ... "GET /health")
+    into that terminal. Those paths call _ensure_std_streams() instead - writable, no console."""
     if sys.platform == "win32":
         try:
             import ctypes
@@ -42,11 +52,7 @@ def _reattach_console() -> None:
                     pass
         except OSError:
             pass
-    # a windowed PyInstaller build can leave these None; keep print()/logging from crashing if no console
-    if sys.stdout is None:
-        sys.stdout = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
-    if sys.stderr is None:
-        sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+    _ensure_std_streams()
 
 
 def _relay_already_serving(host: str, port: int) -> bool:
@@ -189,7 +195,6 @@ def _autostart_status(argv: list[str]) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    _reattach_console()  # windowed build: attach to the launching terminal (if any) so CLI output shows
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and not argv[0].startswith("-"):
         cmd, rest = argv[0], argv[1:]
@@ -197,6 +202,14 @@ def main(argv: list[str] | None = None) -> int:
         # bare invocation (a double-clicked exe) opens the desktop app. The serve child (setup.start_serve)
         # and the autostart entries pass an explicit command, so only a bare double-click is affected.
         cmd, rest = "app", argv
+
+    # Background / GUI subcommands must NOT attach to the launching console - a reattached `serve` leaks
+    # uvicorn's access logs (INFO: ... "GET /health") into whatever terminal spawned it. Hand-run CLI
+    # subcommands DO attach, so their output shows. Both guarantee stdout/stderr are writable.
+    if cmd in ("serve", "app", "update-apply"):
+        _ensure_std_streams()
+    else:
+        _reattach_console()
 
     if cmd == "serve":
         return _serve(rest)

--- a/relay/src/ucnexus_relay/cli.py
+++ b/relay/src/ucnexus_relay/cli.py
@@ -8,6 +8,8 @@ Subcommands:
   protect-secret       DPAPI-encrypt the shared_secret currently in config.toml
   health               GET the local /health endpoint and print it (exit 0 if status ok)
   print-build          print this exe's build tag (used by promote to compare against the installed exe)
+  update-apply --pid N the detached self-update helper: wait for app pid N to exit, swap the staged exe,
+                       relaunch (spawned by updater.stage_update; not run by hand)
   install-autostart    register a no-admin logon autostart (HKCU Run) so the relay starts at logon
   uninstall-autostart  remove that logon autostart entry
   autostart-status     print whether the logon autostart is installed (JSON)
@@ -213,6 +215,22 @@ def main(argv: list[str] | None = None) -> int:
         except OSError:
             sys.stdout.write(data.decode("utf-8"))
         return 0
+    if cmd == "update-apply":
+        # the detached self-update helper (spawned by updater.stage_update). Windowless, logged to
+        # update.log, bounded by a deadline + attempt ledger. --pid is the app process to wait for.
+        from .config import DEFAULT_CONFIG_PATH
+        from .updater import apply_staged_update
+
+        app_pid = None
+        if "--pid" in rest:
+            i = rest.index("--pid")
+            if i + 1 < len(rest):
+                try:
+                    app_pid = int(rest[i + 1])
+                except ValueError:
+                    app_pid = None
+        apply_staged_update(app_pid, DEFAULT_CONFIG_PATH.parent)
+        return 0
     if cmd == "enroll":
         from .enroll import main as enroll_main
         return enroll_main(rest)
@@ -230,7 +248,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"unknown command: {cmd!r} (expected: serve | app | enroll | protect-secret | health | print-build | "
-        "install-autostart | uninstall-autostart | autostart-status)",
+        "update-apply | install-autostart | uninstall-autostart | autostart-status)",
         file=sys.stderr,
     )
     return 2

--- a/relay/src/ucnexus_relay/config.py
+++ b/relay/src/ucnexus_relay/config.py
@@ -57,6 +57,9 @@ class SqlCfg(BaseModel):
     driver: str = "ODBC Driver 17 for SQL Server"
     trusted_connection: bool = True
     encrypt: str = "yes"
+    # Encrypt=yes but TrustServerCertificate=yes: the connection is encrypted, but the SQL Server cert is
+    # NOT validated (a self-signed cert is accepted). Acceptable for the trusted internal LAN this relay
+    # runs on; if the SQL box gets a CA-issued/pinned cert, set this False to actually validate against it.
     trust_server_certificate: bool = True
     connection_timeout: int = 10
     command_timeout: int = 30

--- a/relay/src/ucnexus_relay/layout.py
+++ b/relay/src/ucnexus_relay/layout.py
@@ -1,0 +1,126 @@
+"""Onedir install layout: versioned app-<build>/ folders under the data dir, fronted by a stable `current`
+directory junction that shortcuts + autostart target.
+
+Why: the relay ships as a PyInstaller ONEDIR bundle (exe + _internal/ with the C-extension .pyd as
+permanent files - see ucnexus-relay.spec). A running relay holds its _internal/*.pyd open, so its folder
+can't be renamed/overwritten in place, and a self-update can't run its helper from the folder it is
+replacing. So each version lives in its own `app-<build>/` folder and `current` is a junction pointing at
+the active one. An update extracts the new version alongside, repoints the junction, and relaunches - no
+rename or copy of a running folder. Repointing a junction is safe while the old relay runs: its open .pyd
+handles resolved the old real path at launch and are unaffected by swapping the reparse point.
+
+Data (config.toml, relay.log, relay.pid, app.lock, update-state.json, update.log) lives in the data dir
+itself, NOT in a version folder, so it survives updates. config._default_config_path is LOCALAPPDATA-based
+(not exe-relative), so config resolves to the data dir regardless of which version is current.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+ASSET_NAME = "ucnexus-relay.exe"  # the exe name inside a version folder
+CURRENT_LINK = "current"
+VERSION_PREFIX = "app-"
+_NO_WINDOW = 0x08000000  # CREATE_NO_WINDOW
+_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def current_link(data_dir) -> Path:
+    return Path(data_dir) / CURRENT_LINK
+
+
+def version_dir_name(build: str) -> str:
+    """The folder name for a build tag: app-<sanitized-build>, e.g. app-relay-v0.1.0-build.27."""
+    return VERSION_PREFIX + (_SAFE.sub("-", build) if build else "staged")
+
+
+def version_dir(data_dir, build: str) -> Path:
+    return Path(data_dir) / version_dir_name(build)
+
+
+def _build_number(name: str) -> int:
+    m = re.search(r"build\.(\d+)$", name or "")
+    return int(m.group(1)) if m else -1
+
+
+def newest_version_dir(data_dir) -> Path | None:
+    """The app-*/ version folder with the highest build number that actually contains the exe, or None."""
+    candidates = [p for p in Path(data_dir).glob(VERSION_PREFIX + "*") if (p / ASSET_NAME).exists()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: _build_number(p.name))
+
+
+def installed_exe(data_dir) -> Path:
+    """The exe to run/inspect: via the `current` junction if it resolves, else the newest app-*/ version,
+    else the legacy flat data_dir/ucnexus-relay.exe (a onefile install / dev checkout)."""
+    data_dir = Path(data_dir)
+    link_exe = current_link(data_dir) / ASSET_NAME
+    if link_exe.exists():
+        return link_exe
+    newest = newest_version_dir(data_dir)
+    if newest is not None:
+        return newest / ASSET_NAME
+    return data_dir / ASSET_NAME  # legacy flat layout (pre-onedir)
+
+
+def running_version_dir() -> Path | None:
+    """The version folder the CURRENT process runs from (resolving the `current` junction to its real
+    target), or None outside a frozen onedir. Used to keep the running version during cleanup."""
+    import sys
+
+    if not getattr(sys, "frozen", False):
+        return None
+    try:
+        return Path(sys.executable).resolve().parent
+    except OSError:
+        return Path(sys.executable).parent
+
+
+def remove_junction(link) -> None:
+    """Remove the `current` junction (a directory reparse point) without touching its target. A no-op if
+    it's absent. os.rmdir on a junction deletes only the reparse point; on a real non-empty dir it fails,
+    which is the safe outcome (we never want to delete a real folder here)."""
+    try:
+        os.rmdir(Path(link))
+    except OSError:
+        pass
+
+
+def repoint_current(data_dir, target_version_dir) -> bool:
+    """Point data_dir/current at target_version_dir (create or repoint the junction). No admin needed
+    (mklink /J). Returns True on success. Safe while the old relay runs - see the module docstring."""
+    link = current_link(data_dir)
+    remove_junction(link)
+    result = subprocess.run(  # noqa: S603,S607 (fixed cmd + our own paths)
+        ["cmd", "/c", "mklink", "/J", str(link), str(target_version_dir)],
+        creationflags=_NO_WINDOW,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def extract_zip(zip_path, dest_dir) -> Path:
+    """Extract a onedir zip (ucnexus-relay.exe + _internal/ at its root) into dest_dir, replacing any
+    existing contents. Returns dest_dir."""
+    dest = Path(dest_dir)
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(dest)
+    return dest
+
+
+def cleanup_old_versions(data_dir, keep) -> None:
+    """Delete every app-*/ version folder except the ones named in `keep` (folder names). Best-effort: a
+    folder still held open by an exiting helper is skipped and cleaned on a later pass."""
+    keep_names = {Path(k).name for k in keep}
+    for p in Path(data_dir).glob(VERSION_PREFIX + "*"):
+        if p.is_dir() and p.name not in keep_names:
+            shutil.rmtree(p, ignore_errors=True)

--- a/relay/src/ucnexus_relay/logging_setup.py
+++ b/relay/src/ucnexus_relay/logging_setup.py
@@ -1,10 +1,16 @@
 """Structured JSON logging to file + console."""
 
 import logging
+from logging.handlers import RotatingFileHandler
 
 from pythonjsonlogger import jsonlogger
 
 _CONFIGURED = False
+
+# Rotate relay.log so a long-lived relay never grows it without bound (a workstation relay runs for weeks).
+# ~2 MB is thousands of JSON events; keep a few rollovers for history.
+_MAX_BYTES = 2_000_000
+_BACKUP_COUNT = 3
 
 
 def configure_logging(level: str = "INFO", file_path: str = "relay.log") -> None:
@@ -14,7 +20,7 @@ def configure_logging(level: str = "INFO", file_path: str = "relay.log") -> None
     fmt = jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s")
     root = logging.getLogger()
     root.setLevel(level)
-    fh = logging.FileHandler(file_path)
+    fh = RotatingFileHandler(file_path, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8")
     fh.setFormatter(fmt)
     root.addHandler(fh)
     ch = logging.StreamHandler()

--- a/relay/src/ucnexus_relay/main.py
+++ b/relay/src/ucnexus_relay/main.py
@@ -17,12 +17,12 @@ import time
 import pyodbc
 from fastapi import Depends, FastAPI, HTTPException
 
+from . import __version__ as VERSION
 from . import auth, buyers, channel, db, econnect, errors, models, ops
 from .config import get_settings
 from .cors import configure_cors
 from .logging_setup import configure_logging, get_logger
 
-VERSION = "0.1.0"
 _START = time.monotonic()
 
 

--- a/relay/src/ucnexus_relay/single_instance.py
+++ b/relay/src/ucnexus_relay/single_instance.py
@@ -395,13 +395,15 @@ def installed_build(config_dir, timeout: float = 8.0) -> str | None:
     return (out.stdout or "").strip() or None
 
 
-def launch_installed(config_dir, minimized: bool = False) -> None:
+def launch_installed(config_dir, minimized: bool = False) -> int | None:
     """Spawn the installed exe (via the `current` junction) as the desktop app, detached so it outlives
     this process. The relaunched exe runs the single-instance gate itself and becomes the owner.
-    Autostart + shortcuts target the stable `current` path, so a version change needs no refresh here."""
+    Autostart + shortcuts target the stable `current` path, so a version change needs no refresh here.
+    Returns the launched app's pid so a caller (the updater's health-gated retry) can force it down BY PID
+    if it comes up unhealthy - onedir, so the exe process IS the app process (no bootloader child)."""
     exe = installed_exe_path(config_dir)
     args = [str(exe), "app"] + (["--minimized"] if minimized else [])
-    subprocess.Popen(  # noqa: S603 (our own installed exe path)
+    proc = subprocess.Popen(  # noqa: S603 (our own installed exe path)
         args,
         cwd=str(config_dir),
         creationflags=_DETACHED,  # DETACHED alone (GUI exe: no console either way; not paired with NO_WINDOW)
@@ -409,3 +411,4 @@ def launch_installed(config_dir, minimized: bool = False) -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    return proc.pid

--- a/relay/src/ucnexus_relay/single_instance.py
+++ b/relay/src/ucnexus_relay/single_instance.py
@@ -10,9 +10,9 @@ same serve. This module makes `app` single-instance and version-aware:
     build), or defers to it (older / dev), per decide_action();
   - a session-local named mutex serialises two simultaneous cold starts so exactly one becomes owner.
 
-Promote-to-installed lives here too: a newer exe launched from anywhere (Downloads, a USB stick) swaps
-itself over the installed exe and relaunches from there, so the single-file distributable doubles as its
-own upgrader (see promote_decision / promote_swap).
+The installed exe is resolved through the onedir `current` junction (see layout.installed_exe); updates
+swap versions by repointing that junction (see updater), not by copying an exe, so there is no
+promote-from-Downloads path here anymore.
 
 Everything is import-safe without a GUI backend - app.py wires the show / quit callbacks to the window -
 so the decision logic and the lockfile plumbing unit-test without opening a window.
@@ -21,7 +21,6 @@ so the decision logic and the lockfile plumbing unit-test without opening a wind
 import json
 import os
 import secrets
-import shutil
 import socket
 import subprocess
 import sys
@@ -29,7 +28,7 @@ import threading
 import time
 from pathlib import Path
 
-from . import updater
+from . import layout, updater
 from .logging_setup import get_logger
 
 logger = get_logger()
@@ -67,18 +66,6 @@ def decide_action(new_build: str, running_build: str, force: bool = False) -> st
     if force:
         return "replace"
     return "replace" if build_is_newer(new_build, running_build) else "focus"
-
-
-def promote_decision(*, frozen: bool, same_path: bool, installed_build: str | None, my_build: str, force: bool) -> str:
-    """Whether a launched exe should copy itself over the installed exe. Returns:
-    'skip'     - run in place (a dev run, or already the installed exe);
-    'promote'  - swap self in + relaunch from the install dir (newer, forced, or no install yet);
-    'delegate' - the installed exe is same/newer, so launch it instead of running from here."""
-    if not frozen or same_path:
-        return "skip"
-    if force or installed_build is None or build_is_newer(my_build, installed_build):
-        return "promote"
-    return "delegate"
 
 
 # --- lockfile -----------------------------------------------------------------------------------------
@@ -381,7 +368,9 @@ def bring_to_front(title: str = WINDOW_TITLE) -> bool:
 
 
 def installed_exe_path(config_dir) -> Path:
-    return Path(config_dir) / ASSET_NAME
+    """The exe to run/inspect for this install - resolved through the onedir `current` junction to the
+    active app-<build>/ version (see layout.installed_exe)."""
+    return layout.installed_exe(config_dir)
 
 
 def same_path(a, b) -> bool:
@@ -406,54 +395,17 @@ def installed_build(config_dir, timeout: float = 8.0) -> str | None:
     return (out.stdout or "").strip() or None
 
 
-def promote_swap(src_exe, config_dir, retries: int = 30) -> dict:
-    """Copy `src_exe` (this newer running exe, e.g. from Downloads) over the installed exe, renaming the
-    installed one aside first - Windows locks a running/held image but permits renaming it (the updater
-    relies on the same trick). Retries while the handle releases."""
-    install_dir = Path(config_dir)
-    install_dir.mkdir(parents=True, exist_ok=True)
-    exe = installed_exe_path(install_dir)
-    error = None
-    for _ in range(retries):
-        try:
-            if exe.exists():
-                os.replace(exe, updater._free_old_path(install_dir))  # move the installed exe aside
-            shutil.copy2(src_exe, exe)  # drop our newer exe into place
-            updater._cleanup_old(install_dir)
-            return {"ok": True, "path": str(exe)}
-        except OSError as e:
-            error = str(e)
-            time.sleep(0.5)
-    return {"ok": False, "error": f"promote swap failed: {error}"}
-
-
 def launch_installed(config_dir, minimized: bool = False) -> None:
-    """Spawn the installed exe as the desktop app, detached so it outlives this (promoting/delegating)
-    process. The relaunched exe runs the single-instance gate itself and becomes the owner."""
+    """Spawn the installed exe (via the `current` junction) as the desktop app, detached so it outlives
+    this process. The relaunched exe runs the single-instance gate itself and becomes the owner.
+    Autostart + shortcuts target the stable `current` path, so a version change needs no refresh here."""
     exe = installed_exe_path(config_dir)
     args = [str(exe), "app"] + (["--minimized"] if minimized else [])
     subprocess.Popen(  # noqa: S603 (our own installed exe path)
         args,
         cwd=str(config_dir),
-        creationflags=_DETACHED | _NO_WINDOW,
+        creationflags=_DETACHED,  # DETACHED alone (GUI exe: no console either way; not paired with NO_WINDOW)
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-
-
-def refresh_autostart_if_present(config_dir) -> None:
-    """After a promote, repoint the HKCU Run entry at the (stable) installed exe path - a no-op if it
-    already points there. Only touches autostart when it's already installed, so a promote never silently
-    enables start-at-logon for someone who didn't ask for it. Shortcuts need no refresh: they already
-    target the fixed installed path, which a promote doesn't change."""
-    from . import autostart
-
-    if autostart.winreg is None:
-        return
-    try:
-        if autostart.autostart_status().get("installed"):
-            exe = installed_exe_path(config_dir)
-            autostart.install_autostart(command=f'"{exe}" app --minimized')
-    except OSError:
-        logger.exception("could not refresh autostart after promote")

--- a/relay/src/ucnexus_relay/ui.py
+++ b/relay/src/ucnexus_relay/ui.py
@@ -273,13 +273,14 @@ class Api:
         return {"ok": True}
 
     def shutdown_app(self) -> dict:
-        """Stop the relay and quit the desktop app (the Status/tray 'Shut down'). The JS confirms first."""
+        """Stop the relay and quit the desktop app (the Status/tray 'Shut down'). The JS confirms first.
+        user_shutdown so an in-flight update is cancelled rather than relaunched."""
         from . import app
 
         running = app.current()
         if running is None:
             return {"ok": False, "error": "not running as the desktop app"}
-        running.shutdown()
+        running.user_shutdown()
         return {"ok": True}
 
     def uninstall_autostart(self) -> dict:
@@ -297,7 +298,7 @@ class Api:
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
 
-    def apply_update(self, url: str) -> dict:
+    def apply_update(self, url: str, build: str | None = None) -> dict:
         if not _frozen():
             return {"ok": False, "error": "updates can only be applied to the packaged exe"}
         if not (url or "").strip():
@@ -313,8 +314,13 @@ class Api:
             # unlocked exe and relaunch - no renaming of a running exe.
             import os
 
-            result = updater.stage_update(url.strip(), DEFAULT_CONFIG_PATH.parent, os.getpid())
+            result = updater.stage_update(
+                url.strip(), DEFAULT_CONFIG_PATH.parent, os.getpid(), target_build=(build or "").strip() or None
+            )
             if result.get("ok"):
+                # mark this teardown as the update handoff so it's NOT treated as a user cancel
+                # (RelayApp.user_shutdown writes the cancel flag only when _updating is False).
+                running._updating = True
                 running.shutdown()
                 # Make sure this process actually exits so the helper's swap can proceed promptly.
                 # shutdown() stopped serve + tray and asked the window to close, but destroy() runs from
@@ -329,6 +335,14 @@ class Api:
             return result
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
+
+    def last_update_result(self) -> dict:
+        """The last update outcome from the ledger (update-state.json), so the Updates tab can show
+        'updated to build N' or a failure - instead of a silent mystery. {} if no update was ever run."""
+        try:
+            return updater.read_ledger(DEFAULT_CONFIG_PATH.parent)
+        except Exception:  # noqa: BLE001
+            return {}
 
 
 _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Relay</title>
@@ -435,6 +449,7 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
           <button id="u-apply" onclick="applyUpdate()" hidden>Update now</button></div>
         <div id="r-update" class="result"></div>
         <p class="muted" id="u-note" style="margin:6px 0 0"></p>
+        <div id="u-last" class="result" style="margin-top:6px"></div>
       </div>
     </section>
   </main>
@@ -527,19 +542,33 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
     refresh();
   }
 
-  let _updateUrl = null;
+  let _updateUrl = null, _updateBuild = null;
+  function showLastUpdate(u) {
+    if (!u || !u.status || !u.target_build) { $('u-last').innerHTML = ''; return; }
+    const when = u.updated_at ? ' (' + esc(u.updated_at) + ')' : '';
+    if (u.status === 'success') {
+      $('u-last').innerHTML = `<span class="ok">last update: installed ${esc(u.target_build)}${when}</span>`;
+    } else if (u.status === 'failed') {
+      $('u-last').innerHTML = `<span class="bad">last update to ${esc(u.target_build)} failed: ${esc(u.last_error || 'unknown')}</span>`;
+    } else if (u.status === 'cancelled') {
+      $('u-last').innerHTML = `<span class="muted">last update to ${esc(u.target_build)} was cancelled${when}</span>`;
+    } else {
+      $('u-last').innerHTML = `<span class="muted">update to ${esc(u.target_build)}: ${esc(u.status)}…</span>`;
+    }
+  }
   async function loadUpdates() {
     const s = await window.pywebview.api.get_status();
     $('u-current').innerText = s.build || '-';
+    try { showLastUpdate(await window.pywebview.api.last_update_result()); } catch (e) {}
   }
   async function checkUpdate() {
     $('r-update').innerHTML = '<span class="muted">checking…</span>';
-    $('u-apply').hidden = true; _updateUrl = null;
+    $('u-apply').hidden = true; _updateUrl = null; _updateBuild = null;
     const r = await window.pywebview.api.check_update();
     if (!r.ok) { result('r-update', false, r.error || 'check failed'); return; }
     $('u-current').innerText = r.current; $('u-latest').innerText = r.latest;
     if (r.update_available) {
-      _updateUrl = r.url; $('u-apply').hidden = false;
+      _updateUrl = r.url; _updateBuild = r.latest; $('u-apply').hidden = false;
       result('r-update', true, 'update available: ' + r.latest);
     } else {
       result('r-update', true, 'up to date');
@@ -549,8 +578,8 @@ _HTML = """<!doctype html><html><head><meta charset="utf-8"><title>UC Nexus Rela
     if (!_updateUrl) return;
     $('r-update').innerHTML = '<span class="muted">downloading and applying… the app will close and reopen on the new version</span>';
     $('u-apply').hidden = true;
-    const r = await window.pywebview.api.apply_update(_updateUrl);
-    result('r-update', r.ok, r.ok ? 'updated - relay restarted' : (r.error || 'update failed'));
+    const r = await window.pywebview.api.apply_update(_updateUrl, _updateBuild);
+    result('r-update', r.ok, r.ok ? 'updating - the app will close and reopen on the new version' : (r.error || 'update failed'));
     $('u-note').innerText = r.note || '';
     setTimeout(refresh, 2000);
   }

--- a/relay/src/ucnexus_relay/ui.py
+++ b/relay/src/ucnexus_relay/ui.py
@@ -88,10 +88,20 @@ def relay_health(host: str = "127.0.0.1", port: int = 7321) -> dict:
 def _tail_lines(path: Path, limit: int) -> list[str]:
     if not path.exists():
         return []
-    # relay.log stays small (a few events per op); reading it whole and slicing is fine and avoids
-    # seek-based tailing edge cases with the JSON-per-line format.
-    with open(path, encoding="utf-8", errors="replace") as f:
-        return f.readlines()[-limit:]
+    # Read only a bounded tail from the END rather than the whole file. relay.log is capped at ~2MB by
+    # rotation (logging_setup), and the UI polls this every few seconds, so reading megabytes for the last
+    # N events is wasteful. Grab ~400 bytes per requested line from the end, drop the partial first line.
+    approx = max(int(limit), 1) * 400
+    with open(path, "rb") as f:
+        f.seek(0, 2)
+        size = f.tell()
+        start = max(0, size - approx)
+        f.seek(start)
+        data = f.read()
+    lines = data.decode("utf-8", errors="replace").splitlines()
+    if start > 0 and lines:
+        lines = lines[1:]  # first line is likely truncated by the offset read
+    return lines[-limit:]
 
 
 def recent_log_events(config_path: str | Path | None = None, limit: int = 200) -> list[dict]:

--- a/relay/src/ucnexus_relay/ui.py
+++ b/relay/src/ucnexus_relay/ui.py
@@ -20,10 +20,9 @@ import tomllib
 import urllib.request
 from pathlib import Path
 
+from . import __version__ as VERSION
 from . import autostart, updater
 from .config import ChannelCfg, DEFAULT_CONFIG_PATH, KNOWN_COMPANIES, SqlCfg
-
-VERSION = "0.1.0"
 
 
 def _resolve_log_path(config_path: Path, logging_file: str) -> Path:

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -313,19 +313,21 @@ def _wait_for_health(url: str, deadline: float) -> bool:
 def _relaunch_and_wait_healthy(install_dir: Path, deadline: float, log: logging.Logger, attempts: int = 2) -> bool:
     """Launch the current version and wait for /health, retrying up to `attempts` within the deadline. The
     first launch after an extract also completes Defender's scan of the new .pyd, so a retry lands clean if
-    the first ever stumbles. Between attempts, kill the serve child so the port frees for a fresh bind."""
+    the first ever stumbles. Between attempts, kill the app we just launched AND its serve child: the app is
+    single-instance, so a still-alive-but-unhealthy owner would focus-deflect (and never re-serve) the next
+    launch and the rollback launch, leaving the relay down - the exact failure the health gate must prevent."""
     from . import single_instance
 
     url = _health_url(install_dir)
     for i in range(1, attempts + 1):
         if _monotonic() >= deadline:
             break
-        single_instance.launch_installed(install_dir)
-        log.info("relaunch attempt %d of %d", i, attempts)
+        app_pid = single_instance.launch_installed(install_dir)
+        log.info("relaunch attempt %d of %d (pid %s)", i, attempts, app_pid)
         if _wait_for_health(url, min(deadline, _monotonic() + _HEALTH_WAIT_PER_ATTEMPT)):
             log.info("relay healthy after relaunch")
             return True
-        _kill_relay_pids(None, install_dir, log)  # clear a crashed/half attempt before retrying
+        _kill_relay_pids(app_pid, install_dir, log)  # clear the crashed/hung app + serve before retrying
     return False
 
 
@@ -408,7 +410,10 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
     ledger["status"] = "applying"
     ledger["attempts"] = attempts
     ledger["updated_at"] = _now_iso()
-    ledger.setdefault("first_attempt_at", _now_iso())
+    if not ledger.get("first_attempt_at"):
+        # _stage_ledger seeds this key as None for a fresh target, so setdefault would never stamp it -
+        # set it explicitly on the first apply that has no timestamp yet.
+        ledger["first_attempt_at"] = _now_iso()
     _write_ledger(install_dir, ledger)
     log.info("update-apply start: target=%s attempt=%s app_pid=%s", target, attempts, app_pid)
 
@@ -442,7 +447,16 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
         return {"ok": False, "cancelled": True}
 
     if not layout.repoint_current(install_dir, new_dir):
-        log.warning("could not repoint the current junction to %s", new_dir)
+        # The junction is the single source of truth for autostart + shortcuts (they target
+        # current\ucnexus-relay.exe). A failed repoint may have removed the link without recreating it;
+        # relaunching would come up via the newest-version fallback and record "success" while current is
+        # broken, silently breaking the next logon's autostart. Roll back to the previous version instead.
+        log.warning("could not repoint the current junction to %s; rolling back", new_dir)
+        if old_target is not None and old_target != new_dir:
+            layout.repoint_current(install_dir, old_target)
+        _relaunch_and_wait_healthy(install_dir, _monotonic() + 30.0, log)
+        _finish_ledger(install_dir, "failed", "could not repoint the current junction to the new version")
+        return {"ok": False, "error": "could not repoint the current junction to the new version"}
 
     if _relaunch_and_wait_healthy(install_dir, deadline, log):
         _finish_ledger(install_dir, "success", None)

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -1,17 +1,17 @@
 """Self-update from the public GitHub releases - the relay UI's third purpose (setup, updates, logs).
 
-The repo is public, so the relay checks the releases API and downloads the exe with no auth token and no
-backend involvement. Applying an update on Windows is the tricky part: a running exe is locked and can't
-be overwritten, but it CAN be renamed. So we download the new exe, rename the current one aside, drop the
-new one into its place, and restart.
+The repo is public, so the relay checks the releases API and downloads the build (a ucnexus-relay.zip
+onedir bundle) with no auth token and no backend involvement.
 
-The desktop app can't swap the exe it is running from and keep running, so it hands the swap to a detached
-helper: it stages the download, then exits, and a SEPARATE process (this exe re-invoked as `update-apply`)
-waits for the app to go, swaps the exe, and relaunches. That helper used to be a fire-and-forget .bat that
-could resurrect a closed app, kill every relay process by image name, spawn visible consoles, and loop with
-no timeout or record. It is now `apply_staged_update()` below: windowless, logged to update.log, bounded by
-a wall-clock deadline and an attempt ledger (update-state.json), killing only by pid and relaunching
-exactly once. See the module-level constants for the bounds.
+Applying an update: the relay is a PyInstaller ONEDIR bundle installed under a versioned app-<build>/ folder,
+fronted by a stable `current` directory junction that shortcuts + autostart target (see layout.py). An
+update downloads the zip, extracts the new version alongside the current one, and hands off to a detached
+helper (this exe re-invoked as `update-apply`) that - running from the OLD, already-settled version -
+force-stops the old relay by pid, repoints the `current` junction to the new version, and relaunches it,
+health-gated. Nothing renames or copies a running folder, and the new version's .pyd were written to disk
+at extract time (so Windows Defender scans them before launch, not during it - the crash that killed the
+old onefile self-update). The helper is windowless, logged to update.log, and bounded by a wall-clock
+deadline + an attempt ledger (update-state.json) so it can never loop or hang.
 
 The build identity comes from _build.py, which CI stamps into the package at build time (see
 .github/workflows/relay-release.yml). A dev checkout has no _build.py, so current_build() is 'dev', which
@@ -25,27 +25,30 @@ import subprocess
 import sys
 import time
 import urllib.request
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+from . import layout
+
 REPO = "Upper-Canada-Specialty-Hardware/uc-nexus"
 _RELEASES_API = f"https://api.github.com/repos/{REPO}/releases?per_page=30"
-_ASSET_NAME = "ucnexus-relay.exe"
-_MIN_EXE_BYTES = 5_000_000  # a real exe is ~20MB; guard against a truncated body / HTML error page
+_RELEASE_ASSET = "ucnexus-relay.zip"  # the onedir bundle published on each release
+_MIN_ZIP_BYTES = 5_000_000  # a real bundle zip is ~27MB; guard against a truncated body / HTML error page
+_MIN_EXE_BYTES = 5_000_000  # the extracted exe
 
 # --- self-update helper bounds ------------------------------------------------------------------------
 _STATE_FILE = "update-state.json"  # the attempt ledger the helper reads/writes and the UI surfaces
 _CANCEL_FLAG = "update-cancel"     # touched by a user-initiated shutdown to abort an in-flight update
 _UPDATE_LOG = "update.log"         # the helper's own log, next to config.toml
+_DOWNLOAD_NAME = "ucnexus-relay-download.zip"
 MAX_ATTEMPTS = 3                   # circuit breaker: give up on a target build after this many helper runs
-_GLOBAL_DEADLINE_SECONDS = 90.0    # hard wall-clock cap on the whole wait+kill+swap sequence
+_GLOBAL_DEADLINE_SECONDS = 90.0    # hard wall-clock cap on the whole sequence
 _APP_EXIT_WAIT_SECONDS = 20.0      # how long to wait for the app to exit on its own before force-killing
-_SWAP_RETRY_SECONDS = 1.0          # pause between swap attempts while Windows releases the exe handle
-_POLL_SECONDS = 0.5                # app-exit poll interval
+_HEALTH_WAIT_PER_ATTEMPT = 25.0    # per relaunch attempt, how long to wait for /health before retrying
+_POLL_SECONDS = 0.5
 
-# Windows process-creation flags. DETACHED_PROCESS alone (NOT combined with CREATE_NO_WINDOW - the two are
-# contradictory and that pairing is what made the old .bat helper's cmd children pop visible consoles).
-_DETACHED_PROCESS = 0x00000008
+_DETACHED_PROCESS = 0x00000008  # DETACHED alone (never paired with CREATE_NO_WINDOW - see stage/_spawn)
 
 _monotonic = time.monotonic  # module-level seams so tests can drive the deadline/retry loops
 _sleep = time.sleep
@@ -68,9 +71,8 @@ def build_number(tag: str) -> int:
 
 
 def latest_release() -> dict:
-    """The relay-v* release with the HIGHEST build number that carries the exe asset. GitHub's /releases
-    list is not reliably newest-first (a newer build can appear mid-list), so pick by build number rather
-    than trusting list order. {} if none."""
+    """The relay-v* release with the HIGHEST build number that carries the bundle zip. GitHub's /releases
+    list is not reliably newest-first, so pick by build number rather than trusting list order. {} if none."""
     req = urllib.request.Request(_RELEASES_API, headers={"Accept": "application/vnd.github+json"})
     with urllib.request.urlopen(req, timeout=15) as r:  # noqa: S310 (fixed public GitHub API URL)
         releases = json.loads(r.read().decode())
@@ -80,7 +82,7 @@ def latest_release() -> dict:
         tag = rel.get("tag_name", "")
         if not tag.startswith("relay-v"):
             continue
-        asset = next((a for a in rel.get("assets", []) if a.get("name") == _ASSET_NAME), None)
+        asset = next((a for a in rel.get("assets", []) if a.get("name") == _RELEASE_ASSET), None)
         if not (asset and asset.get("browser_download_url")):
             continue
         n = build_number(tag)
@@ -97,9 +99,8 @@ def check_update() -> dict:
     except OSError as e:
         return {"ok": False, "error": f"could not reach GitHub releases: {e}"}
     if not latest:
-        return {"ok": False, "error": "no relay release with an exe asset was found"}
+        return {"ok": False, "error": "no relay release with a bundle was found"}
     # Only offer an update when the release is a HIGHER build than the installed one - never a downgrade.
-    # 'dev' has build number -1, so any real release is an update from a dev checkout.
     update_available = build_number(latest["tag"]) > build_number(cur)
     return {
         "ok": True,
@@ -117,76 +118,10 @@ def _unlink_quietly(p: Path) -> None:
         pass
 
 
-def _free_old_path(install_dir: Path) -> Path:
-    """A '.old' path to rename the running exe aside to that isn't currently locked. A prior update's
-    '.old' may still be held by an app/ui window that hasn't closed; picking a free variant instead of
-    reusing a locked one is what keeps a second update from failing the swap."""
-    base = install_dir / (_ASSET_NAME + ".old")
-    for candidate in [base, *(install_dir / f"{_ASSET_NAME}.old.{i}" for i in range(1, 20))]:
-        _unlink_quietly(candidate)  # clear a stale one if we can
-        if not candidate.exists():
-            return candidate
-    return install_dir / (_ASSET_NAME + ".old.x")  # last resort
-
-
-def _cleanup_old(install_dir: Path) -> None:
-    for p in install_dir.glob(_ASSET_NAME + ".old*"):
-        _unlink_quietly(p)
-
-
-def apply_update(url: str, install_dir: str | Path) -> dict:
-    """Download `url` and swap it in for the installed exe, then restart serve. The relay is ALWAYS
-    restarted on the way out, so a failed swap leaves it running on the CURRENT version rather than down
-    (rename-while-running; see the module docstring). This is the STANDALONE (non-desktop) path; the
-    desktop app uses stage_update + apply_staged_update instead."""
-    from . import setup
-
-    install_dir = Path(install_dir)
-    exe = install_dir / _ASSET_NAME
-    new = install_dir / (_ASSET_NAME + ".new")
-
-    try:
-        urllib.request.urlretrieve(url, str(new))  # noqa: S310 (release asset URL from latest_release)
-    except OSError as e:
-        return {"ok": False, "error": f"download failed: {e}"}
-    if new.stat().st_size < _MIN_EXE_BYTES:
-        _unlink_quietly(new)
-        return {"ok": False, "error": "the downloaded file is too small - aborting the swap"}
-
-    # Stop serve (releases its exe lock), swap, then ALWAYS restart serve in the finally so GP comes back
-    # up even if the swap fails. The app/ui process still holds the exe image, hence rename-not-overwrite.
-    setup.stop_serve(install_dir)
-    old = _free_old_path(install_dir)
-    swapped = False
-    error = None
-    try:
-        os.replace(exe, old)  # rename the running exe aside (Windows permits renaming a running image)
-        os.replace(new, exe)  # move the new exe into place
-        swapped = True
-    except OSError as e:
-        error = str(e)
-        if not exe.exists() and old.exists():  # renamed aside but couldn't drop the new one -> roll back
-            try:
-                os.replace(old, exe)
-            except OSError:
-                pass
-    finally:
-        setup.start_serve(exe, install_dir)
-
-    if swapped:
-        _cleanup_old(install_dir)
-        return {"ok": True, "restarted": True, "note": "reopen the window to load the updated UI"}
-    _unlink_quietly(new)
-    return {
-        "ok": False,
-        "error": f"swap failed ({error}); the relay was restarted on the current version - reboot and retry",
-    }
-
-
 # --- attempt ledger (update-state.json) ---------------------------------------------------------------
 # One small JSON file the staging step seeds and the helper updates, so a failure is recorded (surfaced in
 # the Updates tab) and repeated attempts at the SAME target build are capped. Shape:
-#   {status, target_build, target_url, attempts, last_error, first_attempt_at, updated_at}
+#   {status, target_build, target_url, target_dir, attempts, last_error, first_attempt_at, updated_at}
 # status in: staging | applying | success | failed | cancelled.
 
 
@@ -209,7 +144,7 @@ def _write_ledger(install_dir: Path, data: dict) -> None:
         pass
 
 
-def _stage_ledger(install_dir: Path, target_build: str, target_url: str) -> None:
+def _stage_ledger(install_dir: Path, target_build: str, target_url: str, target_dir: str) -> None:
     """Seed the ledger for a fresh staging. Preserves the attempt count only when re-staging the SAME
     still-unfinished target (so hammering a failing build is capped); a new target or a prior success
     resets it to 0."""
@@ -221,6 +156,7 @@ def _stage_ledger(install_dir: Path, target_build: str, target_url: str) -> None
             "status": "staging",
             "target_build": target_build,
             "target_url": target_url,
+            "target_dir": target_dir,
             "attempts": prev.get("attempts", 0) if same else 0,
             "last_error": prev.get("last_error") if same else None,
             "first_attempt_at": prev.get("first_attempt_at") if same else None,
@@ -257,12 +193,12 @@ def _clear_cancel(install_dir: Path) -> None:
     _unlink_quietly(install_dir / _CANCEL_FLAG)
 
 
-# --- the detached helper ------------------------------------------------------------------------------
+# --- process helpers ----------------------------------------------------------------------------------
 
 
 def _spawn_detached(args: list[str], cwd: str | Path) -> None:
     """Launch our own GUI-subsystem exe fully detached, windowless. DETACHED_PROCESS alone - never paired
-    with CREATE_NO_WINDOW (contradictory; that pairing spawned the visible consoles in the old .bat)."""
+    with CREATE_NO_WINDOW (contradictory; that pairing spawned visible consoles in the old .bat)."""
     subprocess.Popen(  # noqa: S603 (our own exe path + fixed subcommand)
         args,
         cwd=str(cwd),
@@ -275,8 +211,7 @@ def _spawn_detached(args: list[str], cwd: str | Path) -> None:
 
 
 def _update_logger(install_dir: Path) -> logging.Logger:
-    """A dedicated logger writing update.log next to config.toml, so a broken update is diagnosable
-    (the old .bat swallowed everything with >nul 2>&1)."""
+    """A dedicated logger writing update.log next to config.toml, so a broken update is diagnosable."""
     logger = logging.getLogger("ucnexus_relay.update")
     if not logger.handlers:
         logger.setLevel(logging.INFO)
@@ -291,8 +226,7 @@ def _update_logger(install_dir: Path) -> logging.Logger:
 
 
 def _pid_alive(pid) -> bool:
-    """True if `pid` is a live process. Windows: OpenProcess + GetExitCodeProcess (no tasklist, which the
-    old helper piped through find and which flashed consoles)."""
+    """True if `pid` is a live process. Windows: OpenProcess + GetExitCodeProcess (no tasklist)."""
     if not pid:
         return False
     if sys.platform != "win32":
@@ -327,8 +261,6 @@ def _read_serve_pid(install_dir: Path) -> int | None:
 
 
 def _wait_for_pid_exit(pid, deadline: float, log: logging.Logger) -> None:
-    """Wait (bounded by both _APP_EXIT_WAIT_SECONDS and the global deadline) for the app to exit on its
-    own, so a clean shutdown can finish before we force anything."""
     until = min(deadline, _monotonic() + _APP_EXIT_WAIT_SECONDS)
     while _monotonic() < until:
         if not _pid_alive(pid):
@@ -353,81 +285,126 @@ def _kill_relay_pids(app_pid, install_dir: Path, log: logging.Logger) -> None:
         log.info("force-killed serve pid %s", serve_pid)
 
 
-def _swap_new_over_exe(exe: Path, new: Path, install_dir: Path, deadline: float, log: logging.Logger):
-    """Rename the (now-unlocked) exe aside and drop the new one in, retrying while Windows releases the
-    handle, until the deadline. On a partial failure (renamed aside but couldn't move the new one in) the
-    old exe is put back, so the relay is never left without an exe. Returns (swapped: bool, error|None)."""
-    error = None
-    while True:
-        old = _free_old_path(install_dir)
+# --- health-gated relaunch ----------------------------------------------------------------------------
+
+
+def _health_url(install_dir: Path) -> str:
+    try:
+        from .config import get_settings
+
+        s = get_settings()
+        return f"http://{s.server.host}:{s.server.port}/health"
+    except Exception:  # noqa: BLE001 - a missing/odd config falls back to the baked default port
+        return "http://127.0.0.1:7321/health"
+
+
+def _wait_for_health(url: str, deadline: float) -> bool:
+    while _monotonic() < deadline:
         try:
-            os.replace(exe, old)  # rename running/held image aside (permitted on Win10/11)
-        except OSError as e:
-            error = f"rename-aside failed: {e}"
-        else:
-            try:
-                os.replace(new, exe)  # move the new bytes into place
-                return True, None
-            except OSError as e:
-                error = f"move-new-in failed: {e}"
-                if not exe.exists():  # roll back so we never leave the relay without its exe
-                    try:
-                        os.replace(old, exe)
-                    except OSError:
-                        pass
-        if _monotonic() >= deadline:
-            return False, error
-        log.info("swap retry (%s)", error)
-        _sleep(_SWAP_RETRY_SECONDS)
+            with urllib.request.urlopen(url, timeout=2) as r:  # noqa: S310 (localhost health URL)
+                if json.loads(r.read().decode()).get("status") == "ok":
+                    return True
+        except (OSError, json.JSONDecodeError):
+            pass
+        _sleep(2.0)
+    return False
 
 
-def _relaunch(exe: Path, log: logging.Logger) -> None:
-    """Relaunch the desktop app from `exe`, exactly once. Reuses the single-instance detached launcher."""
+def _relaunch_and_wait_healthy(install_dir: Path, deadline: float, log: logging.Logger, attempts: int = 2) -> bool:
+    """Launch the current version and wait for /health, retrying up to `attempts` within the deadline. The
+    first launch after an extract also completes Defender's scan of the new .pyd, so a retry lands clean if
+    the first ever stumbles. Between attempts, kill the serve child so the port frees for a fresh bind."""
     from . import single_instance
 
+    url = _health_url(install_dir)
+    for i in range(1, attempts + 1):
+        if _monotonic() >= deadline:
+            break
+        single_instance.launch_installed(install_dir)
+        log.info("relaunch attempt %d of %d", i, attempts)
+        if _wait_for_health(url, min(deadline, _monotonic() + _HEALTH_WAIT_PER_ATTEMPT)):
+            log.info("relay healthy after relaunch")
+            return True
+        _kill_relay_pids(None, install_dir, log)  # clear a crashed/half attempt before retrying
+    return False
+
+
+def _current_target(install_dir: Path) -> Path | None:
+    """The real folder the `current` junction points at now (for rollback on a failed update)."""
+    link = layout.current_link(install_dir)
     try:
-        single_instance.launch_installed(exe.parent)
-        log.info("relaunched %s app", exe.name)
-    except Exception:
-        log.exception("failed to relaunch %s", exe.name)
+        if link.exists():
+            return link.resolve()
+    except OSError:
+        pass
+    return None
+
+
+# --- staging + applying -------------------------------------------------------------------------------
+
+
+def _download_and_extract(url: str, install_dir: Path, target_build: str | None) -> tuple[Path | None, str | None]:
+    """Download the bundle zip and extract it to a versioned app-<build>/ folder. Returns (version_dir,
+    None) on success or (None, error)."""
+    zip_path = install_dir / _DOWNLOAD_NAME
+    try:
+        urllib.request.urlretrieve(url, str(zip_path))  # noqa: S310 (release asset URL from latest_release)
+    except OSError as e:
+        return None, f"download failed: {e}"
+    if zip_path.stat().st_size < _MIN_ZIP_BYTES:
+        _unlink_quietly(zip_path)
+        return None, "the downloaded file is too small - aborting the update"
+    ver = layout.version_dir(install_dir, target_build or "staged")
+    try:
+        layout.extract_zip(zip_path, ver)
+    except (OSError, zipfile.BadZipFile) as e:
+        _unlink_quietly(zip_path)
+        return None, f"extract failed: {e}"
+    _unlink_quietly(zip_path)
+    new_exe = ver / layout.ASSET_NAME
+    if not new_exe.exists() or new_exe.stat().st_size < _MIN_EXE_BYTES:
+        return None, "the extracted bundle is missing ucnexus-relay.exe"
+    return ver, None
 
 
 def stage_update(url: str, install_dir: str | Path, app_pid: int, target_build: str | None = None) -> dict:
-    """Download the new exe, seed the attempt ledger, and spawn the detached windowless helper
-    (`ucnexus-relay update-apply`). The caller (ui.apply_update) then shuts the app down so the helper can
-    swap the now-unlocked exe and relaunch. No batch file, no image-name kills, no visible console."""
-    install_dir = Path(install_dir)
-    exe = install_dir / _ASSET_NAME
-    new = install_dir / (_ASSET_NAME + ".new")
+    """Download + extract the new version alongside the current one, seed the ledger, and spawn the detached
+    windowless helper from the CURRENT (settled) exe. The caller (ui.apply_update) then shuts the app down
+    so the helper can repoint the junction and relaunch."""
+    from . import single_instance
 
-    try:
-        urllib.request.urlretrieve(url, str(new))  # noqa: S310 (release asset URL from latest_release)
-    except OSError as e:
-        return {"ok": False, "error": f"download failed: {e}"}
-    if new.stat().st_size < _MIN_EXE_BYTES:
-        _unlink_quietly(new)
-        return {"ok": False, "error": "the downloaded file is too small - aborting the update"}
+    install_dir = Path(install_dir)
+    ver, error = _download_and_extract(url, install_dir, target_build)
+    if ver is None:
+        return {"ok": False, "error": error}
 
     _clear_cancel(install_dir)
-    _stage_ledger(install_dir, target_build or "", url)
-    _spawn_detached([str(exe), "update-apply", "--pid", str(int(app_pid))], cwd=install_dir)
+    _stage_ledger(install_dir, target_build or "", url, str(ver))
+    helper_exe = single_instance.installed_exe_path(install_dir)  # the current, already-scanned version
+    _spawn_detached([str(helper_exe), "update-apply", "--pid", str(int(app_pid))], cwd=install_dir)
     return {"ok": True, "note": "the relay will close and reopen on the new version"}
 
 
+def _give_up(install_dir: Path, log: logging.Logger, reason: str) -> dict:
+    log.warning("update giving up: %s", reason)
+    _finish_ledger(install_dir, "failed", reason)
+    _relaunch_and_wait_healthy(install_dir, _monotonic() + 30.0, log, attempts=1)
+    return {"ok": False, "error": reason}
+
+
 def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
-    """The detached helper (run as `ucnexus-relay update-apply`): wait for the app to exit, force any
-    remaining relay process down by pid, swap the staged exe in, and relaunch exactly once - all bounded
-    by a wall-clock deadline and an attempt ledger, all logged to update.log. Relaunches the NEW exe on a
-    clean swap, the CURRENT exe on failure (so the relay is never left down), and NOTHING on a user
-    cancel. Never loops and never re-enters staging."""
+    """The detached helper (run as `ucnexus-relay update-apply`), running from the OLD version: wait for the
+    app to exit, force any remaining relay process down by pid, repoint the `current` junction to the staged
+    new version, and relaunch it (health-gated). Rolls the junction back to the previous version if the new
+    one doesn't come up, so the relay is never left down. Relaunches nothing on a user cancel. Bounded by a
+    deadline + an attempt ledger; never loops."""
     install_dir = Path(install_dir)
-    exe = install_dir / _ASSET_NAME
-    new = install_dir / (_ASSET_NAME + ".new")
     log = _update_logger(install_dir)
 
     ledger = read_ledger(install_dir)
     attempts = ledger.get("attempts", 0) + 1
     target = ledger.get("target_build") or "?"
+    target_dir = ledger.get("target_dir")
     ledger["status"] = "applying"
     ledger["attempts"] = attempts
     ledger["updated_at"] = _now_iso()
@@ -435,30 +412,26 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
     _write_ledger(install_dir, ledger)
     log.info("update-apply start: target=%s attempt=%s app_pid=%s", target, attempts, app_pid)
 
-    # circuit breaker: never keep retrying the same failing target forever
     if attempts > MAX_ATTEMPTS:
-        msg = f"gave up after {MAX_ATTEMPTS} attempts to update to {target}; reboot and retry"
-        log.warning(msg)
-        _finish_ledger(install_dir, "failed", msg)
-        _unlink_quietly(new)
-        _relaunch(exe, log)
-        return {"ok": False, "error": msg}
+        return _give_up(install_dir, log, f"gave up after {MAX_ATTEMPTS} attempts to update to {target}; reboot and retry")
 
     if _cancel_requested(install_dir):
         log.info("cancel requested before apply; aborting without relaunch")
         _finish_ledger(install_dir, "cancelled", None)
         _clear_cancel(install_dir)
-        _unlink_quietly(new)
         return {"ok": False, "cancelled": True}
 
-    if not new.exists():
-        msg = "staged update file (.new) is missing; nothing to apply"
+    new_dir = Path(target_dir) if target_dir else None
+    if new_dir is None or not (new_dir / layout.ASSET_NAME).exists():
+        msg = "the staged version folder is missing; nothing to apply"
         log.warning(msg)
         _finish_ledger(install_dir, "failed", msg)
-        _relaunch(exe, log)
+        _relaunch_and_wait_healthy(install_dir, _monotonic() + 30.0, log, attempts=1)
         return {"ok": False, "error": msg}
 
+    old_target = _current_target(install_dir)  # for rollback
     deadline = _monotonic() + _GLOBAL_DEADLINE_SECONDS
+
     _wait_for_pid_exit(app_pid, deadline, log)
     _kill_relay_pids(app_pid, install_dir, log)
 
@@ -466,19 +439,47 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
         log.info("cancel requested during teardown; aborting without relaunch")
         _finish_ledger(install_dir, "cancelled", None)
         _clear_cancel(install_dir)
-        _unlink_quietly(new)
         return {"ok": False, "cancelled": True}
 
-    swapped, error = _swap_new_over_exe(exe, new, install_dir, deadline, log)
-    if swapped:
-        _cleanup_old(install_dir)
+    if not layout.repoint_current(install_dir, new_dir):
+        log.warning("could not repoint the current junction to %s", new_dir)
+
+    if _relaunch_and_wait_healthy(install_dir, deadline, log):
         _finish_ledger(install_dir, "success", None)
-        log.info("update applied: now on %s; relaunching", target)
-        _relaunch(exe, log)
+        layout.cleanup_old_versions(install_dir, keep={new_dir.name})
+        log.info("update applied: now on %s", target)
         return {"ok": True}
 
-    _unlink_quietly(new)
-    _finish_ledger(install_dir, "failed", error)
-    log.warning("swap failed (%s); relaunching current build so the relay stays up", error)
-    _relaunch(exe, log)
-    return {"ok": False, "error": error}
+    # the new version didn't come up healthy - roll the junction back and relaunch the previous version
+    log.warning("the updated version did not become healthy; rolling back")
+    if old_target is not None and old_target != new_dir:
+        layout.repoint_current(install_dir, old_target)
+    _relaunch_and_wait_healthy(install_dir, _monotonic() + 30.0, log)
+    _finish_ledger(install_dir, "failed", "the updated version did not start; rolled back to the previous one")
+    return {"ok": False, "error": "the updated version did not start; rolled back to the previous one"}
+
+
+def apply_update(url: str, install_dir: str | Path) -> dict:
+    """Standalone (non-desktop) in-process apply: download + extract the new version, stop serve, repoint
+    the junction, and restart serve from it. Rolls back on a failed repoint so the relay is never left down.
+    The desktop app uses stage_update + apply_staged_update instead."""
+    from . import setup, single_instance
+
+    install_dir = Path(install_dir)
+    ver, error = _download_and_extract(url, install_dir, None)
+    if ver is None:
+        return {"ok": False, "error": error}
+
+    old_target = _current_target(install_dir)
+    setup.stop_serve(install_dir)
+    ok = layout.repoint_current(install_dir, ver)
+    try:
+        setup.start_serve(single_instance.installed_exe_path(install_dir), install_dir)
+    except Exception:  # noqa: BLE001
+        pass
+    if ok:
+        layout.cleanup_old_versions(install_dir, keep={ver.name})
+        return {"ok": True, "restarted": True, "note": "reopen the window to load the updated UI"}
+    if old_target is not None:
+        layout.repoint_current(install_dir, old_target)
+    return {"ok": False, "error": "could not repoint to the new version; the relay stays on the current one"}

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -3,24 +3,52 @@
 The repo is public, so the relay checks the releases API and downloads the exe with no auth token and no
 backend involvement. Applying an update on Windows is the tricky part: a running exe is locked and can't
 be overwritten, but it CAN be renamed. So we download the new exe, rename the current one aside, drop the
-new one into its place, and restart serve. The ui process keeps running from the renamed file; reopening
-the window loads the new UI.
+new one into its place, and restart.
+
+The desktop app can't swap the exe it is running from and keep running, so it hands the swap to a detached
+helper: it stages the download, then exits, and a SEPARATE process (this exe re-invoked as `update-apply`)
+waits for the app to go, swaps the exe, and relaunches. That helper used to be a fire-and-forget .bat that
+could resurrect a closed app, kill every relay process by image name, spawn visible consoles, and loop with
+no timeout or record. It is now `apply_staged_update()` below: windowless, logged to update.log, bounded by
+a wall-clock deadline and an attempt ledger (update-state.json), killing only by pid and relaunching
+exactly once. See the module-level constants for the bounds.
 
 The build identity comes from _build.py, which CI stamps into the package at build time (see
 .github/workflows/relay-release.yml). A dev checkout has no _build.py, so current_build() is 'dev', which
 compares unequal to any release tag (always "behind")."""
 
 import json
+import logging
 import os
 import re
 import subprocess
+import sys
+import time
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO = "Upper-Canada-Specialty-Hardware/uc-nexus"
 _RELEASES_API = f"https://api.github.com/repos/{REPO}/releases?per_page=30"
 _ASSET_NAME = "ucnexus-relay.exe"
 _MIN_EXE_BYTES = 5_000_000  # a real exe is ~20MB; guard against a truncated body / HTML error page
+
+# --- self-update helper bounds ------------------------------------------------------------------------
+_STATE_FILE = "update-state.json"  # the attempt ledger the helper reads/writes and the UI surfaces
+_CANCEL_FLAG = "update-cancel"     # touched by a user-initiated shutdown to abort an in-flight update
+_UPDATE_LOG = "update.log"         # the helper's own log, next to config.toml
+MAX_ATTEMPTS = 3                   # circuit breaker: give up on a target build after this many helper runs
+_GLOBAL_DEADLINE_SECONDS = 90.0    # hard wall-clock cap on the whole wait+kill+swap sequence
+_APP_EXIT_WAIT_SECONDS = 20.0      # how long to wait for the app to exit on its own before force-killing
+_SWAP_RETRY_SECONDS = 1.0          # pause between swap attempts while Windows releases the exe handle
+_POLL_SECONDS = 0.5                # app-exit poll interval
+
+# Windows process-creation flags. DETACHED_PROCESS alone (NOT combined with CREATE_NO_WINDOW - the two are
+# contradictory and that pairing is what made the old .bat helper's cmd children pop visible consoles).
+_DETACHED_PROCESS = 0x00000008
+
+_monotonic = time.monotonic  # module-level seams so tests can drive the deadline/retry loops
+_sleep = time.sleep
 
 
 def current_build() -> str:
@@ -109,7 +137,8 @@ def _cleanup_old(install_dir: Path) -> None:
 def apply_update(url: str, install_dir: str | Path) -> dict:
     """Download `url` and swap it in for the installed exe, then restart serve. The relay is ALWAYS
     restarted on the way out, so a failed swap leaves it running on the CURRENT version rather than down
-    (rename-while-running; see the module docstring)."""
+    (rename-while-running; see the module docstring). This is the STANDALONE (non-desktop) path; the
+    desktop app uses stage_update + apply_staged_update instead."""
     from . import setup
 
     install_dir = Path(install_dir)
@@ -154,51 +183,219 @@ def apply_update(url: str, install_dir: str | Path) -> dict:
     }
 
 
-# A running exe can't reliably be renamed/overwritten in place, so the desktop app updates by exiting
-# first. This detached helper is the safety net around that, hardened so a stuck app can never leave the
-# relay hung or down:
-#   1. wait a BOUNDED time (~20s) for the app (pid) to exit on its own, so a clean shutdown can finish;
-#   2. then FORCE any remaining relay process down (a stuck app that never exited + the serve child, both
-#      ucnexus-relay.exe and both holding the exe lock) - a no-op if step 1 already succeeded;
-#   3. swap the downloaded .new over the now-unlocked exe, retrying while Windows releases the handle;
-#   4. relaunch - the new exe on success, or the CURRENT exe if the swap never took, so the relay is
-#      never left down.
-# It deletes itself at the end.
-_HELPER_BAT = r"""@echo off
-set _w=0
-:waitapp
-tasklist /fi "PID eq {pid}" /nh 2>nul | find /i "ucnexus-relay" >nul
-if errorlevel 1 goto force
-set /a _w+=1
-if %_w% geq 20 goto force
-timeout /t 1 /nobreak >nul
-goto waitapp
-:force
-taskkill /f /im ucnexus-relay.exe >nul 2>&1
-timeout /t 2 /nobreak >nul
-set _n=0
-:swap
-move /y "{new}" "{exe}" >nul 2>&1
-if not errorlevel 1 goto relaunch
-set /a _n+=1
-if %_n% geq 30 goto failed
-timeout /t 1 /nobreak >nul
-goto swap
-:relaunch
-start "" "{exe}" app
-goto done
-:failed
-if exist "{exe}" start "" "{exe}" app
-:done
-del "%~f0"
-"""
+# --- attempt ledger (update-state.json) ---------------------------------------------------------------
+# One small JSON file the staging step seeds and the helper updates, so a failure is recorded (surfaced in
+# the Updates tab) and repeated attempts at the SAME target build are capped. Shape:
+#   {status, target_build, target_url, attempts, last_error, first_attempt_at, updated_at}
+# status in: staging | applying | success | failed | cancelled.
 
 
-def stage_update(url: str, install_dir: str | Path, app_pid: int) -> dict:
-    """Download the new exe and spawn a detached helper that swaps the exe and relaunches the app once
-    the relay is no longer running. The caller should shut the app down so the swap is clean, but the
-    helper no longer depends on it: it waits a bounded time for `app_pid` to exit, then force-stops any
-    remaining relay process so it can't hang forever, and always relaunches (see _HELPER_BAT)."""
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def read_ledger(install_dir: str | Path) -> dict:
+    """The current update-state.json, or {} if absent/corrupt. Public so the UI can show the last result."""
+    try:
+        return json.loads((Path(install_dir) / _STATE_FILE).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_ledger(install_dir: Path, data: dict) -> None:
+    try:
+        (install_dir / _STATE_FILE).write_text(json.dumps(data), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _stage_ledger(install_dir: Path, target_build: str, target_url: str) -> None:
+    """Seed the ledger for a fresh staging. Preserves the attempt count only when re-staging the SAME
+    still-unfinished target (so hammering a failing build is capped); a new target or a prior success
+    resets it to 0."""
+    prev = read_ledger(install_dir)
+    same = bool(target_build) and prev.get("target_build") == target_build and prev.get("status") != "success"
+    _write_ledger(
+        install_dir,
+        {
+            "status": "staging",
+            "target_build": target_build,
+            "target_url": target_url,
+            "attempts": prev.get("attempts", 0) if same else 0,
+            "last_error": prev.get("last_error") if same else None,
+            "first_attempt_at": prev.get("first_attempt_at") if same else None,
+            "updated_at": _now_iso(),
+        },
+    )
+
+
+def _finish_ledger(install_dir: Path, status: str, error: str | None) -> None:
+    ledger = read_ledger(install_dir)
+    ledger["status"] = status
+    ledger["last_error"] = error
+    ledger["updated_at"] = _now_iso()
+    _write_ledger(install_dir, ledger)
+
+
+# --- cancel flag --------------------------------------------------------------------------------------
+
+
+def request_cancel(install_dir: str | Path) -> None:
+    """Ask an in-flight update to abort WITHOUT relaunching. Written by a user-initiated shutdown so
+    closing the relay mid-update is respected (see app.RelayApp.user_shutdown)."""
+    try:
+        (Path(install_dir) / _CANCEL_FLAG).write_text("1", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _cancel_requested(install_dir: Path) -> bool:
+    return (install_dir / _CANCEL_FLAG).exists()
+
+
+def _clear_cancel(install_dir: Path) -> None:
+    _unlink_quietly(install_dir / _CANCEL_FLAG)
+
+
+# --- the detached helper ------------------------------------------------------------------------------
+
+
+def _spawn_detached(args: list[str], cwd: str | Path) -> None:
+    """Launch our own GUI-subsystem exe fully detached, windowless. DETACHED_PROCESS alone - never paired
+    with CREATE_NO_WINDOW (contradictory; that pairing spawned the visible consoles in the old .bat)."""
+    subprocess.Popen(  # noqa: S603 (our own exe path + fixed subcommand)
+        args,
+        cwd=str(cwd),
+        creationflags=_DETACHED_PROCESS,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+
+def _update_logger(install_dir: Path) -> logging.Logger:
+    """A dedicated logger writing update.log next to config.toml, so a broken update is diagnosable
+    (the old .bat swallowed everything with >nul 2>&1)."""
+    logger = logging.getLogger("ucnexus_relay.update")
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        try:
+            fh = logging.FileHandler(install_dir / _UPDATE_LOG, encoding="utf-8")
+            fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+            logger.addHandler(fh)
+        except OSError:
+            logger.addHandler(logging.NullHandler())
+        logger.propagate = False
+    return logger
+
+
+def _pid_alive(pid) -> bool:
+    """True if `pid` is a live process. Windows: OpenProcess + GetExitCodeProcess (no tasklist, which the
+    old helper piped through find and which flashed consoles)."""
+    if not pid:
+        return False
+    if sys.platform != "win32":
+        try:
+            os.kill(int(pid), 0)
+            return True
+        except (OSError, ValueError):
+            return False
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    k = ctypes.windll.kernel32
+    handle = k.OpenProcess(process_query_limited_information, False, int(pid))
+    if not handle:
+        return False
+    try:
+        code = wintypes.DWORD()
+        if not k.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value == still_active
+    finally:
+        k.CloseHandle(handle)
+
+
+def _read_serve_pid(install_dir: Path) -> int | None:
+    try:
+        return int((install_dir / "relay.pid").read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _wait_for_pid_exit(pid, deadline: float, log: logging.Logger) -> None:
+    """Wait (bounded by both _APP_EXIT_WAIT_SECONDS and the global deadline) for the app to exit on its
+    own, so a clean shutdown can finish before we force anything."""
+    until = min(deadline, _monotonic() + _APP_EXIT_WAIT_SECONDS)
+    while _monotonic() < until:
+        if not _pid_alive(pid):
+            log.info("app pid %s exited", pid)
+            return
+        _sleep(_POLL_SECONDS)
+    if _pid_alive(pid):
+        log.info("app pid %s still alive after %ss; will force-kill", pid, _APP_EXIT_WAIT_SECONDS)
+
+
+def _kill_relay_pids(app_pid, install_dir: Path, log: logging.Logger) -> None:
+    """Force any remaining relay process down BY PID (the app pid we were handed + the serve child from
+    relay.pid). Never by image name - this helper IS ucnexus-relay.exe and would kill itself."""
+    from . import single_instance
+
+    if app_pid:
+        single_instance.force_kill_pid(app_pid)
+        log.info("force-killed app pid %s (no-op if already gone)", app_pid)
+    serve_pid = _read_serve_pid(install_dir)
+    if serve_pid and serve_pid != app_pid:
+        single_instance.force_kill_pid(serve_pid)
+        log.info("force-killed serve pid %s", serve_pid)
+
+
+def _swap_new_over_exe(exe: Path, new: Path, install_dir: Path, deadline: float, log: logging.Logger):
+    """Rename the (now-unlocked) exe aside and drop the new one in, retrying while Windows releases the
+    handle, until the deadline. On a partial failure (renamed aside but couldn't move the new one in) the
+    old exe is put back, so the relay is never left without an exe. Returns (swapped: bool, error|None)."""
+    error = None
+    while True:
+        old = _free_old_path(install_dir)
+        try:
+            os.replace(exe, old)  # rename running/held image aside (permitted on Win10/11)
+        except OSError as e:
+            error = f"rename-aside failed: {e}"
+        else:
+            try:
+                os.replace(new, exe)  # move the new bytes into place
+                return True, None
+            except OSError as e:
+                error = f"move-new-in failed: {e}"
+                if not exe.exists():  # roll back so we never leave the relay without its exe
+                    try:
+                        os.replace(old, exe)
+                    except OSError:
+                        pass
+        if _monotonic() >= deadline:
+            return False, error
+        log.info("swap retry (%s)", error)
+        _sleep(_SWAP_RETRY_SECONDS)
+
+
+def _relaunch(exe: Path, log: logging.Logger) -> None:
+    """Relaunch the desktop app from `exe`, exactly once. Reuses the single-instance detached launcher."""
+    from . import single_instance
+
+    try:
+        single_instance.launch_installed(exe.parent)
+        log.info("relaunched %s app", exe.name)
+    except Exception:
+        log.exception("failed to relaunch %s", exe.name)
+
+
+def stage_update(url: str, install_dir: str | Path, app_pid: int, target_build: str | None = None) -> dict:
+    """Download the new exe, seed the attempt ledger, and spawn the detached windowless helper
+    (`ucnexus-relay update-apply`). The caller (ui.apply_update) then shuts the app down so the helper can
+    swap the now-unlocked exe and relaunch. No batch file, no image-name kills, no visible console."""
     install_dir = Path(install_dir)
     exe = install_dir / _ASSET_NAME
     new = install_dir / (_ASSET_NAME + ".new")
@@ -211,16 +408,77 @@ def stage_update(url: str, install_dir: str | Path, app_pid: int) -> dict:
         _unlink_quietly(new)
         return {"ok": False, "error": "the downloaded file is too small - aborting the update"}
 
-    helper = install_dir / "update-helper.bat"
-    helper.write_text(_HELPER_BAT.format(pid=int(app_pid), new=str(new), exe=str(exe)), encoding="utf-8")
-    detached = 0x00000008  # DETACHED_PROCESS
-    no_window = 0x08000000  # CREATE_NO_WINDOW
-    subprocess.Popen(  # noqa: S603 (fixed cmd + our own helper path)
-        ["cmd", "/c", str(helper)],
-        cwd=str(install_dir),
-        creationflags=detached | no_window,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    _clear_cancel(install_dir)
+    _stage_ledger(install_dir, target_build or "", url)
+    _spawn_detached([str(exe), "update-apply", "--pid", str(int(app_pid))], cwd=install_dir)
     return {"ok": True, "note": "the relay will close and reopen on the new version"}
+
+
+def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
+    """The detached helper (run as `ucnexus-relay update-apply`): wait for the app to exit, force any
+    remaining relay process down by pid, swap the staged exe in, and relaunch exactly once - all bounded
+    by a wall-clock deadline and an attempt ledger, all logged to update.log. Relaunches the NEW exe on a
+    clean swap, the CURRENT exe on failure (so the relay is never left down), and NOTHING on a user
+    cancel. Never loops and never re-enters staging."""
+    install_dir = Path(install_dir)
+    exe = install_dir / _ASSET_NAME
+    new = install_dir / (_ASSET_NAME + ".new")
+    log = _update_logger(install_dir)
+
+    ledger = read_ledger(install_dir)
+    attempts = ledger.get("attempts", 0) + 1
+    target = ledger.get("target_build") or "?"
+    ledger["status"] = "applying"
+    ledger["attempts"] = attempts
+    ledger["updated_at"] = _now_iso()
+    ledger.setdefault("first_attempt_at", _now_iso())
+    _write_ledger(install_dir, ledger)
+    log.info("update-apply start: target=%s attempt=%s app_pid=%s", target, attempts, app_pid)
+
+    # circuit breaker: never keep retrying the same failing target forever
+    if attempts > MAX_ATTEMPTS:
+        msg = f"gave up after {MAX_ATTEMPTS} attempts to update to {target}; reboot and retry"
+        log.warning(msg)
+        _finish_ledger(install_dir, "failed", msg)
+        _unlink_quietly(new)
+        _relaunch(exe, log)
+        return {"ok": False, "error": msg}
+
+    if _cancel_requested(install_dir):
+        log.info("cancel requested before apply; aborting without relaunch")
+        _finish_ledger(install_dir, "cancelled", None)
+        _clear_cancel(install_dir)
+        _unlink_quietly(new)
+        return {"ok": False, "cancelled": True}
+
+    if not new.exists():
+        msg = "staged update file (.new) is missing; nothing to apply"
+        log.warning(msg)
+        _finish_ledger(install_dir, "failed", msg)
+        _relaunch(exe, log)
+        return {"ok": False, "error": msg}
+
+    deadline = _monotonic() + _GLOBAL_DEADLINE_SECONDS
+    _wait_for_pid_exit(app_pid, deadline, log)
+    _kill_relay_pids(app_pid, install_dir, log)
+
+    if _cancel_requested(install_dir):
+        log.info("cancel requested during teardown; aborting without relaunch")
+        _finish_ledger(install_dir, "cancelled", None)
+        _clear_cancel(install_dir)
+        _unlink_quietly(new)
+        return {"ok": False, "cancelled": True}
+
+    swapped, error = _swap_new_over_exe(exe, new, install_dir, deadline, log)
+    if swapped:
+        _cleanup_old(install_dir)
+        _finish_ledger(install_dir, "success", None)
+        log.info("update applied: now on %s; relaunching", target)
+        _relaunch(exe, log)
+        return {"ok": True}
+
+    _unlink_quietly(new)
+    _finish_ledger(install_dir, "failed", error)
+    log.warning("swap failed (%s); relaunching current build so the relay stays up", error)
+    _relaunch(exe, log)
+    return {"ok": False, "error": error}

--- a/relay/tests/test_app.py
+++ b/relay/tests/test_app.py
@@ -214,49 +214,17 @@ def test_acquire_defers_when_it_loses_the_cold_start_race(monkeypatch):
     assert 7 in sent and (9, "z") in sent
 
 
-def test_maybe_promote_skips_when_launched_from_install_dir(monkeypatch):
+def test_cleanup_old_versions_keeps_running_drops_others(monkeypatch, tmp_path):
+    from ucnexus_relay import layout
+
     a = appmod.RelayApp()
-    monkeypatch.setattr(si, "same_path", lambda x, y: True)
-    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
-    monkeypatch.setattr(si, "current_build", lambda: BUILD5)
-    assert a._maybe_promote(force=False) is False
+    monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
+    for name in ("app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.27", "app-old"):
+        (tmp_path / name).mkdir()
+    running = tmp_path / "app-relay-v0.1.0-build.27"
+    monkeypatch.setattr(layout, "running_version_dir", lambda: running)
 
+    a._cleanup_old_versions()
 
-def test_maybe_promote_delegates_when_installed_is_current(monkeypatch):
-    a = appmod.RelayApp()
-    monkeypatch.setattr(si, "same_path", lambda x, y: False)
-    monkeypatch.setattr(si, "installed_build", lambda d: BUILD6)
-    monkeypatch.setattr(si, "current_build", lambda: BUILD5)  # we're older -> delegate to installed
-    monkeypatch.setattr(si, "live_owner", lambda d: None)
-    launched = []
-    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
-    assert a._maybe_promote(force=False) is True
-    assert launched == [True]
-
-
-def test_maybe_promote_swaps_and_relaunches_when_newer(monkeypatch):
-    a = appmod.RelayApp()
-    monkeypatch.setattr(si, "same_path", lambda x, y: False)
-    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
-    monkeypatch.setattr(si, "current_build", lambda: BUILD6)  # newer -> promote
-    monkeypatch.setattr(si, "live_owner", lambda d: None)
-    swapped = []
-    monkeypatch.setattr(si, "promote_swap", lambda src, d: swapped.append(src) or {"ok": True})
-    monkeypatch.setattr(si, "refresh_autostart_if_present", lambda d: None)
-    launched = []
-    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
-    assert a._maybe_promote(force=False) is True
-    assert swapped and launched == [True]
-
-
-def test_maybe_promote_runs_in_place_when_swap_fails(monkeypatch):
-    a = appmod.RelayApp()
-    monkeypatch.setattr(si, "same_path", lambda x, y: False)
-    monkeypatch.setattr(si, "installed_build", lambda d: BUILD5)
-    monkeypatch.setattr(si, "current_build", lambda: BUILD6)
-    monkeypatch.setattr(si, "live_owner", lambda d: None)
-    monkeypatch.setattr(si, "promote_swap", lambda src, d: {"ok": False, "error": "locked"})
-    launched = []
-    monkeypatch.setattr(si, "launch_installed", lambda d, **k: launched.append(True))
-    assert a._maybe_promote(force=False) is False  # fall back to running in place
-    assert launched == []
+    remaining = sorted(p.name for p in tmp_path.glob("app-*"))
+    assert remaining == ["app-relay-v0.1.0-build.27"]  # kept the running version, dropped the rest

--- a/relay/tests/test_app.py
+++ b/relay/tests/test_app.py
@@ -79,6 +79,8 @@ def test_api_shutdown_app_errors_when_not_in_app_mode(monkeypatch):
 
 
 def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
+    import os
+
     from ucnexus_relay import updater
 
     a = appmod.RelayApp()
@@ -86,10 +88,16 @@ def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
     monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
     monkeypatch.setattr(appmod, "_APP", a)
     monkeypatch.setattr(ui, "_frozen", lambda: True)
-    monkeypatch.setattr(updater, "stage_update", lambda url, d, pid: {"ok": True, "note": "restarting"})
-    r = ui.Api().apply_update("https://x/e.exe")
+    monkeypatch.setattr(os, "_exit", lambda code: None)  # neutralize the hard-exit fallback timer
+    passed = {}
+    monkeypatch.setattr(
+        updater, "stage_update", lambda url, d, pid, target_build=None: passed.update(build=target_build) or {"ok": True}
+    )
+    r = ui.Api().apply_update("https://x/e.exe", "relay-v0.1.0-build.11")
     assert r["ok"] is True
     assert shut == [True]  # the app shut itself down so the helper can swap the unlocked exe
+    assert a._updating is True  # marked as the update handoff, so a later teardown isn't a user cancel
+    assert passed["build"] == "relay-v0.1.0-build.11"  # target build threaded through to the ledger
 
 
 def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
@@ -100,10 +108,35 @@ def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
     monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
     monkeypatch.setattr(appmod, "_APP", a)
     monkeypatch.setattr(ui, "_frozen", lambda: True)
-    monkeypatch.setattr(updater, "stage_update", lambda url, d, pid: {"ok": False, "error": "download failed"})
+    monkeypatch.setattr(
+        updater, "stage_update", lambda url, d, pid, target_build=None: {"ok": False, "error": "download failed"}
+    )
     r = ui.Api().apply_update("https://x/e.exe")
     assert r["ok"] is False
     assert shut == []  # a failed stage must NOT close the app
+    assert a._updating is False  # not marked updating, so a later user shutdown still cancels normally
+
+
+def test_user_shutdown_cancels_a_pending_update(monkeypatch, tmp_path):
+    from ucnexus_relay import updater
+
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
+    monkeypatch.setattr(a, "shutdown", lambda: None)
+    updater._write_ledger(tmp_path, {"status": "applying", "target_build": "b", "attempts": 1})
+    a.user_shutdown()
+    assert (tmp_path / updater._CANCEL_FLAG).exists()  # user closing mid-update signals the helper to abort
+
+
+def test_update_handoff_shutdown_does_not_cancel_itself(monkeypatch, tmp_path):
+    from ucnexus_relay import updater
+
+    a = appmod.RelayApp()
+    a._updating = True  # this teardown IS the update handoff
+    monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
+    updater._write_ledger(tmp_path, {"status": "applying", "target_build": "b", "attempts": 1})
+    a._cancel_update_if_pending()
+    assert not (tmp_path / updater._CANCEL_FLAG).exists()  # must not cancel the update it just started
 
 
 # --- single-instance gate ----------------------------------------------------------------------------

--- a/relay/tests/test_layout.py
+++ b/relay/tests/test_layout.py
@@ -1,0 +1,71 @@
+"""Onedir install layout: version-folder naming, installed-exe resolution, old-version cleanup, and the
+junction repoint (mklink mocked). Pure path logic, no real junction."""
+
+import zipfile
+
+from ucnexus_relay import layout
+
+
+def test_version_dir_name_sanitizes():
+    assert layout.version_dir_name("relay-v0.1.0-build.27") == "app-relay-v0.1.0-build.27"
+    assert layout.version_dir_name("") == "app-staged"
+    assert layout.version_dir_name("weird/\\ name") == "app-weird---name"  # path separators + space sanitized (dots kept)
+
+
+def test_installed_exe_prefers_current(tmp_path):
+    cur = tmp_path / "current"  # a plain dir stands in for the junction (exists() + child exe)
+    cur.mkdir()
+    (cur / "ucnexus-relay.exe").write_bytes(b"exe")
+    assert layout.installed_exe(tmp_path) == cur / "ucnexus-relay.exe"
+
+
+def test_installed_exe_falls_back_to_newest_version(tmp_path):
+    for b in ("app-relay-v0.1.0-build.8", "app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.9"):
+        d = tmp_path / b
+        d.mkdir()
+        (d / "ucnexus-relay.exe").write_bytes(b"exe")
+    assert layout.installed_exe(tmp_path) == tmp_path / "app-relay-v0.1.0-build.26" / "ucnexus-relay.exe"
+
+
+def test_installed_exe_legacy_flat_fallback(tmp_path):
+    # no junction, no app-*/ -> the legacy flat path (a onefile install / a dev checkout)
+    assert layout.installed_exe(tmp_path) == tmp_path / "ucnexus-relay.exe"
+
+
+def test_newest_version_dir_ignores_folders_without_the_exe(tmp_path):
+    (tmp_path / "app-relay-v0.1.0-build.8").mkdir()  # no exe inside -> not a candidate
+    good = tmp_path / "app-relay-v0.1.0-build.5"
+    good.mkdir()
+    (good / "ucnexus-relay.exe").write_bytes(b"e")
+    assert layout.newest_version_dir(tmp_path) == good
+
+
+def test_cleanup_old_versions_keeps_named(tmp_path):
+    for b in ("app-a", "app-b", "app-c"):
+        (tmp_path / b).mkdir()
+    layout.cleanup_old_versions(tmp_path, keep={"app-b"})
+    assert sorted(p.name for p in tmp_path.glob("app-*")) == ["app-b"]
+
+
+def test_extract_zip_roundtrip(tmp_path):
+    zp = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(zp, "w") as zf:
+        zf.writestr("ucnexus-relay.exe", b"exe")
+        zf.writestr("_internal/x", b"y")
+    dest = tmp_path / "app-x"
+    layout.extract_zip(zp, dest)
+    assert (dest / "ucnexus-relay.exe").read_bytes() == b"exe"
+    assert (dest / "_internal" / "x").exists()
+
+
+def test_repoint_current_calls_mklink_junction(tmp_path, monkeypatch):
+    calls = []
+
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(layout.subprocess, "run", lambda args, **k: calls.append(args) or _R())
+    target = tmp_path / "app-relay-v0.1.0-build.27"
+    assert layout.repoint_current(tmp_path, target) is True
+    assert calls and calls[0][:4] == ["cmd", "/c", "mklink", "/J"]
+    assert str(target) in calls[0]

--- a/relay/tests/test_logging_setup.py
+++ b/relay/tests/test_logging_setup.py
@@ -1,0 +1,22 @@
+"""Logging setup: relay.log rotates so a long-lived relay can't grow it without bound."""
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+from ucnexus_relay import logging_setup
+
+
+def test_configure_logging_uses_a_rotating_file_handler(tmp_path, monkeypatch):
+    # reset the one-shot guard so this call actually (re)configures, and restore it after
+    monkeypatch.setattr(logging_setup, "_CONFIGURED", False)
+    root = logging.getLogger()
+    before = set(root.handlers)
+    try:
+        logging_setup.configure_logging("INFO", str(tmp_path / "relay.log"))
+        rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+        assert rotating, "relay.log must use a RotatingFileHandler so it can't grow unbounded"
+        assert rotating[0].maxBytes > 0 and rotating[0].backupCount >= 1
+    finally:
+        for h in [h for h in root.handlers if h not in before]:
+            root.removeHandler(h)
+            h.close()

--- a/relay/tests/test_single_instance.py
+++ b/relay/tests/test_single_instance.py
@@ -28,17 +28,6 @@ def test_decide_action_matrix():
     assert si.decide_action("dev", BUILD5, force=True) == "replace"  # --force always replaces
 
 
-def test_promote_decision_matrix():
-    d = si.promote_decision
-    assert d(frozen=False, same_path=False, installed_build=BUILD5, my_build=BUILD6, force=False) == "skip"
-    assert d(frozen=True, same_path=True, installed_build=BUILD5, my_build=BUILD6, force=False) == "skip"
-    assert d(frozen=True, same_path=False, installed_build=None, my_build=BUILD5, force=False) == "promote"
-    assert d(frozen=True, same_path=False, installed_build=BUILD5, my_build=BUILD6, force=False) == "promote"
-    assert d(frozen=True, same_path=False, installed_build=BUILD6, my_build=BUILD5, force=False) == "delegate"
-    assert d(frozen=True, same_path=False, installed_build=BUILD5, my_build=BUILD5, force=False) == "delegate"
-    assert d(frozen=True, same_path=False, installed_build=BUILD6, my_build=BUILD5, force=True) == "promote"
-
-
 # --- lockfile -----------------------------------------------------------------------------------------
 
 
@@ -134,28 +123,7 @@ def test_evict_force_kills_when_graceful_times_out(monkeypatch, tmp_path):
     assert killed == [9]
 
 
-# --- promote-to-installed -----------------------------------------------------------------------------
-
-
-def test_promote_swap_replaces_installed(tmp_path):
-    installed = si.installed_exe_path(tmp_path)
-    installed.write_text("OLD", encoding="utf-8")
-    src = tmp_path / "Downloads" / "ucnexus-relay.exe"
-    src.parent.mkdir()
-    src.write_text("NEW", encoding="utf-8")
-
-    res = si.promote_swap(src, tmp_path)
-    assert res["ok"] is True
-    assert installed.read_text(encoding="utf-8") == "NEW"
-    assert not list(tmp_path.glob("ucnexus-relay.exe.old*"))  # the aside copy is cleaned up
-
-
-def test_promote_swap_fresh_install(tmp_path):
-    src = tmp_path / "src.exe"
-    src.write_text("NEW", encoding="utf-8")
-    res = si.promote_swap(src, tmp_path)
-    assert res["ok"] is True
-    assert si.installed_exe_path(tmp_path).read_text(encoding="utf-8") == "NEW"
+# --- installed-exe resolution -------------------------------------------------------------------------
 
 
 def test_installed_build_reads_print_build(monkeypatch, tmp_path):

--- a/relay/tests/test_ui.py
+++ b/relay/tests/test_ui.py
@@ -88,6 +88,18 @@ def test_recent_log_events_limit(tmp_path):
     assert len(ui.recent_log_events(p, limit=10)) == 10
 
 
+def test_tail_lines_reads_a_bounded_tail_of_a_large_log(tmp_path):
+    # the UI polls the log every few seconds; a large file must be tailed from the END, not read whole,
+    # and must still return the last `limit` COMPLETE (parseable) lines in order.
+    log = tmp_path / "relay.log"
+    events = [json.dumps({"asctime": f"t{i}", "levelname": "INFO", "message": "x" * 60, "i": i}) for i in range(5000)]
+    log.write_text("\n".join(events) + "\n", encoding="utf-8")
+    tail = ui._tail_lines(log, 20)
+    assert len(tail) == 20
+    parsed = [json.loads(t) for t in tail]  # every returned line is complete, not truncated by the offset read
+    assert [row["i"] for row in parsed] == list(range(4980, 5000))  # the LAST 20 events, in order
+
+
 def test_channel_state_connected_wins_over_earlier_drop(tmp_path):
     p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
     _log(

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -1,12 +1,12 @@
-"""Updater: release discovery over the public GitHub API, the current-vs-latest comparison, and the
-download + rename-swap that applies an update. No network (urlopen/urlretrieve mocked), no real exe."""
+"""Updater: release discovery over the public GitHub API, the current-vs-latest comparison, and the onedir
+zip-download + junction-repoint self-update. No network (urlopen/urlretrieve mocked), no real junction."""
 
 import json
 import logging
-import os
+import zipfile
 from pathlib import Path
 
-from ucnexus_relay import setup, updater
+from ucnexus_relay import layout, single_instance, updater
 
 _LOG = logging.getLogger("relay-test-update")  # throwaway; the helper only writes to it
 
@@ -25,56 +25,47 @@ class _Resp:
         return False
 
 
+def _bundle_zip(dest):
+    # ZIP_STORED so the archive is actually >_MIN_ZIP_BYTES (a compressed run of one byte would be tiny and
+    # trip the too-small guard); mirrors a real ~27MB onedir bundle.
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("ucnexus-relay.exe", b"N" * 6_000_000)
+        zf.writestr("_internal/base_library.zip", b"stub")
+
+
+# --- release discovery / check_update -----------------------------------------------------------------
+
+
 def test_current_build_falls_back_to_dev():
-    # a dev checkout has no _build.py (CI stamps it); the fallback keeps the updater always "behind"
     assert updater.current_build() == "dev"
 
 
 def test_latest_release_picks_highest_build_not_list_order(monkeypatch):
-    # regression: GitHub's /releases list is NOT reliably newest-first - the real API returned
-    # build.9, build.8, build.7, build.10 in that order. Picking the first entry gives build.9 and
-    # would offer a DOWNGRADE to anyone on build.10. Pick by build number, not position.
+    # regression: GitHub's /releases list is NOT reliably newest-first. Pick by build number, not position.
     payload = [
         {"tag_name": "some-other-v1", "assets": []},
-        {
-            "tag_name": "relay-v0.1.0-build.9",
-            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build9.exe"}],
-        },
-        {
-            "tag_name": "relay-v0.1.0-build.8",
-            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build8.exe"}],
-        },
-        {
-            "tag_name": "relay-v0.1.0-build.10",  # newest, but appears AFTER the older ones in the list
-            "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "https://x/build10.exe"}],
-            "published_at": "t10",
-        },
+        {"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b9.zip"}]},
+        {"tag_name": "relay-v0.1.0-build.8", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b8.zip"}]},
+        {"tag_name": "relay-v0.1.0-build.10", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b10.zip"}], "published_at": "t10"},
     ]
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
     r = updater.latest_release()
     assert r["tag"] == "relay-v0.1.0-build.10"
-    assert r["url"].endswith("build10.exe")
+    assert r["url"].endswith("b10.zip")
 
 
-def test_latest_release_returns_empty_when_no_relay_release(monkeypatch):
-    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp([{"tag_name": "some-other-v1", "assets": []}]))
-    assert updater.latest_release() == {}
-
-
-def test_latest_release_skips_releases_without_the_exe_asset(monkeypatch):
-    payload = [{"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "notes.txt", "browser_download_url": "u"}]}]
+def test_latest_release_requires_the_zip_bundle(monkeypatch):
+    # a release with only the old onefile exe asset (no zip bundle) does not count
+    payload = [{"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "u"}]}]
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
     assert updater.latest_release() == {}
 
 
 def test_check_update_reports_available(monkeypatch):
     monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.7")
-    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "https://x/e.exe"})
+    monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "https://x/b.zip"})
     r = updater.check_update()
-    assert r["ok"] is True
-    assert r["update_available"] is True
-    assert r["latest"] == "relay-v0.1.0-build.9"
-    assert r["url"].endswith("e.exe")
+    assert r["ok"] is True and r["update_available"] is True and r["latest"] == "relay-v0.1.0-build.9"
 
 
 def test_check_update_up_to_date(monkeypatch):
@@ -84,8 +75,6 @@ def test_check_update_up_to_date(monkeypatch):
 
 
 def test_check_update_never_offers_a_downgrade(monkeypatch):
-    # installed build is NEWER than what discovery returns (e.g. GitHub API lag) -> must NOT offer to
-    # "update" to the older build.
     monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.10")
     monkeypatch.setattr(updater, "latest_release", lambda: {"tag": "relay-v0.1.0-build.9", "url": "u"})
     assert updater.check_update()["update_available"] is False
@@ -102,85 +91,32 @@ def test_check_update_no_release(monkeypatch):
     assert updater.check_update()["ok"] is False
 
 
-def test_apply_update_swaps_and_restarts(tmp_path, monkeypatch):
-    exe = tmp_path / "ucnexus-relay.exe"
-    exe.write_bytes(b"OLD-EXE")
-
-    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
-    stopped, started = {}, {}
-
-    def _stop(d):
-        stopped["d"] = d
-        return {"ok": True}
-
-    def _start(e, d):
-        started["exe"] = e
-        return {"ok": True}
-
-    monkeypatch.setattr(setup, "stop_serve", _stop)
-    monkeypatch.setattr(setup, "start_serve", _start)
-
-    r = updater.apply_update("https://x/e.exe", tmp_path)
-    assert r["ok"] is True
-    assert exe.read_bytes()[:1] == b"N"  # exe now holds the new bytes
-    assert not (tmp_path / "ucnexus-relay.exe.old").exists()  # cleaned up after a successful swap
-    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # moved into place
-    assert started["exe"] == exe  # serve restarted from the new exe
-    assert stopped["d"] == tmp_path
+# --- stage_update: download + extract a new version + spawn the helper from the CURRENT exe ------------
 
 
-def test_apply_update_restarts_serve_even_when_the_swap_fails(tmp_path, monkeypatch):
-    # regression: a failed swap must NOT leave the relay stopped (it took GP down once).
-    exe = tmp_path / "ucnexus-relay.exe"
-    exe.write_bytes(b"OLD")
-    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
-    started = []
-    monkeypatch.setattr(setup, "stop_serve", lambda d: {"ok": True})
-    monkeypatch.setattr(setup, "start_serve", lambda e, d: started.append(e) or {"ok": True})
-
-    def _raise(a, b):
-        raise OSError("locked")
-
-    monkeypatch.setattr(updater.os, "replace", _raise)
-    r = updater.apply_update("u", tmp_path)
-    assert r["ok"] is False
-    assert "swap failed" in r["error"]
-    assert started == [exe]  # serve was restarted on the current version despite the failure
-
-
-def test_apply_update_rejects_a_tiny_download(tmp_path, monkeypatch):
-    exe = tmp_path / "ucnexus-relay.exe"
-    exe.write_bytes(b"OLD")
-    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"tiny"))
-    monkeypatch.setattr(setup, "stop_serve", lambda d: {"ok": True})
-
-    r = updater.apply_update("u", tmp_path)
-    assert r["ok"] is False
-    assert "too small" in r["error"]
-    assert exe.read_bytes() == b"OLD"  # left untouched on a bad download
-
-
-def test_stage_update_downloads_seeds_ledger_and_spawns_the_helper(tmp_path, monkeypatch):
-    # NO batch file anymore: staging downloads the exe, seeds the attempt ledger, and spawns the
-    # windowless `ucnexus-relay update-apply` helper (never `cmd /c a .bat`, never a taskkill /im).
-    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+def test_stage_update_extracts_version_seeds_ledger_and_spawns_helper(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: _bundle_zip(dest))
+    helper_exe = tmp_path / "app-old" / "ucnexus-relay.exe"
+    monkeypatch.setattr(single_instance, "installed_exe_path", lambda d: helper_exe)
     calls = []
     monkeypatch.setattr(updater, "_spawn_detached", lambda args, cwd: calls.append((args, cwd)))
-    exe = tmp_path / "ucnexus-relay.exe"
 
     r = updater.stage_update("u", tmp_path, 4242, target_build="relay-v0.1.0-build.11")
     assert r["ok"] is True
-    assert not (tmp_path / "update-helper.bat").exists()  # the .bat is gone
-    assert (tmp_path / "ucnexus-relay.exe.new").exists()  # downloaded, not yet swapped
 
-    ledger = updater.read_ledger(tmp_path)
-    assert ledger["status"] == "staging"
-    assert ledger["target_build"] == "relay-v0.1.0-build.11"
-    assert ledger["attempts"] == 0
+    ver = tmp_path / "app-relay-v0.1.0-build.11"
+    assert (ver / "ucnexus-relay.exe").exists()  # new version extracted ALONGSIDE the current one
+    assert not (tmp_path / "ucnexus-relay-download.zip").exists()  # download cleaned up
+
+    led = updater.read_ledger(tmp_path)
+    assert led["status"] == "staging"
+    assert led["target_build"] == "relay-v0.1.0-build.11"
+    assert led["target_dir"] == str(ver)
+    assert led["attempts"] == 0
 
     assert len(calls) == 1
     args, _ = calls[0]
-    assert args == [str(exe), "update-apply", "--pid", "4242"]  # windowless helper, waits for the app pid
+    assert args == [str(helper_exe), "update-apply", "--pid", "4242"]  # helper runs from the CURRENT exe
 
 
 def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monkeypatch):
@@ -191,14 +127,13 @@ def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monke
 
     monkeypatch.setattr(updater, "_spawn_detached", _no_spawn)
     r = updater.stage_update("u", tmp_path, 1)
-    assert r["ok"] is False
-    assert "too small" in r["error"]
+    assert r["ok"] is False and "too small" in r["error"]
 
 
-def test_stage_update_keeps_attempts_for_the_same_target_but_resets_for_a_new_one(tmp_path, monkeypatch):
-    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+def test_stage_update_keeps_attempts_for_same_target_but_resets_for_new(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: _bundle_zip(dest))
+    monkeypatch.setattr(single_instance, "installed_exe_path", lambda d: tmp_path / "cur" / "ucnexus-relay.exe")
     monkeypatch.setattr(updater, "_spawn_detached", lambda args, cwd: None)
-    # a prior FAILED attempt at build.11 (attempts already 2)
     updater._write_ledger(tmp_path, {"status": "failed", "target_build": "relay-v0.1.0-build.11", "attempts": 2})
 
     updater.stage_update("u", tmp_path, 1, target_build="relay-v0.1.0-build.11")
@@ -208,107 +143,109 @@ def test_stage_update_keeps_attempts_for_the_same_target_but_resets_for_a_new_on
     assert updater.read_ledger(tmp_path)["attempts"] == 0  # a new target -> fresh count
 
 
-# --- apply_staged_update: the detached helper state machine -------------------------------------------
+# --- apply_staged_update: the helper repoints the junction + health-gates the relaunch ----------------
 
 
-def _seed_stage(install_dir, *, build="relay-v0.1.0-build.11", attempts=0, new_bytes=b"NEW-EXE"):
-    (install_dir / "ucnexus-relay.exe").write_bytes(b"OLD-EXE")
-    if new_bytes is not None:
-        (install_dir / "ucnexus-relay.exe.new").write_bytes(new_bytes)
-    updater._write_ledger(install_dir, {"status": "staging", "target_build": build, "attempts": attempts})
+def _seed_staged(install_dir, *, build="relay-v0.1.0-build.11", attempts=0, make_new=True):
+    ver = install_dir / layout.version_dir_name(build)
+    if make_new:
+        ver.mkdir(parents=True, exist_ok=True)
+        (ver / layout.ASSET_NAME).write_bytes(b"NEW-EXE")
+    updater._write_ledger(
+        install_dir,
+        {"status": "staging", "target_build": build, "target_dir": str(ver), "attempts": attempts},
+    )
+    return ver
 
 
-def _patch_helper_side_effects(monkeypatch, *, relaunches):
-    """Stub the process-touching steps so the orchestration is testable off-Windows and without real
-    processes. Records every relaunch target."""
+def _patch_apply(monkeypatch, *, healthy, repoints):
     monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
     monkeypatch.setattr(updater, "_wait_for_pid_exit", lambda pid, deadline, log: None)
     monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: None)
-    monkeypatch.setattr(updater, "_relaunch", lambda exe, log: relaunches.append(Path(exe)))
+    monkeypatch.setattr(layout, "repoint_current", lambda d, target: repoints.append(Path(target)) or True)
+    monkeypatch.setattr(layout, "cleanup_old_versions", lambda d, keep: None)
+    seq = iter(healthy)
+    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: next(seq))
 
 
-def test_apply_staged_update_swaps_and_relaunches_once(tmp_path, monkeypatch):
-    _seed_stage(tmp_path)
-    relaunches = []
-    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)  # real swap runs (os.replace on tmp files)
+def test_apply_staged_update_repoints_and_relaunches_healthy(tmp_path, monkeypatch):
+    ver = _seed_staged(tmp_path)
+    repoints = []
+    _patch_apply(monkeypatch, healthy=[True], repoints=repoints)
 
     r = updater.apply_staged_update(4242, tmp_path)
 
     assert r["ok"] is True
-    exe = tmp_path / "ucnexus-relay.exe"
-    assert exe.read_bytes() == b"NEW-EXE"  # new bytes swapped in
-    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # consumed
-    assert not list(tmp_path.glob("ucnexus-relay.exe.old*"))  # cleaned up
-    assert relaunches == [exe]  # exactly ONE relaunch, of the new exe
+    assert repoints == [ver]  # the current junction was pointed at the new version
     assert updater.read_ledger(tmp_path)["status"] == "success"
 
 
-def test_apply_staged_update_relaunches_current_exe_when_the_swap_fails(tmp_path, monkeypatch):
-    _seed_stage(tmp_path)
-    relaunches = []
-    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
-    monkeypatch.setattr(updater, "_swap_new_over_exe", lambda exe, new, d, deadline, log: (False, "locked"))
+def test_apply_staged_update_rolls_back_when_new_version_unhealthy(tmp_path, monkeypatch):
+    ver = _seed_staged(tmp_path)
+    old = tmp_path / "app-relay-v0.1.0-build.10"
+    old.mkdir()
+    repoints = []
+    _patch_apply(monkeypatch, healthy=[False, False], repoints=repoints)  # new fails, then the rollback relaunch
+    monkeypatch.setattr(updater, "_current_target", lambda d: old)
 
     r = updater.apply_staged_update(4242, tmp_path)
 
     assert r["ok"] is False
-    exe = tmp_path / "ucnexus-relay.exe"
-    assert exe.read_bytes() == b"OLD-EXE"  # left on the current version, never down
-    assert relaunches == [exe]  # relaunched exactly once (the current exe)
-    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # bad staging cleared
-    led = updater.read_ledger(tmp_path)
-    assert led["status"] == "failed" and led["last_error"] == "locked"
-
-
-def test_apply_staged_update_circuit_breaker_gives_up_after_max_attempts(tmp_path, monkeypatch):
-    _seed_stage(tmp_path, attempts=updater.MAX_ATTEMPTS)  # next run is attempt MAX+1
-    relaunches = []
-    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
-
-    def _must_not_swap(*a, **k):
-        raise AssertionError("circuit breaker must trip before attempting a swap")
-
-    monkeypatch.setattr(updater, "_swap_new_over_exe", _must_not_swap)
-
-    r = updater.apply_staged_update(4242, tmp_path)
-
-    assert r["ok"] is False
-    assert "gave up" in r["error"]
-    assert relaunches == [tmp_path / "ucnexus-relay.exe"]  # relaunch current, then STOP (no loop)
+    assert repoints == [ver, old]  # pointed at the new version, then rolled the junction back to the old one
     assert updater.read_ledger(tmp_path)["status"] == "failed"
 
 
-def test_apply_staged_update_honors_the_cancel_flag_and_does_not_relaunch(tmp_path, monkeypatch):
-    _seed_stage(tmp_path)
+def test_apply_staged_update_circuit_breaker_gives_up(tmp_path, monkeypatch):
+    _seed_staged(tmp_path, attempts=updater.MAX_ATTEMPTS)  # next run is attempt MAX+1
+    monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
     relaunches = []
-    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
-    updater.request_cancel(tmp_path)  # user closed the relay mid-update
+    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(attempts) or True)
+
+    def _no_repoint(*a, **k):
+        raise AssertionError("circuit breaker must trip before repointing")
+
+    monkeypatch.setattr(layout, "repoint_current", _no_repoint)
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is False and "gave up" in r["error"]
+    assert relaunches == [1]  # relaunched the CURRENT version once, then stopped (no loop)
+    assert updater.read_ledger(tmp_path)["status"] == "failed"
+
+
+def test_apply_staged_update_honors_cancel(tmp_path, monkeypatch):
+    _seed_staged(tmp_path)
+    monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
+
+    def _no_repoint(*a, **k):
+        raise AssertionError("cancel must not repoint or relaunch")
+
+    monkeypatch.setattr(layout, "repoint_current", _no_repoint)
+    updater.request_cancel(tmp_path)
 
     r = updater.apply_staged_update(4242, tmp_path)
 
     assert r.get("cancelled") is True
-    assert relaunches == []  # a deliberate close is respected: nothing is resurrected
     assert updater.read_ledger(tmp_path)["status"] == "cancelled"
-    assert not (tmp_path / updater._CANCEL_FLAG).exists()  # flag cleared
+    assert not (tmp_path / updater._CANCEL_FLAG).exists()
 
 
-def test_apply_staged_update_fails_cleanly_when_the_new_file_is_missing(tmp_path, monkeypatch):
-    _seed_stage(tmp_path, new_bytes=None)  # .new never downloaded
+def test_apply_staged_update_missing_staged_version(tmp_path, monkeypatch):
+    _seed_staged(tmp_path, make_new=False)  # the ledger's target_dir doesn't exist
+    monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
     relaunches = []
-    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
+    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(1) or True)
 
     r = updater.apply_staged_update(4242, tmp_path)
 
     assert r["ok"] is False
-    assert relaunches == [tmp_path / "ucnexus-relay.exe"]  # relaunch current so the relay stays up
+    assert relaunches == [1]  # relaunched the current version so the relay stays up
     assert updater.read_ledger(tmp_path)["status"] == "failed"
 
 
 def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
     (tmp_path / "relay.pid").write_text("9001", encoding="utf-8")
     killed = []
-    from ucnexus_relay import single_instance
-
     monkeypatch.setattr(single_instance, "force_kill_pid", lambda pid: killed.append(int(pid)))
 
     updater._kill_relay_pids(4242, tmp_path, _LOG)
@@ -316,59 +253,24 @@ def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
     assert killed == [4242, 9001]  # app pid + serve pid, both by pid (never taskkill /im)
 
 
-# --- _swap_new_over_exe: bounded retry with rollback --------------------------------------------------
+# --- _relaunch_and_wait_healthy -----------------------------------------------------------------------
 
 
-def test_swap_retries_then_succeeds(tmp_path, monkeypatch):
-    exe = tmp_path / "ucnexus-relay.exe"
-    exe.write_bytes(b"OLD")
-    new = tmp_path / "ucnexus-relay.exe.new"
-    new.write_bytes(b"NEWBYTES")
-    real = os.replace
-    calls = {"move_new": 0}
+def test_relaunch_and_wait_healthy_stops_when_health_ok(tmp_path, monkeypatch):
+    launches = []
+    monkeypatch.setattr(single_instance, "launch_installed", lambda d: launches.append(1))
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: True)
 
-    def flaky(src, dst):
-        if str(src) == str(new):  # the move-new-in step: fail twice, then let it through
-            calls["move_new"] += 1
-            if calls["move_new"] <= 2:
-                raise OSError("handle still held")
-        return real(src, dst)
+    assert updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 30, _LOG) is True
+    assert launches == [1]  # one launch, healthy - no retry
 
-    monkeypatch.setattr(updater.os, "replace", flaky)
+
+def test_relaunch_and_wait_healthy_retries_then_gives_up(tmp_path, monkeypatch):
+    launches = []
+    monkeypatch.setattr(single_instance, "launch_installed", lambda d: launches.append(1))
+    monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: None)
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: False)
     monkeypatch.setattr(updater, "_sleep", lambda s: None)
-    monkeypatch.setattr(updater, "_monotonic", lambda: 0.0)  # far from the deadline
 
-    ok, err = updater._swap_new_over_exe(exe, new, tmp_path, deadline=100.0, log=_LOG)
-
-    assert ok is True and err is None
-    assert exe.read_bytes() == b"NEWBYTES"
-    assert calls["move_new"] == 3  # two failures, then success
-
-
-def test_swap_gives_up_at_the_deadline_and_leaves_the_exe_in_place(tmp_path, monkeypatch):
-    exe = tmp_path / "ucnexus-relay.exe"
-    exe.write_bytes(b"OLD")
-    new = tmp_path / "ucnexus-relay.exe.new"
-    new.write_bytes(b"NEWBYTES")
-    real = os.replace
-
-    def always_fail_move(src, dst):
-        if str(src) == str(new):
-            raise OSError("locked forever")
-        return real(src, dst)  # rename-aside + rollback still work
-
-    monkeypatch.setattr(updater.os, "replace", always_fail_move)
-    monkeypatch.setattr(updater, "_sleep", lambda s: None)
-    clock = {"t": 0.0}
-
-    def tick():
-        clock["t"] += 5.0
-        return clock["t"]
-
-    monkeypatch.setattr(updater, "_monotonic", tick)
-
-    ok, err = updater._swap_new_over_exe(exe, new, tmp_path, deadline=10.0, log=_LOG)
-
-    assert ok is False
-    assert "move-new-in failed" in err
-    assert exe.read_bytes() == b"OLD"  # rolled back: the relay still has its exe
+    ok = updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 1000, _LOG, attempts=2)
+    assert ok is False and len(launches) == 2  # tried twice within the deadline, never healthy

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -2,9 +2,13 @@
 download + rename-swap that applies an update. No network (urlopen/urlretrieve mocked), no real exe."""
 
 import json
+import logging
+import os
 from pathlib import Path
 
 from ucnexus_relay import setup, updater
+
+_LOG = logging.getLogger("relay-test-update")  # throwaway; the helper only writes to it
 
 
 class _Resp:
@@ -156,23 +160,27 @@ def test_apply_update_rejects_a_tiny_download(tmp_path, monkeypatch):
     assert exe.read_bytes() == b"OLD"  # left untouched on a bad download
 
 
-def test_stage_update_downloads_writes_helper_and_spawns_it(tmp_path, monkeypatch):
+def test_stage_update_downloads_seeds_ledger_and_spawns_the_helper(tmp_path, monkeypatch):
+    # NO batch file anymore: staging downloads the exe, seeds the attempt ledger, and spawns the
+    # windowless `ucnexus-relay update-apply` helper (never `cmd /c a .bat`, never a taskkill /im).
     monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
     calls = []
-    monkeypatch.setattr(updater.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
-    r = updater.stage_update("u", tmp_path, 4242)
+    monkeypatch.setattr(updater, "_spawn_detached", lambda args, cwd: calls.append((args, cwd)))
+    exe = tmp_path / "ucnexus-relay.exe"
+
+    r = updater.stage_update("u", tmp_path, 4242, target_build="relay-v0.1.0-build.11")
     assert r["ok"] is True
-    helper = tmp_path / "update-helper.bat"
-    assert helper.exists()
-    txt = helper.read_text(encoding="utf-8")
-    assert "4242" in txt  # waits for the app pid
-    assert "ucnexus-relay.exe" in txt  # relaunches the exe
-    # robustness: bounded wait -> force-kill any stuck relay process, and relaunch even if the swap fails
-    assert "taskkill /f /im ucnexus-relay.exe" in txt  # force any hung relay/serve process down
-    assert "geq 20" in txt  # the app-exit wait is bounded (can't loop forever)
-    assert ":failed" in txt and "if exist" in txt  # relaunch the current exe if the swap never takes
-    assert (tmp_path / "ucnexus-relay.exe.new").exists()  # the new exe downloaded, not yet swapped
-    assert calls and calls[0][0][0] == ["cmd", "/c", str(helper)]  # helper spawned
+    assert not (tmp_path / "update-helper.bat").exists()  # the .bat is gone
+    assert (tmp_path / "ucnexus-relay.exe.new").exists()  # downloaded, not yet swapped
+
+    ledger = updater.read_ledger(tmp_path)
+    assert ledger["status"] == "staging"
+    assert ledger["target_build"] == "relay-v0.1.0-build.11"
+    assert ledger["attempts"] == 0
+
+    assert len(calls) == 1
+    args, _ = calls[0]
+    assert args == [str(exe), "update-apply", "--pid", "4242"]  # windowless helper, waits for the app pid
 
 
 def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monkeypatch):
@@ -181,7 +189,186 @@ def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monke
     def _no_spawn(*a, **k):
         raise AssertionError("must not spawn the helper on a bad download")
 
-    monkeypatch.setattr(updater.subprocess, "Popen", _no_spawn)
+    monkeypatch.setattr(updater, "_spawn_detached", _no_spawn)
     r = updater.stage_update("u", tmp_path, 1)
     assert r["ok"] is False
     assert "too small" in r["error"]
+
+
+def test_stage_update_keeps_attempts_for_the_same_target_but_resets_for_a_new_one(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"N" * 6_000_000))
+    monkeypatch.setattr(updater, "_spawn_detached", lambda args, cwd: None)
+    # a prior FAILED attempt at build.11 (attempts already 2)
+    updater._write_ledger(tmp_path, {"status": "failed", "target_build": "relay-v0.1.0-build.11", "attempts": 2})
+
+    updater.stage_update("u", tmp_path, 1, target_build="relay-v0.1.0-build.11")
+    assert updater.read_ledger(tmp_path)["attempts"] == 2  # same still-unfinished target -> keep the count
+
+    updater.stage_update("u", tmp_path, 1, target_build="relay-v0.1.0-build.12")
+    assert updater.read_ledger(tmp_path)["attempts"] == 0  # a new target -> fresh count
+
+
+# --- apply_staged_update: the detached helper state machine -------------------------------------------
+
+
+def _seed_stage(install_dir, *, build="relay-v0.1.0-build.11", attempts=0, new_bytes=b"NEW-EXE"):
+    (install_dir / "ucnexus-relay.exe").write_bytes(b"OLD-EXE")
+    if new_bytes is not None:
+        (install_dir / "ucnexus-relay.exe.new").write_bytes(new_bytes)
+    updater._write_ledger(install_dir, {"status": "staging", "target_build": build, "attempts": attempts})
+
+
+def _patch_helper_side_effects(monkeypatch, *, relaunches):
+    """Stub the process-touching steps so the orchestration is testable off-Windows and without real
+    processes. Records every relaunch target."""
+    monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
+    monkeypatch.setattr(updater, "_wait_for_pid_exit", lambda pid, deadline, log: None)
+    monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: None)
+    monkeypatch.setattr(updater, "_relaunch", lambda exe, log: relaunches.append(Path(exe)))
+
+
+def test_apply_staged_update_swaps_and_relaunches_once(tmp_path, monkeypatch):
+    _seed_stage(tmp_path)
+    relaunches = []
+    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)  # real swap runs (os.replace on tmp files)
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is True
+    exe = tmp_path / "ucnexus-relay.exe"
+    assert exe.read_bytes() == b"NEW-EXE"  # new bytes swapped in
+    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # consumed
+    assert not list(tmp_path.glob("ucnexus-relay.exe.old*"))  # cleaned up
+    assert relaunches == [exe]  # exactly ONE relaunch, of the new exe
+    assert updater.read_ledger(tmp_path)["status"] == "success"
+
+
+def test_apply_staged_update_relaunches_current_exe_when_the_swap_fails(tmp_path, monkeypatch):
+    _seed_stage(tmp_path)
+    relaunches = []
+    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
+    monkeypatch.setattr(updater, "_swap_new_over_exe", lambda exe, new, d, deadline, log: (False, "locked"))
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is False
+    exe = tmp_path / "ucnexus-relay.exe"
+    assert exe.read_bytes() == b"OLD-EXE"  # left on the current version, never down
+    assert relaunches == [exe]  # relaunched exactly once (the current exe)
+    assert not (tmp_path / "ucnexus-relay.exe.new").exists()  # bad staging cleared
+    led = updater.read_ledger(tmp_path)
+    assert led["status"] == "failed" and led["last_error"] == "locked"
+
+
+def test_apply_staged_update_circuit_breaker_gives_up_after_max_attempts(tmp_path, monkeypatch):
+    _seed_stage(tmp_path, attempts=updater.MAX_ATTEMPTS)  # next run is attempt MAX+1
+    relaunches = []
+    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
+
+    def _must_not_swap(*a, **k):
+        raise AssertionError("circuit breaker must trip before attempting a swap")
+
+    monkeypatch.setattr(updater, "_swap_new_over_exe", _must_not_swap)
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is False
+    assert "gave up" in r["error"]
+    assert relaunches == [tmp_path / "ucnexus-relay.exe"]  # relaunch current, then STOP (no loop)
+    assert updater.read_ledger(tmp_path)["status"] == "failed"
+
+
+def test_apply_staged_update_honors_the_cancel_flag_and_does_not_relaunch(tmp_path, monkeypatch):
+    _seed_stage(tmp_path)
+    relaunches = []
+    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
+    updater.request_cancel(tmp_path)  # user closed the relay mid-update
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r.get("cancelled") is True
+    assert relaunches == []  # a deliberate close is respected: nothing is resurrected
+    assert updater.read_ledger(tmp_path)["status"] == "cancelled"
+    assert not (tmp_path / updater._CANCEL_FLAG).exists()  # flag cleared
+
+
+def test_apply_staged_update_fails_cleanly_when_the_new_file_is_missing(tmp_path, monkeypatch):
+    _seed_stage(tmp_path, new_bytes=None)  # .new never downloaded
+    relaunches = []
+    _patch_helper_side_effects(monkeypatch, relaunches=relaunches)
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is False
+    assert relaunches == [tmp_path / "ucnexus-relay.exe"]  # relaunch current so the relay stays up
+    assert updater.read_ledger(tmp_path)["status"] == "failed"
+
+
+def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
+    (tmp_path / "relay.pid").write_text("9001", encoding="utf-8")
+    killed = []
+    from ucnexus_relay import single_instance
+
+    monkeypatch.setattr(single_instance, "force_kill_pid", lambda pid: killed.append(int(pid)))
+
+    updater._kill_relay_pids(4242, tmp_path, _LOG)
+
+    assert killed == [4242, 9001]  # app pid + serve pid, both by pid (never taskkill /im)
+
+
+# --- _swap_new_over_exe: bounded retry with rollback --------------------------------------------------
+
+
+def test_swap_retries_then_succeeds(tmp_path, monkeypatch):
+    exe = tmp_path / "ucnexus-relay.exe"
+    exe.write_bytes(b"OLD")
+    new = tmp_path / "ucnexus-relay.exe.new"
+    new.write_bytes(b"NEWBYTES")
+    real = os.replace
+    calls = {"move_new": 0}
+
+    def flaky(src, dst):
+        if str(src) == str(new):  # the move-new-in step: fail twice, then let it through
+            calls["move_new"] += 1
+            if calls["move_new"] <= 2:
+                raise OSError("handle still held")
+        return real(src, dst)
+
+    monkeypatch.setattr(updater.os, "replace", flaky)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
+    monkeypatch.setattr(updater, "_monotonic", lambda: 0.0)  # far from the deadline
+
+    ok, err = updater._swap_new_over_exe(exe, new, tmp_path, deadline=100.0, log=_LOG)
+
+    assert ok is True and err is None
+    assert exe.read_bytes() == b"NEWBYTES"
+    assert calls["move_new"] == 3  # two failures, then success
+
+
+def test_swap_gives_up_at_the_deadline_and_leaves_the_exe_in_place(tmp_path, monkeypatch):
+    exe = tmp_path / "ucnexus-relay.exe"
+    exe.write_bytes(b"OLD")
+    new = tmp_path / "ucnexus-relay.exe.new"
+    new.write_bytes(b"NEWBYTES")
+    real = os.replace
+
+    def always_fail_move(src, dst):
+        if str(src) == str(new):
+            raise OSError("locked forever")
+        return real(src, dst)  # rename-aside + rollback still work
+
+    monkeypatch.setattr(updater.os, "replace", always_fail_move)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
+    clock = {"t": 0.0}
+
+    def tick():
+        clock["t"] += 5.0
+        return clock["t"]
+
+    monkeypatch.setattr(updater, "_monotonic", tick)
+
+    ok, err = updater._swap_new_over_exe(exe, new, tmp_path, deadline=10.0, log=_LOG)
+
+    assert ok is False
+    assert "move-new-in failed" in err
+    assert exe.read_bytes() == b"OLD"  # rolled back: the relay still has its exe

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -274,3 +274,49 @@ def test_relaunch_and_wait_healthy_retries_then_gives_up(tmp_path, monkeypatch):
 
     ok = updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 1000, _LOG, attempts=2)
     assert ok is False and len(launches) == 2  # tried twice within the deadline, never healthy
+
+
+def test_relaunch_and_wait_healthy_kills_the_launched_app_between_retries(tmp_path, monkeypatch):
+    # regression: an unhealthy-but-alive app is the single-instance owner, so the next attempt (and the
+    # rollback launch) would focus-deflect to it and never re-serve. The between-attempts kill must target
+    # the app pid launch_installed returned, NOT None (which would leave that owner alive).
+    pids = iter([111, 222])
+    monkeypatch.setattr(single_instance, "launch_installed", lambda d: next(pids))
+    killed = []
+    monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: killed.append(pid))
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: False)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
+
+    ok = updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 1000, _LOG, attempts=2)
+
+    assert ok is False
+    assert killed == [111, 222]  # each unhealthy attempt's own app pid is force-killed before the next
+
+
+def test_apply_staged_update_rolls_back_when_the_repoint_fails(tmp_path, monkeypatch):
+    # regression: a failed junction repoint (removed the link but couldn't recreate it) left `current`
+    # broken; proceeding would relaunch via the newest-version fallback and record success while autostart
+    # + shortcuts point at a dead junction. Must roll the junction back to the previous version + fail.
+    ver = _seed_staged(tmp_path)
+    old = tmp_path / "app-relay-v0.1.0-build.10"
+    old.mkdir()
+    monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
+    monkeypatch.setattr(updater, "_wait_for_pid_exit", lambda pid, deadline, log: None)
+    monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: None)
+    monkeypatch.setattr(updater, "_current_target", lambda d: old)
+    repoints = []
+
+    def _repoint(d, target):
+        repoints.append(Path(target))
+        return Path(target).name != ver.name  # the repoint TO the new version fails; the rollback succeeds
+
+    monkeypatch.setattr(layout, "repoint_current", _repoint)
+    relaunched = []
+    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunched.append(1) or True)
+
+    r = updater.apply_staged_update(4242, tmp_path)
+
+    assert r["ok"] is False
+    assert repoints == [ver, old]  # tried the new version, then rolled the junction back to the old one
+    assert relaunched == [1]  # relaunched the rolled-back (previous) version so the relay stays up
+    assert updater.read_ledger(tmp_path)["status"] == "failed"

--- a/relay/ucnexus-relay.spec
+++ b/relay/ucnexus-relay.spec
@@ -42,12 +42,19 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
+# ONEDIR (not onefile): a onefile exe re-extracts its whole bundle - including C-extension .pyd like
+# _multiprocessing and PIL._imaging - to %TEMP%\_MEIxxxx on EVERY launch. On a Windows Defender box with no
+# %TEMP%/install-dir exclusions, a freshly-written exe (a self-update swap) launched immediately has its
+# just-extracted .pyd scanned as they load, and the relaunched relay crashes (ModuleNotFoundError:
+# _multiprocessing / ImportError: _imaging). Onedir writes the .pyd once, as permanent files in the install
+# folder (Defender scans them at install/update time, before launch), so every launch loads the same
+# pre-scanned files - no per-launch extraction, no scan collision. See docs/relay-deployment.md + the
+# updater's versioned-folder self-update.
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.datas,
     [],
+    exclude_binaries=True,  # onedir: binaries/datas go in COLLECT below, not baked into the exe
     name="ucnexus-relay",
     debug=False,
     bootloader_ignore_signals=False,
@@ -63,4 +70,16 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+)
+
+# Collect the exe + binaries + datas into dist/ucnexus-relay/ (ucnexus-relay.exe + _internal/). The install
+# and self-update flows ship/extract this whole folder (zipped) into a versioned app-<build>/ directory.
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="ucnexus-relay",
 )


### PR DESCRIPTION
relay update looped a popping console window (`find /i "ucnexus-relay"`), returned on every close. two layered causes.

1. self-update helper was a detached `update-helper.bat`:
- both success + failure branches ran `start "" exe app`, so closing the relay did not end the sequence
- `taskkill /f /im ucnexus-relay.exe` killed every relay process, not the target pid
- no circuit breaker, timeout, or graceful abort
- `DETACHED_PROCESS | CREATE_NO_WINDOW` is contradictory -> cmd children each opened a window

replaced with an update-apply subcommand:
- windowless, logged to `update.log`
- bounded by ~90s deadline + per-target attempt ledger (`update-state.json`, max 3 attempts)
- kills by pid (reuses `single_instance.force_kill_pid`)
- relaunches once

Updates tab surfaces the last outcome.

2. relay was PyInstaller ONEFILE, re-extracts the C-extension `.pyd` to `%TEMP%` every launch. on a Windows Defender box a freshly-written exe's extraction is scanned as it loads -> the relaunched relay crashes (`_multiprocessing` / `PIL._imaging`). immediate post-update relaunch = the loop.

migrated onefile -> ONEDIR. `.pyd` permanent, scanned once at install/update. a running relay holds them open, so its folder cannot be renamed in place; each version lives in `app-<build>/`, and a stable `current` directory junction (shortcuts + autostart target it) points at the active version.

update flow: extract the new version alongside -> a helper from the OLD settled version force-stops by pid -> repoints the junction -> health-gated relaunch -> rolls the junction back to the previous version if the new one does not come up.

also polished:
- log rotation
- single-sourced VERSION
- quieted the de-enrolled reconnect flood
- bounded UI log tailing
- documented the TrustServerCertificate trade-off

validated on a Defender box: installed the CI onedir build, ran a real update, relaunched HEALTHY (serve + channel, no C-ext crash), junction repointed, clean update.log, success ledger, single relaunch, zero console windows.

onefile -> onedir cannot self-update (the old updater downloads a zip it cannot apply), so the first onedir build is installed manually. onedir -> onedir updates work via the junction. release ships `ucnexus-relay.zip`.
