### PR TITLE
surface post-pull assembly assign/complete + shipping-out processing in the UI (#324)

### DIFF
--- a/backend/alembic/versions/057_shop_assembly_opening_assigned_user_id.py
+++ b/backend/alembic/versions/057_shop_assembly_opening_assigned_user_id.py
@@ -1,0 +1,32 @@
+"""Stable assignment identity (#324): shop_assembly_openings.assigned_to_user_id
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-07-23
+
+Adds a nullable assigned_to_user_id column holding the stable Clerk user id an opening is claimed
+by. myWork now filters on this instead of the display-name string in assigned_to (which stays for
+display). Additive, nullable, no backfill: dev-only data, and any in-flight assignment is re-claimed
+through the UI (existing rows keep their assigned_to name but a null user id, so they drop off My
+Work until re-assigned).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shop_assembly_openings",
+        sa.Column("assigned_to_user_id", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("shop_assembly_openings", "assigned_to_user_id")

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -27,6 +27,8 @@ type ShopAssemblyOpening {
   shop_assembly_request_id: ID!
   opening_id: ID!
   pull_status: PullStatus!
+  # Stable Clerk user id the opening is claimed by (#324); assigned_to is the display name.
+  assigned_to_user_id: String
   assigned_to: String
   assembly_status: AssemblyStatus!
   completed_at: DateTime
@@ -54,6 +56,7 @@ type ShopAssemblyOpeningItem {
 
 input AssignOpeningsInput {
   opening_ids: [ID!]!
+  assigned_to_user_id: String!
   assigned_to: String!
 }
 
@@ -74,7 +77,7 @@ input CompleteOpeningInput {
 
 type Query {
   assembleList(projectId: ID!): [ShopAssemblyOpening!]!
-  myWork(assignedTo: String!): [ShopAssemblyOpening!]!
+  myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
   # Accept UI (#293): shop-assembly requests, PENDING by default.
   shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus): [ShopAssemblyRequest!]!
 }

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -75,6 +75,10 @@ class ShopAssemblyOpening(Base):
         Enum(PullStatus, name="pull_status", create_constraint=True),
         nullable=False,
     )
+    # Stable Clerk user id the opening is claimed by (#324): the identity myWork filters on, so a
+    # display-name change or a non-UI caller no longer detaches in-flight work. assigned_to below
+    # stays the human-readable name for display; both are set/cleared together.
+    assigned_to_user_id: Mapped[str | None] = mapped_column(String, nullable=True)
     assigned_to: Mapped[str | None] = mapped_column(String, nullable=True)
     assembly_status: Mapped[AssemblyStatus] = mapped_column(
         Enum(AssemblyStatus, name="assembly_status", create_constraint=True),

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -71,9 +71,10 @@ def get_assemble_list(
 
 def get_my_work(
     session: Session,
-    assigned_to: str,
+    assigned_to_user_id: str,
 ) -> list[ShopAssemblyOpening]:
-    """Query ShopAssemblyOpenings assigned to a user with Pending assembly_status."""
+    """Query ShopAssemblyOpenings claimed by a user (by stable Clerk user id, #324) with Pending
+    assembly_status."""
     stmt = (
         select(ShopAssemblyOpening)
         .join(
@@ -82,7 +83,7 @@ def get_my_work(
         )
         .options(selectinload(ShopAssemblyOpening.items))
         .where(
-            ShopAssemblyOpening.assigned_to == assigned_to,
+            ShopAssemblyOpening.assigned_to_user_id == assigned_to_user_id,
             ShopAssemblyOpening.assembly_status == AssemblyStatus.PENDING,
             PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
             PullRequestModel.status == PullRequestStatus.COMPLETED,
@@ -95,13 +96,15 @@ def get_my_work(
 def assign_openings(
     session: Session,
     opening_ids: list[uuid.UUID],
-    assigned_to: str,
+    assigned_to_user_id: str,
+    assigned_to_name: str,
 ) -> list[ShopAssemblyOpening]:
-    """Assign ShopAssemblyOpenings to a user with pessimistic locking."""
+    """Assign ShopAssemblyOpenings to a user with pessimistic locking. Keyed on the stable Clerk
+    user id (#324); assigned_to_name is the display name stored alongside for the UI."""
     if not opening_ids:
         raise ValidationError("opening_ids must not be empty", field="opening_ids")
-    if not assigned_to:
-        raise ValidationError("assigned_to must not be empty", field="assigned_to")
+    if not assigned_to_user_id:
+        raise ValidationError("assigned_to_user_id must not be empty", field="assigned_to_user_id")
 
     locked = lock_rows(session, ShopAssemblyOpening, opening_ids)
     if len(locked) != len(opening_ids):
@@ -114,9 +117,10 @@ def assign_openings(
             raise InvalidStateTransitionError("Opening is not ready for assignment - hardware has not been pulled")
         if opening.assembly_status != AssemblyStatus.PENDING:
             raise InvalidStateTransitionError("Opening assembly is already completed")
-        if opening.assigned_to is not None:
+        if opening.assigned_to_user_id is not None:
             raise ConflictError(f"Opening already assigned to {opening.assigned_to}")
-        opening.assigned_to = assigned_to
+        opening.assigned_to_user_id = assigned_to_user_id
+        opening.assigned_to = assigned_to_name
 
     return locked
 
@@ -137,9 +141,10 @@ def remove_opening_from_user(
 
     if opening.assembly_status != AssemblyStatus.PENDING:
         raise InvalidStateTransitionError("Cannot unassign a completed opening")
-    if opening.assigned_to is None:
+    if opening.assigned_to_user_id is None:
         raise ValidationError("Opening is not assigned to anyone", field="assigned_to")
 
+    opening.assigned_to_user_id = None
     opening.assigned_to = None
     return opening
 

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -105,6 +105,9 @@ def assign_openings(
         raise ValidationError("opening_ids must not be empty", field="opening_ids")
     if not assigned_to_user_id:
         raise ValidationError("assigned_to_user_id must not be empty", field="assigned_to_user_id")
+    # Keep the pre-#324 invariant that an assigned opening always carries a display name.
+    if not assigned_to_name:
+        raise ValidationError("assigned_to must not be empty", field="assigned_to")
 
     locked = lock_rows(session, ShopAssemblyOpening, opening_ids)
     if len(locked) != len(opening_ids):
@@ -142,7 +145,7 @@ def remove_opening_from_user(
     if opening.assembly_status != AssemblyStatus.PENDING:
         raise InvalidStateTransitionError("Cannot unassign a completed opening")
     if opening.assigned_to_user_id is None:
-        raise ValidationError("Opening is not assigned to anyone", field="assigned_to")
+        raise ValidationError("Opening is not assigned to anyone", field="assigned_to_user_id")
 
     opening.assigned_to_user_id = None
     opening.assigned_to = None

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -471,6 +471,7 @@ def shop_assembly_opening_to_type(opening) -> ShopAssemblyOpening:
         pull_request_id=(strawberry.ID(str(opening.pull_request_id)) if opening.pull_request_id else None),
         opening_id=strawberry.ID(str(opening.opening_id)),
         pull_status=opening.pull_status,
+        assigned_to_user_id=opening.assigned_to_user_id,
         assigned_to=opening.assigned_to,
         assembly_status=opening.assembly_status,
         completed_at=opening.completed_at,

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -429,6 +429,9 @@ class CreateShipmentReturnInput:
 @strawberry.input
 class AssignOpeningsInput:
     opening_ids: list[strawberry.ID] = strawberry.field(default_factory=list)
+    # Stable Clerk user id the openings are claimed by (#324) - the key myWork filters on.
+    assigned_to_user_id: str = ""
+    # Human-readable display name stored alongside for the UI.
     assigned_to: str = ""
 
 

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -32,9 +32,9 @@ class ShopAssemblyQueries:
             return [shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.field
-    def my_work(self, assigned_to: str) -> list[ShopAssemblyOpening]:
+    def my_work(self, assigned_to_user_id: str) -> list[ShopAssemblyOpening]:
         with SessionLocal() as session:
-            saos = shop_assembly_repository.get_my_work(session, assigned_to)
+            saos = shop_assembly_repository.get_my_work(session, assigned_to_user_id)
             return [shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.field
@@ -100,7 +100,9 @@ class ShopAssemblyMutations:
     def assign_openings(self, input: AssignOpeningsInput) -> list[ShopAssemblyOpening]:
         opening_ids = [uuid.UUID(str(oid)) for oid in input.opening_ids]
         with SessionLocal() as session:
-            result = shop_assembly_repository.assign_openings(session, opening_ids, input.assigned_to)
+            result = shop_assembly_repository.assign_openings(
+                session, opening_ids, input.assigned_to_user_id, input.assigned_to
+            )
             session.commit()
             saos = shop_assembly_repository.get_openings_with_items(session, [o.id for o in result])
             return [shop_assembly_opening_to_type(sao) for sao in saos]

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -522,6 +522,8 @@ class ShopAssemblyOpening:
     pull_request_id: strawberry.ID | None
     opening_id: strawberry.ID
     pull_status: PullStatus
+    # Stable Clerk user id the opening is claimed by (#324); assigned_to is the display name.
+    assigned_to_user_id: str | None
     assigned_to: str | None
     assembly_status: AssemblyStatus
     completed_at: datetime | None

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -442,7 +442,9 @@ def test_sar_queries_work_after_opening_deleted(db_session):
     pr.status = PullRequestStatus.COMPLETED
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
     sao.pull_status = PullStatus.PULLED
-    sao.assigned_to = "tester"
+    # my_work keys on the stable user id (#324); assigned_to is the display name.
+    sao.assigned_to_user_id = "tester"
+    sao.assigned_to = "Tester Name"
     db_session.flush()
 
     # Re-upload removing A01
@@ -471,6 +473,67 @@ def test_sar_queries_work_after_opening_deleted(db_session):
     my_work_rows = shop_assembly_repository.get_my_work(db_session, "tester")
     assert len(my_work_rows) == 1
     assert my_work_rows[0].opening_number == "A01"
+
+
+def _pulled_opening(db_session, project, opening_number="A01"):
+    """Drive one shop-assembly opening to a PULLED, unassigned, PENDING state and return its row."""
+    req_number = f"SA-{uuid.uuid4().hex[:6]}"
+    result = import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input(opening_number)],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": req_number,
+            "shop_assembly_openings": [
+                {
+                    "opening_number": opening_number,
+                    "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 1}],
+                },
+            ],
+        },
+    )
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, result["shop_assembly_request"].id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    pr.status = PullRequestStatus.COMPLETED
+    sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
+    sao.pull_status = PullStatus.PULLED
+    db_session.flush()
+    return sao
+
+
+def test_assign_and_my_work_key_on_stable_user_id(db_session):
+    """#324: assignment stores the stable user id + display name; my_work filters on the user id,
+    NOT the display name - the exact mismatch that broke the e2e when assigning by raw id."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, product_code="HG-100", quantity=1)
+    db_session.commit()
+
+    sao = _pulled_opening(db_session, project)
+
+    shop_assembly_repository.assign_openings(
+        db_session, [sao.id], assigned_to_user_id="user_clerk_123", assigned_to_name="Jane Doe"
+    )
+    db_session.flush()
+    db_session.refresh(sao)
+    assert sao.assigned_to_user_id == "user_clerk_123"
+    assert sao.assigned_to == "Jane Doe"
+
+    # my_work resolves by the stable id...
+    assert len(shop_assembly_repository.get_my_work(db_session, "user_clerk_123")) == 1
+    # ...and NOT by the display name (the pre-#324 key).
+    assert shop_assembly_repository.get_my_work(db_session, "Jane Doe") == []
+
+    # Returning it to the pool clears both fields, so it drops off my_work.
+    shop_assembly_repository.remove_opening_from_user(db_session, sao.id)
+    db_session.flush()
+    db_session.refresh(sao)
+    assert sao.assigned_to_user_id is None
+    assert sao.assigned_to is None
+    assert shop_assembly_repository.get_my_work(db_session, "user_clerk_123") == []
 
 
 def test_existing_openings_updated_on_replace(db_session):

--- a/frontend/src/components/RequestsReviewPage.tsx
+++ b/frontend/src/components/RequestsReviewPage.tsx
@@ -43,6 +43,8 @@ interface RequestsReviewPageProps<TRequest extends ReviewableRequest> {
   renderSummary: (req: TRequest) => ReactNode;
   /** The expanded body: the request's items or openings. */
   renderDetails: (req: TRequest) => ReactNode;
+  /** Optional standing note under the description (e.g. where accepted requests get processed). */
+  note?: ReactNode;
 }
 
 /**
@@ -63,6 +65,7 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
   onChanged,
   renderSummary,
   renderDetails,
+  note,
 }: RequestsReviewPageProps<TRequest>) {
   const { showToast } = useToast();
   const { displayName } = useIdentity();
@@ -104,6 +107,8 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         {description}
       </Typography>
+
+      {note && <Box sx={{ mb: 2 }}>{note}</Box>}
 
       {loading && !loaded && (
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -8,6 +8,7 @@ export const GET_ASSEMBLE_LIST = gql`
       pullRequestId
       openingId
       pullStatus
+      assignedToUserId
       assignedTo
       assemblyStatus
       completedAt
@@ -27,13 +28,14 @@ export const GET_ASSEMBLE_LIST = gql`
 `;
 
 export const GET_MY_WORK = gql`
-  query GetMyWork($assignedTo: String!) {
-    myWork(assignedTo: $assignedTo) {
+  query GetMyWork($assignedToUserId: String!) {
+    myWork(assignedToUserId: $assignedToUserId) {
       id
       shopAssemblyRequestId
       pullRequestId
       openingId
       pullStatus
+      assignedToUserId
       assignedTo
       assemblyStatus
       completedAt
@@ -111,6 +113,7 @@ export const ASSIGN_OPENINGS = gql`
       shopAssemblyRequestId
       openingId
       pullStatus
+      assignedToUserId
       assignedTo
       assemblyStatus
       completedAt
@@ -136,6 +139,7 @@ export const REMOVE_OPENING_FROM_USER = gql`
       shopAssemblyRequestId
       openingId
       pullStatus
+      assignedToUserId
       assignedTo
       assemblyStatus
       completedAt

--- a/frontend/src/hooks/useIdentity.ts
+++ b/frontend/src/hooks/useIdentity.ts
@@ -9,10 +9,13 @@ interface PublicMetadata {
 export function useIdentity() {
   const { user } = useUser();
   const displayName = user?.fullName || user?.primaryEmailAddress?.emailAddress || 'Unknown';
+  // Stable Clerk user id (#324): the key shop-assembly assignment / My Work agree on, so a
+  // display-name change never detaches in-flight work. Empty string until Clerk has loaded.
+  const userId = user?.id ?? '';
   const metadata = (user?.publicMetadata ?? {}) as PublicMetadata;
   const roles = metadata.roles ?? [];
   const hasRole = (role: string) => roles.includes(role);
   const isAdmin = hasRole('Admin/Manager');
   const gpBuyerId = metadata.gpBuyerId || null;
-  return { displayName, roles, hasRole, isAdmin, gpBuyerId, user };
+  return { displayName, userId, roles, hasRole, isAdmin, gpBuyerId, user };
 }

--- a/frontend/src/modules/shipping/ShippingRequestsPage.tsx
+++ b/frontend/src/modules/shipping/ShippingRequestsPage.tsx
@@ -1,4 +1,5 @@
-import { Chip, Table, TableHead, TableBody, TableRow, TableCell, Typography } from '@mui/material';
+import { Chip, Table, TableHead, TableBody, TableRow, TableCell, Typography, Alert, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
 import { useQuery } from '@apollo/client/react';
 import {
   GET_SHIPPING_OUT_REQUESTS,
@@ -48,6 +49,15 @@ export default function ShippingRequestsPage({ projectId }: Props) {
       acceptMutation={ACCEPT_SHIPPING_OUT_REQUEST}
       rejectMutation={REJECT_SHIPPING_OUT_REQUEST}
       onChanged={refetch}
+      note={
+        <Alert severity="info">
+          Accepting a request creates a warehouse pull request. Process it under{' '}
+          <Link component={RouterLink} to="/app/warehouse/pull-requests">
+            Warehouse → Pull Requests → Shipping Out
+          </Link>{' '}
+          (Approve and Start, then Mark as Pulled) to move items to ship-ready.
+        </Alert>
+      }
       renderSummary={(req) => (
         <Chip label={`${req.items.length} item(s)`} size="small" variant="outlined" />
       )}

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback, type ReactNode } from 'react';
 import {
   Box,
   Typography,
@@ -13,12 +13,16 @@ import {
   TableRow,
   TableCell,
   Stack,
+  Button,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { useQuery } from '@apollo/client/react';
-import { GET_ASSEMBLE_LIST } from '../../graphql/shop-assembly';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { GET_ASSEMBLE_LIST, ASSIGN_OPENINGS, REMOVE_OPENING_FROM_USER } from '../../graphql/shop-assembly';
 import { leafSuffix } from '../../utils/leaf';
 import OpeningLeafStatusPanel from '../../components/OpeningLeafStatusPanel';
+import { useIdentity } from '../../hooks/useIdentity';
+import { useToast } from '../../components/Toast';
+import AssemblyDetailModal from './AssemblyDetailModal';
 
 // --- Types ---
 
@@ -35,10 +39,14 @@ interface AssembleOpening {
   shopAssemblyRequestId: string;
   openingId: string;
   pullStatus: string;
+  assignedToUserId: string | null;
   assignedTo: string | null;
   assemblyStatus: string;
   completedAt: string | null;
   leaf: number | null;
+  openingNumber: string | null;
+  building: string | null;
+  floor: string | null;
   items: AssembleOpeningItem[];
 }
 
@@ -60,12 +68,88 @@ const PULL_STATUS_SECTIONS: PullStatusSection[] = [
 // --- Component ---
 
 export default function AssembleListPage() {
+  const { displayName, userId } = useIdentity();
+  const { showToast } = useToast();
+  const [completing, setCompleting] = useState<AssembleOpening | null>(null);
+
   const {
     data,
     loading,
+    refetch,
   } = useQuery<{ assembleList: AssembleOpening[] }>(GET_ASSEMBLE_LIST);
 
   const openings = data?.assembleList ?? [];
+
+  const [assignOpenings] = useMutation(ASSIGN_OPENINGS, {
+    onCompleted: () => {
+      showToast('Assigned to you', 'success');
+      refetch();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const [removeOpening] = useMutation(REMOVE_OPENING_FROM_USER, {
+    onCompleted: () => {
+      showToast('Opening returned to available pool', 'success');
+      refetch();
+    },
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const claim = useCallback(
+    (opening: AssembleOpening) => {
+      if (!userId) {
+        showToast('Still signing in - try again in a moment', 'error');
+        return;
+      }
+      assignOpenings({
+        variables: {
+          input: { openingIds: [opening.id], assignedToUserId: userId, assignedTo: displayName },
+        },
+      });
+    },
+    [assignOpenings, userId, displayName, showToast]
+  );
+
+  // Per-opening assemble action, gated on the opening being pulled. Drives the assign -> complete
+  // flow directly from this list (#324) so a user never has to bounce to the board / My Work.
+  const renderActions = useCallback(
+    (opening: AssembleOpening): ReactNode => {
+      if (opening.pullStatus !== 'PULLED') return null;
+      if (opening.assemblyStatus === 'COMPLETED') {
+        return <Chip label="Assembled" color="success" size="small" />;
+      }
+      if (opening.assignedToUserId == null) {
+        return (
+          <Button size="small" variant="contained" onClick={() => claim(opening)}>
+            Assign to me
+          </Button>
+        );
+      }
+      if (opening.assignedToUserId === userId) {
+        return (
+          <Stack direction="row" spacing={1}>
+            <Button size="small" variant="contained" onClick={() => setCompleting(opening)}>
+              Complete assembly
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => removeOpening({ variables: { openingId: opening.id } })}
+            >
+              Return
+            </Button>
+          </Stack>
+        );
+      }
+      return (
+        <Typography variant="body2" color="text.secondary">
+          Assigned to {opening.assignedTo}
+        </Typography>
+      );
+    },
+    [claim, removeOpening, userId]
+  );
 
   // Group openings by pullStatus
   const grouped = useMemo(() => {
@@ -130,55 +214,72 @@ export default function AssembleListPage() {
                   No openings in this category.
                 </Typography>
               ) : (
-                sectionOpenings.map((opening) => (
-                  <Accordion key={opening.id} variant="outlined" sx={{ mb: 1 }}>
-                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                      <Stack direction="row" spacing={2} alignItems="center">
-                        <Typography fontWeight="bold">
-                          Opening: {opening.openingId}
-                          {leafSuffix(opening.leaf)}
-                        </Typography>
-                        <Chip
-                          label={formatPullStatus(opening.pullStatus)}
-                          color={section.badgeColor}
-                          size="small"
-                          variant="outlined"
-                        />
-                      </Stack>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      {opening.items.length > 0 ? (
-                        <Table size="small">
-                          <TableHead>
-                            <TableRow>
-                              <TableCell>Product Code</TableCell>
-                              <TableCell>Hardware Category</TableCell>
-                              <TableCell align="right">Quantity</TableCell>
-                            </TableRow>
-                          </TableHead>
-                          <TableBody>
-                            {opening.items.map((item) => (
-                              <TableRow key={item.id}>
-                                <TableCell>{item.productCode}</TableCell>
-                                <TableCell>{item.hardwareCategory}</TableCell>
-                                <TableCell align="right">{item.quantity}</TableCell>
+                sectionOpenings.map((opening) => {
+                  const actions = renderActions(opening);
+                  return (
+                    <Accordion key={opening.id} variant="outlined" sx={{ mb: 1 }}>
+                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <Stack direction="row" spacing={2} alignItems="center">
+                          <Typography fontWeight="bold">
+                            Opening: {opening.openingNumber || opening.openingId}
+                            {leafSuffix(opening.leaf)}
+                          </Typography>
+                          <Chip
+                            label={formatPullStatus(opening.pullStatus)}
+                            color={section.badgeColor}
+                            size="small"
+                            variant="outlined"
+                          />
+                        </Stack>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        {actions && <Box sx={{ mb: 2 }}>{actions}</Box>}
+                        {opening.items.length > 0 ? (
+                          <Table size="small">
+                            <TableHead>
+                              <TableRow>
+                                <TableCell>Product Code</TableCell>
+                                <TableCell>Hardware Category</TableCell>
+                                <TableCell align="right">Quantity</TableCell>
                               </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      ) : (
-                        <Typography variant="body2" color="text.secondary">
-                          No hardware items.
-                        </Typography>
-                      )}
-                    </AccordionDetails>
-                  </Accordion>
-                ))
+                            </TableHead>
+                            <TableBody>
+                              {opening.items.map((item) => (
+                                <TableRow key={item.id}>
+                                  <TableCell>{item.productCode}</TableCell>
+                                  <TableCell>{item.hardwareCategory}</TableCell>
+                                  <TableCell align="right">{item.quantity}</TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">
+                            No hardware items.
+                          </Typography>
+                        )}
+                      </AccordionDetails>
+                    </Accordion>
+                  );
+                })
               )}
             </Box>
           );
         })}
       </Stack>
+
+      {completing && (
+        <AssemblyDetailModal
+          open={!!completing}
+          opening={completing}
+          onClose={() => setCompleting(null)}
+          onCompleted={() => {
+            setCompleting(null);
+            refetch();
+          }}
+          completedBy={displayName}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, type ReactNode } from 'react';
 import {
   Box,
   Typography,
@@ -6,6 +6,7 @@ import {
   Chip,
   Stack,
   Grid,
+  Button,
 } from '@mui/material';
 import {
   DndContext,
@@ -24,6 +25,7 @@ import { GET_ASSEMBLE_LIST, ASSIGN_OPENINGS, REMOVE_OPENING_FROM_USER } from '..
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { leafSuffix } from '../../utils/leaf';
+import AssemblyDetailModal from './AssemblyDetailModal';
 
 interface OpeningItem {
   id: string;
@@ -38,6 +40,7 @@ interface AssembleOpening {
   shopAssemblyRequestId: string;
   openingId: string;
   pullStatus: string;
+  assignedToUserId: string | null;
   assignedTo: string | null;
   assemblyStatus: string;
   completedAt: string | null;
@@ -48,7 +51,15 @@ interface AssembleOpening {
   items: OpeningItem[];
 }
 
-function DraggableCard({ opening, isDragOverlay }: { opening: AssembleOpening; isDragOverlay?: boolean }) {
+function DraggableCard({
+  opening,
+  isDragOverlay,
+  actions,
+}: {
+  opening: AssembleOpening;
+  isDragOverlay?: boolean;
+  actions?: ReactNode;
+}) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: opening.id,
     data: { opening },
@@ -91,6 +102,12 @@ function DraggableCard({ opening, isDragOverlay }: { opening: AssembleOpening; i
             {[opening.building, opening.floor].filter(Boolean).join(' / ')}
           </Typography>
         )}
+        {!isDragOverlay && actions && (
+          // Stop pointer-down from reaching the drag sensor so buttons click instead of drag.
+          <Box sx={{ mt: 1 }} onPointerDown={(e) => e.stopPropagation()}>
+            {actions}
+          </Box>
+        )}
       </Paper>
     </Box>
   );
@@ -101,12 +118,14 @@ function DroppablePanel({
   openings,
   emptyText,
   color,
+  renderActions,
 }: {
   id: string;
   title: string;
   openings: AssembleOpening[];
   emptyText: string;
   color?: string;
+  renderActions?: (opening: AssembleOpening) => ReactNode;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id });
 
@@ -131,7 +150,7 @@ function DroppablePanel({
         </Typography>
       ) : (
         openings.map((opening) => (
-          <DraggableCard key={opening.id} opening={opening} />
+          <DraggableCard key={opening.id} opening={opening} actions={renderActions?.(opening)} />
         ))
       )}
     </Paper>
@@ -139,8 +158,10 @@ function DroppablePanel({
 }
 export default function AssignmentBoard() {
   const { showToast } = useToast();
-  const { displayName } = useIdentity();
+  const { displayName, userId } = useIdentity();
   const [activeOpening, setActiveOpening] = useState<AssembleOpening | null>(null);
+  // Opening whose completion modal is open (reuses the same checklist modal as My Work).
+  const [completing, setCompleting] = useState<AssembleOpening | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -178,21 +199,42 @@ export default function AssignmentBoard() {
       openings.filter(
         (o) =>
           o.pullStatus === 'PULLED' &&
-          o.assignedTo === null &&
+          o.assignedToUserId === null &&
           o.assemblyStatus === 'PENDING'
       ),
     [openings]
   );
 
+  // "Assigned" shows only what THIS user has claimed (keyed on the stable user id, #324),
+  // not everything assigned to anyone.
   const assigned = useMemo(
     () =>
       openings.filter(
         (o) =>
           o.pullStatus === 'PULLED' &&
-          o.assignedTo !== null &&
+          o.assignedToUserId === userId &&
           o.assemblyStatus === 'PENDING'
       ),
-    [openings]
+    [openings, userId]
+  );
+
+  const claim = useCallback(
+    (opening: AssembleOpening) => {
+      if (!userId) {
+        showToast('Still signing in - try again in a moment', 'error');
+        return;
+      }
+      assignOpenings({
+        variables: {
+          input: {
+            openingIds: [opening.id],
+            assignedToUserId: userId,
+            assignedTo: displayName,
+          },
+        },
+      });
+    },
+    [assignOpenings, userId, displayName, showToast]
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -210,30 +252,26 @@ export default function AssignmentBoard() {
       if (!opening) return;
 
       const droppedOn = over.id as string;
-      const isCurrentlyAssigned = opening.assignedTo !== null;
+      const isCurrentlyAssigned = opening.assignedToUserId !== null;
 
       if (droppedOn === 'assigned' && !isCurrentlyAssigned) {
-        assignOpenings({
-          variables: {
-            input: {
-              openingIds: [opening.id],
-              assignedTo: displayName,
-            },
-          },
-        });
+        claim(opening);
       } else if (droppedOn === 'available' && isCurrentlyAssigned) {
         removeOpening({
           variables: { openingId: opening.id },
         });
       }
     },
-    [assignOpenings, removeOpening, displayName]
+    [claim, removeOpening]
   );
 
   return (
     <Box>
       <Typography variant='h5' gutterBottom>
         Opening Assignment Board
+      </Typography>
+      <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+        Claim a pulled opening with "Assign to me" (or drag it across), then complete its assembly here or from My Work.
       </Typography>
 
       <DndContext
@@ -248,6 +286,11 @@ export default function AssignmentBoard() {
               title='Available Openings (Pulled)'
               openings={available}
               emptyText='No unassigned openings available'
+              renderActions={(opening) => (
+                <Button size='small' variant='contained' onClick={() => claim(opening)}>
+                  Assign to me
+                </Button>
+              )}
             />
           </Grid>
           <Grid size={6}>
@@ -257,6 +300,20 @@ export default function AssignmentBoard() {
               openings={assigned}
               emptyText='Drop openings here to assign'
               color='action.hover'
+              renderActions={(opening) => (
+                <Stack direction='row' spacing={1}>
+                  <Button size='small' variant='contained' onClick={() => setCompleting(opening)}>
+                    Complete
+                  </Button>
+                  <Button
+                    size='small'
+                    variant='outlined'
+                    onClick={() => removeOpening({ variables: { openingId: opening.id } })}
+                  >
+                    Return
+                  </Button>
+                </Stack>
+              )}
             />
           </Grid>
         </Grid>
@@ -267,6 +324,19 @@ export default function AssignmentBoard() {
           ) : null}
         </DragOverlay>
       </DndContext>
+
+      {completing && (
+        <AssemblyDetailModal
+          open={!!completing}
+          opening={completing}
+          onClose={() => setCompleting(null)}
+          onCompleted={() => {
+            setCompleting(null);
+            refetch();
+          }}
+          completedBy={displayName}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -21,6 +21,7 @@ interface MyWorkOpening {
   shopAssemblyRequestId: string;
   openingId: string;
   pullStatus: string;
+  assignedToUserId: string | null;
   assignedTo: string | null;
   assemblyStatus: string;
   completedAt: string | null;
@@ -50,11 +51,13 @@ const columns: GridColDef[] = [
 ];
 
 export default function MyWorkPage() {
-  const { displayName } = useIdentity();
+  const { displayName, userId } = useIdentity();
   const [selectedOpening, setSelectedOpening] = useState<MyWorkOpening | null>(null);
 
   const { data, loading, refetch } = useQuery<{ myWork: MyWorkOpening[] }>(GET_MY_WORK, {
-    variables: { assignedTo: displayName },
+    // Filter on the stable Clerk user id (#324); skip until Clerk has resolved it.
+    variables: { assignedToUserId: userId },
+    skip: !userId,
   });
 
   const rows = useMemo(() => data?.myWork ?? [], [data]);


### PR DESCRIPTION
Closes #324.

two stages had no working UI path, e2e drove them by raw GraphQL:
- assign + assemble shop-assembly leaves
- accept + process shipping-out request

backend adds stable assignment identity. assignment was keyed on the Clerk display name and myWork filtered on that same string -> broke the instant work was assigned by raw user id (myWork showed "No rows"):
- new nullable shop_assembly_openings.assigned_to_user_id (migration 057) = stable Clerk user id. assigned_to stays display name.
- assign_openings writes id + name; get_my_work filters on user id; remove_opening_from_user clears both.
- AssignOpeningsInput gains assigned_to_user_id; ShopAssemblyOpening type + converter expose it; myWork arg renamed assignedToUserId.

useIdentity exposes userId (Clerk user.id). My Work queries by userId, skips until Clerk resolves.

Assignment Board cards get buttons, drag-drop (dnd-kit) kept:
"Assign to me"
"Complete"
"Return"
assigned panel shows only current user's work, keyed on user id.

Assemble List per-work-unit actions reuse AssemblyDetailModal, driven by assignment state:
"Assign to me"
"Complete assembly"
"Return"

Shipping Requests shows a standing note -> Warehouse -> Pull Requests -> Shipping Out -> approve+complete -> SHIP_READY (processing already worked, just wasn't discoverable from Shipping).

no backfill, dev-only. existing in-flight assignments keep display name + null user id, re-claimed through UI.
