### PR TITLE
feat(shop-assembly): manager UI to assign pulled openings to team members (#330)

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -20,6 +20,7 @@ from app.errors import AppError
 from app.repositories import user_repository
 
 ADMIN_ROLE = "Admin/Manager"
+SHOP_ASSEMBLY_MANAGER_ROLE = "Shop Assembly Manager"
 
 _CLERK_JWKS_URL = "https://api.clerk.com/v1/jwks"
 _JWKS_TTL_SECONDS = 3600.0
@@ -146,4 +147,24 @@ def require_admin(info) -> dict:
     roles = user_repository.get_user_roles(user_id)
     if ADMIN_ROLE not in roles:
         raise ForbiddenError("Admin/Manager role required")
+    return {"user_id": user_id, "roles": roles}
+
+
+def require_role(info, role: str) -> dict:
+    """Enforce that the caller holds a specific role (looked up via the Clerk Backend API, like
+    require_admin). Returns {user_id, roles}. Use for role-gated resolvers other than Admin/Manager,
+    e.g. the shop-assembly manager assignment tools (#330)."""
+    request = info.context["request"]
+    token = _bearer_token(request)
+    if not token:
+        raise AuthError("Authentication required")
+
+    claims = verify_clerk_token(token)
+    user_id = claims.get("sub")
+    if not user_id:
+        raise AuthError("Authentication token has no subject")
+
+    roles = user_repository.get_user_roles(user_id)
+    if role not in roles:
+        raise ForbiddenError(f"{role} role required")
     return {"user_id": user_id, "roles": roles}

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -80,6 +80,8 @@ type Query {
   myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
   # Accept UI (#293): shop-assembly requests, PENDING by default.
   shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus): [ShopAssemblyRequest!]!
+  # Manager assignment picker (#330). Manager-gated (Shop Assembly Manager). ClerkUser in user.graphql.
+  shopAssemblyMembers: [ClerkUser!]!
 }
 
 type Mutation {

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -7,6 +7,10 @@ from app.errors import AppError
 
 CLERK_API_BASE = "https://api.clerk.com/v1"
 
+# Roles that make a user a shop-assembly team member (#330): assignable work in the shop-assembly
+# module. A manager can assign to a plain user or to another manager.
+SHOP_ASSEMBLY_ROLES = ("Shop Assembly User", "Shop Assembly Manager")
+
 _client = httpx.Client(base_url=CLERK_API_BASE, timeout=30.0)
 
 
@@ -78,6 +82,14 @@ def list_users() -> list[dict]:
         offset += limit
 
     return users
+
+
+def list_shop_assembly_members() -> list[dict]:
+    """Shop-assembly team members (#330): the subset of Clerk users holding a shop-assembly role,
+    for the manager assignment picker. Reuses list_users() and filters client-side to keep one
+    source of the user summary shape."""
+    members = set(SHOP_ASSEMBLY_ROLES)
+    return [u for u in list_users() if members.intersection(u["roles"])]
 
 
 def get_user(user_id: str) -> dict:

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -122,7 +122,13 @@ class ShopAssemblyMutations:
             return shop_assembly_request_to_type(refreshed)
 
     @strawberry.mutation
-    def assign_openings(self, input: AssignOpeningsInput) -> list[ShopAssemblyOpening]:
+    def assign_openings(self, info: strawberry.Info, input: AssignOpeningsInput) -> list[ShopAssemblyOpening]:
+        """Assign pulled openings to a user (#330). Any signed-in user may self-assign (the "Assign to
+        me" board); assigning to *another* user is Shop Assembly Manager-gated, so the manager-only
+        guarantee holds at the data layer, not just the UI."""
+        auth = require_user(info)
+        if input.assigned_to_user_id != auth["user_id"]:
+            require_role(info, SHOP_ASSEMBLY_MANAGER_ROLE)
         opening_ids = [uuid.UUID(str(oid)) for oid in input.opening_ids]
         with SessionLocal() as session:
             result = shop_assembly_repository.assign_openings(

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -4,21 +4,22 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user
+from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, require_role, require_user
 from app.database import SessionLocal
 from app.errors import InventoryShortfallError
-from app.repositories import shop_assembly_repository
+from app.repositories import shop_assembly_repository, user_repository
 from app.repositories import warehouse as warehouse_repository
 from app.services import notification_service
 
 from .converters import (
+    clerk_user_to_type,
     opening_item_to_type,
     shop_assembly_opening_to_type,
     shop_assembly_request_to_type,
 )
 from .enums import ShopAssemblyRequestStatus
 from .inputs import AssignOpeningsInput, CompleteOpeningInput
-from .types import OpeningItem, ShopAssemblyOpening, ShopAssemblyRequest
+from .types import ClerkUser, OpeningItem, ShopAssemblyOpening, ShopAssemblyRequest
 
 
 @strawberry.type
@@ -49,6 +50,13 @@ class ShopAssemblyQueries:
                 session, uuid.UUID(str(project_id)) if project_id else None, status
             )
             return [shop_assembly_request_to_type(r) for r in reqs]
+
+    @strawberry.field
+    def shop_assembly_members(self, info: strawberry.Info) -> list[ClerkUser]:
+        """Shop-assembly team members for the manager assignment picker (#330). Manager-gated: only
+        a Shop Assembly Manager may enumerate members and assign pulled openings to them."""
+        require_role(info, SHOP_ASSEMBLY_MANAGER_ROLE)
+        return [clerk_user_to_type(u) for u in user_repository.list_shop_assembly_members()]
 
 
 @strawberry.type

--- a/backend/tests/test_shop_assembly_members.py
+++ b/backend/tests/test_shop_assembly_members.py
@@ -4,12 +4,15 @@ Covers the repository role filter, the resolver's dict->ClerkUser mapping, and t
 that restricts the query to a Shop Assembly Manager. Resolver is exercised directly against a
 ShopAssemblyQueries instance (matches test_gp_relay_reads.py)."""
 
+import uuid
+
 import pytest
 
 from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, ForbiddenError, require_role
-from app.repositories import user_repository
+from app.repositories import shop_assembly_repository, user_repository
 from app.schemas import shop_assembly as shop_assembly_module
-from app.schemas.shop_assembly import ShopAssemblyQueries
+from app.schemas.inputs import AssignOpeningsInput
+from app.schemas.shop_assembly import ShopAssemblyMutations, ShopAssemblyQueries
 
 
 def _summary(uid, roles):
@@ -82,3 +85,51 @@ def test_require_role_allows_when_role_present(monkeypatch):
 
     assert result["user_id"] == "u1"
     assert SHOP_ASSEMBLY_MANAGER_ROLE in result["roles"]
+
+
+class _FakeSession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def commit(self):
+        pass
+
+
+def _bypass_assign_db(monkeypatch):
+    """Stub out the DB layer of assign_openings so tests exercise only its authorization branch."""
+    monkeypatch.setattr(shop_assembly_module, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(shop_assembly_repository, "assign_openings", lambda *a, **k: [])
+    monkeypatch.setattr(shop_assembly_repository, "get_openings_with_items", lambda *a, **k: [])
+
+
+def _assign_input(assigned_to_user_id):
+    return AssignOpeningsInput(
+        opening_ids=[str(uuid.uuid4())],
+        assigned_to_user_id=assigned_to_user_id,
+        assigned_to="Someone",
+    )
+
+
+def test_assign_openings_self_assign_skips_manager_gate(monkeypatch):
+    role_calls = []
+    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
+    monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: role_calls.append(role))
+    _bypass_assign_db(monkeypatch)
+
+    ShopAssemblyMutations().assign_openings(FakeInfo(), _assign_input("caller"))
+
+    assert role_calls == []
+
+
+def test_assign_openings_to_other_requires_manager_role(monkeypatch):
+    role_calls = []
+    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
+    monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: role_calls.append(role))
+    _bypass_assign_db(monkeypatch)
+
+    ShopAssemblyMutations().assign_openings(FakeInfo(), _assign_input("other"))
+
+    assert role_calls == [SHOP_ASSEMBLY_MANAGER_ROLE]

--- a/backend/tests/test_shop_assembly_members.py
+++ b/backend/tests/test_shop_assembly_members.py
@@ -1,0 +1,84 @@
+"""shopAssemblyMembers query (#330): the manager assignment picker.
+
+Covers the repository role filter, the resolver's dict->ClerkUser mapping, and the require_role gate
+that restricts the query to a Shop Assembly Manager. Resolver is exercised directly against a
+ShopAssemblyQueries instance (matches test_gp_relay_reads.py)."""
+
+import pytest
+
+from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, ForbiddenError, require_role
+from app.repositories import user_repository
+from app.schemas import shop_assembly as shop_assembly_module
+from app.schemas.shop_assembly import ShopAssemblyQueries
+
+
+def _summary(uid, roles):
+    return {
+        "id": uid,
+        "first_name": "First",
+        "last_name": uid,
+        "email": f"{uid}@example.com",
+        "roles": roles,
+        "gp_buyer_id": None,
+        "image_url": "",
+    }
+
+
+class FakeRequest:
+    def __init__(self, token):
+        self.headers = {"authorization": f"Bearer {token}"} if token else {}
+
+
+class FakeInfo:
+    def __init__(self, request=None):
+        self.context = {"request": request}
+
+
+def test_list_shop_assembly_members_filters_by_role(monkeypatch):
+    users = [
+        _summary("mgr", ["Shop Assembly Manager"]),
+        _summary("worker", ["Shop Assembly User"]),
+        _summary("both", ["Shop Assembly User", "PO User"]),
+        _summary("po", ["PO User"]),
+        _summary("admin", ["Admin/Manager"]),
+        _summary("none", []),
+    ]
+    monkeypatch.setattr(user_repository, "list_users", lambda: users)
+
+    members = user_repository.list_shop_assembly_members()
+
+    assert {m["id"] for m in members} == {"mgr", "worker", "both"}
+
+
+def test_resolver_gates_on_manager_role_and_maps_to_type(monkeypatch):
+    calls = []
+    monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: calls.append(role))
+    monkeypatch.setattr(
+        user_repository,
+        "list_shop_assembly_members",
+        lambda: [_summary("mgr", ["Shop Assembly Manager"]), _summary("worker", ["Shop Assembly User"])],
+    )
+
+    result = ShopAssemblyQueries().shop_assembly_members(FakeInfo())
+
+    assert calls == [SHOP_ASSEMBLY_MANAGER_ROLE]
+    assert [u.id for u in result] == ["mgr", "worker"]
+    assert result[0].email == "mgr@example.com"
+
+
+def test_require_role_forbids_when_role_absent(monkeypatch):
+    monkeypatch.setattr("app.auth.verify_clerk_token", lambda token: {"sub": "u1"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda uid: ["Shop Assembly User"])
+
+    with pytest.raises(ForbiddenError):
+        require_role(FakeInfo(FakeRequest("tok")), SHOP_ASSEMBLY_MANAGER_ROLE)
+
+
+def test_require_role_allows_when_role_present(monkeypatch):
+    monkeypatch.setattr("app.auth.verify_clerk_token", lambda token: {"sub": "u1"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda uid: ["Shop Assembly Manager", "PO User"])
+
+    result = require_role(FakeInfo(FakeRequest("tok")), SHOP_ASSEMBLY_MANAGER_ROLE)
+
+    assert result["user_id"] == "u1"
+    assert SHOP_ASSEMBLY_MANAGER_ROLE in result["roles"]

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -1,5 +1,19 @@
 import { gql } from '@apollo/client/core';
 
+// Shop-assembly team members for the manager assignment picker (#330). Manager-gated backend query.
+export const GET_SHOP_ASSEMBLY_MEMBERS = gql`
+  query GetShopAssemblyMembers {
+    shopAssemblyMembers {
+      id
+      firstName
+      lastName
+      email
+      roles
+      imageUrl
+    }
+  }
+`;
+
 export const GET_ASSEMBLE_LIST = gql`
   query GetAssembleList($projectId: ID) {
     assembleList(projectId: $projectId) {

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -26,6 +26,7 @@ import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { leafSuffix } from '../../utils/leaf';
 import AssemblyDetailModal from './AssemblyDetailModal';
+import ManagerAssignPanel from './ManagerAssignPanel';
 
 interface OpeningItem {
   id: string;
@@ -158,7 +159,8 @@ function DroppablePanel({
 }
 export default function AssignmentBoard() {
   const { showToast } = useToast();
-  const { displayName, userId } = useIdentity();
+  const { displayName, userId, hasRole } = useIdentity();
+  const isManager = hasRole('Shop Assembly Manager');
   const [activeOpening, setActiveOpening] = useState<AssembleOpening | null>(null);
   // Opening whose completion modal is open (reuses the same checklist modal as My Work).
   const [completing, setCompleting] = useState<AssembleOpening | null>(null);
@@ -273,6 +275,8 @@ export default function AssignmentBoard() {
       <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
         Claim a pulled opening with "Assign to me" (or drag it across), then complete its assembly here or from My Work.
       </Typography>
+
+      {isManager && <ManagerAssignPanel />}
 
       <DndContext
         sensors={sensors}

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -27,6 +27,7 @@ import { useIdentity } from '../../hooks/useIdentity';
 import { leafSuffix } from '../../utils/leaf';
 import AssemblyDetailModal from './AssemblyDetailModal';
 import ManagerAssignPanel from './ManagerAssignPanel';
+import { isAvailableForAssignment } from './openingFilters';
 
 interface OpeningItem {
   id: string;
@@ -196,16 +197,7 @@ export default function AssignmentBoard() {
 
   const openings = data?.assembleList ?? [];
 
-  const available = useMemo(
-    () =>
-      openings.filter(
-        (o) =>
-          o.pullStatus === 'PULLED' &&
-          o.assignedToUserId === null &&
-          o.assemblyStatus === 'PENDING'
-      ),
-    [openings]
-  );
+  const available = useMemo(() => openings.filter(isAvailableForAssignment), [openings]);
 
   // "Assigned" shows only what THIS user has claimed (keyed on the stable user id, #324),
   // not everything assigned to anyone.

--- a/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState, useCallback } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Checkbox,
+  Button,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Stack,
+  Chip,
+  type SelectChangeEvent,
+} from '@mui/material';
+import { useQuery, useMutation } from '@apollo/client/react';
+import {
+  GET_ASSEMBLE_LIST,
+  GET_SHOP_ASSEMBLY_MEMBERS,
+  ASSIGN_OPENINGS,
+} from '../../graphql/shop-assembly';
+import { leafSuffix } from '../../utils/leaf';
+import { useToast } from '../../components/Toast';
+
+interface AssembleOpening {
+  id: string;
+  openingId: string;
+  pullStatus: string;
+  assignedToUserId: string | null;
+  assignedTo: string | null;
+  assemblyStatus: string;
+  openingNumber: string | null;
+  building: string | null;
+  floor: string | null;
+  leaf: number | null;
+  items: { id: string }[];
+}
+
+interface Member {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  roles: string[];
+  imageUrl: string;
+}
+
+/** Display name for a member: full name, falling back to email (mirrors useIdentity()). */
+function memberName(m: Member): string {
+  return `${m.firstName} ${m.lastName}`.trim() || m.email;
+}
+
+/**
+ * Manager-only tool (#330) to assign one or more pulled openings to a shop-assembly team member.
+ * Mounted above the self-claim board; gated to the Shop Assembly Manager role at the mount site.
+ */
+export default function ManagerAssignPanel() {
+  const { showToast } = useToast();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [memberId, setMemberId] = useState('');
+
+  // Shares the GET_ASSEMBLE_LIST cache with the board (same query + vars), so a refetch here keeps
+  // both views in sync.
+  const { data: listData, refetch } = useQuery<{ assembleList: AssembleOpening[] }>(GET_ASSEMBLE_LIST);
+  const { data: memberData } = useQuery<{ shopAssemblyMembers: Member[] }>(GET_SHOP_ASSEMBLY_MEMBERS);
+
+  const openings = listData?.assembleList ?? [];
+  const members = memberData?.shopAssemblyMembers ?? [];
+
+  const available = useMemo(
+    () =>
+      openings.filter(
+        (o) =>
+          o.pullStatus === 'PULLED' &&
+          o.assignedToUserId === null &&
+          o.assemblyStatus === 'PENDING'
+      ),
+    [openings]
+  );
+
+  // Current load per member: pending pulled openings already assigned to someone.
+  const loadByMember = useMemo(() => {
+    const counts = new Map<string, { name: string; count: number }>();
+    for (const o of openings) {
+      if (o.pullStatus === 'PULLED' && o.assemblyStatus === 'PENDING' && o.assignedToUserId) {
+        const prev = counts.get(o.assignedToUserId);
+        counts.set(o.assignedToUserId, {
+          name: o.assignedTo || prev?.name || o.assignedToUserId,
+          count: (prev?.count ?? 0) + 1,
+        });
+      }
+    }
+    return [...counts.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [openings]);
+
+  const [assignOpenings, { loading: assigning }] = useMutation(ASSIGN_OPENINGS, {
+    onCompleted: (data) => {
+      const count = (data as { assignOpenings: unknown[] }).assignOpenings.length;
+      const member = members.find((m) => m.id === memberId);
+      showToast(`${count} opening(s) assigned to ${member ? memberName(member) : 'member'}`, 'success');
+      setSelectedIds(new Set());
+      refetch();
+    },
+    onError: (err) => {
+      showToast(err.message, 'error');
+      refetch();
+    },
+  });
+
+  const toggleOne = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const allSelected = available.length > 0 && selectedIds.size === available.length;
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  const toggleAll = useCallback(() => {
+    setSelectedIds((prev) =>
+      prev.size === available.length ? new Set() : new Set(available.map((o) => o.id))
+    );
+  }, [available]);
+
+  const handleMemberChange = useCallback((e: SelectChangeEvent) => setMemberId(e.target.value), []);
+
+  const handleAssign = useCallback(() => {
+    const member = members.find((m) => m.id === memberId);
+    if (!member) {
+      showToast('Pick a team member to assign to', 'error');
+      return;
+    }
+    if (selectedIds.size === 0) {
+      showToast('Select at least one opening', 'error');
+      return;
+    }
+    assignOpenings({
+      variables: {
+        input: {
+          openingIds: [...selectedIds],
+          assignedToUserId: member.id,
+          assignedTo: memberName(member),
+        },
+      },
+    });
+  }, [members, memberId, selectedIds, assignOpenings, showToast]);
+
+  const selectedMember = members.find((m) => m.id === memberId);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+      <Typography variant="h6" gutterBottom>
+        Assign to Team Member
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Select pulled openings and assign them to a shop-assembly team member. Assigned work shows up
+        in that member's My Work.
+      </Typography>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }} sx={{ mb: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 240 }}>
+          <InputLabel id="assign-member-label">Team member</InputLabel>
+          <Select
+            labelId="assign-member-label"
+            label="Team member"
+            value={memberId}
+            onChange={handleMemberChange}
+          >
+            {members.length === 0 && (
+              <MenuItem value="" disabled>
+                No shop-assembly members found
+              </MenuItem>
+            )}
+            {members.map((m) => (
+              <MenuItem key={m.id} value={m.id}>
+                {memberName(m)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          disabled={assigning || selectedIds.size === 0 || !memberId}
+          onClick={handleAssign}
+        >
+          {`Assign ${selectedIds.size || ''} ${selectedMember ? `to ${memberName(selectedMember)}` : 'selected'}`.replace(
+            /\s+/g,
+            ' '
+          )}
+        </Button>
+      </Stack>
+
+      {loadByMember.length > 0 && (
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+            Current load:
+          </Typography>
+          {loadByMember.map((l) => (
+            <Chip key={l.name} size="small" variant="outlined" label={`${l.name}: ${l.count}`} />
+          ))}
+        </Stack>
+      )}
+
+      {available.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No unassigned pulled openings available.
+        </Typography>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox">
+                <Checkbox
+                  indeterminate={someSelected}
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  inputProps={{ 'aria-label': 'select all openings' }}
+                />
+              </TableCell>
+              <TableCell>Opening</TableCell>
+              <TableCell>Location</TableCell>
+              <TableCell align="right">Items</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {available.map((o) => {
+              const label = (o.openingNumber || o.openingId.slice(0, 8)) + leafSuffix(o.leaf);
+              return (
+                <TableRow key={o.id} hover onClick={() => toggleOne(o.id)} sx={{ cursor: 'pointer' }}>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selectedIds.has(o.id)}
+                      onChange={() => toggleOne(o.id)}
+                      onClick={(e) => e.stopPropagation()}
+                      inputProps={{ 'aria-label': `select ${label}` }}
+                    />
+                  </TableCell>
+                  <TableCell>{label}</TableCell>
+                  <TableCell>
+                    {[o.building, o.floor].filter(Boolean).join(' / ') || (
+                      <Box component="span" sx={{ color: 'text.disabled' }}>
+                        -
+                      </Box>
+                    )}
+                  </TableCell>
+                  <TableCell align="right">{o.items.length}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </Paper>
+  );
+}

--- a/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../graphql/shop-assembly';
 import { leafSuffix } from '../../utils/leaf';
 import { useToast } from '../../components/Toast';
+import { isAvailableForAssignment } from './openingFilters';
 
 interface AssembleOpening {
   id: string;
@@ -72,25 +73,18 @@ export default function ManagerAssignPanel() {
   const openings = listData?.assembleList ?? [];
   const members = memberData?.shopAssemblyMembers ?? [];
 
-  const available = useMemo(
-    () =>
-      openings.filter(
-        (o) =>
-          o.pullStatus === 'PULLED' &&
-          o.assignedToUserId === null &&
-          o.assemblyStatus === 'PENDING'
-      ),
-    [openings]
-  );
+  const available = useMemo(() => openings.filter(isAvailableForAssignment), [openings]);
 
   // Current load per member: pending pulled openings already assigned to someone.
   const loadByMember = useMemo(() => {
-    const counts = new Map<string, { name: string; count: number }>();
+    const counts = new Map<string, { id: string; name: string; count: number }>();
     for (const o of openings) {
       if (o.pullStatus === 'PULLED' && o.assemblyStatus === 'PENDING' && o.assignedToUserId) {
-        const prev = counts.get(o.assignedToUserId);
-        counts.set(o.assignedToUserId, {
-          name: o.assignedTo || prev?.name || o.assignedToUserId,
+        const id = o.assignedToUserId;
+        const prev = counts.get(id);
+        counts.set(id, {
+          id,
+          name: o.assignedTo || prev?.name || id,
           count: (prev?.count ?? 0) + 1,
         });
       }
@@ -204,7 +198,7 @@ export default function ManagerAssignPanel() {
             Current load:
           </Typography>
           {loadByMember.map((l) => (
-            <Chip key={l.name} size="small" variant="outlined" label={`${l.name}: ${l.count}`} />
+            <Chip key={l.id} size="small" variant="outlined" label={`${l.name}: ${l.count}`} />
           ))}
         </Stack>
       )}

--- a/frontend/src/modules/shop-assembly/__tests__/AssignmentBoard.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssignmentBoard.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import AssignmentBoard from '../AssignmentBoard';
+import { GET_ASSEMBLE_LIST, GET_SHOP_ASSEMBLY_MEMBERS } from '../../../graphql/shop-assembly';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// Role is driven per-test through this mutable list (vi.mock factory may read `mock`-prefixed vars).
+let mockRoles: string[] = [];
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Me',
+    userId: 'me',
+    roles: mockRoles,
+    hasRole: (r: string) => mockRoles.includes(r),
+    isAdmin: false,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+const emptyListMock: MockedResponse = {
+  request: { query: GET_ASSEMBLE_LIST },
+  result: { data: { assembleList: [] } },
+};
+const membersMock: MockedResponse = {
+  request: { query: GET_SHOP_ASSEMBLY_MEMBERS },
+  result: { data: { shopAssemblyMembers: [] } },
+};
+
+function renderBoard(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <AssignmentBoard />
+      </ToastProvider>
+    </MockedProvider>
+  );
+}
+
+it('shows the manager assign panel for a Shop Assembly Manager', async () => {
+  mockRoles = ['Shop Assembly Manager'];
+  renderBoard([emptyListMock, membersMock]);
+  expect(await screen.findByText('Assign to Team Member')).toBeInTheDocument();
+});
+
+it('hides the manager assign panel for a plain Shop Assembly User', async () => {
+  mockRoles = ['Shop Assembly User'];
+  renderBoard([emptyListMock]);
+  // The board itself renders (its heading), but the manager panel does not.
+  expect(await screen.findByText('Opening Assignment Board')).toBeInTheDocument();
+  await waitFor(() => expect(screen.queryByText('Assign to Team Member')).not.toBeInTheDocument());
+});

--- a/frontend/src/modules/shop-assembly/__tests__/ManagerAssignPanel.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/ManagerAssignPanel.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import ManagerAssignPanel from '../ManagerAssignPanel';
+import {
+  GET_ASSEMBLE_LIST,
+  GET_SHOP_ASSEMBLY_MEMBERS,
+  ASSIGN_OPENINGS,
+} from '../../../graphql/shop-assembly';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const MEMBERS = [
+  { id: 'mgr', firstName: 'Jane', lastName: 'Doe', email: 'jane@x.com', roles: ['Shop Assembly Manager'], imageUrl: '' },
+  { id: 'wk', firstName: 'Bob', lastName: 'Lee', email: 'bob@x.com', roles: ['Shop Assembly User'], imageUrl: '' },
+];
+
+function opening(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'o1',
+    shopAssemblyRequestId: null,
+    pullRequestId: 'pr1',
+    openingId: 'op1',
+    pullStatus: 'PULLED',
+    assignedToUserId: null,
+    assignedTo: null,
+    assemblyStatus: 'PENDING',
+    completedAt: null,
+    openingNumber: '0019-EX',
+    building: 'A',
+    floor: '2',
+    leaf: null,
+    items: [
+      { id: 'i1', shopAssemblyOpeningId: 'o1', hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 2 },
+    ],
+    ...overrides,
+  };
+}
+
+const membersMock: MockedResponse = {
+  request: { query: GET_SHOP_ASSEMBLY_MEMBERS },
+  result: { data: { shopAssemblyMembers: MEMBERS } },
+};
+
+function assembleListMock(list: unknown[]): MockedResponse {
+  return { request: { query: GET_ASSEMBLE_LIST }, result: { data: { assembleList: list } } };
+}
+
+function renderPanel(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <ManagerAssignPanel />
+      </ToastProvider>
+    </MockedProvider>
+  );
+}
+
+async function pickMember(name: RegExp) {
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  const option = await screen.findByRole('option', { name });
+  fireEvent.click(option);
+}
+
+it('assigns selected openings to the chosen member with the right variables', async () => {
+  let capturedVars: unknown = null;
+  const assignMock: MockedResponse = {
+    request: {
+      query: ASSIGN_OPENINGS,
+      variables: { input: { openingIds: ['o1'], assignedToUserId: 'mgr', assignedTo: 'Jane Doe' } },
+    },
+    result: (vars: unknown) => {
+      capturedVars = vars;
+      return { data: { assignOpenings: [opening({ assignedToUserId: 'mgr', assignedTo: 'Jane Doe' })] } };
+    },
+  };
+
+  renderPanel([
+    assembleListMock([opening()]),
+    membersMock,
+    assignMock,
+    assembleListMock([opening({ assignedToUserId: 'mgr', assignedTo: 'Jane Doe' })]), // refetch after assign
+  ]);
+
+  // The unassigned pulled opening is listed.
+  const checkbox = await screen.findByLabelText('select 0019-EX');
+  fireEvent.click(checkbox);
+
+  await pickMember(/Jane Doe/);
+
+  const assignBtn = screen.getByRole('button', { name: /Assign 1 to Jane Doe/i });
+  fireEvent.click(assignBtn);
+
+  await waitFor(() => expect(capturedVars).toEqual({
+    input: { openingIds: ['o1'], assignedToUserId: 'mgr', assignedTo: 'Jane Doe' },
+  }));
+});
+
+it('keeps the assign button disabled until a member and an opening are both selected', async () => {
+  renderPanel([assembleListMock([opening()]), membersMock]);
+
+  // Button starts disabled (nothing selected).
+  const btn = await screen.findByRole('button', { name: /Assign/i });
+  expect(btn).toBeDisabled();
+
+  // Select an opening only -> still disabled (no member).
+  fireEvent.click(await screen.findByLabelText('select 0019-EX'));
+  expect(screen.getByRole('button', { name: /Assign/i })).toBeDisabled();
+
+  // Pick a member -> now enabled.
+  await pickMember(/Jane Doe/);
+  await waitFor(() => expect(screen.getByRole('button', { name: /Assign 1 to Jane Doe/i })).toBeEnabled());
+});
+
+it('shows an empty state when there are no unassigned pulled openings', async () => {
+  renderPanel([
+    assembleListMock([opening({ assignedToUserId: 'wk', assignedTo: 'Bob Lee' })]),
+    membersMock,
+  ]);
+
+  expect(await screen.findByText(/No unassigned pulled openings available/i)).toBeInTheDocument();
+  // The already-assigned opening surfaces in the per-member load summary instead.
+  expect(await screen.findByText(/Bob Lee: 1/)).toBeInTheDocument();
+});

--- a/frontend/src/modules/shop-assembly/openingFilters.ts
+++ b/frontend/src/modules/shop-assembly/openingFilters.ts
@@ -1,0 +1,13 @@
+// Shared shop-assembly opening predicates so the manager assign panel and the self-claim board agree
+// on which openings are assignable (#330 review). Change the definition here, not in each view.
+
+interface AssignableFields {
+  pullStatus: string;
+  assignedToUserId: string | null;
+  assemblyStatus: string;
+}
+
+/** A pulled opening not yet claimed by anyone and still pending assembly - the assignable pool. */
+export function isAvailableForAssignment(o: AssignableFields): boolean {
+  return o.pullStatus === 'PULLED' && o.assignedToUserId === null && o.assemblyStatus === 'PENDING';
+}


### PR DESCRIPTION
shop-assembly manager can now assign unassigned pulled openings to other team members.

Closes #330.

/app/shop-assembly/assignments (issue's URL) has trailing "s" -> falls through wildcard redirect -> empty stub.
real route /app/shop-assembly/assign, already renders self-claim drag-drop board. this PR adds on top.

backend
- shopAssemblyMembers query -> shop-assembly members holding "Shop Assembly User" or "Shop Assembly Manager", from Clerk list_users().
- require_role(info, role) auth helper gates it; only "Shop Assembly Manager" enumerates members.
- user_repository.list_shop_assembly_members() filters list_users() by role.
- assignOpenings unchanged; accepts arbitrary assignedToUserId + display name.

frontend
- ManagerAssignPanel on Assignments board. multi-select unassigned pulled openings -> pick team member -> assign one or more. per-member current-load summary.
- mounted above self-claim board, gated to "Shop Assembly Manager". plain "Shop Assembly User" sees board only.
- assigned work -> member's My Work (myWork filters by assignedToUserId).

decisions
- accept-flow assignment rejected; openings not PULLED until warehouse pulls. Assignments page is home.
- reassign/unassign of assigned openings out of scope; panel lists only unassigned. removeOpeningFromUser exists for fast-follow.
