### PR TITLE
fix(shipping): absolute tab-nav paths so Requests/Returns render (#328)

### DIFF
--- a/frontend/src/modules/shipping/index.tsx
+++ b/frontend/src/modules/shipping/index.tsx
@@ -55,7 +55,7 @@ export default function ShippingModule() {
             exclusive
             value={view}
             onChange={(_, v) => {
-              if (v) navigate(v === 'ship' ? 'browse' : v);
+              if (v) navigate(`/app/shipping/${v === 'ship' ? 'browse' : v}`);
             }}
           >
             <ToggleButton value="requests">Requests</ToggleButton>


### PR DESCRIPTION
Fixes #328.

shipping tab bar (Requests / Ship / Returns) navigated relative paths from the module top-level useNavigate:

```jsx
onChange={(_, v) => { if (v) navigate(v === 'ship' ? 'browse' : v); }}
```

that useNavigate lives in the shipping/* splat-route context (App.tsx).
React Router 7 v7_relativeSplatPath default resolves a relative target against the full matched pathname, incl the splat segment.
from Ship at /app/shipping/browse, click Requests -> /app/shipping/browse/requests, matching no nested route (requests, browse, returns).
nested Routes render nothing; these stay:
header
toggle
cart badge
-> Requests tab looks empty.
PENDING ShippingOutRequest unreachable -> accept step unavailable via UI (follow-up to #324).
same defect broke Returns tab (/app/shipping/browse/returns also missed).

switch toggle to absolute paths (/app/shipping/<sub>), mirroring shop-assembly landing.
repairs Requests, Returns, Ship in one line.
selectedProject preserved (all three URLs resolve to the same shipping/* route, so the module never remounts).

no backend, GraphQL, or component changes.
these were already correct:
query (shippingOutRequests, PENDING)
accept/reject mutations
RequestsReviewPage
backend resolver/repo
request surfaces once the route matches.
