### PR TITLE
fix(import): drop BY_OTHERS from shop-assembly finalize classifications (#321)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -36,7 +36,7 @@ import { GET_PROJECT_EXCLUDED_ITEMS, GET_PROJECT_HARDWARE_SCHEDULE, RECONCILE_SC
 import { GET_PROJECTS } from '../../graphql/shared';
 import type { ClassificationRow } from './ClassificationGrid';
 import type { AggregatedHardwareItem, ImportPurpose, ReconciliationRow, ShippingPRDraft } from './types';
-import { aggregationKey, classificationKey } from './types';
+import { aggregationKey, classificationKey, toClassificationInputs } from './types';
 import type { Project } from '../../types/project';
 import type { ProjectHardwareScheduleResponse } from './hydrateSchedule';
 import { mapScheduleResponseToParseResult } from './hydrateSchedule';
@@ -694,10 +694,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         : null,
       excludedItems,
       classifications: purpose === 'assembly'
-        ? Array.from(classifications.entries()).map(([key, cls]) => {
-            const [hardwareCategory, productCode, unitCost] = key.split('|');
-            return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };
-          })
+        // #321: only Site/Shop belong here. Re-imports pre-populate the classifications Map with
+        // BY_OTHERS (ownership) from the exclusion table; those items are out of scope for shop
+        // assembly and BY_OTHERS is not in the Classification enum, so toClassificationInputs drops them.
+        ? toClassificationInputs(classifications)
         : purpose === 'po'
           // Issue #216: the PM's Site/Shop picks from the Classification step's second axis.
           // By-Others items are out of scope and carry none.

--- a/frontend/src/modules/import/__tests__/classificationInputs.test.ts
+++ b/frontend/src/modules/import/__tests__/classificationInputs.test.ts
@@ -1,0 +1,47 @@
+import { toClassificationInputs } from '../types';
+
+// Regression for #321: a shop-assembly re-import pre-populates the shared classifications Map with
+// BY_OTHERS entries (from the project's exclusion table). Those must never reach the finalize
+// payload, because the Classification GraphQL enum only accepts SITE_HARDWARE / SHOP_HARDWARE.
+describe('toClassificationInputs', () => {
+  it('drops BY_OTHERS entries and keeps only Site/Shop (the #321 regression)', () => {
+    const map = new Map<string, string>([
+      ['Hinges|HNG-100|10', 'SHOP_HARDWARE'],
+      ['Locks|LCK-200|25', 'SITE_HARDWARE'],
+      ['Closers|CLO-300|40', 'BY_OTHERS'],
+      ['Seals|SEA-400|5', 'BY_OTHERS'],
+    ]);
+
+    const result = toClassificationInputs(map);
+
+    expect(result).toEqual([
+      { hardwareCategory: 'Hinges', productCode: 'HNG-100', unitCost: 10, classification: 'SHOP_HARDWARE' },
+      { hardwareCategory: 'Locks', productCode: 'LCK-200', unitCost: 25, classification: 'SITE_HARDWARE' },
+    ]);
+    expect(result.some((e) => e.classification === 'BY_OTHERS')).toBe(false);
+  });
+
+  it('parses hardwareCategory|productCode|unitCost, including a decimal unit cost', () => {
+    const map = new Map<string, string>([['Hinges|HNG-100|12.75', 'SHOP_HARDWARE']]);
+
+    expect(toClassificationInputs(map)).toEqual([
+      { hardwareCategory: 'Hinges', productCode: 'HNG-100', unitCost: 12.75, classification: 'SHOP_HARDWARE' },
+    ]);
+  });
+
+  it('drops empty-string and unexpected values (allow-list, not deny-list)', () => {
+    const map = new Map<string, string>([
+      ['Hinges|HNG-100|10', ''],
+      ['Locks|LCK-200|25', 'SOMETHING_ELSE'],
+      ['Closers|CLO-300|40', 'SHOP_HARDWARE'],
+    ]);
+
+    expect(toClassificationInputs(map)).toEqual([
+      { hardwareCategory: 'Closers', productCode: 'CLO-300', unitCost: 40, classification: 'SHOP_HARDWARE' },
+    ]);
+  });
+
+  it('returns an empty array for an empty Map', () => {
+    expect(toClassificationInputs(new Map())).toEqual([]);
+  });
+});

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -59,3 +59,24 @@ export const ASSEMBLY_OPTIONS: ClassificationOption[] = [
   { value: 'SITE_HARDWARE', label: 'Site', color: 'success' },
   { value: 'SHOP_HARDWARE', label: 'Shop', color: 'info' },
 ];
+
+export interface ClassificationInputEntry {
+  hardwareCategory: string;
+  productCode: string;
+  unitCost: number;
+  classification: string;
+}
+
+// #321: project the shared classifications Map into finalize ClassificationInput entries, keeping
+// only real Site/Shop values. Re-imports seed the Map with BY_OTHERS (an ownership value, not a
+// Site/Shop one) from the exclusion table; those items are out of scope for shop assembly and the
+// Classification GraphQL enum only accepts SITE_HARDWARE/SHOP_HARDWARE, so they are dropped here.
+// Allow-listing the two valid values also drops any empty/unexpected value.
+export function toClassificationInputs(classifications: Map<string, string>): ClassificationInputEntry[] {
+  return Array.from(classifications.entries())
+    .filter(([, cls]) => cls === 'SITE_HARDWARE' || cls === 'SHOP_HARDWARE')
+    .map(([key, cls]) => {
+      const [hardwareCategory, productCode, unitCost] = key.split('|');
+      return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };
+    });
+}


### PR DESCRIPTION
Fixes #321.

Shop-assembly re-import Finalize rejected at GraphQL: "Value 'BY_OTHERS' does not exist in 'Classification' enum". hits any schedule with By-Others items (i.e. essentially every real schedule). blocks SAR creation.

import wizard keeps one shared classifications Map keyed hardware_category|product_code|unit_cost.
on re-import a useEffect pre-populates Map with BY_OTHERS for every parsed item matching project exclusion table.
effect gated on isReimport only, not import purpose.
assembly Classification step shows only RECEIVED items, sets SITE_HARDWARE/SHOP_HARDWARE.
BY_OTHERS entries stay in Map invisibly.
finalize assembly branch maps every Map entry -> input.classifications -> BY_OTHERS into Site/Shop-only Classification field -> Strawberry rejects mutation before resolver.

fix must be frontend-side: GraphQL enum rejects BY_OTHERS before the resolver runs, backend can't guard it.

exclude ownership-By-Others from classifications array (issue option 2).

- add toClassificationInputs() in frontend/src/modules/import/types.ts. projects classifications Map -> finalize ClassificationInput entries, keeps only SITE_HARDWARE/SHOP_HARDWARE. allow-list also drops empty/unexpected values (more robust than != BY_OTHERS deny-list).
- use in assembly branch of buildFinalizeInput in ImportWizard.tsx.
- PO branch unchanged (already excludes By-Others via byOthersKeys; its values are always Site/Shop).
- backend unchanged: By-Others AVAILABLE rows already persist with classification = None, same as the existing PO path.

classificationInputs.test.ts covers:
- BY_OTHERS dropped, Site/Shop kept
- decimal unit-cost parsing
- empty/unexpected dropped
- empty Map
