### PR TITLE
fix(relay): bundle idna codec's stringprep dep so self-update health probe can't crash the helper (#318)

### DIFF
--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -39,13 +39,13 @@ _MIN_EXE_BYTES = 5_000_000  # the extracted exe
 
 # --- self-update helper bounds ------------------------------------------------------------------------
 _STATE_FILE = "update-state.json"  # the attempt ledger the helper reads/writes and the UI surfaces
-_CANCEL_FLAG = "update-cancel"     # touched by a user-initiated shutdown to abort an in-flight update
-_UPDATE_LOG = "update.log"         # the helper's own log, next to config.toml
+_CANCEL_FLAG = "update-cancel"  # touched by a user-initiated shutdown to abort an in-flight update
+_UPDATE_LOG = "update.log"  # the helper's own log, next to config.toml
 _DOWNLOAD_NAME = "ucnexus-relay-download.zip"
-MAX_ATTEMPTS = 3                   # circuit breaker: give up on a target build after this many helper runs
-_GLOBAL_DEADLINE_SECONDS = 90.0    # hard wall-clock cap on the whole sequence
-_APP_EXIT_WAIT_SECONDS = 20.0      # how long to wait for the app to exit on its own before force-killing
-_HEALTH_WAIT_PER_ATTEMPT = 25.0    # per relaunch attempt, how long to wait for /health before retrying
+MAX_ATTEMPTS = 3  # circuit breaker: give up on a target build after this many helper runs
+_GLOBAL_DEADLINE_SECONDS = 90.0  # hard wall-clock cap on the whole sequence
+_APP_EXIT_WAIT_SECONDS = 20.0  # how long to wait for the app to exit on its own before force-killing
+_HEALTH_WAIT_PER_ATTEMPT = 25.0  # per relaunch attempt, how long to wait for /health before retrying
 _POLL_SECONDS = 0.5
 
 _DETACHED_PROCESS = 0x00000008  # DETACHED alone (never paired with CREATE_NO_WINDOW - see stage/_spawn)
@@ -304,7 +304,10 @@ def _wait_for_health(url: str, deadline: float) -> bool:
             with urllib.request.urlopen(url, timeout=2) as r:  # noqa: S310 (localhost health URL)
                 if json.loads(r.read().decode()).get("status") == "ok":
                     return True
-        except (OSError, json.JSONDecodeError):
+        except Exception:  # noqa: BLE001 - the probe's ONLY job is "is it up yet?"; ANY failure (connection
+            # refused, a partial body, or a missing text codec like #318's `LookupError: unknown encoding:
+            # idna`) means not-up-yet. Swallow it and retry within the deadline rather than letting it
+            # propagate out of the detached update helper as an unhandled traceback (the #318 crash).
             pass
         _sleep(2.0)
     return False
@@ -418,7 +421,9 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
     log.info("update-apply start: target=%s attempt=%s app_pid=%s", target, attempts, app_pid)
 
     if attempts > MAX_ATTEMPTS:
-        return _give_up(install_dir, log, f"gave up after {MAX_ATTEMPTS} attempts to update to {target}; reboot and retry")
+        return _give_up(
+            install_dir, log, f"gave up after {MAX_ATTEMPTS} attempts to update to {target}; reboot and retry"
+        )
 
     if _cancel_requested(install_dir):
         log.info("cancel requested before apply; aborting without relaunch")

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -298,18 +298,23 @@ def _health_url(install_dir: Path) -> str:
         return "http://127.0.0.1:7321/health"
 
 
-def _wait_for_health(url: str, deadline: float) -> bool:
+def _wait_for_health(url: str, deadline: float, log: logging.Logger | None = None) -> bool:
+    last_err: Exception | None = None
     while _monotonic() < deadline:
         try:
             with urllib.request.urlopen(url, timeout=2) as r:  # noqa: S310 (localhost health URL)
                 if json.loads(r.read().decode()).get("status") == "ok":
                     return True
-        except Exception:  # noqa: BLE001 - the probe's ONLY job is "is it up yet?"; ANY failure (connection
-            # refused, a partial body, or a missing text codec like #318's `LookupError: unknown encoding:
-            # idna`) means not-up-yet. Swallow it and retry within the deadline rather than letting it
-            # propagate out of the detached update helper as an unhandled traceback (the #318 crash).
-            pass
+        except Exception as e:  # noqa: BLE001 - the probe's ONLY job is "is it up yet?"; ANY failure
+            # (connection refused, a partial body, or a missing text codec like #318's
+            # `LookupError: unknown encoding: idna`) means not-up-yet. Swallow it and retry within the
+            # deadline rather than letting it propagate out of the detached update helper as an unhandled
+            # traceback (the #318 crash). Keep the last one so a never-healthy timeout still leaves a
+            # diagnostic trail instead of a silent rollback with no signal.
+            last_err = e
         _sleep(2.0)
+    if log is not None and last_err is not None:
+        log.warning("health probe %s never returned ok before the deadline; last error: %r", url, last_err)
     return False
 
 
@@ -327,7 +332,7 @@ def _relaunch_and_wait_healthy(install_dir: Path, deadline: float, log: logging.
             break
         app_pid = single_instance.launch_installed(install_dir)
         log.info("relaunch attempt %d of %d (pid %s)", i, attempts, app_pid)
-        if _wait_for_health(url, min(deadline, _monotonic() + _HEALTH_WAIT_PER_ATTEMPT)):
+        if _wait_for_health(url, min(deadline, _monotonic() + _HEALTH_WAIT_PER_ATTEMPT), log):
             log.info("relay healthy after relaunch")
             return True
         _kill_relay_pids(app_pid, install_dir, log)  # clear the crashed/hung app + serve before retrying

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -44,9 +44,19 @@ def test_latest_release_picks_highest_build_not_list_order(monkeypatch):
     # regression: GitHub's /releases list is NOT reliably newest-first. Pick by build number, not position.
     payload = [
         {"tag_name": "some-other-v1", "assets": []},
-        {"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b9.zip"}]},
-        {"tag_name": "relay-v0.1.0-build.8", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b8.zip"}]},
-        {"tag_name": "relay-v0.1.0-build.10", "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b10.zip"}], "published_at": "t10"},
+        {
+            "tag_name": "relay-v0.1.0-build.9",
+            "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b9.zip"}],
+        },
+        {
+            "tag_name": "relay-v0.1.0-build.8",
+            "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b8.zip"}],
+        },
+        {
+            "tag_name": "relay-v0.1.0-build.10",
+            "assets": [{"name": "ucnexus-relay.zip", "browser_download_url": "https://x/b10.zip"}],
+            "published_at": "t10",
+        },
     ]
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
     r = updater.latest_release()
@@ -56,7 +66,9 @@ def test_latest_release_picks_highest_build_not_list_order(monkeypatch):
 
 def test_latest_release_requires_the_zip_bundle(monkeypatch):
     # a release with only the old onefile exe asset (no zip bundle) does not count
-    payload = [{"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "u"}]}]
+    payload = [
+        {"tag_name": "relay-v0.1.0-build.9", "assets": [{"name": "ucnexus-relay.exe", "browser_download_url": "u"}]}
+    ]
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
     assert updater.latest_release() == {}
 
@@ -199,7 +211,9 @@ def test_apply_staged_update_circuit_breaker_gives_up(tmp_path, monkeypatch):
     _seed_staged(tmp_path, attempts=updater.MAX_ATTEMPTS)  # next run is attempt MAX+1
     monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
     relaunches = []
-    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(attempts) or True)
+    monkeypatch.setattr(
+        updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(attempts) or True
+    )
 
     def _no_repoint(*a, **k):
         raise AssertionError("circuit breaker must trip before repointing")
@@ -234,7 +248,9 @@ def test_apply_staged_update_missing_staged_version(tmp_path, monkeypatch):
     _seed_staged(tmp_path, make_new=False)  # the ledger's target_dir doesn't exist
     monkeypatch.setattr(updater, "_update_logger", lambda d: _LOG)
     relaunches = []
-    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(1) or True)
+    monkeypatch.setattr(
+        updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunches.append(1) or True
+    )
 
     r = updater.apply_staged_update(4242, tmp_path)
 
@@ -251,6 +267,31 @@ def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
     updater._kill_relay_pids(4242, tmp_path, _LOG)
 
     assert killed == [4242, 9001]  # app pid + serve pid, both by pid (never taskkill /im)
+
+
+# --- _wait_for_health ---------------------------------------------------------------------------------
+
+
+def test_wait_for_health_returns_true_on_ok(monkeypatch):
+    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp({"status": "ok"}))
+    monkeypatch.setattr(updater, "_monotonic", lambda: 0.0)  # always before the deadline
+    assert updater._wait_for_health("http://127.0.0.1:7321/health", 5.0) is True
+
+
+def test_wait_for_health_swallows_a_probe_error_instead_of_crashing(monkeypatch):
+    # regression #318: a frozen build missing the `idna` text codec made getaddrinfo raise
+    # `LookupError: unknown encoding: idna`, which the probe did NOT catch (only OSError/JSONDecodeError),
+    # so it propagated out of the detached update helper as an unhandled traceback. ANY probe error must be
+    # treated as "not up yet" and time out to False - never crash the helper.
+    def _boom(*a, **k):
+        raise LookupError("unknown encoding: idna")
+
+    monkeypatch.setattr(updater.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
+    ticks = [0.0, 1.0, 2.0]  # three probes, then the next monotonic check is past the deadline
+    monkeypatch.setattr(updater, "_monotonic", lambda: ticks.pop(0) if ticks else 999.0)
+
+    assert updater._wait_for_health("http://127.0.0.1:7321/health", 5.0) is False
 
 
 # --- _relaunch_and_wait_healthy -----------------------------------------------------------------------
@@ -312,7 +353,9 @@ def test_apply_staged_update_rolls_back_when_the_repoint_fails(tmp_path, monkeyp
 
     monkeypatch.setattr(layout, "repoint_current", _repoint)
     relaunched = []
-    monkeypatch.setattr(updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunched.append(1) or True)
+    monkeypatch.setattr(
+        updater, "_relaunch_and_wait_healthy", lambda d, deadline, log, attempts=2: relaunched.append(1) or True
+    )
 
     r = updater.apply_staged_update(4242, tmp_path)
 

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -274,8 +274,32 @@ def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
 
 def test_wait_for_health_returns_true_on_ok(monkeypatch):
     monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp({"status": "ok"}))
-    monkeypatch.setattr(updater, "_monotonic", lambda: 0.0)  # always before the deadline
+    # drive _monotonic off a tick list that steps PAST the deadline (and no-op _sleep) so a regression that
+    # stops returning True times out to False instead of spinning forever on the real clock/sleep.
+    ticks = [0.0, 1.0, 2.0]
+    monkeypatch.setattr(updater, "_monotonic", lambda: ticks.pop(0) if ticks else 999.0)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
     assert updater._wait_for_health("http://127.0.0.1:7321/health", 5.0) is True
+
+
+def test_wait_for_health_logs_last_error_on_timeout(monkeypatch):
+    # a never-healthy probe must leave a diagnostic trail (the last swallowed error), not roll back in
+    # silence - otherwise the next codec/TLS/logic regression is invisible.
+    def _boom(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(updater.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(updater, "_sleep", lambda s: None)
+    ticks = [0.0, 1.0]
+    monkeypatch.setattr(updater, "_monotonic", lambda: ticks.pop(0) if ticks else 999.0)
+    warned = []
+
+    class _CapLog:
+        def warning(self, *args, **kwargs):
+            warned.append(args)
+
+    assert updater._wait_for_health("http://127.0.0.1:7321/health", 5.0, _CapLog()) is False
+    assert warned and "connection refused" in repr(warned[-1])
 
 
 def test_wait_for_health_swallows_a_probe_error_instead_of_crashing(monkeypatch):
@@ -300,7 +324,7 @@ def test_wait_for_health_swallows_a_probe_error_instead_of_crashing(monkeypatch)
 def test_relaunch_and_wait_healthy_stops_when_health_ok(tmp_path, monkeypatch):
     launches = []
     monkeypatch.setattr(single_instance, "launch_installed", lambda d: launches.append(1))
-    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: True)
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline, log=None: True)
 
     assert updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 30, _LOG) is True
     assert launches == [1]  # one launch, healthy - no retry
@@ -310,7 +334,7 @@ def test_relaunch_and_wait_healthy_retries_then_gives_up(tmp_path, monkeypatch):
     launches = []
     monkeypatch.setattr(single_instance, "launch_installed", lambda d: launches.append(1))
     monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: None)
-    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: False)
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline, log=None: False)
     monkeypatch.setattr(updater, "_sleep", lambda s: None)
 
     ok = updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 1000, _LOG, attempts=2)
@@ -325,7 +349,7 @@ def test_relaunch_and_wait_healthy_kills_the_launched_app_between_retries(tmp_pa
     monkeypatch.setattr(single_instance, "launch_installed", lambda d: next(pids))
     killed = []
     monkeypatch.setattr(updater, "_kill_relay_pids", lambda pid, d, log: killed.append(pid))
-    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline: False)
+    monkeypatch.setattr(updater, "_wait_for_health", lambda url, deadline, log=None: False)
     monkeypatch.setattr(updater, "_sleep", lambda s: None)
 
     ok = updater._relaunch_and_wait_healthy(tmp_path, updater._monotonic() + 1000, _LOG, attempts=2)

--- a/relay/ucnexus-relay.spec
+++ b/relay/ucnexus-relay.spec
@@ -15,10 +15,14 @@ hiddenimports = collect_submodules("uvicorn") + [
     "pythonjsonlogger.jsonlogger",
     "clr",  # pythonnet's runtime import name (the `ui` window loads the WebView2 backend through it)
     # The `idna` text codec is loaded LAZILY by the codec registry the first time socket.getaddrinfo()
-    # has to encode a hostname that isn't compact-ASCII. Static analysis can't see that lazy codec import,
-    # so it was left out of the bundle and the self-update health probe crashed the detached update helper
-    # with `LookupError: unknown encoding: idna` (issue #318). Name it explicitly; PyInstaller then follows
-    # its stringprep/unicodedata deps. Listed alongside stringprep as belt-and-braces.
+    # has to encode a hostname. The onedir bundle DID carry encodings/idna.pyc (default encodings
+    # collection), but that collection doesn't analyze it, so idna.py's `import stringprep` was never
+    # followed and stringprep was left out. At runtime `import encodings.idna` then died on the missing
+    # stringprep, the codec registry swallowed that ImportError, and the caller got the misleading
+    # `LookupError: unknown encoding: idna` - which crashed the self-update health probe (issue #318).
+    # Naming encodings.idna explicitly makes PyInstaller analyze it and follow its stringprep + unicodedata
+    # deps into the bundle; stringprep is listed too as belt-and-braces. Verified by a pre/post spec build:
+    # pre-fix bundle has idna.pyc + unicodedata but NO stringprep; post-fix has all three.
     "encodings.idna",
     "stringprep",
 ]

--- a/relay/ucnexus-relay.spec
+++ b/relay/ucnexus-relay.spec
@@ -14,6 +14,13 @@ hiddenimports = collect_submodules("uvicorn") + [
     "pythonjsonlogger",
     "pythonjsonlogger.jsonlogger",
     "clr",  # pythonnet's runtime import name (the `ui` window loads the WebView2 backend through it)
+    # The `idna` text codec is loaded LAZILY by the codec registry the first time socket.getaddrinfo()
+    # has to encode a hostname that isn't compact-ASCII. Static analysis can't see that lazy codec import,
+    # so it was left out of the bundle and the self-update health probe crashed the detached update helper
+    # with `LookupError: unknown encoding: idna` (issue #318). Name it explicitly; PyInstaller then follows
+    # its stringprep/unicodedata deps. Listed alongside stringprep as belt-and-braces.
+    "encodings.idna",
+    "stringprep",
 ]
 
 # The `ui` subcommand's native window (pywebview) reaches the Edge WebView2 backend through pythonnet/clr.


### PR DESCRIPTION
Closes #318.

IT admin updated relay -> unhandled traceback `LookupError: unknown encoding: idna`.

self-update spawns detached helper (`ucnexus-relay update-apply`) -> repoints `current` junction to new build -> health-gates relaunch polling `http://127.0.0.1:7321/health`. poll goes urllib -> http.client -> `socket.getaddrinfo` -> loads `idna` codec to encode host.

onedir bundle carries `encodings/idna.pyc`, not idna.py's `import stringprep`.
PyInstaller default `encodings` collection adds idna.pyc without analyzing imports -> `stringprep` never bundled.
runtime `import encodings.idna` dies on missing `stringprep` -> codec registry swallows ImportError -> caller gets `LookupError: unknown encoding: idna`.

pre-fix bundle -> idna.pyc + unicodedata present, stringprep MISSING -> codecs.lookup('idna') fails (#318).
post-fix bundle -> all three present -> codecs.lookup('idna') succeeds.

- add `encodings.idna` + `stringprep` to spec `hiddenimports`. stringprep is the load-bearing line; naming `encodings.idna` makes PyInstaller analyze it and follow its stringprep + unicodedata deps.
- broaden `_wait_for_health` from `(OSError, json.JSONDecodeError)` to swallow any probe error, retry within deadline.
- regression test added.

pre-fix installs run the old crashing probe on the transition update (helper runs from OLD build exe); junction is already repointed + new build already launched before the crash, so relay still comes up on the fixed build. one traceback on that one update; later updates clean.
