### PR TITLE
feat(po): GP PO tax detail, vendor currency, freight/misc/trade discount (#257)

### DIFF
--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -16,6 +16,7 @@ from .types import (
     DeficientItemRow,
     GpCostCode,
     GpJob,
+    GpTaxDetail,
     GpVendor,
     InventoryLocation,
     Notification,
@@ -156,11 +157,20 @@ def gp_vendor_to_type(v: dict) -> GpVendor:
         vendor_name=v["vendor_name"],
         vendor_class=v.get("vendor_class"),
         status=v["status"],
+        # older relays predate the currency field (issue #257); default to CAD so a mixed-version
+        # relay doesn't break the vendor dropdown.
+        currency=v.get("currency") or "CAD",
     )
 
 
 def gp_cost_code_to_type(c: dict) -> GpCostCode:
     return GpCostCode(cost_code=c["cost_code"], description=c.get("description"), cost_element=c["cost_element"])
+
+
+def gp_tax_detail_to_type(t: dict) -> GpTaxDetail:
+    return GpTaxDetail(
+        tax_detail_id=t["tax_detail_id"], description=t.get("description"), percent=t["percent"]
+    )
 
 
 def warehouse_to_type(w) -> Warehouse:

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -168,9 +168,7 @@ def gp_cost_code_to_type(c: dict) -> GpCostCode:
 
 
 def gp_tax_detail_to_type(t: dict) -> GpTaxDetail:
-    return GpTaxDetail(
-        tax_detail_id=t["tax_detail_id"], description=t.get("description"), percent=t["percent"]
-    )
+    return GpTaxDetail(tax_detail_id=t["tax_detail_id"], description=t.get("description"), percent=t["percent"])
 
 
 def warehouse_to_type(w) -> Warehouse:

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -229,8 +229,15 @@ class RegisterPOInput:
     vendor_id: strawberry.ID | None = None
     cost_code: str | None = None
     # Issue #156: optional order-time dollar costs. Null means "not entered"; 0 is a valid value.
+    # shipping_cost also feeds GP's Freight (FRTAMNT) at push time (issue #257); tariff_amount stays
+    # nexus-only (its own PO-document line, not a GP charge).
     shipping_cost: float | None = None
     tariff_amount: float | None = None
+    # Issue #257: GP purchase tax detail (TX00201 TXDTLTYP=2, picked from gpTaxDetails; CAD only) plus
+    # the Miscellaneous (MSCCHAMT) and Trade Discount (TRDISAMT) charges written to the GP PO header.
+    tax_detail_id: str | None = None
+    miscellaneous: float | None = None
+    trade_discount: float | None = None
     # Issue #202 #1: client-generated key that makes this GP-first write idempotent on retry.
     idempotency_key: str = ""
 

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -106,8 +106,17 @@ def _assert_buyer_identity(caller_gp_buyer_id: str | None, input_buyer_id: str) 
 
 
 def _prepare_register_po(
-    *, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code, line_items_data,
-    tax_detail_id=None, shipping_cost=None, miscellaneous=None, trade_discount=None,
+    *,
+    po_id,
+    vendor_id,
+    gp_vendor_id,
+    buyer_id,
+    cost_code,
+    line_items_data,
+    tax_detail_id=None,
+    shipping_cost=None,
+    miscellaneous=None,
+    trade_discount=None,
 ) -> dict:
     """Read-only pre-flight for register_po_in_gp: confirm the PO is a registerable DRAFT, resolve the
     job number, pre-validate, and build the relay create_po payload (po_number=None; GP assigns it).

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -105,7 +105,10 @@ def _assert_buyer_identity(caller_gp_buyer_id: str | None, input_buyer_id: str) 
         raise ValidationError("POs can only be created as your own GP buyer", field="buyer_id")
 
 
-def _prepare_register_po(*, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code, line_items_data) -> dict:
+def _prepare_register_po(
+    *, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code, line_items_data,
+    tax_detail_id=None, shipping_cost=None, miscellaneous=None, trade_discount=None,
+) -> dict:
     """Read-only pre-flight for register_po_in_gp: confirm the PO is a registerable DRAFT, resolve the
     job number, pre-validate, and build the relay create_po payload (po_number=None; GP assigns it).
     A lean scalar read - the resolver never needs the PO's documents/vendor here."""
@@ -151,6 +154,11 @@ def _prepare_register_po(*, po_id, vendor_id, gp_vendor_id, buyer_id, cost_code,
         cost_code=cost_code,
         po_number=None,
         line_items=line_items_data,
+        # Issue #257: freight maps from the PO's shipping_cost; misc + trade discount are new inputs.
+        tax_detail_id=tax_detail_id,
+        freight_amount=shipping_cost,
+        misc_amount=miscellaneous,
+        trade_discount=trade_discount,
     )
     # build_create_po_payload emits one line per line_items_data entry, in order, so index-align the
     # resolved manufacturers onto the relay payload lines (the relay caps/RTRIMs to USRDEFND1's char(50)).
@@ -343,6 +351,10 @@ class POMutations:
             buyer_id=input.buyer_id,
             cost_code=input.cost_code,
             line_items_data=line_items_data,
+            tax_detail_id=input.tax_detail_id,
+            shipping_cost=input.shipping_cost,
+            miscellaneous=input.miscellaneous,
+            trade_discount=input.trade_discount,
         )
 
         if state is not None and state.relay_result is not None:

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -7,12 +7,19 @@ from app.database import SessionLocal
 from app.repositories import relay_repository
 from app.services.relay_gateway import gateway as relay_gateway
 
-from .converters import gp_cost_code_to_type, gp_job_to_type, gp_vendor_to_type, relay_install_to_type
+from .converters import (
+    gp_cost_code_to_type,
+    gp_job_to_type,
+    gp_tax_detail_to_type,
+    gp_vendor_to_type,
+    relay_install_to_type,
+)
 from .inputs import EnrollRelayInstallInput
 from .types import (
     GpCostCode,
     GpJob,
     GpPoTotals,
+    GpTaxDetail,
     GpVendor,
     RelayEnrollResult,
     RelayInstallInfo,
@@ -65,6 +72,14 @@ class RelayQueries:
         require_user(info)
         result = await relay_gateway.relay_call(company, "list_cost_codes", {"job": job})
         return [gp_cost_code_to_type(c) for c in result["cost_codes"]]
+
+    @strawberry.field
+    async def gp_tax_details(self, info: strawberry.Info, company: str) -> list[GpTaxDetail]:
+        """Live GP purchase tax details (TX00201, TXDTLTYP=2) via the connected relay, for the
+        register-PO tax-detail dropdown (issue #257)."""
+        require_user(info)
+        result = await relay_gateway.relay_call(company, "list_tax_details")
+        return [gp_tax_detail_to_type(t) for t in result["tax_details"]]
 
     @strawberry.field
     async def gp_po_totals(self, info: strawberry.Info, company: str, po_number: str) -> GpPoTotals | None:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -147,6 +147,9 @@ class GpVendor:
     vendor_name: str
     vendor_class: str | None
     status: int
+    # GP CURNCYID (issue #257: the vendor dictates the PO currency). Blank in GP -> 'CAD'. Shown
+    # read-only on the register-PO form; USD vendors have no tax-detail dropdown.
+    currency: str
 
 
 @strawberry.type
@@ -154,6 +157,17 @@ class GpCostCode:
     cost_code: str  # two-segment number 'cc1-cc2' e.g. '310-000'
     description: str | None
     cost_element: int
+
+
+@strawberry.type
+class GpTaxDetail:
+    """A GP purchase tax detail (TX00201, TXDTLTYP=2) read live via the relay, for the register-PO
+    tax-detail dropdown (issue #257). GP-first: the options are whatever the company defines
+    (e.g. BC HST P / ON HST - P / PST 7% in production)."""
+
+    tax_detail_id: str
+    description: str | None
+    percent: float
 
 
 @strawberry.type

--- a/backend/app/services/gp_po.py
+++ b/backend/app/services/gp_po.py
@@ -68,10 +68,19 @@ def build_create_po_payload(
     cost_code: str | None,
     po_number: str | None,
     line_items: list[dict],
+    tax_detail_id: str | None = None,
+    freight_amount: float | None = None,
+    misc_amount: float | None = None,
+    trade_discount: float | None = None,
 ) -> dict:
     """line_items: the same dicts create_po/register_po_in_gp build for the repository call, each
     with hardware_category, product_code, ordered_quantity, unit_cost, order_as. job_number present
-    means every line is job-cost (product_indicator=2); absent means non-inventoried (1)."""
+    means every line is job-cost (product_indicator=2); absent means non-inventoried (1).
+
+    Issue #257 GP header charges: tax_detail_id is the GP purchase tax detail the relay computes tax
+    from (CAD only; the relay resolves currency from the vendor). freight_amount maps from the PO's
+    shipping_cost, misc_amount + trade_discount are the new register-form inputs. None -> 0 (the relay
+    POHeader charge fields are non-null Decimals)."""
     is_job = job_number is not None
     confirm_with = (vendor_contact_name or buyer_id).strip()[:_MAX_CONFIRM_WITH]
 
@@ -101,6 +110,12 @@ def build_create_po_payload(
             "buyer_id": buyer_id,
             "confirm_with": confirm_with,
             "doc_date": date.today().isoformat(),
+            # Issue #257: GP header charges. None -> 0 for the non-null relay Decimals; tax_detail_id
+            # stays None when no detail was picked (relay then writes no tax).
+            "tax_detail_id": tax_detail_id,
+            "freight_amount": freight_amount or 0,
+            "misc_amount": misc_amount or 0,
+            "trade_discount": trade_discount or 0,
         },
         "lines": lines,
         "po_number": po_number,

--- a/backend/tests/test_gp_po.py
+++ b/backend/tests/test_gp_po.py
@@ -44,8 +44,13 @@ def test_build_create_po_payload_defaults_gp_charges_to_zero_without_tax_detail(
     # issue #257: with no charges/tax passed, the header carries the zeroed GP charge fields (the
     # relay POHeader Decimals are non-null) and a null tax detail (relay writes no tax).
     payload = gp_po.build_create_po_payload(
-        vendor_gp_id="ING100", vendor_contact_name=None, buyer_id="mira",
-        job_number=None, cost_code=None, po_number=None, line_items=[_line_item()],
+        vendor_gp_id="ING100",
+        vendor_contact_name=None,
+        buyer_id="mira",
+        job_number=None,
+        cost_code=None,
+        po_number=None,
+        line_items=[_line_item()],
     )
     h = payload["header"]
     assert h["tax_detail_id"] is None
@@ -58,9 +63,17 @@ def test_build_create_po_payload_maps_gp_charges_with_freight_from_shipping_cost
     # issue #257: freight_amount is passed from the PO's shipping_cost at the call site; misc + trade
     # discount are the new register-form inputs; tax_detail_id drives the relay's tax computation.
     payload = gp_po.build_create_po_payload(
-        vendor_gp_id="ING100", vendor_contact_name=None, buyer_id="mira",
-        job_number=None, cost_code=None, po_number=None, line_items=[_line_item()],
-        tax_detail_id="ON HST - P", freight_amount=25.0, misc_amount=5.0, trade_discount=2.0,
+        vendor_gp_id="ING100",
+        vendor_contact_name=None,
+        buyer_id="mira",
+        job_number=None,
+        cost_code=None,
+        po_number=None,
+        line_items=[_line_item()],
+        tax_detail_id="ON HST - P",
+        freight_amount=25.0,
+        misc_amount=5.0,
+        trade_discount=2.0,
     )
     h = payload["header"]
     assert h["tax_detail_id"] == "ON HST - P"

--- a/backend/tests/test_gp_po.py
+++ b/backend/tests/test_gp_po.py
@@ -40,6 +40,35 @@ def test_build_create_po_payload_non_job_line():
     assert line["cost_code"] is None
 
 
+def test_build_create_po_payload_defaults_gp_charges_to_zero_without_tax_detail():
+    # issue #257: with no charges/tax passed, the header carries the zeroed GP charge fields (the
+    # relay POHeader Decimals are non-null) and a null tax detail (relay writes no tax).
+    payload = gp_po.build_create_po_payload(
+        vendor_gp_id="ING100", vendor_contact_name=None, buyer_id="mira",
+        job_number=None, cost_code=None, po_number=None, line_items=[_line_item()],
+    )
+    h = payload["header"]
+    assert h["tax_detail_id"] is None
+    assert h["freight_amount"] == 0
+    assert h["misc_amount"] == 0
+    assert h["trade_discount"] == 0
+
+
+def test_build_create_po_payload_maps_gp_charges_with_freight_from_shipping_cost():
+    # issue #257: freight_amount is passed from the PO's shipping_cost at the call site; misc + trade
+    # discount are the new register-form inputs; tax_detail_id drives the relay's tax computation.
+    payload = gp_po.build_create_po_payload(
+        vendor_gp_id="ING100", vendor_contact_name=None, buyer_id="mira",
+        job_number=None, cost_code=None, po_number=None, line_items=[_line_item()],
+        tax_detail_id="ON HST - P", freight_amount=25.0, misc_amount=5.0, trade_discount=2.0,
+    )
+    h = payload["header"]
+    assert h["tax_detail_id"] == "ON HST - P"
+    assert h["freight_amount"] == 25.0
+    assert h["misc_amount"] == 5.0
+    assert h["trade_discount"] == 2.0
+
+
 def test_build_create_po_payload_job_cost_line_carries_job_and_cost_code():
     payload = gp_po.build_create_po_payload(
         vendor_gp_id="ING100",

--- a/backend/tests/test_gp_relay_reads.py
+++ b/backend/tests/test_gp_relay_reads.py
@@ -55,9 +55,7 @@ def test_gp_jobs_maps_relay_result_to_type(monkeypatch):
 def test_gp_vendors_maps_relay_result_to_type(monkeypatch):
     fake = _install_fake_gateway(
         monkeypatch,
-        {"vendors": [
-            {"vendor_id": "V1", "vendor_name": "Acme", "vendor_class": "HW", "status": 1, "currency": "USD"}
-        ]},
+        {"vendors": [{"vendor_id": "V1", "vendor_name": "Acme", "vendor_class": "HW", "status": 1, "currency": "USD"}]},
     )
 
     async def run():
@@ -89,10 +87,12 @@ def test_gp_vendors_currency_defaults_to_cad_for_older_relay(monkeypatch):
 def test_gp_tax_details_maps_relay_result_to_type(monkeypatch):
     fake = _install_fake_gateway(
         monkeypatch,
-        {"tax_details": [
-            {"tax_detail_id": "ON HST - P", "description": "ON HST on Purchases", "percent": 13.0},
-            {"tax_detail_id": "PST 7%", "description": None, "percent": 7.0},
-        ]},
+        {
+            "tax_details": [
+                {"tax_detail_id": "ON HST - P", "description": "ON HST on Purchases", "percent": 13.0},
+                {"tax_detail_id": "PST 7%", "description": None, "percent": 7.0},
+            ]
+        },
     )
 
     async def run():

--- a/backend/tests/test_gp_relay_reads.py
+++ b/backend/tests/test_gp_relay_reads.py
@@ -55,7 +55,9 @@ def test_gp_jobs_maps_relay_result_to_type(monkeypatch):
 def test_gp_vendors_maps_relay_result_to_type(monkeypatch):
     fake = _install_fake_gateway(
         monkeypatch,
-        {"vendors": [{"vendor_id": "V1", "vendor_name": "Acme", "vendor_class": "HW", "status": 1}]},
+        {"vendors": [
+            {"vendor_id": "V1", "vendor_name": "Acme", "vendor_class": "HW", "status": 1, "currency": "USD"}
+        ]},
     )
 
     async def run():
@@ -67,7 +69,41 @@ def test_gp_vendors_maps_relay_result_to_type(monkeypatch):
     assert vendors[0].vendor_name == "Acme"
     assert vendors[0].vendor_class == "HW"
     assert vendors[0].status == 1
+    assert vendors[0].currency == "USD"  # issue #257: vendor dictates PO currency
     assert fake.calls == [("TUBC", "list_vendors", None)]
+
+
+def test_gp_vendors_currency_defaults_to_cad_for_older_relay(monkeypatch):
+    # a relay predating the currency field (issue #257) omits it -> default CAD, dropdown still works
+    _install_fake_gateway(
+        monkeypatch,
+        {"vendors": [{"vendor_id": "V1", "vendor_name": "Acme", "vendor_class": None, "status": 1}]},
+    )
+
+    async def run():
+        return await Query().gp_vendors(FakeInfo(), company="TUBC")
+
+    assert asyncio.run(run())[0].currency == "CAD"
+
+
+def test_gp_tax_details_maps_relay_result_to_type(monkeypatch):
+    fake = _install_fake_gateway(
+        monkeypatch,
+        {"tax_details": [
+            {"tax_detail_id": "ON HST - P", "description": "ON HST on Purchases", "percent": 13.0},
+            {"tax_detail_id": "PST 7%", "description": None, "percent": 7.0},
+        ]},
+    )
+
+    async def run():
+        return await Query().gp_tax_details(FakeInfo(), company="TUBC")
+
+    details = asyncio.run(run())
+    assert [(d.tax_detail_id, d.description, d.percent) for d in details] == [
+        ("ON HST - P", "ON HST on Purchases", 13.0),
+        ("PST 7%", None, 7.0),
+    ]
+    assert fake.calls == [("TUBC", "list_tax_details", None)]
 
 
 def test_gp_buyers_returns_relay_result_directly(monkeypatch):

--- a/frontend/src/graphql/po.ts
+++ b/frontend/src/graphql/po.ts
@@ -157,6 +157,18 @@ export const GET_GP_VENDORS = gql`
       vendorName
       vendorClass
       status
+      currency
+    }
+  }
+`;
+
+// Issue #257: GP purchase tax details (TX00201, TXDTLTYP=2) for the register-PO tax-detail dropdown.
+export const GET_GP_TAX_DETAILS = gql`
+  query GetGpTaxDetails($company: String!) {
+    gpTaxDetails(company: $company) {
+      taxDetailId
+      description
+      percent
     }
   }
 `;

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -468,8 +468,11 @@ export default function GpPurchaseOrderDialog({
       else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
       if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
       // Issue #257: a CAD PO must carry a tax detail (the relay computes tax from it); a foreign-currency
-      // PO carries none (the relay blanks the schedule), so require it for CAD only.
-      if (!isForeignCurrency && gpVendorId && !taxDetailId) errs.taxDetail = 'Select a tax detail';
+      // PO carries none (the relay blanks the schedule), so require it for CAD only. Only enforce it when
+      // the company actually defines purchase tax details - a company with none would otherwise be
+      // hard-blocked, since the dropdown is disabled/empty when gpTaxDetails is empty.
+      if (!isForeignCurrency && gpVendorId && gpTaxDetails.length > 0 && !taxDetailId)
+        errs.taxDetail = 'Select a tax detail';
     }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
@@ -483,7 +486,7 @@ export default function GpPurchaseOrderDialog({
       errs.tradeDiscount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, miscellaneous, tradeDiscount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, gpTaxDetails.length, miscellaneous, tradeDiscount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -862,7 +865,7 @@ export default function GpPurchaseOrderDialog({
         <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap alignItems="flex-start" sx={{ mt: 2 }}>
           <TextField
             label="Currency"
-            value={gpVendorId ? gpVendorCurrency : '—'}
+            value={gpVendorId ? gpVendorCurrency : '-'}
             size="small"
             sx={{ minWidth: 120 }}
             disabled

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -17,7 +17,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
-import { CREATE_DRAFT_PO, REGISTER_PO_IN_GP, GET_GP_COST_CODES, GET_GP_VENDORS, SUGGEST_VENDOR_FOR_MANUFACTURER } from '../../graphql/po';
+import { CREATE_DRAFT_PO, REGISTER_PO_IN_GP, GET_GP_COST_CODES, GET_GP_VENDORS, GET_GP_TAX_DETAILS, SUGGEST_VENDOR_FOR_MANUFACTURER } from '../../graphql/po';
 import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/shared';
 import { useIdentity } from '../../hooks/useIdentity';
 import VendorSelect from '../../components/VendorSelect';
@@ -52,12 +52,19 @@ interface GpVendorOption {
   vendorName: string;
   vendorClass: string | null;
   status: number;
+  currency: string; // GP CURNCYID (issue #257); the PO inherits it, blank -> 'CAD'
 }
 
 interface GpCostCode {
   costCode: string; // two-segment number 'cc1-cc2' e.g. '310-000'
   description: string | null;
   costElement: number; // GP Cost_Element (varies by code); the /po cost_code trailing digit
+}
+
+interface GpTaxDetailOption {
+  taxDetailId: string; // GP TAXDTLID (purchase detail, TX00201 TXDTLTYP=2)
+  description: string | null;
+  percent: number; // GP TXDTLPCT
 }
 
 const EMPTY_LINE_ITEM: Omit<LineItemRow, 'key' | 'id'> = {
@@ -134,6 +141,11 @@ export default function GpPurchaseOrderDialog({
   // Issue #156: optional order-time dollar costs. Kept as strings ('' = not entered, distinct from 0).
   const [shippingCost, setShippingCost] = useState('');
   const [tariffAmount, setTariffAmount] = useState('');
+  // Issue #257: GP header charges captured at register time. taxDetailId is a GP purchase tax detail
+  // (CAD only); miscellaneous + tradeDiscount are dollar inputs. Freight maps from shippingCost above.
+  const [taxDetailId, setTaxDetailId] = useState('');
+  const [miscellaneous, setMiscellaneous] = useState('');
+  const [tradeDiscount, setTradeDiscount] = useState('');
   // Issue #256: create mode drafts carry an optional Nexus vendor link + the PM's preferred date.
   const [vendorId, setVendorId] = useState<string | null>(null);
   const [preferredDeliveryDate, setPreferredDeliveryDate] = useState('');
@@ -203,6 +215,20 @@ export default function GpPurchaseOrderDialog({
     fetchPolicy: 'cache-first',
   });
   const gpVendors = gpVendorsData?.gpVendors ?? [];
+
+  // Issue #257: live GP purchase tax details (TX00201, TXDTLTYP=2) for the tax-detail dropdown.
+  const { data: gpTaxDetailsData } = useQuery<{ gpTaxDetails: GpTaxDetailOption[] }>(GET_GP_TAX_DETAILS, {
+    variables: { company },
+    skip: !open || !isRegister || !relayConnected || !company,
+    fetchPolicy: 'cache-first',
+  });
+  const gpTaxDetails = gpTaxDetailsData?.gpTaxDetails ?? [];
+
+  // Issue #257: the PO currency is the selected GP vendor's (GP-first, resolved again server-side).
+  // USD POs need exchange-rate handling not yet built (the relay guards them), so surface USD here and
+  // show the CAD-only tax-detail dropdown accordingly.
+  const gpVendorCurrency = gpVendors.find((v) => v.vendorId === gpVendorId)?.currency ?? 'CAD';
+  const isUsdVendor = isRegister && !!gpVendorId && gpVendorCurrency !== 'CAD';
 
   // Issue #232: suggest the ordering vendor from each line's TITAN manufacturer. The manufacturer is
   // the derived POLineItem.manufacturer (resolved server-side from the line's linked HardwareItem),
@@ -308,6 +334,10 @@ export default function GpPurchaseOrderDialog({
       setNotes(registerPo.notes ?? '');
       setShippingCost(registerPo.shippingCost != null ? String(registerPo.shippingCost) : '');
       setTariffAmount(registerPo.tariffAmount != null ? String(registerPo.tariffAmount) : '');
+      // Issue #257: no draft-side source for these; the user enters them at register time.
+      setTaxDetailId('');
+      setMiscellaneous('');
+      setTradeDiscount('');
       const rows: LineItemRow[] = registerPo.lineItems.map((li, i) => ({
         key: i + 1,
         id: li.id,
@@ -326,6 +356,9 @@ export default function GpPurchaseOrderDialog({
       setNotes('');
       setShippingCost('');
       setTariffAmount('');
+      setTaxDetailId('');
+      setMiscellaneous('');
+      setTradeDiscount('');
       setVendorId(null);
       setPreferredDeliveryDate('');
       setLineItems([{ key: 1, ...EMPTY_LINE_ITEM }]);
@@ -433,15 +466,26 @@ export default function GpPurchaseOrderDialog({
       if (!gpBuyerId) errs.buyer = 'Your account has no GP buyer identity - ask an Admin to set it in User Management';
       else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
       if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
+      // Issue #257: USD (foreign-currency) POs need exchange-rate handling not yet built - the relay
+      // rejects them - so block registration here with a clear message instead of a relay error.
+      if (isUsdVendor)
+        errs.vendor = `${gpVendorCurrency} vendor POs are not supported yet (issue #257 follow-up); pick a CAD vendor`;
+      // A CAD PO must carry a tax detail (the relay computes tax from it). USD carries none.
+      else if (gpVendorId && !taxDetailId) errs.taxDetail = 'Select a tax detail';
     }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
       errs.shippingCost = 'Must be >= 0';
     if (tariffAmount.trim() !== '' && (isNaN(parseFloat(tariffAmount)) || parseFloat(tariffAmount) < 0))
       errs.tariffAmount = 'Must be >= 0';
+    // Issue #257: the new GP charges are optional but must be valid non-negative dollars when entered.
+    if (miscellaneous.trim() !== '' && (isNaN(parseFloat(miscellaneous)) || parseFloat(miscellaneous) < 0))
+      errs.miscellaneous = 'Must be >= 0';
+    if (tradeDiscount.trim() !== '' && (isNaN(parseFloat(tradeDiscount)) || parseFloat(tradeDiscount) < 0))
+      errs.tradeDiscount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isUsdVendor, gpVendorCurrency, taxDetailId, miscellaneous, tradeDiscount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -464,6 +508,10 @@ export default function GpPurchaseOrderDialog({
     // Issue #156: '' = not entered (null); 0 is a valid entered value.
     const shippingCostValue = shippingCost.trim() === '' ? null : parseFloat(shippingCost);
     const tariffAmountValue = tariffAmount.trim() === '' ? null : parseFloat(tariffAmount);
+    // Issue #257: same '' -> null convention. tax detail is not sent for a USD PO (it carries none).
+    const miscellaneousValue = miscellaneous.trim() === '' ? null : parseFloat(miscellaneous);
+    const tradeDiscountValue = tradeDiscount.trim() === '' ? null : parseFloat(tradeDiscount);
+    const taxDetailIdValue = isUsdVendor || !taxDetailId ? null : taxDetailId;
 
     setGpError(null);
     setGpBusy(true);
@@ -482,6 +530,9 @@ export default function GpPurchaseOrderDialog({
               costCode: gpCostCode,
               shippingCost: shippingCostValue,
               tariffAmount: tariffAmountValue,
+              taxDetailId: taxDetailIdValue,
+              miscellaneous: miscellaneousValue,
+              tradeDiscount: tradeDiscountValue,
               idempotencyKey,
               lineItems: lineItems.map((li, idx) => ({
                 id: li.id ?? null,
@@ -543,6 +594,10 @@ export default function GpPurchaseOrderDialog({
     notes,
     shippingCost,
     tariffAmount,
+    taxDetailId,
+    miscellaneous,
+    tradeDiscount,
+    isUsdVendor,
     registerPo,
     isRegister,
     createDraftPo,
@@ -803,6 +858,60 @@ export default function GpPurchaseOrderDialog({
               <RefreshIcon fontSize="small" />
             </IconButton>
           </Box>
+        </Stack>
+        {/* Issue #257: GP currency (read-only, from the vendor), the CAD-only tax detail, and the
+            Miscellaneous / Trade discount charges. Freight is the "Shipping costs" field above. */}
+        <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap alignItems="flex-start" sx={{ mt: 2 }}>
+          <TextField
+            label="Currency"
+            value={gpVendorId ? gpVendorCurrency : '—'}
+            size="small"
+            sx={{ minWidth: 120 }}
+            disabled
+            error={isUsdVendor}
+            helperText={isUsdVendor ? 'USD not supported yet' : ' '}
+          />
+          <TextField
+            select
+            label="Tax detail (required)"
+            value={taxDetailId}
+            onChange={(e) => setTaxDetailId(e.target.value)}
+            size="small"
+            sx={{ minWidth: 260 }}
+            disabled={!relayConnected || isUsdVendor || gpTaxDetails.length === 0}
+            error={!!errors.taxDetail}
+            helperText={errors.taxDetail || (isUsdVendor ? 'Not applicable for USD' : '')}
+          >
+            {gpTaxDetails.map((t) => (
+              <MenuItem key={t.taxDetailId} value={t.taxDetailId}>
+                {t.description
+                  ? `${t.taxDetailId} · ${t.description} (${t.percent}%)`
+                  : `${t.taxDetailId} (${t.percent}%)`}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Miscellaneous (optional)"
+            value={miscellaneous}
+            onChange={(e) => setMiscellaneous(e.target.value)}
+            size="small"
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+            sx={{ width: 190 }}
+            error={!!errors.miscellaneous}
+            helperText={errors.miscellaneous}
+          />
+          <TextField
+            label="Trade discount (optional)"
+            value={tradeDiscount}
+            onChange={(e) => setTradeDiscount(e.target.value)}
+            size="small"
+            type="number"
+            slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+            sx={{ width: 190 }}
+            error={!!errors.tradeDiscount}
+            helperText={errors.tradeDiscount}
+          />
         </Stack>
         {errors.gp && (
           <Alert severity="error" sx={{ mt: 2 }}>

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -225,10 +225,11 @@ export default function GpPurchaseOrderDialog({
   const gpTaxDetails = gpTaxDetailsData?.gpTaxDetails ?? [];
 
   // Issue #257: the PO currency is the selected GP vendor's (GP-first, resolved again server-side).
-  // USD POs need exchange-rate handling not yet built (the relay guards them), so surface USD here and
-  // show the CAD-only tax-detail dropdown accordingly.
+  // A foreign-currency PO (non-CAD) carries no tax schedule/detail - the relay blanks TAXSCHID and
+  // prices the PO from GP's own maintained exchange rate - so the CAD-only tax-detail dropdown is
+  // hidden for it. Freight/misc/trade discount still apply (in the PO's currency).
   const gpVendorCurrency = gpVendors.find((v) => v.vendorId === gpVendorId)?.currency ?? 'CAD';
-  const isUsdVendor = isRegister && !!gpVendorId && gpVendorCurrency !== 'CAD';
+  const isForeignCurrency = isRegister && !!gpVendorId && gpVendorCurrency !== 'CAD';
 
   // Issue #232: suggest the ordering vendor from each line's TITAN manufacturer. The manufacturer is
   // the derived POLineItem.manufacturer (resolved server-side from the line's linked HardwareItem),
@@ -466,12 +467,9 @@ export default function GpPurchaseOrderDialog({
       if (!gpBuyerId) errs.buyer = 'Your account has no GP buyer identity - ask an Admin to set it in User Management';
       else if (!registerProjectAllowed) errs.buyer = `Buyer ${gpBuyerId} is not assigned to this project`;
       if (isJob && !costCode) errs.costCode = 'Cost code is required for a project PO';
-      // Issue #257: USD (foreign-currency) POs need exchange-rate handling not yet built - the relay
-      // rejects them - so block registration here with a clear message instead of a relay error.
-      if (isUsdVendor)
-        errs.vendor = `${gpVendorCurrency} vendor POs are not supported yet (issue #257 follow-up); pick a CAD vendor`;
-      // A CAD PO must carry a tax detail (the relay computes tax from it). USD carries none.
-      else if (gpVendorId && !taxDetailId) errs.taxDetail = 'Select a tax detail';
+      // Issue #257: a CAD PO must carry a tax detail (the relay computes tax from it); a foreign-currency
+      // PO carries none (the relay blanks the schedule), so require it for CAD only.
+      if (!isForeignCurrency && gpVendorId && !taxDetailId) errs.taxDetail = 'Select a tax detail';
     }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
@@ -485,7 +483,7 @@ export default function GpPurchaseOrderDialog({
       errs.tradeDiscount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isUsdVendor, gpVendorCurrency, taxDetailId, miscellaneous, tradeDiscount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, miscellaneous, tradeDiscount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -508,10 +506,10 @@ export default function GpPurchaseOrderDialog({
     // Issue #156: '' = not entered (null); 0 is a valid entered value.
     const shippingCostValue = shippingCost.trim() === '' ? null : parseFloat(shippingCost);
     const tariffAmountValue = tariffAmount.trim() === '' ? null : parseFloat(tariffAmount);
-    // Issue #257: same '' -> null convention. tax detail is not sent for a USD PO (it carries none).
+    // Issue #257: same '' -> null convention. tax detail is not sent for a foreign-currency PO (none).
     const miscellaneousValue = miscellaneous.trim() === '' ? null : parseFloat(miscellaneous);
     const tradeDiscountValue = tradeDiscount.trim() === '' ? null : parseFloat(tradeDiscount);
-    const taxDetailIdValue = isUsdVendor || !taxDetailId ? null : taxDetailId;
+    const taxDetailIdValue = isForeignCurrency || !taxDetailId ? null : taxDetailId;
 
     setGpError(null);
     setGpBusy(true);
@@ -597,7 +595,7 @@ export default function GpPurchaseOrderDialog({
     taxDetailId,
     miscellaneous,
     tradeDiscount,
-    isUsdVendor,
+    isForeignCurrency,
     registerPo,
     isRegister,
     createDraftPo,
@@ -868,19 +866,18 @@ export default function GpPurchaseOrderDialog({
             size="small"
             sx={{ minWidth: 120 }}
             disabled
-            error={isUsdVendor}
-            helperText={isUsdVendor ? 'USD not supported yet' : ' '}
+            helperText={isForeignCurrency ? `${gpVendorCurrency}: no tax schedule, GP rate applied` : ' '}
           />
           <TextField
             select
-            label="Tax detail (required)"
-            value={taxDetailId}
+            label={isForeignCurrency ? 'Tax detail' : 'Tax detail (required)'}
+            value={isForeignCurrency ? '' : taxDetailId}
             onChange={(e) => setTaxDetailId(e.target.value)}
             size="small"
             sx={{ minWidth: 260 }}
-            disabled={!relayConnected || isUsdVendor || gpTaxDetails.length === 0}
+            disabled={!relayConnected || isForeignCurrency || gpTaxDetails.length === 0}
             error={!!errors.taxDetail}
-            helperText={errors.taxDetail || (isUsdVendor ? 'Not applicable for USD' : '')}
+            helperText={errors.taxDetail || (isForeignCurrency ? 'Not applicable for a foreign-currency PO' : '')}
           >
             {gpTaxDetails.map((t) => (
               <MenuItem key={t.taxDetailId} value={t.taxDetailId}>

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -482,6 +482,28 @@ describe('GpPurchaseOrderDialog', () => {
     expect(calls[0]).toMatchObject({ input: { taxDetailId: 'ON HST - P' } });
   });
 
+  it('does not require a tax detail when the company defines none (issue #257)', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const registerMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: registerData() };
+      },
+    };
+    // A company with no purchase tax details: the dropdown is empty/disabled, so registration must not
+    // be hard-blocked on picking one.
+    const mocksNoTax = baseMocks().map((m) =>
+      m.request.query === GET_GP_TAX_DETAILS ? { ...m, result: { data: { gpTaxDetails: [] } } } : m,
+    );
+    const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [...mocksNoTax, registerMock]);
+    await waitForVendorPreselect();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+    expect(calls[0]).toMatchObject({ input: { taxDetailId: null } });
+  });
+
   it('registers a USD vendor PO with no tax detail (foreign currency, issue #257)', async () => {
     const calls: Record<string, unknown>[] = [];
     const registerMock: MockedResponse = {

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -177,6 +177,7 @@ function baseMocks(
           gpVendors: [
             { vendorId: 'V-ACE', vendorName: 'Ace Hardware Co', vendorClass: null, status: 1, currency: 'CAD', __typename: 'GpVendor' },
             { vendorId: 'V-ALL', vendorName: 'Allegion Hardware', vendorClass: null, status: 1, currency: 'CAD', __typename: 'GpVendor' },
+            { vendorId: 'V-USD', vendorName: 'US Supplier Co', vendorClass: null, status: 1, currency: 'USD', __typename: 'GpVendor' },
           ],
         },
       },
@@ -479,6 +480,28 @@ describe('GpPurchaseOrderDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
     expect(calls[0]).toMatchObject({ input: { taxDetailId: 'ON HST - P' } });
+  });
+
+  it('registers a USD vendor PO with no tax detail (foreign currency, issue #257)', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const registerMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: registerData() };
+      },
+    };
+    // A draft whose vendor name exact-matches the USD vendor auto-preselects it (confident).
+    const usdDraft = { ...stockDraft, vendorNameSnapshot: 'US Supplier Co' };
+    const { onSubmitted } = renderDialog({ registerPo: usdDraft }, [...baseMocks(), registerMock]);
+    await waitFor(() => expect(screen.getByLabelText('GP Vendor')).toHaveTextContent('US Supplier Co'));
+
+    // Foreign currency: the tax detail is not applicable and not required to register.
+    expect(screen.getByLabelText('Currency')).toHaveValue('USD');
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+    // No tax detail sent; the relay resolves the GP exchange rate + blanks TAXSCHID server-side.
+    expect(calls[0]).toMatchObject({ input: { gpVendorId: 'V-USD', taxDetailId: null } });
   });
 
   it('create mode saves a plain draft via CREATE_DRAFT_PO with no GP fields, even with the relay down', async () => {

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -9,6 +9,7 @@ import {
   REGISTER_PO_IN_GP,
   GET_GP_COST_CODES,
   GET_GP_VENDORS,
+  GET_GP_TAX_DETAILS,
 } from '../../../graphql/po';
 import {
   GET_BUYER_ASSIGNMENTS,
@@ -174,8 +175,19 @@ function baseMocks(
       result: {
         data: {
           gpVendors: [
-            { vendorId: 'V-ACE', vendorName: 'Ace Hardware Co', vendorClass: null, status: 1, __typename: 'GpVendor' },
-            { vendorId: 'V-ALL', vendorName: 'Allegion Hardware', vendorClass: null, status: 1, __typename: 'GpVendor' },
+            { vendorId: 'V-ACE', vendorName: 'Ace Hardware Co', vendorClass: null, status: 1, currency: 'CAD', __typename: 'GpVendor' },
+            { vendorId: 'V-ALL', vendorName: 'Allegion Hardware', vendorClass: null, status: 1, currency: 'CAD', __typename: 'GpVendor' },
+          ],
+        },
+      },
+      maxUsageCount: INFINITE,
+    },
+    {
+      request: { query: GET_GP_TAX_DETAILS, variables: { company: 'UCS' } },
+      result: {
+        data: {
+          gpTaxDetails: [
+            { taxDetailId: 'ON HST - P', description: 'ON HST on Purchases', percent: 13, __typename: 'GpTaxDetail' },
           ],
         },
       },
@@ -281,6 +293,13 @@ async function waitForVendorPreselect() {
   );
 }
 
+// Issue #257: a CAD PO requires a tax detail before it can be registered.
+async function selectTaxDetail() {
+  const listbox = await openSelect('Tax detail (required)');
+  fireEvent.click(within(listbox).getByText(/ON HST - P/));
+  await closeSelect();
+}
+
 describe('GpPurchaseOrderDialog', () => {
   it('register mode seeds the draft, shows the caller as buyer and pre-selects an exact-match GP vendor', async () => {
     renderDialog({ registerPo: stockDraft });
@@ -362,11 +381,12 @@ describe('GpPurchaseOrderDialog', () => {
     fireEvent.click(
       screen.getByRole('checkbox', { name: 'This is the correct GP vendor (Ace Hardware Co)' }),
     );
+    await selectTaxDetail();
     fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
 
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({ input: { gpVendorId: 'V-ACE' } });
+    expect(calls[0]).toMatchObject({ input: { gpVendorId: 'V-ACE', taxDetailId: 'ON HST - P' } });
   });
 
   it('registers a project draft with gpCompany, a designated cost code and an idempotency key', async () => {
@@ -402,6 +422,7 @@ describe('GpPurchaseOrderDialog', () => {
     fireEvent.change(screen.getByLabelText('Shipping costs (optional)'), {
       target: { value: '25' },
     });
+    await selectTaxDetail();
     fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
 
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
@@ -416,6 +437,9 @@ describe('GpPurchaseOrderDialog', () => {
         costCode: '310-000-3',
         shippingCost: 25,
         tariffAmount: null,
+        taxDetailId: 'ON HST - P',
+        miscellaneous: null,
+        tradeDiscount: null,
         idempotencyKey: expect.stringMatching(UUID_RE) as string,
         lineItems: [
           {
@@ -430,6 +454,31 @@ describe('GpPurchaseOrderDialog', () => {
         ],
       },
     });
+  });
+
+  it('requires a tax detail before a CAD PO can be registered (issue #257)', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const registerMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: registerData() };
+      },
+    };
+    const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [...baseMocks(), registerMock]);
+    await waitForVendorPreselect();
+
+    // No tax detail picked yet -> blocked with a clear message; nothing reaches GP.
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    expect(await screen.findByText('Select a tax detail')).toBeInTheDocument();
+    expect(calls).toHaveLength(0);
+    expect(onSubmitted).not.toHaveBeenCalled();
+
+    // Pick it and the PO registers, carrying the chosen detail.
+    await selectTaxDetail();
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+    expect(calls[0]).toMatchObject({ input: { taxDetailId: 'ON HST - P' } });
   });
 
   it('create mode saves a plain draft via CREATE_DRAFT_PO with no GP fields, even with the relay down', async () => {
@@ -552,6 +601,7 @@ describe('GpPurchaseOrderDialog', () => {
       okMock,
     ]);
     await waitForVendorPreselect();
+    await selectTaxDetail();
 
     fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
     // The persistent GP error detail (issue #187), not just a toast; the dialog stays open.

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -99,6 +99,13 @@ def _run_list_buyers(company: str, payload: dict) -> dict:
     return {"company": company, "buyers": ids}
 
 
+def _run_list_tax_details(company: str, payload: dict) -> dict:
+    ops.check_company_allowed(company)
+    with db.get_read_connection(company) as conn:
+        rows = econnect.list_tax_details(conn)
+    return {"company": company, "tax_details": rows}
+
+
 def _run_list_cost_codes(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     job = (payload.get("job") or "").strip()
@@ -155,6 +162,7 @@ def _run_create_receipt(company: str, payload: dict) -> dict:
 _OPS = {
     "list_vendors": _run_list_vendors,
     "list_buyers": _run_list_buyers,
+    "list_tax_details": _run_list_tax_details,
     "list_cost_codes": _run_list_cost_codes,
     "list_jobs": _run_list_jobs,
     "read_po_totals": _run_read_po_totals,

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -66,6 +66,42 @@ def po_number_in_use(conn, po_number: str) -> str | None:
     return None
 
 
+def _exec_tapohdr(conn, fields: dict) -> None:
+    """Build + EXEC dbo.taPoHdr from an ordered {param: value} map (param name minus the @I_v prefix),
+    always appending UpdateIfExists=1 + the OUTPUT error params. One place wires the header upsert so
+    the create / subtotal / currency-rate / tax variants can't drift on parameter naming."""
+    assignments = ",\n        ".join(f"@I_v{name} = ?" for name in fields)
+    sql = f"""
+    DECLARE @err int = 0;
+    DECLARE @err_str varchar(255) = '';
+    EXEC dbo.taPoHdr
+        {assignments},
+        @I_vUpdateIfExists = 1,
+        @O_iErrorState     = @err OUTPUT,
+        @oErrString        = @err_str OUTPUT;
+    SELECT @err AS error_state, @err_str AS err_string;
+    """
+    row = conn.cursor().execute(sql, *fields.values()).fetchone()
+    if row.error_state != 0:
+        raise EConnectError(
+            f"taPoHdr failed: {row.err_string.strip()}", proc="taPoHdr", error_state=row.error_state
+        )
+
+
+def _foreign_currency_fields(rate_type: str | None, exchange_date: date | None, null_tax_schedule: bool) -> dict:
+    """The taPoHdr fields that differ for a foreign-currency PO (issue #257). rate_type set -> pass
+    RATETPID + EXCHDATE and let eConnect auto-resolve XCHGRATE from GP's maintained exchange rate table
+    (DYNAMICS.MC00100). null_tax_schedule -> blank TAXSCHID: a USD PO must carry no tax schedule, and GP
+    would otherwise fill the company default (verified live - it does NOT auto-null for a foreign PO)."""
+    fields: dict = {}
+    if rate_type:
+        fields["RATETPID"] = rate_type
+        fields["EXCHDATE"] = exchange_date
+    if null_tax_schedule:
+        fields["TAXSCHID"] = ""
+    return fields
+
+
 def create_po_header(
     conn,
     *,
@@ -79,37 +115,27 @@ def create_po_header(
     shipping_method: str = "LOCAL DELIVERY",
     po_status: int = 2,  # 2 = Released
     po_type: int = 1,
+    rate_type: str | None = None,
+    exchange_date: date | None = None,
+    null_tax_schedule: bool = False,
 ) -> None:
-    """Create the PO header. SUBTOTAL is NOT passed here (no lines exist yet);
-    it's set by update_po_header_subtotal() after the lines land."""
-    sql = """
-    DECLARE @err int = 0;
-    DECLARE @err_str varchar(255) = '';
-    EXEC dbo.taPoHdr
-        @I_vPOTYPE         = ?,
-        @I_vPONUMBER       = ?,
-        @I_vVENDORID       = ?,
-        @I_vDOCDATE        = ?,
-        @I_vBUYERID        = ?,
-        @I_vCURNCYID       = ?,
-        @I_vPOSTATUS       = ?,
-        @I_vCONFIRM1       = ?,
-        @I_vVADCDPAD       = ?,
-        @I_vSHIPMTHD       = ?,
-        @I_vUpdateIfExists = 1,
-        @O_iErrorState     = @err OUTPUT,
-        @oErrString        = @err_str OUTPUT;
-    SELECT @err AS error_state, @err_str AS err_string;
-    """
-    row = conn.cursor().execute(
-        sql,
-        po_type, po_number, vendor_id, doc_date, buyer_id, currency_id,
-        po_status, confirm_with, vendor_address_code, shipping_method,
-    ).fetchone()
-    if row.error_state != 0:
-        raise EConnectError(
-            f"taPoHdr failed: {row.err_string.strip()}", proc="taPoHdr", error_state=row.error_state
-        )
+    """Create the PO header. SUBTOTAL is NOT passed here (no lines exist yet); update_po_header_subtotal
+    sets it after the lines land. For a foreign-currency PO (issue #257), rate_type/exchange_date let
+    eConnect resolve the exchange rate and null_tax_schedule blanks TAXSCHID."""
+    fields = {
+        "POTYPE": po_type,
+        "PONUMBER": po_number,
+        "VENDORID": vendor_id,
+        "DOCDATE": doc_date,
+        "BUYERID": buyer_id,
+        "CURNCYID": currency_id,
+        "POSTATUS": po_status,
+        "CONFIRM1": confirm_with,
+        "VADCDPAD": vendor_address_code,
+        "SHIPMTHD": shipping_method,
+    }
+    fields.update(_foreign_currency_fields(rate_type, exchange_date, null_tax_schedule))
+    _exec_tapohdr(conn, fields)
 
 
 def create_po_line(
@@ -309,6 +335,9 @@ def update_po_header_subtotal(
     misc_amount: Decimal = Decimal(0),
     tax_amount: Decimal = Decimal(0),
     using_header_taxes: bool = False,
+    rate_type: str | None = None,
+    exchange_date: date | None = None,
+    null_tax_schedule: bool = False,
 ) -> None:
     """Re-call taPoHdr with UpdateIfExists=1 + the computed SUBTOTAL (validated now against the line
     totals from steps 3-4) and the order-time GP charges (issue #257): trade discount, freight, misc,
@@ -317,46 +346,31 @@ def update_po_header_subtotal(
     Freight/misc go on non-taxable (Purchase_Freight_Taxable/Purchase_Misc_Taxable=0), so no
     FRTSCHID/MSCSCHID is needed. When a tax detail was inserted (via insert_po_tax_detail),
     using_header_taxes=1 tells GP to use the passed TAXAMNT rather than compute one - GP does NOT
-    calculate PO tax under header-level taxes (verified live). TAXSCHID is left blank; GP accepts a
-    header-level-tax PO with a blank schedule (verified TUBC)."""
-    sql = """
-    DECLARE @err int = 0;
-    DECLARE @err_str varchar(255) = '';
-    EXEC dbo.taPoHdr
-        @I_vPOTYPE                   = ?,
-        @I_vPONUMBER                 = ?,
-        @I_vVENDORID                 = ?,
-        @I_vDOCDATE                  = ?,
-        @I_vBUYERID                  = ?,
-        @I_vCURNCYID                 = ?,
-        @I_vPOSTATUS                 = ?,
-        @I_vCONFIRM1                 = ?,
-        @I_vVADCDPAD                 = ?,
-        @I_vSHIPMTHD                 = ?,
-        @I_vSUBTOTAL                 = ?,
-        @I_vTRDISAMT                 = ?,
-        @I_vFRTAMNT                  = ?,
-        @I_vMSCCHAMT                 = ?,
-        @I_vTAXAMNT                  = ?,
-        @I_vPurchase_Freight_Taxable = 0,
-        @I_vPurchase_Misc_Taxable    = 0,
-        @I_vUSINGHEADERLEVELTAXES    = ?,
-        @I_vUpdateIfExists           = 1,
-        @O_iErrorState               = @err OUTPUT,
-        @oErrString                  = @err_str OUTPUT;
-    SELECT @err AS error_state, @err_str AS err_string;
-    """
-    row = conn.cursor().execute(
-        sql,
-        po_type, po_number, vendor_id, doc_date, buyer_id, currency_id,
-        po_status, confirm_with, vendor_address_code, shipping_method, subtotal,
-        trade_discount, freight_amount, misc_amount, tax_amount, 1 if using_header_taxes else 0,
-    ).fetchone()
-    if row.error_state != 0:
-        raise EConnectError(
-            f"taPoHdr (subtotal update) failed: {row.err_string.strip()}",
-            proc="taPoHdr", error_state=row.error_state,
-        )
+    calculate PO tax under header-level taxes (verified live). rate_type/exchange_date/null_tax_schedule
+    carry the foreign-currency handling (re-sent here so the UpdateIfExists upsert can't revert the
+    rate or re-default a blanked TAXSCHID)."""
+    fields = {
+        "POTYPE": po_type,
+        "PONUMBER": po_number,
+        "VENDORID": vendor_id,
+        "DOCDATE": doc_date,
+        "BUYERID": buyer_id,
+        "CURNCYID": currency_id,
+        "POSTATUS": po_status,
+        "CONFIRM1": confirm_with,
+        "VADCDPAD": vendor_address_code,
+        "SHIPMTHD": shipping_method,
+        "SUBTOTAL": subtotal,
+        "TRDISAMT": trade_discount,
+        "FRTAMNT": freight_amount,
+        "MSCCHAMT": misc_amount,
+        "TAXAMNT": tax_amount,
+        "Purchase_Freight_Taxable": 0,
+        "Purchase_Misc_Taxable": 0,
+        "USINGHEADERLEVELTAXES": 1 if using_header_taxes else 0,
+    }
+    fields.update(_foreign_currency_fields(rate_type, exchange_date, null_tax_schedule))
+    _exec_tapohdr(conn, fields)
 
 
 def insert_po_tax_detail(
@@ -505,6 +519,23 @@ def get_vendor_currency(conn, vendor_id: str) -> str:
         "SELECT RTRIM(CURNCYID) AS cur FROM dbo.PM00200 WHERE VENDORID = ?", vendor_id
     ).fetchone()
     return ((row.cur if row else "") or "").strip().upper() or "CAD"
+
+
+def get_mc_setup(conn) -> dict:
+    """Read-only: the company's multicurrency setup (MC40000) - functional currency + the default
+    PURCHASING rate type (issue #257). A foreign-currency PO (vendor currency != functional) is priced
+    with that rate type; eConnect then resolves the actual XCHGRATE from GP's maintained exchange rate
+    table (DYNAMICS.MC00100) itself. Returns {'functional': <id>, 'purchase_rate_type': <id or None>};
+    a company with no MC setup (single-currency) yields functional 'CAD' and no rate type."""
+    row = conn.cursor().execute(
+        "SELECT RTRIM(FUNLCURR) AS functional, RTRIM(DEFPURTP) AS purchase_rate_type FROM dbo.MC40000"
+    ).fetchone()
+    if row is None:
+        return {"functional": "CAD", "purchase_rate_type": None}
+    return {
+        "functional": ((row.functional or "").strip().upper() or "CAD"),
+        "purchase_rate_type": ((row.purchase_rate_type or "").strip() or None),
+    }
 
 
 def list_tax_details(conn) -> list[dict]:

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -304,39 +304,98 @@ def update_po_header_subtotal(
     shipping_method: str = "LOCAL DELIVERY",
     po_status: int = 2,
     po_type: int = 1,
+    trade_discount: Decimal = Decimal(0),
+    freight_amount: Decimal = Decimal(0),
+    misc_amount: Decimal = Decimal(0),
+    tax_amount: Decimal = Decimal(0),
+    using_header_taxes: bool = False,
 ) -> None:
-    """Re-call taPoHdr with UpdateIfExists=1 + the computed SUBTOTAL (validated now
-    against the line totals from steps 3-4). May be droppable if the wsi proc sets
-    SUBTOTAL itself — that's one of the two unknowns to resolve after the first create."""
+    """Re-call taPoHdr with UpdateIfExists=1 + the computed SUBTOTAL (validated now against the line
+    totals from steps 3-4) and the order-time GP charges (issue #257): trade discount, freight, misc,
+    and the header-level tax amount.
+
+    Freight/misc go on non-taxable (Purchase_Freight_Taxable/Purchase_Misc_Taxable=0), so no
+    FRTSCHID/MSCSCHID is needed. When a tax detail was inserted (via insert_po_tax_detail),
+    using_header_taxes=1 tells GP to use the passed TAXAMNT rather than compute one - GP does NOT
+    calculate PO tax under header-level taxes (verified live). TAXSCHID is left blank; GP accepts a
+    header-level-tax PO with a blank schedule (verified TUBC)."""
     sql = """
     DECLARE @err int = 0;
     DECLARE @err_str varchar(255) = '';
     EXEC dbo.taPoHdr
-        @I_vPOTYPE         = ?,
-        @I_vPONUMBER       = ?,
-        @I_vVENDORID       = ?,
-        @I_vDOCDATE        = ?,
-        @I_vBUYERID        = ?,
-        @I_vCURNCYID       = ?,
-        @I_vPOSTATUS       = ?,
-        @I_vCONFIRM1       = ?,
-        @I_vVADCDPAD       = ?,
-        @I_vSHIPMTHD       = ?,
-        @I_vSUBTOTAL       = ?,
-        @I_vUpdateIfExists = 1,
-        @O_iErrorState     = @err OUTPUT,
-        @oErrString        = @err_str OUTPUT;
+        @I_vPOTYPE                   = ?,
+        @I_vPONUMBER                 = ?,
+        @I_vVENDORID                 = ?,
+        @I_vDOCDATE                  = ?,
+        @I_vBUYERID                  = ?,
+        @I_vCURNCYID                 = ?,
+        @I_vPOSTATUS                 = ?,
+        @I_vCONFIRM1                 = ?,
+        @I_vVADCDPAD                 = ?,
+        @I_vSHIPMTHD                 = ?,
+        @I_vSUBTOTAL                 = ?,
+        @I_vTRDISAMT                 = ?,
+        @I_vFRTAMNT                  = ?,
+        @I_vMSCCHAMT                 = ?,
+        @I_vTAXAMNT                  = ?,
+        @I_vPurchase_Freight_Taxable = 0,
+        @I_vPurchase_Misc_Taxable    = 0,
+        @I_vUSINGHEADERLEVELTAXES    = ?,
+        @I_vUpdateIfExists           = 1,
+        @O_iErrorState               = @err OUTPUT,
+        @oErrString                  = @err_str OUTPUT;
     SELECT @err AS error_state, @err_str AS err_string;
     """
     row = conn.cursor().execute(
         sql,
         po_type, po_number, vendor_id, doc_date, buyer_id, currency_id,
         po_status, confirm_with, vendor_address_code, shipping_method, subtotal,
+        trade_discount, freight_amount, misc_amount, tax_amount, 1 if using_header_taxes else 0,
     ).fetchone()
     if row.error_state != 0:
         raise EConnectError(
             f"taPoHdr (subtotal update) failed: {row.err_string.strip()}",
             proc="taPoHdr", error_state=row.error_state,
+        )
+
+
+def insert_po_tax_detail(
+    conn,
+    *,
+    po_number: str,
+    vendor_id: str,
+    tax_detail_id: str,
+    tax_amount: Decimal,
+    taxable_purchase: Decimal,
+) -> None:
+    """taPopIvcTaxInsert: attach ONE purchase tax detail to a PO (issue #257). TAXTYPE=0 = the PO item
+    tax. GP does not compute PO tax under header-level taxes, so the caller passes the computed TAXAMNT
+    (= detail rate x taxable purchase) plus the taxable/total purchase base. Called BEFORE the final
+    update_po_header_subtotal, which sets USINGHEADERLEVELTAXES=1 + the matching TAXAMNT."""
+    sql = """
+    DECLARE @err int = 0;
+    DECLARE @err_str varchar(255) = '';
+    EXEC dbo.taPopIvcTaxInsert
+        @I_vPONUMBER   = ?,
+        @I_vTAXTYPE    = 0,
+        @I_vORD        = 0,
+        @I_vTAXDTLID   = ?,
+        @I_vBKOUTTAX   = 0,
+        @I_vTAXAMNT    = ?,
+        @I_vTAXPURCH   = ?,
+        @I_vTOTPURCH   = ?,
+        @I_vVENDORID   = ?,
+        @O_iErrorState = @err OUTPUT,
+        @oErrString    = @err_str OUTPUT;
+    SELECT @err AS error_state, @err_str AS err_string;
+    """
+    row = conn.cursor().execute(
+        sql, po_number, tax_detail_id, tax_amount, taxable_purchase, taxable_purchase, vendor_id
+    ).fetchone()
+    if row.error_state != 0:
+        raise EConnectError(
+            f"taPopIvcTaxInsert failed for detail {tax_detail_id}: {row.err_string.strip()}",
+            proc="taPopIvcTaxInsert", error_state=row.error_state,
         )
 
 
@@ -414,11 +473,12 @@ def read_po_receipt_context(conn, po_number: str):
 
 def list_vendors(conn, *, active_only: bool = True) -> list[dict]:
     """Read-only: PM00200 vendor list for the vendor sync (feeds UC Nexus's Vendor.gp_vendor_id).
-    Returns VENDORID / VENDNAME / VNDCLSID (class) / VENDSTTS (status). VENDSTTS 1 = active; the
-    sync only wants vendors usable on a new PO, so active_only filters to those."""
+    Returns VENDORID / VENDNAME / VNDCLSID (class) / VENDSTTS (status) / CURNCYID (currency). VENDSTTS
+    1 = active; the sync only wants vendors usable on a new PO, so active_only filters to those.
+    currency (issue #257) is the vendor's GP currency the PO inherits; blank -> functional 'CAD'."""
     sql = (
         "SELECT RTRIM(VENDORID) AS vendor_id, RTRIM(VENDNAME) AS vendor_name, "
-        "RTRIM(VNDCLSID) AS vendor_class, VENDSTTS AS status FROM dbo.PM00200 "
+        "RTRIM(VNDCLSID) AS vendor_class, VENDSTTS AS status, RTRIM(CURNCYID) AS currency FROM dbo.PM00200 "
     )
     if active_only:
         sql += "WHERE VENDSTTS = 1 "
@@ -430,9 +490,46 @@ def list_vendors(conn, *, active_only: bool = True) -> list[dict]:
             "vendor_name": r.vendor_name,
             "vendor_class": r.vendor_class or None,
             "status": int(r.status),
+            "currency": (r.currency or "").strip().upper() or "CAD",
         }
         for r in rows
     ]
+
+
+def get_vendor_currency(conn, vendor_id: str) -> str:
+    """Read-only: a vendor's GP currency (PM00200.CURNCYID), for GP-first currency resolution at PO
+    create (issue #257: the vendor dictates PO currency). Blank -> functional currency 'CAD'. Returns
+    an uppercased currency id, or 'CAD' if the vendor row is missing (create_po_header would then fail
+    on VENDORID with a clear eConnect error anyway)."""
+    row = conn.cursor().execute(
+        "SELECT RTRIM(CURNCYID) AS cur FROM dbo.PM00200 WHERE VENDORID = ?", vendor_id
+    ).fetchone()
+    return ((row.cur if row else "") or "").strip().upper() or "CAD"
+
+
+def list_tax_details(conn) -> list[dict]:
+    """Read-only: PURCHASE tax details (TX00201 WHERE TXDTLTYP = 2) for the register-PO tax-detail
+    dropdown (issue #257). TXDTLTYP 1 = Sales, 2 = Purchases. TXDTLPCT is the percent the relay uses
+    to compute the PO tax. GP-first: the options are whatever the company defines (e.g. BC HST P /
+    ON HST - P / PST 7% in production), never a hardcoded list."""
+    rows = conn.cursor().execute(
+        "SELECT RTRIM(TAXDTLID) AS tax_detail_id, RTRIM(TXDTLDSC) AS description, TXDTLPCT AS percent "
+        "FROM dbo.TX00201 WHERE TXDTLTYP = 2 ORDER BY TAXDTLID"
+    ).fetchall()
+    return [
+        {"tax_detail_id": r.tax_detail_id, "description": r.description or None, "percent": float(r.percent)}
+        for r in rows
+    ]
+
+
+def get_tax_detail_percent(conn, tax_detail_id: str) -> Decimal | None:
+    """Read-only: the percent rate of a PURCHASE tax detail (TX00201.TXDTLPCT WHERE TXDTLTYP = 2), for
+    computing the PO tax amount. Returns None if the id isn't a purchase tax detail (caller raises a
+    clean tax_detail_not_found instead of letting taPopIvcTaxInsert reject it mid-transaction)."""
+    row = conn.cursor().execute(
+        "SELECT TXDTLPCT AS pct FROM dbo.TX00201 WHERE TAXDTLID = ? AND TXDTLTYP = 2", tax_detail_id
+    ).fetchone()
+    return Decimal(str(row.pct)) if row is not None else None
 
 
 def list_buyers(conn) -> list[str]:

--- a/relay/src/ucnexus_relay/main.py
+++ b/relay/src/ucnexus_relay/main.py
@@ -5,6 +5,7 @@ Endpoints:
   GET  /info             — config + read-only SQL identity probe (+ workstation hostname), auth required
   GET  /vendors          — PM00200 vendor list for the vendor sync, auth required
   GET  /buyers           — POP00101 registered buyers for the Create PO buyer dropdown, auth required
+  GET  /tax-details      — TX00201 purchase tax details for the register-PO tax-detail dropdown, auth required
   GET  /cost-codes       — JC00701 per-job cost codes for the Create PO cost-code dropdown, auth required
   POST /po/next-number   — reserve a PO number (live taGetPONextNumber), auth required
   POST /po               — create a PO end-to-end (5-step orchestration), auth required
@@ -139,6 +140,19 @@ def create_app() -> FastAPI:
         except pyodbc.Error as e:
             raise HTTPException(status_code=502, detail=errors.error_body("sql_error", str(e)))
         return models.BuyersResponse(company=company, buyers=ids)
+
+    @app.get("/tax-details", response_model=models.TaxDetailsResponse)
+    def tax_details(company: str | None = None, _=Depends(auth.verify_token)):
+        """Purchase tax details (TX00201, TXDTLTYP=2) for the register-PO tax-detail dropdown (issue
+        #257). GP-first: the options are whatever the company defines, read live, not a hardcoded list."""
+        company = company or get_settings().gp.default_company
+        _check_company(company)
+        try:
+            with db.get_read_connection(company) as conn:
+                rows = econnect.list_tax_details(conn)
+        except pyodbc.Error as e:
+            raise HTTPException(status_code=502, detail=errors.error_body("sql_error", str(e)))
+        return models.TaxDetailsResponse(company=company, tax_details=[models.TaxDetailOut(**r) for r in rows])
 
     @app.get("/cost-codes", response_model=models.CostCodesResponse)
     def cost_codes(job: str, company: str | None = None, _=Depends(auth.verify_token)):

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -46,9 +46,18 @@ class POHeader(BaseModel):
     buyer_id: str | None = Field(default=None, max_length=15)
     confirm_with: str = Field(..., max_length=20)
     doc_date: date
+    # currency_id is informational only: the relay resolves the PO currency GP-first from the vendor
+    # master (PM00200.CURNCYID) at create time and ignores whatever is sent here (issue #257).
     currency_id: str = "CAD"
     vendor_address_code: str = "PRIMARY"
     shipping_method: str = "LOCAL DELIVERY"
+    # Issue #257: order-time GP charges. tax_detail_id is a GP purchase tax detail (TX00201,
+    # TXDTLTYP=2) the user picked; the relay looks up its rate and computes the tax. The three
+    # dollar amounts are entered on the register form. All optional; a PO with none is valid.
+    tax_detail_id: str | None = Field(default=None, max_length=15)
+    trade_discount: Decimal = Decimal(0)
+    freight_amount: Decimal = Decimal(0)
+    misc_amount: Decimal = Decimal(0)
 
 
 class CreatePoRequest(BaseModel):
@@ -75,6 +84,10 @@ class CreatePoResponse(BaseModel):
     subtotal: Decimal
     doc_date: date
     vendor_id: str
+    # Issue #257: resolved GP-first from the vendor master, and the tax the relay computed from the
+    # chosen tax detail (0 when none was picked). Returned so the backend can snapshot them.
+    currency: str = "CAD"
+    tax_amount: Decimal = Decimal(0)
 
 
 # --- receiving (workflow 2) ---
@@ -114,11 +127,25 @@ class VendorOut(BaseModel):
     vendor_name: str     # GP VENDNAME
     vendor_class: str | None = None  # GP VNDCLSID
     status: int          # GP VENDSTTS (1 = active)
+    currency: str = "CAD"  # GP CURNCYID, blank -> 'CAD' (issue #257: vendor dictates PO currency)
 
 
 class VendorsResponse(BaseModel):
     company: str
     vendors: list[VendorOut]
+
+
+# --- tax details (per-company, feeds the register-PO tax-detail dropdown - issue #257) ---
+
+class TaxDetailOut(BaseModel):
+    tax_detail_id: str          # GP TAXDTLID (purchase detail, TX00201 TXDTLTYP=2)
+    description: str | None = None  # GP TXDTLDSC
+    percent: float              # GP TXDTLPCT (the rate the relay computes tax with)
+
+
+class TaxDetailsResponse(BaseModel):
+    company: str
+    tax_details: list[TaxDetailOut]
 
 
 class BuyersResponse(BaseModel):

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -59,17 +59,30 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
             f"buyer '{buyer_id}' is not a registered GP buyer for {company} (registered: {registered})",
         )
 
-    # 0c. currency: GP-first, the vendor master dictates the PO currency (issue #257), not the client.
-    #     Foreign-currency POs need an exchange rate (XCHGRATE/RATETPID) that this path does not yet
-    #     supply - eConnect rejects a non-CAD PO with no rate - so guard them out with a clear error
-    #     until the exchange-rate follow-up lands. CAD (functional currency) needs no rate.
+    # 0c. currency + exchange rate: GP-first, the vendor master dictates the PO currency (issue #257),
+    #     not the client. A foreign-currency PO (vendor currency != the company's functional currency)
+    #     is priced with the company's default PURCHASING rate type; eConnect resolves the actual rate
+    #     from GP's maintained exchange rate table (DYNAMICS.MC00100) itself. It must ALSO carry no tax
+    #     schedule - GP would otherwise fill the company default - so a foreign PO blanks TAXSCHID and
+    #     takes no tax detail. CAD (functional) needs no rate and keeps GP's default schedule.
     currency = econnect.get_vendor_currency(conn, h.vendor_id)
-    if currency != "CAD":
-        raise RelayOpError(
-            "currency_unsupported",
-            f"vendor '{h.vendor_id}' is a {currency} vendor; foreign-currency POs need exchange-rate "
-            f"handling not yet implemented (issue #257 follow-up). Only CAD POs are supported for now.",
-        )
+    mc = econnect.get_mc_setup(conn)
+    is_foreign = currency != mc["functional"]
+    rate_type = None
+    if is_foreign:
+        rate_type = mc["purchase_rate_type"]
+        if not rate_type:
+            raise RelayOpError(
+                "rate_type_unresolved",
+                f"no default purchasing rate type (MC40000.DEFPURTP) configured for {company}; "
+                f"cannot price a {currency} PO",
+            )
+        if h.tax_detail_id:
+            raise RelayOpError(
+                "tax_detail_on_foreign_po",
+                f"a {currency} PO carries no tax schedule (issue #257); tax_detail_id must be omitted",
+            )
+    exchange_date = h.doc_date if is_foreign else None
 
     # 0b. job + cost code: the wsi proc (step 4 below) rejects a made-up job or a cost code not set up
     #     on the job with a raw eConnect error mid-transaction, so pre-check job-cost lines here for
@@ -115,6 +128,9 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         currency_id=currency,
         vendor_address_code=h.vendor_address_code,
         shipping_method=h.shipping_method,
+        rate_type=rate_type,
+        exchange_date=exchange_date,
+        null_tax_schedule=is_foreign,
     )
 
     # 3. lines
@@ -183,6 +199,9 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         misc_amount=h.misc_amount,
         tax_amount=tax_amount,
         using_header_taxes=bool(h.tax_detail_id),
+        rate_type=rate_type,
+        exchange_date=exchange_date,
+        null_tax_schedule=is_foreign,
     )
 
     return models.CreatePoResponse(

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -8,6 +8,7 @@ propagate for a raw eConnect failure."""
 
 import socket
 from datetime import date
+from decimal import Decimal
 
 from . import buyers, econnect, models
 from .config import get_settings
@@ -58,6 +59,18 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
             f"buyer '{buyer_id}' is not a registered GP buyer for {company} (registered: {registered})",
         )
 
+    # 0c. currency: GP-first, the vendor master dictates the PO currency (issue #257), not the client.
+    #     Foreign-currency POs need an exchange rate (XCHGRATE/RATETPID) that this path does not yet
+    #     supply - eConnect rejects a non-CAD PO with no rate - so guard them out with a clear error
+    #     until the exchange-rate follow-up lands. CAD (functional currency) needs no rate.
+    currency = econnect.get_vendor_currency(conn, h.vendor_id)
+    if currency != "CAD":
+        raise RelayOpError(
+            "currency_unsupported",
+            f"vendor '{h.vendor_id}' is a {currency} vendor; foreign-currency POs need exchange-rate "
+            f"handling not yet implemented (issue #257 follow-up). Only CAD POs are supported for now.",
+        )
+
     # 0b. job + cost code: the wsi proc (step 4 below) rejects a made-up job or a cost code not set up
     #     on the job with a raw eConnect error mid-transaction, so pre-check job-cost lines here for
     #     clean job_not_registered / cost_code_not_on_job errors, mirroring the buyer check. Only PI=2
@@ -99,7 +112,7 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         doc_date=h.doc_date,
         buyer_id=buyer_id,
         confirm_with=h.confirm_with,
-        currency_id=h.currency_id,
+        currency_id=currency,
         vendor_address_code=h.vendor_address_code,
         shipping_method=h.shipping_method,
     )
@@ -132,8 +145,28 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
             cost_code=line.cost_code,
         )
 
-    # 5. header subtotal
+    # 5. subtotal + order-time charges. GP does NOT compute PO tax under header-level taxes, so when a
+    #    tax detail was picked the relay looks up its rate, computes the tax, inserts the detail
+    #    (taPopIvcTaxInsert) BEFORE the final header, then sets USINGHEADERLEVELTAXES=1 + that TAXAMNT.
     subtotal = sum(line.quantity * line.unit_cost for line in request.lines)
+    tax_amount = Decimal(0)
+    if h.tax_detail_id:
+        pct = econnect.get_tax_detail_percent(conn, h.tax_detail_id)
+        if pct is None:
+            raise RelayOpError(
+                "tax_detail_not_found",
+                f"tax detail '{h.tax_detail_id}' is not a GP purchase tax detail "
+                f"(TX00201 TXDTLTYP=2) for {company}",
+            )
+        tax_amount = (subtotal * pct / Decimal(100)).quantize(Decimal("0.01"))
+        econnect.insert_po_tax_detail(
+            conn,
+            po_number=po_number,
+            vendor_id=h.vendor_id,
+            tax_detail_id=h.tax_detail_id,
+            tax_amount=tax_amount,
+            taxable_purchase=subtotal,
+        )
     econnect.update_po_header_subtotal(
         conn,
         po_number=po_number,
@@ -141,10 +174,15 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         doc_date=h.doc_date,
         buyer_id=buyer_id,
         confirm_with=h.confirm_with,
-        currency_id=h.currency_id,
+        currency_id=currency,
         vendor_address_code=h.vendor_address_code,
         shipping_method=h.shipping_method,
         subtotal=subtotal,
+        trade_discount=h.trade_discount,
+        freight_amount=h.freight_amount,
+        misc_amount=h.misc_amount,
+        tax_amount=tax_amount,
+        using_header_taxes=bool(h.tax_detail_id),
     )
 
     return models.CreatePoResponse(
@@ -154,6 +192,8 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         subtotal=subtotal,
         doc_date=h.doc_date,
         vendor_id=h.vendor_id,
+        currency=currency,
+        tax_amount=tax_amount,
     )
 
 

--- a/relay/tests/test_tax_and_currency.py
+++ b/relay/tests/test_tax_and_currency.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from decimal import Decimal
 
 from ucnexus_relay.econnect import (
+    get_mc_setup,
     get_tax_detail_percent,
     get_vendor_currency,
     list_tax_details,
@@ -65,6 +66,27 @@ def test_vendor_currency_blank_falls_back_to_cad():
 
 def test_vendor_currency_missing_row_falls_back_to_cad():
     assert get_vendor_currency(_FakeConn(one=None), "GHOST") == "CAD"
+
+
+# --- get_mc_setup (MC40000: functional currency + default purchasing rate type) ---
+
+_McRow = namedtuple("_McRow", "functional purchase_rate_type")
+
+
+def test_mc_setup_reads_functional_and_purchase_rate_type():
+    conn = _FakeConn(one=_McRow("CAD", "BUY"))
+    out = get_mc_setup(conn)
+    assert out == {"functional": "CAD", "purchase_rate_type": "BUY"}
+    assert "MC40000" in conn.cursor_obj.sql
+
+
+def test_mc_setup_blank_purchase_rate_type_is_none():
+    assert get_mc_setup(_FakeConn(one=_McRow("CAD", ""))) == {"functional": "CAD", "purchase_rate_type": None}
+
+
+def test_mc_setup_no_row_defaults_to_cad_single_currency():
+    # a single-currency company has no MC40000 row -> functional CAD, no rate type
+    assert get_mc_setup(_FakeConn(one=None)) == {"functional": "CAD", "purchase_rate_type": None}
 
 
 # --- list_tax_details (TX00201 purchase details, TXDTLTYP=2) ---

--- a/relay/tests/test_tax_and_currency.py
+++ b/relay/tests/test_tax_and_currency.py
@@ -1,0 +1,117 @@
+"""Issue #257 GP-first currency + purchase tax-detail reads. No real SQL - a fake cursor records the
+SQL + params and returns canned rows. The write procs (taPoHdr charges, taPopIvcTaxInsert) and the
+ops currency guard / tax computation are verified live against TUBC; these cover the read helpers'
+SQL shape and normalization."""
+
+from collections import namedtuple
+from decimal import Decimal
+
+from ucnexus_relay.econnect import (
+    get_tax_detail_percent,
+    get_vendor_currency,
+    list_tax_details,
+    list_vendors,
+)
+
+
+class _FakeCursor:
+    def __init__(self, *, one=None, many=None):
+        self._one = one
+        self._many = many if many is not None else []
+        self.sql = None
+        self.params = None
+
+    def execute(self, sql, *params):
+        self.sql = sql
+        self.params = params
+        return self
+
+    def fetchone(self):
+        return self._one
+
+    def fetchall(self):
+        return self._many
+
+
+class _FakeConn:
+    def __init__(self, *, one=None, many=None):
+        self.cursor_obj = _FakeCursor(one=one, many=many)
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+# --- get_vendor_currency (PM00200.CURNCYID, GP-first PO currency) ---
+
+_CurRow = namedtuple("_CurRow", "cur")
+
+
+def test_vendor_currency_returns_uppercased_value():
+    conn = _FakeConn(one=_CurRow("USD"))
+    assert get_vendor_currency(conn, "SEL101") == "USD"
+    assert "PM00200" in conn.cursor_obj.sql
+    assert "CURNCYID" in conn.cursor_obj.sql
+    assert conn.cursor_obj.params == ("SEL101",)
+
+
+def test_vendor_currency_normalizes_case_and_whitespace():
+    assert get_vendor_currency(_FakeConn(one=_CurRow("  cad ")), "ING100") == "CAD"
+
+
+def test_vendor_currency_blank_falls_back_to_cad():
+    # 3 active TUBC vendors have a blank currency -> GP functional currency (CAD)
+    assert get_vendor_currency(_FakeConn(one=_CurRow("")), "V1") == "CAD"
+
+
+def test_vendor_currency_missing_row_falls_back_to_cad():
+    assert get_vendor_currency(_FakeConn(one=None), "GHOST") == "CAD"
+
+
+# --- list_tax_details (TX00201 purchase details, TXDTLTYP=2) ---
+
+_TaxRow = namedtuple("_TaxRow", "tax_detail_id description percent")
+
+
+def test_list_tax_details_filters_to_purchases_and_maps_rows():
+    conn = _FakeConn(many=[
+        _TaxRow("ON HST - P", "ON HST on Purchases", 13.0),
+        _TaxRow("PST 7%", "", 7.0),
+    ])
+    out = list_tax_details(conn)
+    assert "TX00201" in conn.cursor_obj.sql
+    assert "TXDTLTYP = 2" in conn.cursor_obj.sql
+    assert out[0] == {"tax_detail_id": "ON HST - P", "description": "ON HST on Purchases", "percent": 13.0}
+    # a blank GP description maps to None, not an empty string
+    assert out[1]["description"] is None
+
+
+# --- get_tax_detail_percent (rate used to compute the PO tax) ---
+
+_PctRow = namedtuple("_PctRow", "pct")
+
+
+def test_tax_detail_percent_returns_decimal_for_a_purchase_detail():
+    conn = _FakeConn(one=_PctRow(13))
+    assert get_tax_detail_percent(conn, "ON HST - P") == Decimal("13")
+    assert "TXDTLTYP = 2" in conn.cursor_obj.sql
+    assert conn.cursor_obj.params == ("ON HST - P",)
+
+
+def test_tax_detail_percent_none_when_not_a_purchase_detail():
+    # a sales-only detail (or unknown id) returns None -> ops raises a clean tax_detail_not_found
+    assert get_tax_detail_percent(_FakeConn(one=None), "BC HST") is None
+
+
+# --- list_vendors now carries the vendor's currency ---
+
+_VendRow = namedtuple("_VendRow", "vendor_id vendor_name vendor_class status currency")
+
+
+def test_list_vendors_includes_currency_blank_defaults_to_cad():
+    conn = _FakeConn(many=[
+        _VendRow("SEL101", "SELECT PRODUCTS", "USA", 1, "USD"),
+        _VendRow("V2", "BLANK CUR VENDOR", "CAN", 1, ""),
+    ])
+    out = list_vendors(conn)
+    assert out[0]["currency"] == "USD"
+    assert out[1]["currency"] == "CAD"


### PR DESCRIPTION
resolves #257 in full incl USD. verified live vs TUBC.

charge mapping:
Freight <- existing shipping_cost (#156) -> GP FRTAMNT
Miscellaneous, Trade Discount = new register-form inputs
tariff_amount stays nexus-only
no DB migration

currency + tax schedule:
currency <- PM00200.CURNCYID inside create_po_op (blank -> CAD), not client-supplied
CAD PO -> user picks tax detail (TX00201 TXDTLTYP=2) -> relay computes tax = pct% x subtotal -> writes via taPopIvcTaxInsert + header-level taxes; GP keeps default tax schedule
USD / foreign-currency PO -> relay blanks TAXSCHID (GP fills the company default otherwise, regardless of currency - it does NOT auto-null), no tax detail

exchange rate (USD):
daily USD rate maintained in DYNAMICS.MC00100 (accounting-updated)
relay reads company default purchasing rate type MC40000.DEFPURTP (e.g. BUY) -> passes RATETPID + EXCHDATE to taPoHdr -> eConnect auto-resolves XCHGRATE from rate table
no cross-DB read, no user entry
TUBC USD PO returned maintained 1.3491 rate + blank tax schedule

relay:
get_vendor_currency (blank -> CAD)
get_mc_setup (MC40000 functional currency + purchase rate type)
list_tax_details read op over TX00201 WHERE TXDTLTYP=2, wired into both transports (GET /tax-details, channel list_tax_details)
taPoHdr wiring centralised in _exec_tapohdr + _foreign_currency_fields
create_po_header + update_po_header_subtotal take:
  rate_type
  exchange_date
  null_tax_schedule
insert_po_tax_detail (taPopIvcTaxInsert)
taPoHdr carries:
  TRDISAMT
  FRTAMNT
  MSCCHAMT
  TAXAMNT
  USINGHEADERLEVELTAXES
ops resolves currency + foreign handling, computes tax for CAD, guards tax detail on foreign PO
list_vendors + CreatePoResponse carry currency

backend:
gpTaxDetails query + GpTaxDetail type
currency on GpVendor (defaults CAD)
RegisterPOInput + build_create_po_payload gain:
  tax_detail_id
  freight (from shipping_cost)
  miscellaneous
  trade_discount
no new PO columns
no backend currency logic

frontend (GpPurchaseOrderDialog register mode):
read-only currency chip from selected GP vendor
tax-detail dropdown required for CAD, hidden for foreign-currency PO
Miscellaneous + Trade discount inputs
freight = existing "Shipping costs" field

Closes #257.
