### PR TITLE
fix(relay): op-parity guard + manual tax-detail fallback (#315)

### DIFF
--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -66,3 +66,20 @@ class RelayCallError(AppError):
     def __init__(self, message: str, detail: dict | None = None):
         super().__init__(message, "RELAY_CALL_FAILED")
         self.detail = detail or {}
+
+
+class RelayOpUnsupportedError(AppError):
+    """The connected relay build doesn't support the requested op (issue #315). Raised either
+    proactively (the relay advertised its op-set on connect and this op isn't in it) or reactively
+    (the relay answered `unknown_op`). Distinct from RelayCallError so the frontend can show an
+    'update the relay' banner and auto-fall back (e.g. manual tax-detail entry) instead of the raw
+    `unknown op '...'` string. `detail` still carries the relay's own error body when there is one."""
+
+    def __init__(self, op: str, detail: dict | None = None):
+        message = (
+            f"The connected GP relay is out of date and does not support '{op}'. Update the relay "
+            f"(Relay app -> Updates -> Update) to the latest build, then retry."
+        )
+        super().__init__(message, "RELAY_OP_UNSUPPORTED")
+        self.op = op
+        self.detail = detail or {}

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -43,7 +43,7 @@ class RelayQueries:
         """Whether the outbound relay WS channel is currently connected (and, if so, the GP company it is
         enrolled for), for the relay status chip and the company-aware PO/receive/adopt dialogs."""
         require_user(info)
-        return RelayStatus(connected=relay_gateway.connected, company=relay_gateway.company)
+        return RelayStatus(connected=relay_gateway.connected, company=relay_gateway.company, build=relay_gateway.build)
 
     @strawberry.field
     async def gp_jobs(self, info: strawberry.Info, company: str) -> list[GpJob]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -138,6 +138,10 @@ class RelayStatus:
     # dialogs drive their company selection from this so they never offer a company the live relay can't
     # serve - a mismatch would fail every gp_* read and reject a submit as RelayUnavailable (issue #202 #6).
     company: str | None = None
+    # The connected relay's build tag from its hello frame (issue #315), e.g. 'relay-v0.1.0-build.30'.
+    # Null when disconnected, or when an older relay that predates the hello frame is connected. Shown on
+    # the Admin -> Relay Installs page so an out-of-date relay is visible before an op fails.
+    build: str | None = None
 
 
 @strawberry.type

--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -17,7 +17,7 @@ import uuid
 
 from fastapi import WebSocket
 
-from app.errors import RelayCallError, RelayTimeoutError, RelayUnavailableError
+from app.errors import RelayCallError, RelayOpUnsupportedError, RelayTimeoutError, RelayUnavailableError
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -34,6 +34,13 @@ class RelayGateway:
         self._socket: WebSocket | None = None
         self._company: str | None = None
         self._pending: dict[str, asyncio.Future] = {}
+        # Relay identity advertised on the connect `hello` frame (issue #315). `_build` is the relay's
+        # build tag (e.g. 'relay-v0.1.0-build.30'); `_ops` is its supported op-set. Both stay None for an
+        # older relay build that doesn't send a hello - in that case relay_call skips the proactive parity
+        # check and relies on the reactive `unknown_op` mapping, so an out-of-date relay still yields a
+        # clean RELAY_OP_UNSUPPORTED instead of a cryptic error.
+        self._build: str | None = None
+        self._ops: frozenset[str] | None = None
         # Heartbeat bookkeeping for the current connection (issue #277). `_unanswered_pings` counts pings
         # sent since the last pong; `_heartbeat_armed` only turns True after the relay answers its first
         # ping, so a relay build that doesn't speak the data heartbeat yet is never falsely reaped - it
@@ -51,6 +58,13 @@ class RelayGateway:
         Surfaced on RelayStatus so the PO/receive/adopt dialogs offer only that company (issue #202 #6)."""
         return self._company
 
+    @property
+    def build(self) -> str | None:
+        """The connected relay's build tag from its hello frame (issue #315), None when disconnected or
+        when an older relay that predates the hello frame is connected. Surfaced on RelayStatus so the
+        Admin -> Relay Installs page can show which build is live."""
+        return self._build
+
     def try_register(self, company: str, websocket: WebSocket) -> bool:
         """Called by the /relay-link route once a connecting socket has authenticated. Returns True and
         takes the single connection slot when it's free; returns False (route closes the socket) when a
@@ -59,6 +73,8 @@ class RelayGateway:
             return False
         self._socket = websocket
         self._company = company
+        self._build = None
+        self._ops = None
         self._unanswered_pings = 0
         self._heartbeat_armed = False
         return True
@@ -68,9 +84,20 @@ class RelayGateway:
         if self._socket is websocket:
             self._socket = None
             self._company = None
+            self._build = None
+            self._ops = None
             self._unanswered_pings = 0
             self._heartbeat_armed = False
             self._fail_all("relay disconnected")
+
+    def note_hello(self, build: str | None, ops: list[str] | None) -> None:
+        """Called by the route's read loop for the relay's one {"type": "hello", build, ops} frame,
+        sent right after it connects (issue #315). Records the build tag and op-set so relay_call can
+        reject an unsupported op before the round-trip and RelayStatus can report the live build. Only
+        honoured for the currently-registered socket."""
+        if self._socket is not None:
+            self._build = build
+            self._ops = frozenset(ops) if ops is not None else None
 
     def note_pong(self) -> None:
         """Called by the route's read loop for each {"type": "pong"} the relay sends. Clears the miss
@@ -104,11 +131,18 @@ class RelayGateway:
     ) -> dict | list | None:
         """Send {id, op, company, payload} to the connected relay and await its correlated reply.
         Raises RelayUnavailableError (no/wrong-company connection or send failure), RelayTimeoutError,
-        or RelayCallError (the relay itself answered ok=false)."""
+        RelayOpUnsupportedError (relay too old for this op, issue #315), or RelayCallError (the relay
+        itself answered ok=false)."""
         if self._socket is None:
             raise RelayUnavailableError()
         if self._company and company != self._company:
             raise RelayUnavailableError(f"connected relay is enrolled for {self._company}, not {company}")
+        # Proactive parity (issue #315): if the relay advertised its op-set on connect and this op isn't
+        # in it, fail fast with a clear 'update the relay' error rather than a 30s round-trip. Skipped when
+        # `_ops` is None (an older relay that sends no hello) - the reactive `unknown_op` mapping below
+        # still catches it.
+        if self._ops is not None and op not in self._ops:
+            raise RelayOpUnsupportedError(op)
 
         job_id = uuid.uuid4().hex
         future: asyncio.Future = asyncio.get_running_loop().create_future()
@@ -127,6 +161,12 @@ class RelayGateway:
 
         if not reply.get("ok"):
             error = reply.get("error") or {}
+            # Reactive parity (issue #315): an out-of-date relay answers a call for an op it lacks with
+            # `unknown_op`. Map that to the same clear 'update the relay' error the proactive check raises,
+            # so a relay that predates the hello frame still surfaces cleanly instead of as a raw
+            # `unknown op '...'` string.
+            if error.get("error") == "unknown_op":
+                raise RelayOpUnsupportedError(op, detail=error)
             raise RelayCallError(error.get("message") or f"{op} failed", detail=error)
         return reply.get("result")
 

--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -90,14 +90,19 @@ class RelayGateway:
             self._heartbeat_armed = False
             self._fail_all("relay disconnected")
 
-    def note_hello(self, build: str | None, ops: list[str] | None) -> None:
+    def note_hello(self, build: object, ops: object) -> None:
         """Called by the route's read loop for the relay's one {"type": "hello", build, ops} frame,
         sent right after it connects (issue #315). Records the build tag and op-set so relay_call can
         reject an unsupported op before the round-trip and RelayStatus can report the live build. Only
-        honoured for the currently-registered socket."""
+        honoured for the currently-registered socket.
+
+        The frame is untrusted wire input, so both fields are shape-checked: only a str build and a
+        list-of-str op-set are accepted. A malformed op-set (a bare string would otherwise become a set
+        of characters and reject every real op; a non-iterable would raise inside the read loop) is
+        treated as 'unknown' (None), so relay_call falls back to the reactive unknown_op mapping."""
         if self._socket is not None:
-            self._build = build
-            self._ops = frozenset(ops) if ops is not None else None
+            self._build = build if isinstance(build, str) else None
+            self._ops = frozenset(ops) if isinstance(ops, list) and all(isinstance(o, str) for o in ops) else None
 
     def note_pong(self) -> None:
         """Called by the route's read loop for each {"type": "pong"} the relay sends. Clears the miss

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,11 +85,14 @@ def health():
 
 
 async def _relay_read_loop(websocket: WebSocket) -> None:
-    """Feed each frame the relay sends to relay_gateway: a {"type": "pong"} answers the heartbeat
-    (issue #277), anything else is a {id, ok, result|error} job reply to correlate with relay_call()."""
+    """Feed each frame the relay sends to relay_gateway: a {"type": "hello"} advertises the relay's build
+    and op-set on connect (issue #315), a {"type": "pong"} answers the heartbeat (issue #277), anything
+    else is a {id, ok, result|error} job reply to correlate with relay_call()."""
     while True:
         message = await websocket.receive_json()
-        if isinstance(message, dict) and message.get("type") == "pong":
+        if isinstance(message, dict) and message.get("type") == "hello":
+            relay_gateway.note_hello(message.get("build"), message.get("ops"))
+        elif isinstance(message, dict) and message.get("type") == "pong":
             relay_gateway.note_pong()
         else:
             relay_gateway.resolve(message)

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -7,7 +7,7 @@ import asyncio
 
 import pytest
 
-from app.errors import RelayCallError, RelayTimeoutError, RelayUnavailableError
+from app.errors import RelayCallError, RelayOpUnsupportedError, RelayTimeoutError, RelayUnavailableError
 from app.services.relay_gateway import RelayGateway
 
 
@@ -185,3 +185,93 @@ def test_try_register_resets_heartbeat_state_for_the_new_connection():
     gateway.try_register("TUBC", FakeWebSocket())
     assert gateway.register_ping_miss() is False  # not armed yet on the new connection
     assert gateway.register_ping_miss() is False
+
+
+# --- issue #315: op-parity guard (hello frame -> build/op-set, proactive + reactive) ---
+
+
+def test_note_hello_records_build_and_op_set():
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket())
+    assert gateway.build is None  # nothing advertised yet
+    gateway.note_hello("relay-v0.1.0-build.30", ["list_vendors", "list_tax_details", "create_po"])
+    assert gateway.build == "relay-v0.1.0-build.30"
+
+
+def test_try_register_and_unregister_clear_the_advertised_build():
+    gateway = RelayGateway()
+    ws = FakeWebSocket()
+    gateway.try_register("TUBC", ws)
+    gateway.note_hello("relay-v0.1.0-build.30", ["list_vendors"])
+    gateway.unregister(ws)
+    assert gateway.build is None
+    # A new connection starts blank - it must not inherit the old relay's build/op-set.
+    gateway.try_register("TUBC", FakeWebSocket())
+    assert gateway.build is None
+
+
+def test_relay_call_rejects_an_op_outside_the_advertised_set_without_sending():
+    # Proactive parity: once the relay advertised its op-set, a call for an op it lacks fails fast with
+    # RELAY_OP_UNSUPPORTED and never hits the wire (no 30s round-trip).
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        gateway.note_hello("relay-v0.1.0-build.28", ["list_vendors", "create_po"])  # no list_tax_details
+        with pytest.raises(RelayOpUnsupportedError) as exc_info:
+            await gateway.relay_call("TUBC", "list_tax_details", timeout=1)
+        assert exc_info.value.op == "list_tax_details"
+        assert exc_info.value.code == "RELAY_OP_UNSUPPORTED"
+        assert ws.sent == []  # never sent
+
+    asyncio.run(run())
+
+
+def test_relay_call_allows_an_advertised_op():
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        gateway.note_hello("relay-v0.1.0-build.30", ["list_vendors", "list_tax_details"])
+
+        async def responder():
+            while not ws.sent:
+                await asyncio.sleep(0)
+            gateway.resolve({"id": ws.sent[0]["id"], "ok": True, "result": {"tax_details": []}})
+
+        responder_task = asyncio.create_task(responder())
+        result = await gateway.relay_call("TUBC", "list_tax_details", timeout=1)
+        await responder_task
+        assert result == {"tax_details": []}
+
+    asyncio.run(run())
+
+
+def test_relay_call_maps_an_unknown_op_reply_to_op_unsupported():
+    # Reactive parity: an older relay that sends no hello (op-set unknown) skips the proactive check, so a
+    # call for a missing op reaches it and comes back `unknown_op` - which must still surface as the clean
+    # RELAY_OP_UNSUPPORTED, not a raw RelayCallError.
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)  # no note_hello -> op-set unknown
+
+        async def responder():
+            while not ws.sent:
+                await asyncio.sleep(0)
+            gateway.resolve(
+                {
+                    "id": ws.sent[0]["id"],
+                    "ok": False,
+                    "error": {"error": "unknown_op", "message": "unknown op 'list_tax_details'", "context": {}},
+                }
+            )
+
+        responder_task = asyncio.create_task(responder())
+        with pytest.raises(RelayOpUnsupportedError) as exc_info:
+            await gateway.relay_call("TUBC", "list_tax_details", timeout=1)
+        await responder_task
+        assert exc_info.value.op == "list_tax_details"
+        assert exc_info.value.detail["error"] == "unknown_op"
+
+    asyncio.run(run())

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -198,6 +198,32 @@ def test_note_hello_records_build_and_op_set():
     assert gateway.build == "relay-v0.1.0-build.30"
 
 
+def test_note_hello_ignores_a_malformed_frame_without_raising():
+    # The hello frame is untrusted wire input. A non-str build is dropped; a non-list op-set (or one with
+    # non-str entries) is treated as 'unknown' rather than turned into a set of characters - otherwise
+    # ops='list_vendors' would become {'l','i',...} and proactively reject every real op. It must not raise.
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        gateway.note_hello(123, "list_vendors")  # build is an int, ops is a bare string
+        assert gateway.build is None  # non-str build dropped
+
+        # op-set unknown -> proactive check skipped, so a real op is NOT rejected outright; it reaches
+        # the wire and the relay answers it (proving _ops is not a set of characters).
+        async def responder():
+            while not ws.sent:
+                await asyncio.sleep(0)
+            gateway.resolve({"id": ws.sent[0]["id"], "ok": True, "result": {"vendors": []}})
+
+        responder_task = asyncio.create_task(responder())
+        result = await gateway.relay_call("TUBC", "list_vendors", timeout=1)
+        await responder_task
+        assert result == {"vendors": []}
+
+    asyncio.run(run())
+
+
 def test_try_register_and_unregister_clear_the_advertised_build():
     gateway = RelayGateway()
     ws = FakeWebSocket()

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -265,3 +265,25 @@ def test_serve_relay_link_swallows_a_cancelled_reader():
             gateway.unregister(ws)
 
     asyncio.run(run())
+
+
+def test_read_loop_records_the_relay_hello_frame(monkeypatch):
+    # Issue #315: the relay's first frame advertises its build + op-set; the read loop must record it on
+    # the gateway (not treat it as a job reply) so relayStatus reports the build and relay_call can gate ops.
+    async def run():
+        ws = _FakeRelaySocket(
+            [
+                {"type": "hello", "build": "relay-v0.1.0-build.30", "ops": ["list_vendors", "list_tax_details"]},
+                WebSocketDisconnect(),
+            ]
+        )
+        gateway.try_register("TEST", ws)
+        try:
+            with pytest.raises(WebSocketDisconnect):
+                await main._relay_read_loop(ws)
+            assert gateway.build == "relay-v0.1.0-build.30"
+        finally:
+            gateway.unregister(ws)
+        assert gateway.build is None  # cleared on unregister
+
+    asyncio.run(run())

--- a/frontend/src/graphql/gpError.ts
+++ b/frontend/src/graphql/gpError.ts
@@ -42,6 +42,16 @@ export function extractGpError(err: unknown): GpError | null {
   return null;
 }
 
+// Backend code (app/errors.py RelayOpUnsupportedError) for a call the connected relay build is too old
+// to serve (issue #315). The dialogs special-case it: show an 'update the relay' banner and fall back
+// (e.g. manual tax-detail entry) instead of leaving a dropdown silently empty.
+export const RELAY_OP_UNSUPPORTED = 'RELAY_OP_UNSUPPORTED';
+
+/** True when an Apollo error is a RELAY_OP_UNSUPPORTED failure (relay too old for the op, issue #315). */
+export function isRelayOpUnsupported(err: unknown): boolean {
+  return extractGpError(err)?.code === RELAY_OP_UNSUPPORTED;
+}
+
 /** Plain-text rendering of a GpError, for the "Copy details" button (a paste-able alternative to a screenshot). */
 export function formatGpErrorText(e: GpError): string {
   const ctx = e.relay?.context ?? {};

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -56,6 +56,7 @@ export const GET_RELAY_STATUS = gql`
     relayStatus {
       connected
       company
+      build
     }
   }
 `;

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -155,6 +155,12 @@ export default function RelayInstallsPage() {
         </Box>
         <Stack direction="row" spacing={2} alignItems="center">
           <RelayStatusChip connected={relay.connected} />
+          {/* Issue #315: show the live relay build so an out-of-date relay is visible at a glance. A
+              connected relay too old to advertise its build (pre-hello-frame) reports null -> 'build
+              unknown', itself a signal it needs updating. */}
+          {relay.connected && (
+            <Chip size="small" variant="outlined" label={relay.build ? `build: ${relay.build}` : 'build unknown'} />
+          )}
           <Button variant="contained" onClick={() => setProvisionOpen(true)}>
             Provision install
           </Button>

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -235,11 +235,15 @@ export default function GpPurchaseOrderDialog({
   const gpVendorCurrency = gpVendors.find((v) => v.vendorId === gpVendorId)?.currency ?? 'CAD';
   const isForeignCurrency = isRegister && !!gpVendorId && gpVendorCurrency !== 'CAD';
 
-  // Issue #315: the live tax-detail dropdown fails when the connected relay is too old to serve
-  // list_tax_details (RELAY_OP_UNSUPPORTED). Rather than leave the dropdown silently disabled, auto-fall
-  // back to manual entry of the GP tax detail id. Also fall back when GP simply returns no purchase tax
-  // details (empty list, once the query has settled), so a CAD PO is never hard-blocked by relay state.
+  // Issue #315: the live tax-detail list can fail to load - the relay is too old to serve
+  // list_tax_details (RELAY_OP_UNSUPPORTED), or it timed out / dropped / errored mid-query. Rather than
+  // leave the dropdown silently disabled, auto-fall back to manual entry of the GP tax detail id.
+  // `taxDetailsFailed` is ANY load error: it's the signal that an empty list can't be trusted to mean
+  // "this company has no purchase tax", so for CAD the manual id becomes REQUIRED (not merely offered) -
+  // otherwise a transient error would let a CAD PO register with no tax. A settled, error-free empty list
+  // is the only case where the tax detail stays optional (that company genuinely defines none).
   const taxDetailsOpUnsupported = isRelayOpUnsupported(gpTaxDetailsError);
+  const taxDetailsFailed = !!gpTaxDetailsError;
   const useManualTaxEntry =
     isRegister && !isForeignCurrency && relayConnected && !gpTaxDetailsLoading && gpTaxDetails.length === 0;
 
@@ -483,13 +487,16 @@ export default function GpPurchaseOrderDialog({
       // PO carries none (the relay blanks the schedule), so require it for CAD only. Only enforce it when
       // the company actually defines purchase tax details - a company with none would otherwise be
       // hard-blocked, since the dropdown is disabled/empty when gpTaxDetails is empty.
-      // Issue #315: when the live list couldn't load because the relay is out of date, require the
-      // manually-entered id instead so the CAD PO still carries tax. A genuinely empty list (no error)
-      // stays optional - that company may simply have no purchase tax details.
-      if (!isForeignCurrency && gpVendorId && !taxDetailId) {
+      // Issue #315: when the live list couldn't load (any error), require the manually-entered id instead
+      // so the CAD PO still carries tax. Trim so a whitespace-only entry doesn't pass here yet submit as
+      // null (handleSubmit trims too). A genuinely empty list (no error) stays optional - that company
+      // may simply have no purchase tax details.
+      if (!isForeignCurrency && gpVendorId && !taxDetailId.trim()) {
         if (gpTaxDetails.length > 0) errs.taxDetail = 'Select a tax detail';
-        else if (taxDetailsOpUnsupported)
-          errs.taxDetail = 'Enter the GP tax detail id - the relay is out of date, so the list could not load';
+        else if (taxDetailsFailed)
+          errs.taxDetail = taxDetailsOpUnsupported
+            ? 'Enter the GP tax detail id - the relay is out of date, so the list could not load'
+            : 'Enter the GP tax detail id - the live list could not load';
       }
     }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
@@ -504,7 +511,7 @@ export default function GpPurchaseOrderDialog({
       errs.tradeDiscount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, gpTaxDetails.length, taxDetailsOpUnsupported, miscellaneous, tradeDiscount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, gpTaxDetails.length, taxDetailsOpUnsupported, taxDetailsFailed, miscellaneous, tradeDiscount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -880,13 +887,15 @@ export default function GpPurchaseOrderDialog({
             </IconButton>
           </Box>
         </Stack>
-        {/* Issue #315: the connected relay is too old to serve the live tax-detail list. Make it visible
-            (and screenshot-friendly) and point at the fix, while the manual id field below keeps CAD
-            registration unblocked. */}
-        {taxDetailsOpUnsupported && !isForeignCurrency && (
+        {/* Issue #315: the live tax-detail list failed to load. Make it visible (and screenshot-friendly)
+            and point at the fix, while the manual id field below keeps CAD registration unblocked. Gated
+            on useManualTaxEntry so the banner never points at a field that isn't rendered (e.g. after the
+            relay disconnects, which reverts the row to the disabled dropdown). */}
+        {useManualTaxEntry && taxDetailsFailed && (
           <Alert severity="warning" sx={{ mt: 2 }}>
-            The GP relay is out of date and can't load live tax details. Update it (an Admin can check its
-            build under Admin → Relay Installs), or enter the GP tax detail id manually below.
+            {taxDetailsOpUnsupported
+              ? "The GP relay is out of date and can't load live tax details. Update it (an Admin can check its build under Admin → Relay Installs), or enter the GP tax detail id manually below."
+              : 'The live GP tax detail list could not load. Enter the GP tax detail id manually below, or retry.'}
           </Alert>
         )}
         {/* Issue #257: GP currency (read-only, from the vendor), the CAD-only tax detail, and the
@@ -903,9 +912,9 @@ export default function GpPurchaseOrderDialog({
           {/* Issue #315: auto-switch to manual entry when the live dropdown can't serve (relay out of
               date, or GP returned no purchase tax details). The typed id is validated GP-side by the
               relay's create_po (get_tax_detail_percent -> tax_detail_not_found on a bad id). */}
-          {useManualTaxEntry && !isForeignCurrency ? (
+          {useManualTaxEntry ? (
             <TextField
-              label={taxDetailsOpUnsupported ? 'Tax detail id (required)' : 'Tax detail id (manual)'}
+              label={taxDetailsFailed ? 'Tax detail id (required)' : 'Tax detail id (manual)'}
               value={taxDetailId}
               onChange={(e) => setTaxDetailId(e.target.value)}
               size="small"
@@ -915,7 +924,9 @@ export default function GpPurchaseOrderDialog({
                 errors.taxDetail ||
                 (taxDetailsOpUnsupported
                   ? 'Relay out of date - enter the GP tax detail id (e.g. ON HST - P)'
-                  : 'No live GP tax details returned - enter the id manually if this company uses purchase tax')
+                  : taxDetailsFailed
+                    ? 'Live tax details could not load - enter the GP tax detail id (e.g. ON HST - P)'
+                    : 'No live GP tax details returned - enter the id manually if this company uses purchase tax')
               }
             />
           ) : (

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -28,7 +28,7 @@ import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from './poVendorName';
 import { computeManufacturerVendorHint, type ManufacturerSuggestion } from './manufacturerVendorHint';
 import GpErrorAlert from '../../components/GpErrorAlert';
-import { extractGpError, type GpError } from '../../graphql/gpError';
+import { extractGpError, isRelayOpUnsupported, type GpError } from '../../graphql/gpError';
 
 // --- Types ---
 
@@ -217,7 +217,11 @@ export default function GpPurchaseOrderDialog({
   const gpVendors = gpVendorsData?.gpVendors ?? [];
 
   // Issue #257: live GP purchase tax details (TX00201, TXDTLTYP=2) for the tax-detail dropdown.
-  const { data: gpTaxDetailsData } = useQuery<{ gpTaxDetails: GpTaxDetailOption[] }>(GET_GP_TAX_DETAILS, {
+  const {
+    data: gpTaxDetailsData,
+    loading: gpTaxDetailsLoading,
+    error: gpTaxDetailsError,
+  } = useQuery<{ gpTaxDetails: GpTaxDetailOption[] }>(GET_GP_TAX_DETAILS, {
     variables: { company },
     skip: !open || !isRegister || !relayConnected || !company,
     fetchPolicy: 'cache-first',
@@ -230,6 +234,14 @@ export default function GpPurchaseOrderDialog({
   // hidden for it. Freight/misc/trade discount still apply (in the PO's currency).
   const gpVendorCurrency = gpVendors.find((v) => v.vendorId === gpVendorId)?.currency ?? 'CAD';
   const isForeignCurrency = isRegister && !!gpVendorId && gpVendorCurrency !== 'CAD';
+
+  // Issue #315: the live tax-detail dropdown fails when the connected relay is too old to serve
+  // list_tax_details (RELAY_OP_UNSUPPORTED). Rather than leave the dropdown silently disabled, auto-fall
+  // back to manual entry of the GP tax detail id. Also fall back when GP simply returns no purchase tax
+  // details (empty list, once the query has settled), so a CAD PO is never hard-blocked by relay state.
+  const taxDetailsOpUnsupported = isRelayOpUnsupported(gpTaxDetailsError);
+  const useManualTaxEntry =
+    isRegister && !isForeignCurrency && relayConnected && !gpTaxDetailsLoading && gpTaxDetails.length === 0;
 
   // Issue #232: suggest the ordering vendor from each line's TITAN manufacturer. The manufacturer is
   // the derived POLineItem.manufacturer (resolved server-side from the line's linked HardwareItem),
@@ -471,8 +483,14 @@ export default function GpPurchaseOrderDialog({
       // PO carries none (the relay blanks the schedule), so require it for CAD only. Only enforce it when
       // the company actually defines purchase tax details - a company with none would otherwise be
       // hard-blocked, since the dropdown is disabled/empty when gpTaxDetails is empty.
-      if (!isForeignCurrency && gpVendorId && gpTaxDetails.length > 0 && !taxDetailId)
-        errs.taxDetail = 'Select a tax detail';
+      // Issue #315: when the live list couldn't load because the relay is out of date, require the
+      // manually-entered id instead so the CAD PO still carries tax. A genuinely empty list (no error)
+      // stays optional - that company may simply have no purchase tax details.
+      if (!isForeignCurrency && gpVendorId && !taxDetailId) {
+        if (gpTaxDetails.length > 0) errs.taxDetail = 'Select a tax detail';
+        else if (taxDetailsOpUnsupported)
+          errs.taxDetail = 'Enter the GP tax detail id - the relay is out of date, so the list could not load';
+      }
     }
     // Issue #156: optional, but a non-empty entry must be a valid non-negative dollar value.
     if (shippingCost.trim() !== '' && (isNaN(parseFloat(shippingCost)) || parseFloat(shippingCost) < 0))
@@ -486,7 +504,7 @@ export default function GpPurchaseOrderDialog({
       errs.tradeDiscount = 'Must be >= 0';
     setErrors(errs);
     return Object.keys(errs).length === 0;
-  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, gpTaxDetails.length, miscellaneous, tradeDiscount]);
+  }, [lineItems, relayConnected, gpVendorId, isRegister, vendorConfirmed, gpBuyerId, registerProjectAllowed, isJob, costCode, shippingCost, tariffAmount, isForeignCurrency, taxDetailId, gpTaxDetails.length, taxDetailsOpUnsupported, miscellaneous, tradeDiscount]);
 
   const handleSubmit = useCallback(async () => {
     if (!validate()) return;
@@ -512,7 +530,9 @@ export default function GpPurchaseOrderDialog({
     // Issue #257: same '' -> null convention. tax detail is not sent for a foreign-currency PO (none).
     const miscellaneousValue = miscellaneous.trim() === '' ? null : parseFloat(miscellaneous);
     const tradeDiscountValue = tradeDiscount.trim() === '' ? null : parseFloat(tradeDiscount);
-    const taxDetailIdValue = isForeignCurrency || !taxDetailId ? null : taxDetailId;
+    // Issue #315: a manually-typed id may carry stray ends; trim them. GP ids can contain internal
+    // spaces (e.g. 'ON HST - P'), so only the ends are trimmed, never the interior.
+    const taxDetailIdValue = isForeignCurrency || !taxDetailId.trim() ? null : taxDetailId.trim();
 
     setGpError(null);
     setGpBusy(true);
@@ -860,6 +880,15 @@ export default function GpPurchaseOrderDialog({
             </IconButton>
           </Box>
         </Stack>
+        {/* Issue #315: the connected relay is too old to serve the live tax-detail list. Make it visible
+            (and screenshot-friendly) and point at the fix, while the manual id field below keeps CAD
+            registration unblocked. */}
+        {taxDetailsOpUnsupported && !isForeignCurrency && (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            The GP relay is out of date and can't load live tax details. Update it (an Admin can check its
+            build under Admin → Relay Installs), or enter the GP tax detail id manually below.
+          </Alert>
+        )}
         {/* Issue #257: GP currency (read-only, from the vendor), the CAD-only tax detail, and the
             Miscellaneous / Trade discount charges. Freight is the "Shipping costs" field above. */}
         <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap alignItems="flex-start" sx={{ mt: 2 }}>
@@ -871,25 +900,45 @@ export default function GpPurchaseOrderDialog({
             disabled
             helperText={isForeignCurrency ? `${gpVendorCurrency}: no tax schedule, GP rate applied` : ' '}
           />
-          <TextField
-            select
-            label={isForeignCurrency ? 'Tax detail' : 'Tax detail (required)'}
-            value={isForeignCurrency ? '' : taxDetailId}
-            onChange={(e) => setTaxDetailId(e.target.value)}
-            size="small"
-            sx={{ minWidth: 260 }}
-            disabled={!relayConnected || isForeignCurrency || gpTaxDetails.length === 0}
-            error={!!errors.taxDetail}
-            helperText={errors.taxDetail || (isForeignCurrency ? 'Not applicable for a foreign-currency PO' : '')}
-          >
-            {gpTaxDetails.map((t) => (
-              <MenuItem key={t.taxDetailId} value={t.taxDetailId}>
-                {t.description
-                  ? `${t.taxDetailId} · ${t.description} (${t.percent}%)`
-                  : `${t.taxDetailId} (${t.percent}%)`}
-              </MenuItem>
-            ))}
-          </TextField>
+          {/* Issue #315: auto-switch to manual entry when the live dropdown can't serve (relay out of
+              date, or GP returned no purchase tax details). The typed id is validated GP-side by the
+              relay's create_po (get_tax_detail_percent -> tax_detail_not_found on a bad id). */}
+          {useManualTaxEntry && !isForeignCurrency ? (
+            <TextField
+              label={taxDetailsOpUnsupported ? 'Tax detail id (required)' : 'Tax detail id (manual)'}
+              value={taxDetailId}
+              onChange={(e) => setTaxDetailId(e.target.value)}
+              size="small"
+              sx={{ minWidth: 260 }}
+              error={!!errors.taxDetail}
+              helperText={
+                errors.taxDetail ||
+                (taxDetailsOpUnsupported
+                  ? 'Relay out of date - enter the GP tax detail id (e.g. ON HST - P)'
+                  : 'No live GP tax details returned - enter the id manually if this company uses purchase tax')
+              }
+            />
+          ) : (
+            <TextField
+              select
+              label={isForeignCurrency ? 'Tax detail' : 'Tax detail (required)'}
+              value={isForeignCurrency ? '' : taxDetailId}
+              onChange={(e) => setTaxDetailId(e.target.value)}
+              size="small"
+              sx={{ minWidth: 260 }}
+              disabled={!relayConnected || isForeignCurrency || gpTaxDetails.length === 0}
+              error={!!errors.taxDetail}
+              helperText={errors.taxDetail || (isForeignCurrency ? 'Not applicable for a foreign-currency PO' : '')}
+            >
+              {gpTaxDetails.map((t) => (
+                <MenuItem key={t.taxDetailId} value={t.taxDetailId}>
+                  {t.description
+                    ? `${t.taxDetailId} · ${t.description} (${t.percent}%)`
+                    : `${t.taxDetailId} (${t.percent}%)`}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
           <TextField
             label="Miscellaneous (optional)"
             value={miscellaneous}

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -548,6 +548,54 @@ describe('GpPurchaseOrderDialog', () => {
     expect(calls[0]).toMatchObject({ input: { taxDetailId: 'ON HST - P' } });
   });
 
+  it('requires manual tax entry when the live list fails for any reason, and rejects whitespace (issue #315)', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const registerMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: registerData() };
+      },
+    };
+    // A transient failure (timeout / dropped / sql_error) - NOT op-unsupported. An empty list here can't
+    // be trusted to mean "company has no purchase tax", so the manual id must be required, not optional.
+    const failedTaxMocks = baseMocks().map((m) =>
+      m.request.query === GET_GP_TAX_DETAILS
+        ? {
+            request: { query: GET_GP_TAX_DETAILS, variables: { company: 'UCS' } },
+            result: {
+              errors: [new GraphQLError('relay did not answer in time', { extensions: { code: 'RELAY_TIMEOUT' } })],
+            },
+            maxUsageCount: INFINITE,
+          }
+        : m,
+    );
+    const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [...failedTaxMocks, registerMock]);
+    await waitForVendorPreselect();
+
+    // Generic (non-out-of-date) banner + a required manual field.
+    expect(await screen.findByText(/The live GP tax detail list could not load/)).toBeInTheDocument();
+    const manualField = screen.getByLabelText('Tax detail id (required)');
+
+    // Empty blocks.
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    expect(await screen.findByText(/the live list could not load/)).toBeInTheDocument();
+    expect(onSubmitted).not.toHaveBeenCalled();
+
+    // Whitespace-only must NOT slip through as a null tax detail.
+    fireEvent.change(manualField, { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    expect(await screen.findByText(/the live list could not load/)).toBeInTheDocument();
+    expect(calls).toHaveLength(0);
+    expect(onSubmitted).not.toHaveBeenCalled();
+
+    // A real id registers.
+    fireEvent.change(manualField, { target: { value: 'PST 7%' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+    expect(calls[0]).toMatchObject({ input: { taxDetailId: 'PST 7%' } });
+  });
+
   it('registers a USD vendor PO with no tax detail (foreign currency, issue #257)', async () => {
     const calls: Record<string, unknown>[] = [];
     const registerMock: MockedResponse = {

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -117,6 +117,7 @@ function baseMocks(
           relayStatus: {
             connected,
             company: connected ? 'UCS' : null,
+            build: connected ? 'relay-v0.1.0-build.30' : null,
             __typename: 'RelayStatus',
           },
         },
@@ -502,6 +503,49 @@ describe('GpPurchaseOrderDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
     expect(calls[0]).toMatchObject({ input: { taxDetailId: null } });
+  });
+
+  it('auto-switches to manual tax-detail entry when the relay is out of date (issue #315)', async () => {
+    const calls: Record<string, unknown>[] = [];
+    const registerMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: registerData() };
+      },
+    };
+    // A relay too old to serve list_tax_details answers RELAY_OP_UNSUPPORTED - the dropdown can't load.
+    const opUnsupportedMocks = baseMocks().map((m) =>
+      m.request.query === GET_GP_TAX_DETAILS
+        ? {
+            request: { query: GET_GP_TAX_DETAILS, variables: { company: 'UCS' } },
+            result: {
+              errors: [
+                new GraphQLError('relay out of date', { extensions: { code: 'RELAY_OP_UNSUPPORTED' } }),
+              ],
+            },
+            maxUsageCount: INFINITE,
+          }
+        : m,
+    );
+    const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [...opUnsupportedMocks, registerMock]);
+    await waitForVendorPreselect();
+
+    // The out-of-date banner shows and the manual id field replaces the dropdown.
+    expect(await screen.findByText(/The GP relay is out of date/)).toBeInTheDocument();
+    const manualField = screen.getByLabelText('Tax detail id (required)');
+
+    // Still required for CAD: an empty manual field blocks the submit with a clear message.
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    expect(await screen.findByText(/the relay is out of date, so the list could not load/)).toBeInTheDocument();
+    expect(calls).toHaveLength(0);
+    expect(onSubmitted).not.toHaveBeenCalled();
+
+    // Type the id (interior spaces preserved) and the PO registers carrying it.
+    fireEvent.change(manualField, { target: { value: '  ON HST - P  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+    expect(calls[0]).toMatchObject({ input: { taxDetailId: 'ON HST - P' } });
   });
 
   it('registers a USD vendor PO with no tax detail (foreign currency, issue #257)', async () => {

--- a/frontend/src/relay/useRelayStatus.ts
+++ b/frontend/src/relay/useRelayStatus.ts
@@ -6,19 +6,26 @@ export interface RelayStatusInfo {
   connected: boolean | null;
   // The GP company the connected relay is enrolled for; null when disconnected.
   company: string | null;
+  // The connected relay's build tag (issue #315), e.g. 'relay-v0.1.0-build.30'. null when disconnected
+  // or when an older relay that predates the hello frame is connected.
+  build: string | null;
 }
 
 // Single definition of the relay-status poll (backend relayStatus field, the relay-to-backend WS
 // channel - not a browser probe). Consumers pass skip: !open on dialogs/modals so a hidden one
 // doesn't poll, which keeps this to one live poller at a time.
 export function useRelayStatus(options?: { skip?: boolean }): RelayStatusInfo {
-  const { data } = useQuery<{ relayStatus: { connected: boolean; company: string | null } }>(GET_RELAY_STATUS, {
-    pollInterval: 10_000,
-    fetchPolicy: 'cache-and-network',
-    skip: options?.skip,
-  });
+  const { data } = useQuery<{ relayStatus: { connected: boolean; company: string | null; build: string | null } }>(
+    GET_RELAY_STATUS,
+    {
+      pollInterval: 10_000,
+      fetchPolicy: 'cache-and-network',
+      skip: options?.skip,
+    },
+  );
   return {
     connected: data ? data.relayStatus.connected : null,
     company: data?.relayStatus.company ?? null,
+    build: data?.relayStatus.build ?? null,
   };
 }

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -25,6 +25,7 @@ import pyodbc
 import websockets
 from pydantic import ValidationError as PydanticValidationError
 
+from . import __version__ as VERSION
 from . import db, econnect, errors, models, ops
 from .config import get_settings
 from .logging_setup import get_logger
@@ -226,6 +227,17 @@ def _heartbeat_reply(message: object) -> dict | None:
     return None
 
 
+def _hello_frame() -> dict:
+    """The relay's identity frame, sent once right after the channel connects (issue #315). It carries
+    the build tag and the exact op-set this relay supports so the backend can reject a call for an op this
+    build lacks with a clear 'update the relay' error - proactively, and without a 30s round-trip - and
+    show the live build on Admin -> Relay Installs. `updater.current_build()` is 'dev' for a source
+    checkout, which is fine: the backend only compares the op-set, and reports the build verbatim."""
+    from . import updater  # lazy: keep channel import-light and avoid any package load-order coupling
+
+    return {"type": "hello", "build": updater.current_build(), "ops": sorted(_OPS), "version": VERSION}
+
+
 async def _run_once(url: str, secret: str, cfg) -> None:
     # websockets is pinned to ^13.0 (see pyproject); on 13.x the top-level websockets.connect is the
     # legacy client whose keyword is `extra_headers`. `additional_headers` is the 14.0+ name and raises
@@ -239,6 +251,11 @@ async def _run_once(url: str, secret: str, cfg) -> None:
     ) as ws:
         logger.info("channel connected", extra={"url": url})
         _mark_connected()
+
+        # Advertise this relay's build + op-set to the backend before anything else (issue #315). Sent
+        # directly here, ahead of the writer coroutine below, so it's the first frame on the wire - the
+        # backend records it and can then reject calls for ops this build lacks with a clear error.
+        await ws.send(json.dumps(_hello_frame()))
 
         # Dispatch each job as its own task so the read loop keeps pulling frames instead of blocking on
         # the current job's GP round-trip (issue #202 #5). The Create-PO page fires list_vendors +

--- a/relay/tests/test_channel.py
+++ b/relay/tests/test_channel.py
@@ -173,3 +173,15 @@ def test_create_receipt_invalid_payload_translates_cleanly():
     reply = channel._dispatch("create_receipt", "TUBC", {"po_number": "PO1"})  # missing required lines
     assert reply["ok"] is False
     assert reply["error"]["error"] == "invalid_payload"
+
+
+def test_hello_frame_advertises_build_and_the_full_op_set():
+    # Issue #315: the relay's connect frame carries its build tag and exact op-set so the backend can gate
+    # a call for an op this build lacks. The op list must mirror channel._OPS - a new op added there is
+    # automatically advertised, closing the parity gap that stranded list_tax_details on an old build.
+    frame = channel._hello_frame()
+    assert frame["type"] == "hello"
+    assert frame["ops"] == sorted(channel._OPS)
+    assert "list_tax_details" in frame["ops"]
+    assert isinstance(frame["build"], str) and frame["build"]  # 'dev' in a checkout, a tag in a CI build
+    assert isinstance(frame["version"], str) and frame["version"]


### PR DESCRIPTION
Fixes #315.

stale relay build.
list_tax_details shipped in #257 (98580e1) across relay + backend + frontend
that merge auto-published relay build.29 (latest build.30)
box runs app-relay-v0.1.0-build.28 (#306 onedir fix), predates #257 -> op-set lacks list_tax_details
answers unknown_op -> [GraphQL error]: unknown op 'list_tax_details'
tax-detail dropdown disabled -> CAD PO registration blocked
update box to build.30 fixes live bug

#4 op-parity guard
new RelayOpUnsupportedError (code RELAY_OP_UNSUPPORTED)
relay_call maps relay unknown_op reply to it -> "relay out of date, update it", relay detail under relayError
relay sends {type:hello, build, ops, version} frame on connect
backend _relay_read_loop records it (gateway.note_hello)
relay_call rejects call for an op the advertised set lacks before round-trip
skipped when op-set unknown (older relay predating hello frame), same backward-compat pattern as the heartbeat
RelayStatus.build exposed end-to-end
Admin -> Relay Installs shows connected build

#3 manual tax-detail fallback
CAD vendor, live list can't load (RELAY_OP_UNSUPPORTED) or GP returns none -> Register dialog auto-switches to manual tax-detail-id field + out-of-date banner
op-unsupported -> id required; empty list -> optional
typed id trimmed at ends (interior spaces preserved, e.g. ON HST - P)
validated GP-side by existing create_po path (tax_detail_not_found on bad id)
no backend/relay change needed

rollout
merge + deploy backend + frontend -> cryptic error actionable + manual entry available against current build.28 relay
update box to newest build (carries hello frame) -> restores live tax-detail list, proactive parity, build visibility
live-bug fix needs only relay bump
