### PR TITLE
fix(relay): TX00201 list_tax_details reserved-keyword alias (#315 follow-up)

### DIFF
--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -542,13 +542,17 @@ def list_tax_details(conn) -> list[dict]:
     """Read-only: PURCHASE tax details (TX00201 WHERE TXDTLTYP = 2) for the register-PO tax-detail
     dropdown (issue #257). TXDTLTYP 1 = Sales, 2 = Purchases. TXDTLPCT is the percent the relay uses
     to compute the PO tax. GP-first: the options are whatever the company defines (e.g. BC HST P /
-    ON HST - P / PST 7% in production), never a hardcoded list."""
+    ON HST - P / PST 7% in production), never a hardcoded list.
+
+    The percent column is aliased AS pct, NOT `AS percent`: PERCENT is a reserved SQL Server keyword
+    (TOP n PERCENT), so a bare `AS percent` throws "Incorrect syntax near the keyword 'percent'" and the
+    dropdown never loads (issue #315 follow-up). Matches get_tax_detail_percent below, which aliases pct."""
     rows = conn.cursor().execute(
-        "SELECT RTRIM(TAXDTLID) AS tax_detail_id, RTRIM(TXDTLDSC) AS description, TXDTLPCT AS percent "
+        "SELECT RTRIM(TAXDTLID) AS tax_detail_id, RTRIM(TXDTLDSC) AS description, TXDTLPCT AS pct "
         "FROM dbo.TX00201 WHERE TXDTLTYP = 2 ORDER BY TAXDTLID"
     ).fetchall()
     return [
-        {"tax_detail_id": r.tax_detail_id, "description": r.description or None, "percent": float(r.percent)}
+        {"tax_detail_id": r.tax_detail_id, "description": r.description or None, "percent": float(r.pct)}
         for r in rows
     ]
 

--- a/relay/tests/test_tax_and_currency.py
+++ b/relay/tests/test_tax_and_currency.py
@@ -91,7 +91,9 @@ def test_mc_setup_no_row_defaults_to_cad_single_currency():
 
 # --- list_tax_details (TX00201 purchase details, TXDTLTYP=2) ---
 
-_TaxRow = namedtuple("_TaxRow", "tax_detail_id description percent")
+# The percent column comes back under the alias `pct`, not `percent` - PERCENT is a reserved SQL Server
+# keyword, so the query aliases TXDTLPCT AS pct (see the assertion below, issue #315 follow-up).
+_TaxRow = namedtuple("_TaxRow", "tax_detail_id description pct")
 
 
 def test_list_tax_details_filters_to_purchases_and_maps_rows():
@@ -102,6 +104,11 @@ def test_list_tax_details_filters_to_purchases_and_maps_rows():
     out = list_tax_details(conn)
     assert "TX00201" in conn.cursor_obj.sql
     assert "TXDTLTYP = 2" in conn.cursor_obj.sql
+    # Regression guard (issue #315 follow-up): PERCENT is a reserved SQL Server keyword, so a bare
+    # `AS percent` throws "Incorrect syntax near the keyword 'percent'" against real GP and the dropdown
+    # never loads. The alias must stay a non-reserved word (pct).
+    assert "as pct" in conn.cursor_obj.sql.lower()
+    assert "as percent" not in conn.cursor_obj.sql.lower()
     assert out[0] == {"tax_detail_id": "ON HST - P", "description": "ON HST on Purchases", "percent": 13.0}
     # a blank GP description maps to None, not an empty string
     assert out[1]["description"] is None


### PR DESCRIPTION
follow-up to #315 / #317. register-PO tax-detail dropdown never populated.

root cause: relay list_tax_details (#257) aliases the percent column `TXDTLPCT AS percent`. PERCENT is a reserved SQL Server keyword (TOP n PERCENT), so against real GP the query throws "Incorrect syntax near the keyword 'percent'" (error 156). escaped CI because the relay's SQL read tests use a fake cursor -> no real DB parse -> a reserved-word alias isn't caught.

distinct from #315 (unknown op 'list_tax_details'). unknown_op is gone, manual tax-detail entry works. this is the third piece of #315 - the live list - failing for a new reason.

fix:
- alias TXDTLPCT AS pct (matches sibling get_tax_detail_percent)
- map r.pct to the "percent" key in the returned dict

verified read-only against live TUBC:
old query reproduces error 156
fixed query returns real purchase detail 'ON HST - P' (13%)
test asserts the alias stays a non-reserved word -> revert to AS percent fails CI

ships as relay build.32. box updates, dropdown populates live, no manual fallback needed.
