### PR TITLE
feat(requests): reopen an approved shipping-out / shop-assembly request (#325)

### DIFF
--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -67,7 +67,8 @@ type Query {
   packingSlips(projectId: ID): [PackingSlip!]!
   returnableLines(packingSlipId: ID!): [ReturnableLine!]!
   # Accept UI (#293): shipping-out requests, PENDING by default.
-  shippingOutRequests(projectId: ID, status: ShippingOutRequestStatus): [ShippingOutRequest!]!
+  # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
+  shippingOutRequests(projectId: ID, status: ShippingOutRequestStatus, reopenableOnly: Boolean! = false): [ShippingOutRequest!]!
 }
 
 type Mutation {
@@ -77,4 +78,7 @@ type Mutation {
   # display name. Accept mints the warehouse PullRequest; the warehouse approve handles shortfalls.
   acceptShippingOutRequest(id: ID!, acceptedBy: String!): ShippingOutRequest!
   rejectShippingOutRequest(id: ID!, rejectedBy: String!, reason: String): ShippingOutRequest!
+  # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
+  # PullRequest. Refused if the warehouse has already worked the pull.
+  reopenShippingOutRequest(id: ID!): ShippingOutRequest!
 }

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -79,7 +79,8 @@ type Query {
   assembleList(projectId: ID!): [ShopAssemblyOpening!]!
   myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
   # Accept UI (#293): shop-assembly requests, PENDING by default.
-  shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus): [ShopAssemblyRequest!]!
+  # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
+  shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus, reopenableOnly: Boolean! = false): [ShopAssemblyRequest!]!
 }
 
 type Mutation {
@@ -90,4 +91,7 @@ type Mutation {
   # display name. Accept re-checks inventory sufficiency and mints the warehouse PullRequest.
   acceptShopAssemblyRequest(id: ID!, acceptedBy: String!): ShopAssemblyRequest!
   rejectShopAssemblyRequest(id: ID!, rejectedBy: String!, reason: String): ShopAssemblyRequest!
+  # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
+  # PullRequest and re-points the openings off it. Refused if the warehouse has already worked the pull.
+  reopenShopAssemblyRequest(id: ID!): ShopAssemblyRequest!
 }

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -548,9 +548,14 @@ def get_shipping_out_requests(
     session: Session,
     project_id: uuid.UUID | None = None,
     status: ShippingOutRequestStatus | None = None,
+    reopenable_only: bool = False,
 ) -> list[ShippingOutRequest]:
     """List shipping-out requests for the accept UI (#293). Defaults to PENDING when no status is
-    given. Items are eagerly loaded (shipping_out_request_to_type walks them)."""
+    given. Items are eagerly loaded (shipping_out_request_to_type walks them).
+
+    reopenable_only (#325): keep only requests still in the reopen window - their minted warehouse
+    PullRequest is still PENDING (the warehouse has not started the pull). The Approved view passes this
+    so it lists exactly the requests Reopen can act on, not every request ever accepted."""
     effective_status = status if status is not None else ShippingOutRequestStatus.PENDING
     stmt = (
         select(ShippingOutRequest)
@@ -560,6 +565,10 @@ def get_shipping_out_requests(
     )
     if project_id is not None:
         stmt = stmt.where(ShippingOutRequest.project_id == project_id)
+    if reopenable_only:
+        stmt = stmt.join(PullRequestModel, ShippingOutRequest.pull_request_id == PullRequestModel.id).where(
+            PullRequestModel.status == PullRequestStatus.PENDING
+        )
     return list(session.scalars(stmt).unique().all())
 
 
@@ -638,4 +647,35 @@ def reject_shipping_out_request(
     req.rejected_by = rejected_by
     req.rejection_reason = (reason or "").strip() or None
     req.rejected_at = datetime.utcnow()
+    return req
+
+
+def reopen_shipping_out_request(
+    session: Session,
+    request_id: uuid.UUID,
+) -> ShippingOutRequest:
+    """Reopen an APPROVED shipping-out request back to PENDING (#325): undo an erroneous accept by
+    hard-deleting the warehouse PullRequest the accept minted (and its items), unlinking it, and
+    flipping the request back to PENDING so it can be re-accepted or rejected. Only allowed while the
+    minted PR is still PENDING - if the warehouse has already approved/completed it, inventory has
+    moved and the reopen is refused (see discard_pending_pull_request)."""
+    from app.repositories import warehouse as warehouse_repository
+
+    req = session.scalars(select(ShippingOutRequest).where(ShippingOutRequest.id == request_id)).first()
+    if req is None:
+        raise NotFoundError(f"Shipping-out request {request_id} not found")
+    if req.status != ShippingOutRequestStatus.APPROVED:
+        raise InvalidStateTransitionError(f"Shipping-out request must be Approved to reopen, got {req.status.value}")
+
+    # Unlink the request and flush BEFORE discarding the PR, so deleting it does not trip the
+    # shipping_out_requests.pull_request_id foreign key. discard_pending_pull_request still guards that
+    # the PR is unworked (PENDING) and rolls the whole transaction back (nothing commits) if not.
+    pr_id = req.pull_request_id
+    req.status = ShippingOutRequestStatus.PENDING
+    req.approved_by = None
+    req.approved_at = None
+    req.pull_request_id = None
+    session.flush()
+
+    warehouse_repository.discard_pending_pull_request(session, pr_id)
     return req

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -336,9 +336,15 @@ def get_shop_assembly_requests(
     session: Session,
     project_id: uuid.UUID | None = None,
     status: ShopAssemblyRequestStatus | None = None,
+    reopenable_only: bool = False,
 ) -> list[ShopAssemblyRequest]:
     """List shop-assembly requests for the accept UI (#293). Defaults to PENDING when no status is
-    given. Openings + their items are eagerly loaded (shop_assembly_request_to_type walks both)."""
+    given. Openings + their items are eagerly loaded (shop_assembly_request_to_type walks both).
+
+    reopenable_only (#325): keep only requests still in the reopen window - their minted warehouse
+    PullRequest is still PENDING (the warehouse has not started the pull). The Approved view passes this
+    so it lists exactly the requests Reopen can act on, not every request ever accepted. The minted PR
+    carries the request's request_number (unique on pull_requests), so it is matched on that."""
     effective_status = status if status is not None else ShopAssemblyRequestStatus.PENDING
     stmt = (
         select(ShopAssemblyRequest)
@@ -348,6 +354,10 @@ def get_shop_assembly_requests(
     )
     if project_id is not None:
         stmt = stmt.where(ShopAssemblyRequest.project_id == project_id)
+    if reopenable_only:
+        stmt = stmt.join(PullRequestModel, ShopAssemblyRequest.request_number == PullRequestModel.request_number).where(
+            PullRequestModel.status == PullRequestStatus.PENDING
+        )
     return list(session.scalars(stmt).unique().all())
 
 
@@ -450,4 +460,48 @@ def reject_shop_assembly_request(
     sar.rejected_by = rejected_by
     sar.rejection_reason = (reason or "").strip() or None
     sar.rejected_at = datetime.utcnow()
+    return sar
+
+
+def reopen_shop_assembly_request(
+    session: Session,
+    request_id: uuid.UUID,
+) -> ShopAssemblyRequest:
+    """Reopen an APPROVED shop-assembly request back to PENDING (#325): undo an erroneous accept by
+    hard-deleting the warehouse PullRequest the accept minted (and its items), re-pointing the
+    request's openings off it, and flipping the request back to PENDING so it can be re-accepted or
+    rejected. The minted PR is found via the openings' pull_request_id (there is no direct link on the
+    request, mirroring accept). Only allowed while the PR is still PENDING - if the warehouse has
+    already approved/completed it, inventory has moved and the reopen is refused."""
+    from app.repositories import warehouse as warehouse_repository
+
+    stmt = (
+        select(ShopAssemblyRequest)
+        .options(selectinload(ShopAssemblyRequest.openings))
+        .where(ShopAssemblyRequest.id == request_id)
+    )
+    sar = session.scalars(stmt).unique().first()
+    if sar is None:
+        raise NotFoundError(f"Shop-assembly request {request_id} not found")
+    if sar.status != ShopAssemblyRequestStatus.APPROVED:
+        raise InvalidStateTransitionError(f"Shop-assembly request must be Approved to reopen, got {sar.status.value}")
+
+    # Find the minted PR by the stable request_number, not by deriving it from the openings'
+    # pull_request_id. accept mints the PR unconditionally (even a zero-opening request gets one), so an
+    # openings-derived lookup can miss it and leave a PENDING PR orphaned - and since request_number is
+    # unique, the next accept would then collide, re-creating the stuck state #325 removes. accept stamps
+    # the PR with request_number == sar.request_number, which is unique on pull_requests.
+    pr = session.scalar(select(PullRequestModel).where(PullRequestModel.request_number == sar.request_number))
+
+    # Re-point the openings + flip the request, then flush BEFORE discarding the PR, so deleting it does
+    # not trip the shop_assembly_openings.pull_request_id foreign key. discard_pending_pull_request still
+    # guards the PR is unworked (PENDING) and rolls the whole transaction back (nothing commits) if not.
+    for opening in sar.openings:
+        opening.pull_request_id = None
+    sar.status = ShopAssemblyRequestStatus.PENDING
+    sar.approved_by = None
+    sar.approved_at = None
+    session.flush()
+
+    warehouse_repository.discard_pending_pull_request(session, pr.id if pr is not None else None)
     return sar

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -47,6 +47,7 @@ from .pull_requests import (
     approve_pull_request,
     check_inventory_sufficiency,
     complete_pull_request,
+    discard_pending_pull_request,
     get_pull_request_details,
     get_pull_requests,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "check_inventory_sufficiency",
     "complete_pull_request",
     "create_receive",
+    "discard_pending_pull_request",
     "get_audit_log",
     "get_back_ordered_items",
     "get_distinct_location_values",

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, delete, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import InvalidStateTransitionError, NotFoundError
@@ -23,6 +23,7 @@ from app.models.enums import (
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.pull_request import PullRequest as PullRequestModel
+from app.models.pull_request import PullRequestItem as PullRequestItemModel
 from app.models.shop_assembly import ShopAssemblyOpening
 from app.services import notification_service
 from app.services.locking import lock_rows
@@ -295,3 +296,28 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestMode
             opening.pull_status = PullStatus.PULLED
 
     return pr
+
+
+def discard_pending_pull_request(session: Session, pr_id: uuid.UUID | None) -> None:
+    """Hard-delete a still-PENDING PullRequest (and its items) that an accept minted, for the request
+    reopen path (#325). Locks the PR to close the race with a concurrent approve, and refuses if it has
+    advanced past PENDING - by then inventory has been deducted (or the pull completed) and reopening
+    the request would leave the warehouse out of sync, so the caller is told to resolve it in the
+    warehouse first. A hard delete (not the soft deleted_at) is required because request_number is
+    unique: a later re-accept re-mints a PR with the same number. A null/missing PR id is a no-op (the
+    accept is already effectively undone)."""
+    if pr_id is None:
+        return
+    locked = lock_rows(session, PullRequestModel, [pr_id])
+    if not locked:
+        return
+    pr = locked[0]
+    if pr.status != PullRequestStatus.PENDING:
+        raise InvalidStateTransitionError(
+            f"Cannot reopen - the warehouse has already started this pull request ({pr.status.value}). "
+            "Resolve it in the warehouse first."
+        )
+    # Bulk-delete the items in one statement (rather than a load + per-row DELETE), then the PR itself.
+    session.execute(delete(PullRequestItemModel).where(PullRequestItemModel.pull_request_id == pr.id))
+    session.delete(pr)
+    session.flush()

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -56,11 +56,14 @@ class ShippingQueries:
         self,
         project_id: strawberry.ID | None = None,
         status: ShippingOutRequestStatus | None = None,
+        reopenable_only: bool = False,
     ) -> list[ShippingOutRequest]:
-        """Accept UI (#293): shipping-out requests for a project, PENDING by default."""
+        """Accept UI (#293): shipping-out requests for a project, PENDING by default. reopenableOnly
+        (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
+        view uses it so it lists only requests Reopen can still act on."""
         with SessionLocal() as session:
             reqs = shipping_repository.get_shipping_out_requests(
-                session, uuid.UUID(str(project_id)) if project_id else None, status
+                session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
             )
             return [shipping_out_request_to_type(r) for r in reqs]
 
@@ -108,6 +111,20 @@ class ShippingMutations:
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
             shipping_repository.reject_shipping_out_request(session, request_id, rejected_by, reason)
+            session.commit()
+            refreshed = shipping_repository.get_shipping_out_request(session, request_id)
+            return shipping_out_request_to_type(refreshed)
+
+    @strawberry.mutation
+    def reopen_shipping_out_request(self, info: strawberry.Info, id: strawberry.ID) -> ShippingOutRequest:
+        """Reopen an APPROVED shipping-out request back to PENDING (#325). Undoes an erroneous accept:
+        hard-deletes the warehouse PullRequest the accept minted and flips the request to PENDING so it
+        can be re-accepted or rejected. Refused if the warehouse has already worked the pull. Open to
+        any signed-in user."""
+        require_user(info)
+        request_id = uuid.UUID(str(id))
+        with SessionLocal() as session:
+            shipping_repository.reopen_shipping_out_request(session, request_id)
             session.commit()
             refreshed = shipping_repository.get_shipping_out_request(session, request_id)
             return shipping_out_request_to_type(refreshed)

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -42,11 +42,14 @@ class ShopAssemblyQueries:
         self,
         project_id: strawberry.ID | None = None,
         status: ShopAssemblyRequestStatus | None = None,
+        reopenable_only: bool = False,
     ) -> list[ShopAssemblyRequest]:
-        """Accept UI (#293): shop-assembly requests for a project, PENDING by default."""
+        """Accept UI (#293): shop-assembly requests for a project, PENDING by default. reopenableOnly
+        (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
+        view uses it so it lists only requests Reopen can still act on."""
         with SessionLocal() as session:
             reqs = shop_assembly_repository.get_shop_assembly_requests(
-                session, uuid.UUID(str(project_id)) if project_id else None, status
+                session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
             )
             return [shop_assembly_request_to_type(r) for r in reqs]
 
@@ -92,6 +95,20 @@ class ShopAssemblyMutations:
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
             shop_assembly_repository.reject_shop_assembly_request(session, request_id, rejected_by, reason)
+            session.commit()
+            refreshed = shop_assembly_repository.get_request_with_openings(session, request_id)
+            return shop_assembly_request_to_type(refreshed)
+
+    @strawberry.mutation
+    def reopen_shop_assembly_request(self, info: strawberry.Info, id: strawberry.ID) -> ShopAssemblyRequest:
+        """Reopen an APPROVED shop-assembly request back to PENDING (#325). Undoes an erroneous accept:
+        hard-deletes the warehouse PullRequest the accept minted, re-points the request's openings off
+        it, and flips the request to PENDING so it can be re-accepted or rejected. Refused if the
+        warehouse has already worked the pull. Open to any signed-in user."""
+        require_user(info)
+        request_id = uuid.UUID(str(id))
+        with SessionLocal() as session:
+            shop_assembly_repository.reopen_shop_assembly_request(session, request_id)
             session.commit()
             refreshed = shop_assembly_repository.get_request_with_openings(session, request_id)
             return shop_assembly_request_to_type(refreshed)

--- a/backend/tests/test_accept_requests.py
+++ b/backend/tests/test_accept_requests.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import pytest
 from sqlalchemy import select
 
-from app.errors import InventoryShortfallError, ValidationError
+from app.errors import InvalidStateTransitionError, InventoryShortfallError, ValidationError
 from app.models.enums import (
     OpeningItemState,
     PullRequestItemType,
@@ -32,6 +32,7 @@ from app.repositories import (
     shop_assembly_repository,
     warehouse_admin_repository,
 )
+from app.repositories import warehouse as warehouse_repository
 
 
 def _make_project(session) -> Project:
@@ -190,6 +191,100 @@ def test_reject_shop_assembly_request(db_session):
     assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is None
 
 
+# --- shop-assembly reopen (#325) -------------------------------------------------------------
+
+
+def test_reopen_shop_assembly_reverts_to_pending_and_deletes_pr(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    result = _finalize_shop_assembly(db_session, project, qty=2)
+    sar = result["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    assert pr is not None
+
+    returned = shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+    db_session.flush()
+
+    # Request is back to PENDING with the approve stamps cleared.
+    assert returned.status == ShopAssemblyRequestStatus.PENDING
+    assert returned.approved_by is None
+    assert returned.approved_at is None
+
+    # The minted PR and its items are hard-deleted, and the openings no longer point at it.
+    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is None
+    assert db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all() == []
+    openings = db_session.scalars(
+        select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id)
+    ).all()
+    assert openings
+    assert all(o.pull_request_id is None for o in openings)
+
+    # From PENDING the existing reject flow works (the recovery path the issue wants).
+    rejected = shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "rejector", "mistake")
+    db_session.flush()
+    assert rejected.status == ShopAssemblyRequestStatus.REJECTED
+
+
+def test_reopen_shop_assembly_blocked_when_pr_already_worked(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    result = _finalize_shop_assembly(db_session, project, qty=2)
+    sar = result["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+
+    # Warehouse approves the pull (deducts inventory, PR -> IN_PROGRESS). Reopen must now refuse.
+    warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+
+
+def test_reopen_shop_assembly_requires_approved(db_session):
+    project = _make_project(db_session)
+    result = _finalize_shop_assembly(db_session, project, qty=2)
+    sar = result["shop_assembly_request"]  # PENDING, never accepted
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+
+
+def test_reopen_shop_assembly_discards_pr_when_openings_do_not_reference_it(db_session):
+    """Regression: reopen must find the minted PR by request_number, not by the openings'
+    pull_request_id. accept mints the PR unconditionally, so an openings-derived lookup would leave it
+    orphaned (and the next accept would collide on the unique request_number)."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    result = _finalize_shop_assembly(db_session, project, qty=2)
+    sar = result["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    # Simulate the orphan case: the openings no longer point at the minted PR, so a lookup that derived
+    # the PR from them would find nothing and skip the delete.
+    for opening in db_session.scalars(
+        select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id)
+    ).all():
+        opening.pull_request_id = None
+    db_session.flush()
+
+    shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+    db_session.flush()
+
+    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is None
+
+
 # --- shipping-out accept / reject ------------------------------------------------------------
 
 
@@ -237,6 +332,129 @@ def test_reject_shipping_out_request(db_session):
     assert returned.rejection_reason == "cancelled"  # trimmed
     assert returned.pull_request_id is None
     assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number)) is None
+
+
+# --- shipping-out reopen (#325) --------------------------------------------------------------
+
+
+def test_reopen_shipping_out_reverts_to_pending_and_deletes_pr(db_session):
+    project = _make_project(db_session)
+    result = _finalize_shipping(db_session, project, qty=2)
+    req = result["shipping_out_requests"][0]
+    req_number = req.request_number
+    db_session.flush()
+
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    assert pr is not None
+
+    returned = shipping_repository.reopen_shipping_out_request(db_session, req.id)
+    db_session.flush()
+
+    # Request is back to PENDING, unlinked, with the approve stamps cleared.
+    assert returned.status == ShippingOutRequestStatus.PENDING
+    assert returned.approved_by is None
+    assert returned.approved_at is None
+    assert returned.pull_request_id is None
+
+    # The minted PR and its items are hard-deleted.
+    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number)) is None
+    assert db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all() == []
+
+    # From PENDING the existing reject flow works (the recovery path the issue wants).
+    rejected = shipping_repository.reject_shipping_out_request(db_session, req.id, "rejector", "mistake")
+    db_session.flush()
+    assert rejected.status == ShippingOutRequestStatus.REJECTED
+
+
+def test_reopen_shipping_out_blocked_when_pr_already_worked(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    result = _finalize_shipping(db_session, project, qty=2)
+    req = result["shipping_out_requests"][0]
+    db_session.flush()
+
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req.request_number))
+
+    # Warehouse approves the pull (deducts inventory, PR -> IN_PROGRESS). Reopen must now refuse.
+    warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shipping_repository.reopen_shipping_out_request(db_session, req.id)
+
+
+def test_reopen_shipping_out_requires_approved(db_session):
+    project = _make_project(db_session)
+    result = _finalize_shipping(db_session, project, qty=2)
+    req = result["shipping_out_requests"][0]  # PENDING, never accepted
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shipping_repository.reopen_shipping_out_request(db_session, req.id)
+
+
+# --- reopenable_only filter for the Approved view (#325) --------------------------------------
+
+
+def test_reopenable_only_excludes_worked_shipping_requests(db_session):
+    """The Approved/reopen view passes reopenable_only so it lists only requests still in the reopen
+    window (minted PR still PENDING), not every request ever accepted."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    worked = _finalize_shipping(db_session, project, qty=2, opening_number="A01")["shipping_out_requests"][0]
+    fresh = _finalize_shipping(db_session, project, qty=2, opening_number="A02")["shipping_out_requests"][0]
+    db_session.flush()
+
+    shipping_repository.accept_shipping_out_request(db_session, worked.id, "acceptor")
+    shipping_repository.accept_shipping_out_request(db_session, fresh.id, "acceptor")
+    db_session.flush()
+
+    # The warehouse starts the pull on one of them (PR -> IN_PROGRESS): it drops out of the reopen window.
+    worked_pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == worked.request_number))
+    warehouse_repository.approve_pull_request(db_session, worked_pr.id, "warehouse")
+    db_session.flush()
+
+    reopenable = shipping_repository.get_shipping_out_requests(
+        db_session, project.id, ShippingOutRequestStatus.APPROVED, reopenable_only=True
+    )
+    ids = {r.id for r in reopenable}
+    assert fresh.id in ids
+    assert worked.id not in ids
+    # Without the filter both APPROVED requests still show.
+    all_approved = {
+        r.id
+        for r in shipping_repository.get_shipping_out_requests(
+            db_session, project.id, ShippingOutRequestStatus.APPROVED
+        )
+    }
+    assert {worked.id, fresh.id} <= all_approved
+
+
+def test_reopenable_only_excludes_worked_shop_assembly_requests(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    worked = _finalize_shop_assembly(db_session, project, qty=2, opening_number="A01")["shop_assembly_request"]
+    fresh = _finalize_shop_assembly(db_session, project, qty=2, opening_number="A02")["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, worked.id, "acceptor")
+    shop_assembly_repository.accept_shop_assembly_request(db_session, fresh.id, "acceptor")
+    db_session.flush()
+
+    worked_pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == worked.request_number))
+    warehouse_repository.approve_pull_request(db_session, worked_pr.id, "warehouse")
+    db_session.flush()
+
+    reopenable = shop_assembly_repository.get_shop_assembly_requests(
+        db_session, project.id, ShopAssemblyRequestStatus.APPROVED, reopenable_only=True
+    )
+    ids = {r.id for r in reopenable}
+    assert fresh.id in ids
+    assert worked.id not in ids
 
 
 # --- REQ-5 assembled-opening guard -----------------------------------------------------------

--- a/frontend/src/components/RequestsReviewPage.tsx
+++ b/frontend/src/components/RequestsReviewPage.tsx
@@ -13,10 +13,12 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
+import UndoIcon from '@mui/icons-material/Undo';
 import { useMutation } from '@apollo/client/react';
 import type { DocumentNode } from 'graphql';
 import { useToast } from './Toast';
 import { useIdentity } from '../hooks/useIdentity';
+import ConfirmDialog from './ConfirmDialog';
 
 interface ReviewableRequest {
   id: string;
@@ -29,7 +31,7 @@ interface RequestsReviewPageProps<TRequest extends ReviewableRequest> {
   title: string;
   /** One-line description under the heading. */
   description: string;
-  /** Alert text shown once loaded with no pending requests. */
+  /** Alert text shown once loaded with no requests. */
   emptyMessage: string;
   loading: boolean;
   /** True once the list query has returned at least once (data !== undefined). */
@@ -37,7 +39,14 @@ interface RequestsReviewPageProps<TRequest extends ReviewableRequest> {
   requests: TRequest[];
   acceptMutation: DocumentNode;
   rejectMutation: DocumentNode;
-  /** Re-run the list query after an accept/reject settles. */
+  /** Reverses an accept (#325). Required for `mode="approved"`; unused in the pending view. */
+  reopenMutation?: DocumentNode;
+  /**
+   * `pending` (default) shows Accept/Reject on each request. `approved` shows a single Reopen action
+   * that undoes the accept and sends the request back to Pending.
+   */
+  mode?: 'pending' | 'approved';
+  /** Re-run the list query after an accept/reject/reopen settles. */
   onChanged: () => void;
   /** Rendered right of the request number: the count chip (item(s) / opening(s)). */
   renderSummary: (req: TRequest) => ReactNode;
@@ -48,10 +57,11 @@ interface RequestsReviewPageProps<TRequest extends ReviewableRequest> {
 }
 
 /**
- * Shared accept/reject review page for the request -> accept -> pull gate (#293). Both the
- * shipping-out and shop-assembly request pages are this shell; they differ only in query, row
- * shape, and copy. Accepting mints the warehouse PullRequest, stamped with the caller's display
- * name; the warehouse handles any shortfall downstream.
+ * Shared accept/reject/reopen review page for the request -> accept -> pull gate (#293, #325). Both
+ * the shipping-out and shop-assembly request pages are this shell; they differ only in query, row
+ * shape, and copy. Accepting mints the warehouse PullRequest, stamped with the caller's display name;
+ * reopening (approved view) hard-deletes that PR and returns the request to Pending, allowed only
+ * while the warehouse has not started the pull (enforced server-side).
  */
 export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
   title,
@@ -62,6 +72,8 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
   requests,
   acceptMutation,
   rejectMutation,
+  reopenMutation,
+  mode = 'pending',
   onChanged,
   renderSummary,
   renderDetails,
@@ -69,9 +81,11 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
 }: RequestsReviewPageProps<TRequest>) {
   const { showToast } = useToast();
   const { displayName } = useIdentity();
-  // Which request is mid-flight, and which action - drives per-button spinners while both
-  // buttons on that request disable so accept and reject can't race each other.
-  const [pending, setPending] = useState<{ id: string; action: 'accept' | 'reject' } | null>(null);
+  // Which request is mid-flight, and which action - drives per-button spinners while every button on
+  // that request disables so the actions can't race each other.
+  const [pending, setPending] = useState<{ id: string; action: 'accept' | 'reject' | 'reopen' } | null>(null);
+  // Reopen undoes an accept, so it goes through a confirmation step. Holds the request id awaiting it.
+  const [confirmReopenId, setConfirmReopenId] = useState<string | null>(null);
 
   const settle = (message: string, severity: 'success' | 'error') => {
     showToast(message, severity);
@@ -89,6 +103,13 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
     onError: (e) => settle(e.message, 'error'),
   });
 
+  // Falls back to acceptMutation so the hook always has a valid document; only fired in approved mode,
+  // where reopenMutation is supplied.
+  const [reopenRequest] = useMutation(reopenMutation ?? acceptMutation, {
+    onCompleted: () => settle('Request reopened - back to pending', 'success'),
+    onError: (e) => settle(e.message, 'error'),
+  });
+
   const handleAccept = (id: string) => {
     setPending({ id, action: 'accept' });
     acceptRequest({ variables: { id, acceptedBy: displayName } });
@@ -97,6 +118,11 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
   const handleReject = (id: string) => {
     setPending({ id, action: 'reject' });
     rejectRequest({ variables: { id, rejectedBy: displayName, reason: null } });
+  };
+
+  const handleReopen = (id: string) => {
+    setPending({ id, action: 'reopen' });
+    reopenRequest({ variables: { id } });
   };
 
   return (
@@ -139,43 +165,76 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
               <Stack spacing={2}>
                 {renderDetails(req)}
 
-                <Stack direction="row" spacing={1}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    startIcon={
-                      pending?.id === req.id && pending.action === 'accept' ? (
-                        <CircularProgress size={16} color="inherit" />
-                      ) : (
-                        <CheckIcon />
-                      )
-                    }
-                    disabled={pending?.id === req.id}
-                    onClick={() => handleAccept(req.id)}
-                  >
-                    Accept
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    color="primary"
-                    startIcon={
-                      pending?.id === req.id && pending.action === 'reject' ? (
-                        <CircularProgress size={16} color="inherit" />
-                      ) : (
-                        <CloseIcon />
-                      )
-                    }
-                    disabled={pending?.id === req.id}
-                    onClick={() => handleReject(req.id)}
-                  >
-                    Reject
-                  </Button>
-                </Stack>
+                {mode === 'approved' ? (
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="outlined"
+                      color="warning"
+                      startIcon={
+                        pending?.id === req.id && pending.action === 'reopen' ? (
+                          <CircularProgress size={16} color="inherit" />
+                        ) : (
+                          <UndoIcon />
+                        )
+                      }
+                      disabled={pending?.id === req.id}
+                      onClick={() => setConfirmReopenId(req.id)}
+                    >
+                      Reopen
+                    </Button>
+                  </Stack>
+                ) : (
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      startIcon={
+                        pending?.id === req.id && pending.action === 'accept' ? (
+                          <CircularProgress size={16} color="inherit" />
+                        ) : (
+                          <CheckIcon />
+                        )
+                      }
+                      disabled={pending?.id === req.id}
+                      onClick={() => handleAccept(req.id)}
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="primary"
+                      startIcon={
+                        pending?.id === req.id && pending.action === 'reject' ? (
+                          <CircularProgress size={16} color="inherit" />
+                        ) : (
+                          <CloseIcon />
+                        )
+                      }
+                      disabled={pending?.id === req.id}
+                      onClick={() => handleReject(req.id)}
+                    >
+                      Reject
+                    </Button>
+                  </Stack>
+                )}
               </Stack>
             </AccordionDetails>
           </Accordion>
         ))}
       </Stack>
+
+      <ConfirmDialog
+        open={confirmReopenId !== null}
+        title="Reopen this request?"
+        message="This undoes the accept: the request goes back to Pending and the warehouse pull request it created is removed. It only works if the warehouse has not started that pull yet."
+        confirmLabel="Reopen"
+        onConfirm={() => {
+          const id = confirmReopenId;
+          setConfirmReopenId(null);
+          if (id) handleReopen(id);
+        }}
+        onCancel={() => setConfirmReopenId(null)}
+      />
     </Box>
   );
 }

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -75,8 +75,8 @@ export const CONFIRM_SHIPMENT = gql`
 `;
 
 export const GET_SHIPPING_OUT_REQUESTS = gql`
-  query GetShippingOutRequests($projectId: ID, $status: ShippingOutRequestStatus) {
-    shippingOutRequests(projectId: $projectId, status: $status) {
+  query GetShippingOutRequests($projectId: ID, $status: ShippingOutRequestStatus, $reopenableOnly: Boolean) {
+    shippingOutRequests(projectId: $projectId, status: $status, reopenableOnly: $reopenableOnly) {
       id
       requestNumber
       projectId
@@ -107,6 +107,15 @@ export const ACCEPT_SHIPPING_OUT_REQUEST = gql`
 export const REJECT_SHIPPING_OUT_REQUEST = gql`
   mutation RejectShippingOutRequest($id: ID!, $rejectedBy: String!, $reason: String) {
     rejectShippingOutRequest(id: $id, rejectedBy: $rejectedBy, reason: $reason) {
+      id
+      status
+    }
+  }
+`;
+
+export const REOPEN_SHIPPING_OUT_REQUEST = gql`
+  mutation ReopenShippingOutRequest($id: ID!) {
+    reopenShippingOutRequest(id: $id) {
       id
       status
     }

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -63,8 +63,8 @@ export const GET_SHOP_ASSEMBLY_STATS = gql`
 `;
 
 export const GET_SHOP_ASSEMBLY_REQUESTS = gql`
-  query GetShopAssemblyRequests($projectId: ID, $status: ShopAssemblyRequestStatus) {
-    shopAssemblyRequests(projectId: $projectId, status: $status) {
+  query GetShopAssemblyRequests($projectId: ID, $status: ShopAssemblyRequestStatus, $reopenableOnly: Boolean) {
+    shopAssemblyRequests(projectId: $projectId, status: $status, reopenableOnly: $reopenableOnly) {
       id
       requestNumber
       projectId
@@ -100,6 +100,15 @@ export const ACCEPT_SHOP_ASSEMBLY_REQUEST = gql`
 export const REJECT_SHOP_ASSEMBLY_REQUEST = gql`
   mutation RejectShopAssemblyRequest($id: ID!, $rejectedBy: String!, $reason: String) {
     rejectShopAssemblyRequest(id: $id, rejectedBy: $rejectedBy, reason: $reason) {
+      id
+      status
+    }
+  }
+`;
+
+export const REOPEN_SHOP_ASSEMBLY_REQUEST = gql`
+  mutation ReopenShopAssemblyRequest($id: ID!) {
+    reopenShopAssemblyRequest(id: $id) {
       id
       status
     }

--- a/frontend/src/modules/shipping/ShippingRequestsPage.tsx
+++ b/frontend/src/modules/shipping/ShippingRequestsPage.tsx
@@ -1,10 +1,25 @@
-import { Chip, Table, TableHead, TableBody, TableRow, TableCell, Typography, Alert, Link } from '@mui/material';
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  Link,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { useQuery } from '@apollo/client/react';
 import {
   GET_SHIPPING_OUT_REQUESTS,
   ACCEPT_SHIPPING_OUT_REQUEST,
   REJECT_SHIPPING_OUT_REQUEST,
+  REOPEN_SHIPPING_OUT_REQUEST,
 } from '../../graphql/shipping';
 import RequestsReviewPage from '../../components/RequestsReviewPage';
 
@@ -33,62 +48,87 @@ interface Props {
 }
 
 export default function ShippingRequestsPage({ projectId }: Props) {
+  const [view, setView] = useState<'PENDING' | 'APPROVED'>('PENDING');
   const { data, loading, refetch } = useQuery<{ shippingOutRequests: ShippingOutRequest[] }>(
     GET_SHIPPING_OUT_REQUESTS,
-    { variables: { projectId: projectId ?? null, status: 'PENDING' }, fetchPolicy: 'cache-and-network' },
+    {
+      variables: { projectId: projectId ?? null, status: view, reopenableOnly: view === 'APPROVED' },
+      fetchPolicy: 'cache-and-network',
+    },
   );
 
   return (
-    <RequestsReviewPage<ShippingOutRequest>
-      title="Shipping Requests"
-      description="Pending requests from Start a Task. Accepting one creates the warehouse pull request."
-      emptyMessage="No pending shipping requests."
-      loading={loading}
-      loaded={data !== undefined}
-      requests={data?.shippingOutRequests ?? []}
-      acceptMutation={ACCEPT_SHIPPING_OUT_REQUEST}
-      rejectMutation={REJECT_SHIPPING_OUT_REQUEST}
-      onChanged={refetch}
-      note={
-        <Alert severity="info">
-          Accepting a request creates a warehouse pull request. Process it under{' '}
-          <Link component={RouterLink} to="/app/warehouse/pull-requests">
-            Warehouse → Pull Requests → Shipping Out
-          </Link>{' '}
-          (Approve and Start, then Mark as Pulled) to move items to ship-ready.
-        </Alert>
-      }
-      renderSummary={(req) => (
-        <Chip label={`${req.items.length} item(s)`} size="small" variant="outlined" />
-      )}
-      renderDetails={(req) =>
-        req.items.length > 0 ? (
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Opening</TableCell>
-                <TableCell>Product Code</TableCell>
-                <TableCell>Hardware Category</TableCell>
-                <TableCell align="right">Quantity</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {req.items.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell>{item.openingNumber || '—'}</TableCell>
-                  <TableCell>{item.productCode || '—'}</TableCell>
-                  <TableCell>{item.hardwareCategory || '—'}</TableCell>
-                  <TableCell align="right">{item.requestedQuantity}</TableCell>
+    <Box>
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        value={view}
+        onChange={(_e, next) => next && setView(next)}
+        sx={{ mb: 2 }}
+      >
+        <ToggleButton value="PENDING">Pending</ToggleButton>
+        <ToggleButton value="APPROVED">Approved</ToggleButton>
+      </ToggleButtonGroup>
+
+      <RequestsReviewPage<ShippingOutRequest>
+        title="Shipping Requests"
+        description={
+          view === 'PENDING'
+            ? 'Pending requests from Start a Task. Accepting one creates the warehouse pull request.'
+            : 'Accepted requests whose warehouse pull has not started yet. Reopen one to undo the accept and send it back to Pending.'
+        }
+        emptyMessage={view === 'PENDING' ? 'No pending shipping requests.' : 'No shipping requests can be reopened.'}
+        loading={loading}
+        loaded={data !== undefined}
+        requests={data?.shippingOutRequests ?? []}
+        acceptMutation={ACCEPT_SHIPPING_OUT_REQUEST}
+        rejectMutation={REJECT_SHIPPING_OUT_REQUEST}
+        reopenMutation={REOPEN_SHIPPING_OUT_REQUEST}
+        mode={view === 'APPROVED' ? 'approved' : 'pending'}
+        onChanged={refetch}
+        note={
+          view === 'PENDING' ? (
+            <Alert severity="info">
+              Accepting a request creates a warehouse pull request. Process it under{' '}
+              <Link component={RouterLink} to="/app/warehouse/pull-requests">
+                Warehouse → Pull Requests → Shipping Out
+              </Link>{' '}
+              (Approve and Start, then Mark as Pulled) to move items to ship-ready.
+            </Alert>
+          ) : undefined
+        }
+        renderSummary={(req) => (
+          <Chip label={`${req.items.length} item(s)`} size="small" variant="outlined" />
+        )}
+        renderDetails={(req) =>
+          req.items.length > 0 ? (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Opening</TableCell>
+                  <TableCell>Product Code</TableCell>
+                  <TableCell>Hardware Category</TableCell>
+                  <TableCell align="right">Quantity</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        ) : (
-          <Typography variant="body2" color="text.secondary">
-            No items.
-          </Typography>
-        )
-      }
-    />
+              </TableHead>
+              <TableBody>
+                {req.items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.openingNumber || '—'}</TableCell>
+                    <TableCell>{item.productCode || '—'}</TableCell>
+                    <TableCell>{item.hardwareCategory || '—'}</TableCell>
+                    <TableCell align="right">{item.requestedQuantity}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No items.
+            </Typography>
+          )
+        }
+      />
+    </Box>
   );
 }

--- a/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
+++ b/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
@@ -1,9 +1,23 @@
-import { Box, Chip, Table, TableHead, TableBody, TableRow, TableCell, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+import {
+  Box,
+  Chip,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
 import { useQuery } from '@apollo/client/react';
 import {
   GET_SHOP_ASSEMBLY_REQUESTS,
   ACCEPT_SHOP_ASSEMBLY_REQUEST,
   REJECT_SHOP_ASSEMBLY_REQUEST,
+  REOPEN_SHOP_ASSEMBLY_REQUEST,
 } from '../../graphql/shop-assembly';
 import RequestsReviewPage from '../../components/RequestsReviewPage';
 import { leafSuffix } from '../../utils/leaf';
@@ -35,26 +49,47 @@ interface ShopAssemblyRequest {
 }
 
 export default function ShopAssemblyRequestsPage() {
+  const [view, setView] = useState<'PENDING' | 'APPROVED'>('PENDING');
   const { data, loading, refetch } = useQuery<{ shopAssemblyRequests: ShopAssemblyRequest[] }>(
     GET_SHOP_ASSEMBLY_REQUESTS,
-    { variables: { status: 'PENDING' }, fetchPolicy: 'cache-and-network' },
+    { variables: { status: view, reopenableOnly: view === 'APPROVED' }, fetchPolicy: 'cache-and-network' },
   );
 
   return (
-    <RequestsReviewPage<ShopAssemblyRequest>
-      title="Shop Assembly Requests"
-      description="Pending requests from Start a Task. Accepting one creates the warehouse pull request."
-      emptyMessage="No pending shop assembly requests."
-      loading={loading}
-      loaded={data !== undefined}
-      requests={data?.shopAssemblyRequests ?? []}
-      acceptMutation={ACCEPT_SHOP_ASSEMBLY_REQUEST}
-      rejectMutation={REJECT_SHOP_ASSEMBLY_REQUEST}
-      onChanged={refetch}
-      renderSummary={(req) => (
-        <Chip label={`${req.openings.length} opening(s)`} size="small" variant="outlined" />
-      )}
-      renderDetails={(req) =>
+    <Box>
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        value={view}
+        onChange={(_e, next) => next && setView(next)}
+        sx={{ mb: 2 }}
+      >
+        <ToggleButton value="PENDING">Pending</ToggleButton>
+        <ToggleButton value="APPROVED">Approved</ToggleButton>
+      </ToggleButtonGroup>
+
+      <RequestsReviewPage<ShopAssemblyRequest>
+        title="Shop Assembly Requests"
+        description={
+          view === 'PENDING'
+            ? 'Pending requests from Start a Task. Accepting one creates the warehouse pull request.'
+            : 'Accepted requests whose warehouse pull has not started yet. Reopen one to undo the accept and send it back to Pending.'
+        }
+        emptyMessage={
+          view === 'PENDING' ? 'No pending shop assembly requests.' : 'No shop assembly requests can be reopened.'
+        }
+        loading={loading}
+        loaded={data !== undefined}
+        requests={data?.shopAssemblyRequests ?? []}
+        acceptMutation={ACCEPT_SHOP_ASSEMBLY_REQUEST}
+        rejectMutation={REJECT_SHOP_ASSEMBLY_REQUEST}
+        reopenMutation={REOPEN_SHOP_ASSEMBLY_REQUEST}
+        mode={view === 'APPROVED' ? 'approved' : 'pending'}
+        onChanged={refetch}
+        renderSummary={(req) => (
+          <Chip label={`${req.openings.length} opening(s)`} size="small" variant="outlined" />
+        )}
+        renderDetails={(req) =>
         req.openings.map((opening) => (
           <Box key={opening.id}>
             <Stack direction="row" spacing={1} alignItems="baseline" sx={{ mb: 0.5 }}>
@@ -93,7 +128,8 @@ export default function ShopAssemblyRequestsPage() {
             )}
           </Box>
         ))
-      }
-    />
+        }
+      />
+    </Box>
   );
 }


### PR DESCRIPTION
Closes #325.

was: accept one-way. an accept made in error stuck APPROVED, no reopen/cancel/delete, only recovery a full DB drop-and-rebuild (SHIP-0019-E2E stuck, unrecoverable).

reopen action on both request surfaces:
shipping-out
shop-assembly
APPROVED -> PENDING.
hard-deletes the warehouse PullRequest the accept minted + its items.
shop-assembly also re-points the request's openings off that PR.
from PENDING, existing reject flow finishes recovery; reject's PENDING-only rule unchanged.

allowed only while the minted PR is still PENDING. already approved/completed in warehouse -> inventory moved (FIFO deducted, opening states -> SHIP_READY/PULLED), reopen refused with error, resolve in warehouse first. auto-unwinding a worked pull is out of scope.

delete the stale PR, not flip to CANCELLED. pull_requests.request_number is unique.

Approved view lists only reopenable requests (minted PR still PENDING) via reopenable_only flag on the list queries, so it never shows already-pulled requests whose Reopen would just error.

shop-assembly reopen finds the minted PR by the unique request_number, not the openings' pull_request_id, so a zero-opening request (accept mints a PR regardless) can't orphan it and re-collide on the next accept.

backend
reopen_shipping_out_request, reopen_shop_assembly_request repo functions
discard_pending_pull_request helper in warehouse/pull_requests.py: lock PR -> guard status == PENDING -> bulk-delete items -> delete PR
reopenShippingOutRequest, reopenShopAssemblyRequest mutations (require_user)
reopenableOnly on both list queries
SDL reference files updated
tests in test_accept_requests.py:
- reopen happy path both surfaces incl reject-from-pending after
- blocked when pull already worked
- blocked when request not approved
- reopen discards the PR even when openings do not reference it (found by request_number)
- reopenable_only excludes worked requests on both surfaces

frontend
Pending/Approved toggle on both request pages
Approved view lists only reopenable requests
Reopen action in shared review shell behind confirmation dialog

no notification to warehouse when a pending pull is withdrawn
no DB migration, no new enum value; reopen reuses existing PENDING state
