### PR TITLE
ship assembled door leaves through the Shipping Out import (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ monorepo layout
 - docs/ - design docs
 
 frontend and backend talk through a single /graphql endpoint.
+
+core domain rule: hardware is procured per opening, loses that identity when it is received into
+fungible inventory, and gets it back when a pull request tags it onto a specific door leaf of a
+specific opening. read docs/HARDWARE_IDENTITY_LIFECYCLE.md before working on receiving, pull
+requests, shop assembly or shipping out.

--- a/backend/alembic/versions/058_shipping_out_request_item_leaf.py
+++ b/backend/alembic/versions/058_shipping_out_request_item_leaf.py
@@ -1,0 +1,30 @@
+"""Shipping-out request items carry the door leaf (#335)
+
+Revision ID: 058
+Revises: 057
+Create Date: 2026-07-24
+
+Issue #335: the Shipping Out import can now request an assembled door leaf (an OPENING_ITEM line
+pointing at an OpeningItem). Snapshot the leaf on the request line so the pre-accept Shipping
+Requests inbox can tell a pair's two lines apart; accept copies it onto pull_request_items.leaf.
+
+Additive, nullable smallint, no backfill. #311's revision 056 added leaf to six tables and skipped
+this one; existing rows stay null and accept falls back to reading OpeningItem.leaf.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "058"
+down_revision = "057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("shipping_out_request_items", sa.Column("leaf", sa.SmallInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("shipping_out_request_items", "leaf")

--- a/backend/app/graphql/import.graphql
+++ b/backend/app/graphql/import.graphql
@@ -93,7 +93,10 @@ input ShippingOutPRDraftInput {
 input ShippingOutPRDraftItemInput {
   item_type: PullRequestItemType!
   opening_number: String!
+  # Required on OPENING_ITEM lines (#335): must name an IN_INVENTORY OpeningItem of this project.
   opening_item_id: ID
+  # Door leaf the OPENING_ITEM line ships (#335). Null on LOOSE.
+  leaf: Int
   hardware_category: String
   product_code: String
   requested_quantity: Int!

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -17,6 +17,8 @@ type ShippingOutRequestItem {
   itemType: PullRequestItemType!
   openingNumber: String!
   openingItemId: ID
+  # Door leaf (#335): set on OPENING_ITEM lines from the assembled OpeningItem, null on LOOSE.
+  leaf: Int
   hardwareCategory: String
   productCode: String
   requestedQuantity: Int!

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -108,6 +108,8 @@ type PullRequestItem {
   item_type: PullRequestItemType!
   opening_number: String!
   opening_item_id: ID
+  # Door leaf this pull line is for (#311). Null = legacy / leaf-agnostic.
+  leaf: Int
   hardware_category: String
   product_code: String
   requested_quantity: Int!

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -8,6 +8,14 @@ from . import Base
 
 
 class InventoryLocation(Base):
+    """A quantity of one product sitting in one warehouse location.
+
+    Note what is NOT here: no opening, no door leaf. Hardware is procured per opening, but receiving
+    deliberately drops that identity and inventory becomes fungible - a hinge is a hinge. Identity is
+    re-attached later, by the pull request that tags a quantity onto a specific leaf of a specific
+    opening. See docs/HARDWARE_IDENTITY_LIFECYCLE.md before adding an opening or leaf column here.
+    """
+
     __tablename__ = "inventory_locations"
     __table_args__ = (
         Index(

--- a/backend/app/models/opening_item.py
+++ b/backend/app/models/opening_item.py
@@ -9,6 +9,15 @@ from .enums import OpeningItemState
 
 
 class OpeningItem(Base):
+    """An assembled door leaf sitting in the warehouse: the pull request's tag made physical.
+
+    Shop assembly completing a work unit turns tagged quantities into one of these per leaf, with
+    OpeningItemHardware recording what actually went on. From here the leaf is its own object with
+    its own state and location, and it ships as itself - an OPENING_ITEM pull line naming this row,
+    never as loose hardware, because its hardware left fungible inventory at assembly.
+    See docs/HARDWARE_IDENTITY_LIFECYCLE.md.
+    """
+
     __tablename__ = "opening_items"
     __table_args__ = (
         Index("ix_opening_items_project_state", "project_id", "state"),

--- a/backend/app/models/pull_request.py
+++ b/backend/app/models/pull_request.py
@@ -45,6 +45,15 @@ class PullRequest(Base):
 
 
 class PullRequestItem(Base):
+    """One tag: this quantity of this product now belongs to this door leaf of this opening.
+
+    This row is where hardware regains the opening identity that receiving dropped (inventory is
+    fungible - see docs/HARDWARE_IDENTITY_LIFECYCLE.md). The two item types tag differently:
+    LOOSE claims fungible stock, so approval deducts inventory FIFO and is gated on sufficiency;
+    OPENING_ITEM moves an assembled leaf that was already tagged at shop assembly, so approval
+    deducts nothing and only locks the OpeningItem row.
+    """
+
     __tablename__ = "pull_request_items"
     __table_args__ = (
         Index("ix_pull_request_items_pull_request", "pull_request_id"),

--- a/backend/app/models/shipping_out_request.py
+++ b/backend/app/models/shipping_out_request.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -64,6 +64,11 @@ class ShippingOutRequestItem(Base):
     )
     opening_number: Mapped[str] = mapped_column(String, nullable=False)
     opening_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("opening_items.id"), nullable=True)
+    # Door leaf this request line is for (#311/#335): OPENING_ITEM lines snapshot the assembled
+    # OpeningItem.leaf so a pair reads as two distinct lines before anyone accepts the request.
+    # LOOSE lines are null - loose stock is fungible and the shipping selection aggregates it
+    # leaf-agnostically. Copied onto PullRequestItem.leaf at accept.
+    leaf: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     hardware_category: Mapped[str | None] = mapped_column(String, nullable=True)
     product_code: Mapped[str | None] = mapped_column(String, nullable=True)
     requested_quantity: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -685,14 +685,23 @@ def finalize_import_session(
 
             for item_input in pr_draft.get("items", []):
                 item_type = PullRequestItemType(item_input["item_type"])
+                opening_item_id = item_input.get("opening_item_id")
+                # #335: an OPENING_ITEM line ships an already-assembled leaf, so it MUST name the
+                # OpeningItem. Without one the line is inert - approve skips it and complete never
+                # flips a leaf to SHIP_READY - so reject it here instead of minting a dead request.
+                if item_type == PullRequestItemType.OPENING_ITEM and not opening_item_id:
+                    raise ValidationError(
+                        f"Shipping-out request {pr_draft['request_number']}: an assembled-opening line "
+                        f"for opening {item_input['opening_number']} must reference an opening item",
+                        field="opening_item_id",
+                    )
                 req_item = ShippingOutRequestItemModel(
                     id=uuid.uuid4(),
                     shipping_out_request_id=req.id,
                     item_type=item_type,
                     opening_number=item_input["opening_number"],
-                    opening_item_id=(
-                        uuid.UUID(str(item_input["opening_item_id"])) if item_input.get("opening_item_id") else None
-                    ),
+                    opening_item_id=(uuid.UUID(str(opening_item_id)) if opening_item_id else None),
+                    leaf=item_input.get("leaf"),
                     hardware_category=item_input.get("hardware_category"),
                     product_code=item_input.get("product_code"),
                     requested_quantity=item_input.get("requested_quantity", 1),

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -309,6 +309,11 @@ def reconcile_schedule(
     return results
 
 
+def _leaf_label(oi: OpeningItemModel) -> str:
+    """ "Opening 0019-EX Leaf 2", or just the opening number for a legacy whole-opening unit."""
+    return f"Opening {oi.opening_number} Leaf {oi.leaf}" if oi.leaf is not None else f"Opening {oi.opening_number}"
+
+
 def _apply_opening_fields(opening: OpeningModel, opening_input: dict) -> None:
     """Copy mutable fields from input dict onto an Opening model."""
     opening.building = opening_input.get("building")
@@ -660,6 +665,24 @@ def finalize_import_session(
     # PullRequest. A signed-in user accepts it later, which mints the warehouse PullRequest.
     created_shipping_requests: list[ShippingOutRequestModel] = []
     if shipping_pr_drafts:
+        # #335: pre-load every OpeningItem an OPENING_ITEM line points at, so each line can be
+        # checked against the real row rather than trusting the id the client sent. One query for
+        # the whole finalize.
+        referenced_oi_ids = {
+            uuid.UUID(str(item["opening_item_id"]))
+            for pr_draft in shipping_pr_drafts
+            for item in pr_draft.get("items", [])
+            if item.get("opening_item_id")
+        }
+        opening_items_by_id: dict[uuid.UUID, OpeningItemModel] = {}
+        if referenced_oi_ids:
+            opening_items_by_id = {
+                oi.id: oi
+                for oi in session.scalars(
+                    select(OpeningItemModel).where(OpeningItemModel.id.in_(referenced_oi_ids))
+                ).all()
+            }
+
         for pr_draft in shipping_pr_drafts:
             # Validate uniqueness against the request entity's own number space.
             existing_req = session.scalars(
@@ -686,15 +709,29 @@ def finalize_import_session(
             for item_input in pr_draft.get("items", []):
                 item_type = PullRequestItemType(item_input["item_type"])
                 opening_item_id = item_input.get("opening_item_id")
-                # #335: an OPENING_ITEM line ships an already-assembled leaf, so it MUST name the
-                # OpeningItem. Without one the line is inert - approve skips it and complete never
-                # flips a leaf to SHIP_READY - so reject it here instead of minting a dead request.
-                if item_type == PullRequestItemType.OPENING_ITEM and not opening_item_id:
-                    raise ValidationError(
-                        f"Shipping-out request {pr_draft['request_number']}: an assembled-opening line "
-                        f"for opening {item_input['opening_number']} must reference an opening item",
-                        field="opening_item_id",
-                    )
+                # #335: an OPENING_ITEM line ships an already-assembled leaf, so it MUST name a real
+                # OpeningItem of this project that is still in inventory. An id that is missing,
+                # foreign, or already pulled/shipped would mint a line that either does nothing
+                # (approve skips it, complete never flips a leaf) or moves someone else's leaf.
+                if item_type == PullRequestItemType.OPENING_ITEM:
+                    label = f"Shipping-out request {pr_draft['request_number']}, opening {item_input['opening_number']}"
+                    if not opening_item_id:
+                        raise ValidationError(
+                            f"{label}: an assembled-opening line must reference an opening item",
+                            field="opening_item_id",
+                        )
+                    oi = opening_items_by_id.get(uuid.UUID(str(opening_item_id)))
+                    if oi is None or oi.project_id != project.id:
+                        raise ValidationError(
+                            f"{label}: opening item {opening_item_id} does not belong to this project",
+                            field="opening_item_id",
+                        )
+                    if oi.state != OpeningItemState.IN_INVENTORY:
+                        raise ValidationError(
+                            f"{label}: {_leaf_label(oi)} is {oi.state.value}, not in inventory, so it "
+                            f"cannot be requested for shipping",
+                            field="opening_item_id",
+                        )
                 req_item = ShippingOutRequestItemModel(
                     id=uuid.uuid4(),
                     shipping_out_request_id=req.id,

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -595,6 +595,17 @@ def accept_shipping_out_request(
     session.add(pr)
     session.flush()
 
+    # Leaf fallback (#335): requests written before shipping_out_request_items.leaf existed carry a
+    # null leaf, so read it off the OpeningItem they point at. One grouped query, not one per line.
+    unleafed_oi_ids = {i.opening_item_id for i in req.items if i.opening_item_id is not None and i.leaf is None}
+    leaf_by_opening_item: dict[uuid.UUID, int | None] = {}
+    if unleafed_oi_ids:
+        leaf_by_opening_item = dict(
+            session.execute(
+                select(OpeningItemModel.id, OpeningItemModel.leaf).where(OpeningItemModel.id.in_(unleafed_oi_ids))
+            ).all()
+        )
+
     for item in req.items:
         session.add(
             PullRequestItemModel(
@@ -603,6 +614,9 @@ def accept_shipping_out_request(
                 item_type=item.item_type,
                 opening_number=item.opening_number,
                 opening_item_id=item.opening_item_id,
+                # Snapshot the door leaf (#311/#335) so a leaf-1 pull reads distinct from a leaf-2 pull,
+                # mirroring what the shop-assembly accept does with ShopAssemblyOpening.leaf.
+                leaf=item.leaf if item.leaf is not None else leaf_by_opening_item.get(item.opening_item_id),
                 hardware_category=item.hardware_category,
                 product_code=item.product_code,
                 requested_quantity=item.requested_quantity,

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -280,11 +280,14 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestMode
 
     # Source-specific side effects
     if pr.source == PullRequestSource.SHIPPING_OUT:
-        # For each Opening_Item item, set the OpeningItem state to Ship_Ready
+        # For each Opening_Item item, set the OpeningItem state to Ship_Ready.
+        # Only from IN_INVENTORY (#335): a leaf that already shipped must not be walked back to
+        # SHIP_READY by a duplicate or stale line, because get_ship_ready_items would list it again
+        # and confirm_shipment's SHIP_READY check would pass, shipping one physical leaf twice.
         for item in pr.items:
             if item.item_type == PullRequestItemType.OPENING_ITEM and item.opening_item_id is not None:
                 oi = session.get(OpeningItemModel, item.opening_item_id)
-                if oi is not None:
+                if oi is not None and oi.state == OpeningItemState.IN_INVENTORY:
                     oi.state = OpeningItemState.SHIP_READY
 
     elif pr.source == PullRequestSource.SHOP_ASSEMBLY:

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -507,6 +507,7 @@ def shipping_out_request_item_to_type(item) -> ShippingOutRequestItem:
         item_type=item.item_type,
         opening_number=item.opening_number,
         opening_item_id=strawberry.ID(str(item.opening_item_id)) if item.opening_item_id else None,
+        leaf=item.leaf,
         hardware_category=item.hardware_category,
         product_code=item.product_code,
         requested_quantity=item.requested_quantity,

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -190,6 +190,7 @@ class ImportMutations:
                             "item_type": item.item_type.value,
                             "opening_number": item.opening_number,
                             "opening_item_id": str(item.opening_item_id) if item.opening_item_id else None,
+                            "leaf": item.leaf,
                             "hardware_category": item.hardware_category,
                             "product_code": item.product_code,
                             "requested_quantity": item.requested_quantity,

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -123,6 +123,8 @@ class ShippingOutPRDraftItemInput:
     item_type: PullRequestItemType
     opening_number: str
     opening_item_id: strawberry.ID | None = None
+    # Door leaf (#335): set on OPENING_ITEM lines from the assembled OpeningItem. Null on LOOSE.
+    leaf: int | None = None
     hardware_category: str | None = None
     product_code: str | None = None
     requested_quantity: int = 1

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -559,6 +559,8 @@ class ShippingOutRequestItem:
     item_type: PullRequestItemType
     opening_number: str
     opening_item_id: strawberry.ID | None
+    # Door leaf this request line is for (#335): 1 or 2 on an OPENING_ITEM line, null on LOOSE.
+    leaf: int | None
     hardware_category: str | None
     product_code: str | None
     requested_quantity: int

--- a/backend/tests/test_accept_requests.py
+++ b/backend/tests/test_accept_requests.py
@@ -21,7 +21,7 @@ from app.models.enums import (
     ShopAssemblyRequestStatus,
 )
 from app.models.inventory import InventoryLocation
-from app.models.opening_item import OpeningItem
+from app.models.opening_item import OpeningItem, OpeningItemHardware
 from app.models.project import Opening, Project
 from app.models.pull_request import PullRequest, PullRequestItem
 from app.models.shop_assembly import ShopAssemblyOpening
@@ -32,6 +32,7 @@ from app.repositories import (
     shop_assembly_repository,
     warehouse_admin_repository,
 )
+from app.repositories import warehouse as warehouse_repository
 
 
 def _make_project(session) -> Project:
@@ -87,6 +88,62 @@ def _finalize_shop_assembly(session, project, *, code="HG-100", qty=2, opening_n
                     "opening_number": opening_number,
                     "items": [{"hardware_category": "HINGE", "product_code": code, "quantity": qty}],
                 },
+            ],
+        },
+    )
+
+
+def _make_assembled_leaf(session, project, opening, *, leaf, code="HG-100", category="HINGE"):
+    """An assembled door leaf sitting in inventory: what shop assembly leaves behind (#311)."""
+    oi = OpeningItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=opening.id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
+        opening_number=opening.opening_number,
+        leaf=leaf,
+        quantity=1,
+        assembly_completed_at=datetime.utcnow(),
+        state=OpeningItemState.IN_INVENTORY,
+    )
+    session.add(oi)
+    session.flush()
+    session.add(
+        OpeningItemHardware(
+            id=uuid.uuid4(),
+            opening_item_id=oi.id,
+            product_code=code,
+            hardware_category=category,
+            quantity=1,
+        )
+    )
+    session.flush()
+    return oi
+
+
+def _finalize_shipping_leaves(session, project, opening_items, *, send_leaf=True):
+    """Finalize a shipping-out request made of OPENING_ITEM lines, one per assembled leaf (#335)."""
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [],
+            "hardware_items": [],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                    "requested_by": "importer",
+                    "items": [
+                        {
+                            "item_type": "OPENING_ITEM",
+                            "opening_number": oi.opening_number,
+                            "opening_item_id": str(oi.id),
+                            "leaf": oi.leaf if send_leaf else None,
+                            "requested_quantity": 1,
+                        }
+                        for oi in opening_items
+                    ],
+                }
             ],
         },
     )
@@ -237,6 +294,125 @@ def test_reject_shipping_out_request(db_session):
     assert returned.rejection_reason == "cancelled"  # trimmed
     assert returned.pull_request_id is None
     assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number)) is None
+
+
+# --- #335 assembled door leaves ship as OPENING_ITEM lines -----------------------------------
+
+
+def _seed_pair(session, *, opening_number="0019-EX"):
+    """A project whose opening_number is a pair with both leaves assembled and in inventory."""
+    project = _make_project(session)
+    session.flush()
+    import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": opening_number, "leaf_count": 2}],
+            "hardware_items": [],
+        },
+    )
+    session.flush()
+    opening = session.scalar(
+        select(Opening).where(Opening.project_id == project.id, Opening.opening_number == opening_number)
+    )
+    leaf1 = _make_assembled_leaf(session, project, opening, leaf=1)
+    leaf2 = _make_assembled_leaf(session, project, opening, leaf=2)
+    return project, leaf1, leaf2
+
+
+def test_accept_shipping_out_carries_leaf_onto_opening_item_pull_lines(db_session):
+    """A pair yields two distinguishable pull lines, each naming its own assembled leaf."""
+    project, leaf1, leaf2 = _seed_pair(db_session)
+    result = _finalize_shipping_leaves(db_session, project, [leaf1, leaf2])
+    req = result["shipping_out_requests"][0]
+    db_session.flush()
+
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req.request_number))
+    assert pr.source == PullRequestSource.SHIPPING_OUT
+    pr_items = db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all()
+    assert len(pr_items) == 2
+    assert {i.item_type for i in pr_items} == {PullRequestItemType.OPENING_ITEM}
+    # The OpeningItem id survives the hop: without it approve skips the line and complete never
+    # flips a leaf to SHIP_READY, which is the #335 dead end.
+    assert {i.opening_item_id for i in pr_items} == {leaf1.id, leaf2.id}
+    assert sorted(i.leaf for i in pr_items) == [1, 2]
+
+
+def test_accept_shipping_out_falls_back_to_opening_item_leaf(db_session):
+    """Requests written before shipping_out_request_items.leaf existed still label their leaves."""
+    project, leaf1, leaf2 = _seed_pair(db_session)
+    result = _finalize_shipping_leaves(db_session, project, [leaf1, leaf2], send_leaf=False)
+    req = result["shipping_out_requests"][0]
+    db_session.flush()
+    assert {i.leaf for i in req.items} == {None}
+
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req.request_number))
+    pr_items = db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all()
+    assert sorted(i.leaf for i in pr_items) == [1, 2]
+
+
+def test_opening_item_shipping_line_approves_and_pulls_leaves_to_ship_ready(db_session):
+    """The whole #335 chain: an assembled-leaf request approves with no loose stock and pulls."""
+    project, leaf1, leaf2 = _seed_pair(db_session)
+    result = _finalize_shipping_leaves(db_session, project, [leaf1, leaf2])
+    req = result["shipping_out_requests"][0]
+    db_session.flush()
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req.request_number))
+
+    # No inventory was seeded: an OPENING_ITEM line claims nothing from fungible stock, so the
+    # sufficiency gate has nothing to fail on. A LOOSE line here would report INSUFFICIENT.
+    _, outcome, _, shortfalls = warehouse_repository.approve_pull_request(db_session, pr.id, "puller")
+    db_session.flush()
+    assert outcome == "APPROVED"
+    assert shortfalls == []
+    assert pr.status == PullRequestStatus.IN_PROGRESS
+
+    warehouse_repository.complete_pull_request(db_session, pr.id)
+    db_session.flush()
+    db_session.refresh(leaf1)
+    db_session.refresh(leaf2)
+    assert leaf1.state == OpeningItemState.SHIP_READY
+    assert leaf2.state == OpeningItemState.SHIP_READY
+
+
+def test_finalize_rejects_opening_item_line_without_an_opening_item(db_session):
+    """An OPENING_ITEM line with no OpeningItem is inert downstream, so it never gets persisted."""
+    project = _make_project(db_session)
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        import_repository.finalize_import_session(
+            db_session,
+            {
+                "project_id": str(project.id),
+                "openings": [],
+                "hardware_items": [],
+                "shipping_out_pr_drafts": [
+                    {
+                        "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                        "requested_by": "importer",
+                        "items": [
+                            {
+                                "item_type": "OPENING_ITEM",
+                                "opening_number": "0019-EX",
+                                "opening_item_id": None,
+                                "requested_quantity": 1,
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+    assert excinfo.value.field == "opening_item_id"
+    assert "0019-EX" in excinfo.value.message
 
 
 # --- REQ-5 assembled-opening guard -----------------------------------------------------------

--- a/backend/tests/test_accept_requests.py
+++ b/backend/tests/test_accept_requests.py
@@ -509,6 +509,56 @@ def test_finalize_rejects_opening_item_line_without_an_opening_item(db_session):
     assert "0019-EX" in excinfo.value.message
 
 
+def test_finalize_rejects_opening_item_from_another_project(db_session):
+    """The client sends the OpeningItem id, so the id is checked against the row, not trusted."""
+    _, other_leaf, _ = _seed_pair(db_session)
+    stranger = _make_project(db_session)
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_shipping_leaves(db_session, stranger, [other_leaf])
+    assert excinfo.value.field == "opening_item_id"
+    assert "does not belong to this project" in excinfo.value.message
+
+
+def test_finalize_rejects_a_leaf_that_is_no_longer_in_inventory(db_session):
+    """A leaf already pulled or shipped cannot be requested again by a stale wizard tab."""
+    project, leaf1, _ = _seed_pair(db_session)
+    leaf1.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_shipping_leaves(db_session, project, [leaf1])
+    assert excinfo.value.field == "opening_item_id"
+    assert "Leaf 1" in excinfo.value.message
+    assert "SHIPPED_OUT" in excinfo.value.message
+
+
+def test_complete_never_walks_a_shipped_leaf_back_to_ship_ready(db_session):
+    """Completing a stale pull must not resurrect a leaf that has already gone out the door."""
+    project, leaf1, leaf2 = _seed_pair(db_session)
+    result = _finalize_shipping_leaves(db_session, project, [leaf1, leaf2])
+    req = result["shipping_out_requests"][0]
+    db_session.flush()
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req.request_number))
+    warehouse_repository.approve_pull_request(db_session, pr.id, "puller")
+    db_session.flush()
+
+    # Leaf 1 ships out from an earlier slip while this pull is still open.
+    leaf1.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    warehouse_repository.complete_pull_request(db_session, pr.id)
+    db_session.flush()
+    db_session.refresh(leaf1)
+    db_session.refresh(leaf2)
+    # Shipped leaf stays shipped; the untouched one still completes normally.
+    assert leaf1.state == OpeningItemState.SHIPPED_OUT
+    assert leaf2.state == OpeningItemState.SHIP_READY
+
+
 # --- shipping-out reopen (#325) --------------------------------------------------------------
 
 

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -1,0 +1,98 @@
+# Hardware Identity Lifecycle
+
+How a piece of hardware gains, loses, and regains its association with a specific door leaf of a
+specific opening. This is the domain rule the rest of the system is built on, and most of the
+lifecycle bugs found so far have been a violation of it.
+
+## The rule
+
+**A pull request is the act of tagging hardware onto a door leaf.**
+
+Hardware enters the system with an opening identity, loses it in the warehouse, and gets it back
+when a pull request is created. That is true of both pull request sources: shop assembly and
+shipping out. Neither is a special case.
+
+## The three stages
+
+### 1. Identity present: schedule and procurement
+
+The TITAN hardware schedule is written per opening, and per door leaf within an opening. Import
+preserves both:
+
+- `openings.leaf_count` - 1 (single) or 2 (pair). The "N of M leaves" denominator.
+- `hardware_items.opening_id` - which opening needs this item.
+- `hardware_items.leaf` - which leaf of that opening, from the `Leaf` attribute on the TITAN
+  Material_List (cross-checked against the material id token).
+
+The PO module procures against these rows. A PO line item exists because some opening needs it.
+
+### 2. Identity dropped: receiving into inventory
+
+Receiving deliberately throws the opening away. `InventoryLocation` is keyed by
+`(project_id, warehouse_id, hardware_category, product_code)` and has **no opening or leaf column**.
+It keeps only an origin FK (PO line item, stock item, or shipment return item) for costing and audit.
+
+Inventory is fungible: a hinge is a hinge. Hardware received against opening 101's PO can be used on
+opening 205. This is intentional, not an oversight. It is also why
+[REALLOCATION_MODULE.md](REALLOCATION_MODULE.md) exists: once an opening ships short, the hardware
+that could fill the gap is sitting in general inventory with nothing tying it to that opening.
+
+The only surviving identity at this stage is the project.
+
+### 3. Identity restored: the pull request
+
+Creating a shop assembly request or a shipping out request is what re-attaches identity. Each
+`pull_request_items` row is a tag:
+
+- `opening_number` - which opening the quantity is now committed to.
+- `leaf` - which door leaf of it.
+- `hardware_category` + `product_code` + `requested_quantity` - what is being claimed from fungible
+  stock.
+
+Approving the pull request deducts that quantity FIFO from `inventory_locations` rows. The physical
+hardware never changed; what changed is that it now belongs to a leaf.
+
+This is why both request types are created from the hardware schedule through **Start a Task**. The
+schedule is the only thing that knows which leaf of which opening a quantity is owed to. Inventory
+cannot answer that question, because it deliberately forgot.
+
+### 4. The tag materializes
+
+- **Shop assembly complete** - the tag becomes physical. An `OpeningItem` row is created per leaf
+  (`opening_items.leaf`), with `OpeningItemHardware` recording what was actually installed on it.
+  From here the leaf is a real object with its own state and warehouse location.
+- **Shipping out complete** - the leaf moves to `SHIP_READY`, then a confirmed shipment writes a
+  `PackingSlipItem` that snapshots the leaf permanently.
+
+## Corollary: LOOSE vs OPENING_ITEM pull lines
+
+Both pull request sources use `pull_request_items`, but the two `item_type` values do fundamentally
+different things:
+
+- `LOOSE` - tags fungible inventory onto a leaf for the first time. Approving it deducts stock, so it
+  is gated on inventory sufficiency.
+- `OPENING_ITEM` - moves a leaf that was **already tagged** at shop assembly. The hardware left
+  fungible inventory when it was installed. Approving it deducts nothing and locks the `OpeningItem`
+  row instead; there is no stock to check.
+
+Confusing the two is issue #335: the Shipping Out import emitted `LOOSE` lines for hardware that had
+already been assembled onto a leaf, so the warehouse pull asked general inventory for hardware that
+had left it, found zero, and blocked approval forever. An assembled leaf ships as an `OPENING_ITEM`
+line naming its `OpeningItem`, never as loose hardware.
+
+The same asymmetry explains the shipping wizard's selection UI: assembled leaves are listed per
+`OpeningItem` (one row per leaf, because each leaf is its own physical object), while loose hardware
+is listed leaf-agnostically per `(opening, category, product)` (because fungible stock carries no
+leaf until a pull tags it onto one).
+
+## Where this is enforced in code
+
+| Stage | Code |
+| --- | --- |
+| Leaf parsed from TITAN | `frontend/src/workers/parserLogic.ts` (`leafFromMaterialId`, ML-level `Leaf` attribute) |
+| Identity dropped | `backend/app/models/inventory.py` (`InventoryLocation`, no opening/leaf column) |
+| Tag written, shop assembly | `backend/app/repositories/shop_assembly_repository.py` (`accept_shop_assembly_request`) |
+| Tag written, shipping out | `backend/app/repositories/shipping_repository.py` (`accept_shipping_out_request`) |
+| Tag consumes stock | `backend/app/repositories/warehouse/pull_requests.py` (`approve_pull_request`, FIFO deduction) |
+| Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`) |
+| Tag shipped | `backend/app/repositories/shipping_repository.py` (`confirm_shipment` -> `PackingSlipItem.leaf`) |

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -87,6 +87,8 @@ export const GET_SHIPPING_OUT_REQUESTS = gql`
         id
         itemType
         openingNumber
+        openingItemId
+        leaf
         hardwareCategory
         productCode
         requestedQuantity

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -213,6 +213,7 @@ export const GET_PULL_REQUESTS = gql`
         itemType
         openingNumber
         openingItemId
+        leaf
         hardwareCategory
         productCode
         requestedQuantity
@@ -508,7 +509,7 @@ export const APPROVE_PULL_REQUEST = gql`
       pullRequest {
         id requestNumber projectId source status requestedBy assignedTo
         createdAt updatedAt approvedAt completedAt cancelledAt
-        items { id pullRequestId itemType openingNumber openingItemId hardwareCategory productCode requestedQuantity }
+        items { id pullRequestId itemType openingNumber openingItemId leaf hardwareCategory productCode requestedQuantity }
       }
       outcome
       notification {
@@ -526,7 +527,7 @@ export const COMPLETE_PULL_REQUEST = gql`
     completePullRequest(id: $id) {
       id requestNumber projectId source status requestedBy assignedTo
       createdAt updatedAt approvedAt completedAt cancelledAt
-      items { id pullRequestId itemType openingNumber openingItemId hardwareCategory productCode requestedQuantity }
+      items { id pullRequestId itemType openingNumber openingItemId leaf hardwareCategory productCode requestedQuantity }
     }
   }
 `;

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -24,7 +24,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { useLazyQuery, useMutation } from '@apollo/client/react';
+import { useLazyQuery, useMutation, useQuery } from '@apollo/client/react';
 import { useWizard } from '../../contexts/WizardContext';
 import { useToast } from '../../components/Toast';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -34,9 +34,17 @@ import { useHardwareScheduleParser } from '../../hooks/useHardwareScheduleParser
 import { useNavigate } from 'react-router-dom';
 import { GET_PROJECT_EXCLUDED_ITEMS, GET_PROJECT_HARDWARE_SCHEDULE, RECONCILE_SCHEDULE, FINALIZE_IMPORT_SESSION } from '../../graphql/import';
 import { GET_PROJECTS } from '../../graphql/shared';
+import { GET_OPENING_ITEMS } from '../../graphql/warehouse';
 import type { ClassificationRow } from './ClassificationGrid';
-import type { AggregatedHardwareItem, ImportPurpose, ReconciliationRow, ShippingPRDraft } from './types';
-import { aggregationKey, classificationKey, toClassificationInputs } from './types';
+import type {
+  AggregatedHardwareItem,
+  AssembledLeafCandidate,
+  ImportPurpose,
+  ReconciliationRow,
+  ShippingPRDraft,
+  ShippingPRItem,
+} from './types';
+import { aggregationKey, classificationKey, shippingPRItemKey, toClassificationInputs } from './types';
 import type { Project } from '../../types/project';
 import type { ProjectHardwareScheduleResponse } from './hydrateSchedule';
 import { mapScheduleResponseToParseResult } from './hydrateSchedule';
@@ -56,6 +64,16 @@ type StepId = 'upload' | 'purpose' | 'openings' | 'reconciliation'
 interface StepDescriptor {
   id: StepId;
   label: string;
+}
+
+/** The slice of GET_OPENING_ITEMS the shipping purpose reads (#335). */
+interface OpeningItemResponse {
+  id: string;
+  openingNumber: string;
+  leaf: number | null;
+  state: string;
+  assemblyCompletedAt: string;
+  installedHardware: Array<{ productCode: string; hardwareCategory: string; quantity: number }>;
 }
 
 // ---- Helpers ----
@@ -178,6 +196,15 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     projectHardwareSchedule: ProjectHardwareScheduleResponse | null;
   }>(GET_PROJECT_HARDWARE_SCHEDULE, { fetchPolicy: 'network-only' });
 
+  // Assembled units for the shipping purpose (#335). A door leaf only exists once shop assembly has
+  // built one, and it lives as an OpeningItem - the hardware schedule cannot supply it. Shipping an
+  // assembled leaf means naming that row, so read it from the warehouse's own list.
+  const { data: openingItemsData } = useQuery<{ openingItems: OpeningItemResponse[] }>(GET_OPENING_ITEMS, {
+    variables: { projectId: existingProjectId },
+    skip: !open || purpose !== 'shipping',
+    fetchPolicy: 'cache-and-network',
+  });
+
   // Eagerly fetch the persisted schedule on wizard open for re-import projects so the
   // upload step can show the "use last uploaded" picker (gated on hardware-item presence).
   useEffect(() => {
@@ -286,10 +313,13 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     }
 
     if (purpose === 'shipping') {
-      // SOR: only items that have RECEIVED or ASSEMBLED quantity
+      // SOR loose lines: RECEIVED quantity only (#335). ASSEMBLED quantity is no longer loose stock -
+      // it was tagged onto a door leaf at shop assembly and now ships as that leaf, selected from
+      // assembledLeafCandidates below. Offering it here too is what made the PR ask the warehouse for
+      // hardware that had already left inventory.
       const eligibleKeys = new Set<string>();
       for (const row of reconciliationRows) {
-        if ((row.status === 'RECEIVED' || row.status === 'ASSEMBLED') && row.quantity > 0) {
+        if (row.status === 'RECEIVED' && row.quantity > 0) {
           eligibleKeys.add(`${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`);
         }
       }
@@ -314,6 +344,47 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     }
     return Array.from(map.values());
   }, [reconFilteredHardwareItems]);
+
+  // ---- Shipping selection candidates (#335) ----
+
+  // Assembled door leaves the user can ship: one per OpeningItem still sitting IN_INVENTORY on a
+  // selected opening. SHIP_READY units are deliberately absent - they have already been pulled and
+  // are waiting on the Ship tab, so re-requesting them would be a second pull of the same leaf.
+  const assembledLeafCandidates = useMemo<AssembledLeafCandidate[]>(() => {
+    if (purpose !== 'shipping') return [];
+    return (openingItemsData?.openingItems ?? [])
+      .filter((oi) => oi.state === 'IN_INVENTORY' && selectedOpenings.has(oi.openingNumber))
+      .map((oi) => ({
+        id: oi.id,
+        openingNumber: oi.openingNumber,
+        leaf: oi.leaf,
+        assemblyCompletedAt: oi.assemblyCompletedAt,
+        installedHardware: oi.installedHardware ?? [],
+      }))
+      .sort(
+        (a, b) =>
+          a.openingNumber.localeCompare(b.openingNumber) || (a.leaf ?? 0) - (b.leaf ?? 0),
+      );
+  }, [purpose, openingItemsData, selectedOpenings]);
+
+  // Loose hardware the user can ship, quantity clamped to what reconciliation says is actually
+  // received and unpulled. Without the clamp a partly-received product would request its full
+  // schedule quantity and short the pull.
+  const looseShippingCandidates = useMemo<AggregatedHardwareItem[]>(() => {
+    if (purpose !== 'shipping' || !isReimport) return aggregatedHardwareItems;
+    const receivedByKey = new Map<string, number>();
+    for (const row of reconciliationRows) {
+      if (row.status !== 'RECEIVED' || row.quantity <= 0) continue;
+      const key = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
+      receivedByKey.set(key, (receivedByKey.get(key) ?? 0) + row.quantity);
+    }
+    return aggregatedHardwareItems
+      .map((hi) => {
+        const received = receivedByKey.get(aggregationKey(hi)) ?? 0;
+        return { ...hi, item_quantity: Math.min(hi.item_quantity, received) };
+      })
+      .filter((hi) => hi.item_quantity > 0);
+  }, [purpose, isReimport, aggregatedHardwareItems, reconciliationRows]);
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
@@ -547,38 +618,21 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     [],
   );
 
-  const toggleShippingPRItem = useCallback(
-    (prIndex: number, hi: AggregatedHardwareItem) => {
-      setShippingPRDrafts((prev) =>
-        prev.map((draft, i) => {
-          if (i !== prIndex) return draft;
-          const existingIdx = draft.items.findIndex(
-            (item) =>
-              item.openingNumber === hi.opening_number &&
-              item.productCode === hi.product_code &&
-              item.hardwareCategory === hi.hardware_category,
-          );
-          if (existingIdx >= 0) {
-            return { ...draft, items: draft.items.filter((_, idx) => idx !== existingIdx) };
-          }
-          return {
-            ...draft,
-            items: [
-              ...draft.items,
-              {
-                itemType: 'LOOSE' as const,
-                openingNumber: hi.opening_number,
-                hardwareCategory: hi.hardware_category,
-                productCode: hi.product_code,
-                requestedQuantity: hi.item_quantity,
-              },
-            ],
-          };
-        }),
-      );
-    },
-    [],
-  );
+  // Add or remove one already-built line on a draft (#335). The step decides what kind of line it
+  // is - an assembled leaf or loose hardware - so this no longer hard-codes LOOSE.
+  const toggleShippingPRItem = useCallback((prIndex: number, item: ShippingPRItem) => {
+    const key = shippingPRItemKey(item);
+    setShippingPRDrafts((prev) =>
+      prev.map((draft, i) => {
+        if (i !== prIndex) return draft;
+        const existingIdx = draft.items.findIndex((existing) => shippingPRItemKey(existing) === key);
+        if (existingIdx >= 0) {
+          return { ...draft, items: draft.items.filter((_, idx) => idx !== existingIdx) };
+        }
+        return { ...draft, items: [...draft.items, item] };
+      }),
+    );
+  }, []);
 
   // ---- Finalize ----
 
@@ -716,6 +770,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               itemType: item.itemType,
               openingNumber: item.openingNumber,
               openingItemId: item.openingItemId || null,
+              leaf: item.leaf ?? null,
               hardwareCategory: item.hardwareCategory || null,
               productCode: item.productCode || null,
               requestedQuantity: item.requestedQuantity,
@@ -1198,7 +1253,8 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
           {effectiveStepId === 'shipping-prs' && (
             <ShippingPRsStep
               shippingPRDrafts={shippingPRDrafts}
-              selectedHardwareItems={aggregatedHardwareItems}
+              assembledLeaves={assembledLeafCandidates}
+              looseItems={looseShippingCandidates}
               onAddPR={addShippingPR}
               onRemovePR={removeShippingPR}
               onUpdatePR={updateShippingPR}

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -34,7 +34,8 @@ import { useHardwareScheduleParser } from '../../hooks/useHardwareScheduleParser
 import { useNavigate } from 'react-router-dom';
 import { GET_PROJECT_EXCLUDED_ITEMS, GET_PROJECT_HARDWARE_SCHEDULE, RECONCILE_SCHEDULE, FINALIZE_IMPORT_SESSION } from '../../graphql/import';
 import { GET_PROJECTS } from '../../graphql/shared';
-import { GET_OPENING_ITEMS } from '../../graphql/warehouse';
+import { GET_OPENING_ITEMS, GET_PULL_REQUESTS } from '../../graphql/warehouse';
+import { GET_SHIPPING_OUT_REQUESTS } from '../../graphql/shipping';
 import type { ClassificationRow } from './ClassificationGrid';
 import type {
   AggregatedHardwareItem,
@@ -72,8 +73,22 @@ interface OpeningItemResponse {
   openingNumber: string;
   leaf: number | null;
   state: string;
-  assemblyCompletedAt: string;
-  installedHardware: Array<{ productCode: string; hardwareCategory: string; quantity: number }>;
+  installedHardware: Array<{ productCode: string; quantity: number }>;
+}
+
+/** The slices used to find leaves already claimed by an open request or pull (#335). */
+interface ShippingLineSummary {
+  itemType: string;
+  openingItemId: string | null;
+}
+
+interface PullRequestSummary {
+  status: string;
+  items: ShippingLineSummary[];
+}
+
+interface ShippingRequestSummary {
+  items: ShippingLineSummary[];
 }
 
 // ---- Helpers ----
@@ -199,9 +214,32 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   // Assembled units for the shipping purpose (#335). A door leaf only exists once shop assembly has
   // built one, and it lives as an OpeningItem - the hardware schedule cannot supply it. Shipping an
   // assembled leaf means naming that row, so read it from the warehouse's own list.
-  const { data: openingItemsData } = useQuery<{ openingItems: OpeningItemResponse[] }>(GET_OPENING_ITEMS, {
+  const shippingStepActive = open && purpose === 'shipping';
+  const {
+    data: openingItemsData,
+    loading: openingItemsLoading,
+    error: openingItemsError,
+  } = useQuery<{ openingItems: OpeningItemResponse[] }>(GET_OPENING_ITEMS, {
     variables: { projectId: existingProjectId },
-    skip: !open || purpose !== 'shipping',
+    skip: !shippingStepActive,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  // Leaves already spoken for. A leaf stays IN_INVENTORY for the whole life of an open shipping
+  // pull - its state only flips at complete - so state alone would re-offer a leaf that someone has
+  // already requested, and one physical leaf would be pulled twice. Loose lines need no equivalent:
+  // reconcile_schedule already moves quantity on an open SHIPPING_OUT pull out of the RECEIVED
+  // bucket, so it never reaches the loose list.
+  const { data: shippingPullsData } = useQuery<{ pullRequests: PullRequestSummary[] }>(GET_PULL_REQUESTS, {
+    variables: { projectId: existingProjectId, source: 'SHIPPING_OUT' },
+    skip: !shippingStepActive,
+    fetchPolicy: 'cache-and-network',
+  });
+  const { data: pendingShippingRequestsData } = useQuery<{
+    shippingOutRequests: ShippingRequestSummary[];
+  }>(GET_SHIPPING_OUT_REQUESTS, {
+    variables: { projectId: existingProjectId, status: 'PENDING', reopenableOnly: false },
+    skip: !shippingStepActive,
     fetchPolicy: 'cache-and-network',
   });
 
@@ -293,6 +331,20 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     return raw.map((r, i) => ({ ...r, id: `recon-${i}` }));
   }, [reconcileData]);
 
+  // Received-and-unpulled quantity per aggregation key. Both request purposes pull from it, and the
+  // shipping loose list also clamps its requested quantity to it, so it is indexed once.
+  // reconcile_schedule has already moved anything sitting on an open pull into its own bucket, so a
+  // RECEIVED row is genuinely available loose stock.
+  const receivedQtyByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of reconciliationRows) {
+      if (row.status !== 'RECEIVED' || row.quantity <= 0) continue;
+      const key = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
+      map.set(key, (map.get(key) ?? 0) + row.quantity);
+    }
+    return map;
+  }, [reconciliationRows]);
+
   // Filter items based on reconciliation data per purpose
   const reconFilteredHardwareItems = useMemo(() => {
     if (!isReimport) return selectedHardwareItems;
@@ -301,33 +353,16 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       return selectedHardwareItems.filter((hi) => selectedReconItems.has(aggregationKey(hi)));
     }
 
-    if (purpose === 'assembly') {
-      // SAR: only items that have RECEIVED quantity in reconciliation
-      const eligibleKeys = new Set<string>();
-      for (const row of reconciliationRows) {
-        if (row.status === 'RECEIVED' && row.quantity > 0) {
-          eligibleKeys.add(`${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`);
-        }
-      }
-      return selectedHardwareItems.filter((hi) => eligibleKeys.has(aggregationKey(hi)));
-    }
-
-    if (purpose === 'shipping') {
-      // SOR loose lines: RECEIVED quantity only (#335). ASSEMBLED quantity is no longer loose stock -
-      // it was tagged onto a door leaf at shop assembly and now ships as that leaf, selected from
-      // assembledLeafCandidates below. Offering it here too is what made the PR ask the warehouse for
-      // hardware that had already left inventory.
-      const eligibleKeys = new Set<string>();
-      for (const row of reconciliationRows) {
-        if (row.status === 'RECEIVED' && row.quantity > 0) {
-          eligibleKeys.add(`${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`);
-        }
-      }
-      return selectedHardwareItems.filter((hi) => eligibleKeys.has(aggregationKey(hi)));
+    // SAR, and SOR loose lines: received stock only. For shipping (#335) that means ASSEMBLED
+    // quantity is excluded - it was tagged onto a door leaf at shop assembly and now ships as that
+    // leaf, from assembledLeafCandidates below. Offering it here too is what made the pull request
+    // ask the warehouse for hardware that had already left inventory.
+    if (purpose === 'assembly' || purpose === 'shipping') {
+      return selectedHardwareItems.filter((hi) => receivedQtyByKey.has(aggregationKey(hi)));
     }
 
     return selectedHardwareItems;
-  }, [selectedHardwareItems, selectedReconItems, purpose, isReimport, reconciliationRows]);
+  }, [selectedHardwareItems, selectedReconItems, purpose, isReimport, receivedQtyByKey]);
 
   const aggregatedHardwareItems = useMemo<AggregatedHardwareItem[]>(() => {
     const map = new Map<string, AggregatedHardwareItem>();
@@ -347,44 +382,95 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // ---- Shipping selection candidates (#335) ----
 
+  // OpeningItems already named by a pending shipping request or an unfinished shipping pull. One
+  // physical leaf can only be pulled once, so these drop out of the offer list.
+  const claimedOpeningItemIds = useMemo(() => {
+    const claimed = new Set<string>();
+    const collect = (lines: ShippingLineSummary[]) => {
+      for (const line of lines) {
+        if (line.itemType === 'OPENING_ITEM' && line.openingItemId) claimed.add(line.openingItemId);
+      }
+    };
+    for (const pr of shippingPullsData?.pullRequests ?? []) {
+      if (pr.status === 'PENDING' || pr.status === 'IN_PROGRESS') collect(pr.items);
+    }
+    for (const req of pendingShippingRequestsData?.shippingOutRequests ?? []) collect(req.items);
+    return claimed;
+  }, [shippingPullsData, pendingShippingRequestsData]);
+
   // Assembled door leaves the user can ship: one per OpeningItem still sitting IN_INVENTORY on a
-  // selected opening. SHIP_READY units are deliberately absent - they have already been pulled and
-  // are waiting on the Ship tab, so re-requesting them would be a second pull of the same leaf.
+  // selected opening and not already claimed. SHIP_READY units are deliberately absent - they have
+  // already been pulled and are waiting on the Ship tab.
   const assembledLeafCandidates = useMemo<AssembledLeafCandidate[]>(() => {
     if (purpose !== 'shipping') return [];
     return (openingItemsData?.openingItems ?? [])
-      .filter((oi) => oi.state === 'IN_INVENTORY' && selectedOpenings.has(oi.openingNumber))
+      .filter(
+        (oi) =>
+          oi.state === 'IN_INVENTORY' &&
+          selectedOpenings.has(oi.openingNumber) &&
+          !claimedOpeningItemIds.has(oi.id),
+      )
       .map((oi) => ({
         id: oi.id,
         openingNumber: oi.openingNumber,
         leaf: oi.leaf,
-        assemblyCompletedAt: oi.assemblyCompletedAt,
         installedHardware: oi.installedHardware ?? [],
       }))
-      .sort(
-        (a, b) =>
-          a.openingNumber.localeCompare(b.openingNumber) || (a.leaf ?? 0) - (b.leaf ?? 0),
-      );
-  }, [purpose, openingItemsData, selectedOpenings]);
+      .sort((a, b) => a.openingNumber.localeCompare(b.openingNumber) || (a.leaf ?? 0) - (b.leaf ?? 0));
+  }, [purpose, openingItemsData, selectedOpenings, claimedOpeningItemIds]);
 
   // Loose hardware the user can ship, quantity clamped to what reconciliation says is actually
   // received and unpulled. Without the clamp a partly-received product would request its full
   // schedule quantity and short the pull.
   const looseShippingCandidates = useMemo<AggregatedHardwareItem[]>(() => {
     if (purpose !== 'shipping' || !isReimport) return aggregatedHardwareItems;
-    const receivedByKey = new Map<string, number>();
-    for (const row of reconciliationRows) {
-      if (row.status !== 'RECEIVED' || row.quantity <= 0) continue;
-      const key = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
-      receivedByKey.set(key, (receivedByKey.get(key) ?? 0) + row.quantity);
-    }
     return aggregatedHardwareItems
-      .map((hi) => {
-        const received = receivedByKey.get(aggregationKey(hi)) ?? 0;
-        return { ...hi, item_quantity: Math.min(hi.item_quantity, received) };
-      })
+      .map((hi) => ({
+        ...hi,
+        item_quantity: Math.min(hi.item_quantity, receivedQtyByKey.get(aggregationKey(hi)) ?? 0),
+      }))
       .filter((hi) => hi.item_quantity > 0);
-  }, [purpose, isReimport, aggregatedHardwareItems, reconciliationRows]);
+  }, [purpose, isReimport, aggregatedHardwareItems, receivedQtyByKey]);
+
+  // Every line the shipping step can currently offer, keyed the same way draft lines are.
+  const shippingCandidateKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const leaf of assembledLeafCandidates) {
+      keys.add(
+        shippingPRItemKey({
+          itemType: 'OPENING_ITEM',
+          openingNumber: leaf.openingNumber,
+          openingItemId: leaf.id,
+          requestedQuantity: 1,
+        }),
+      );
+    }
+    for (const hi of looseShippingCandidates) {
+      keys.add(
+        shippingPRItemKey({
+          itemType: 'LOOSE',
+          openingNumber: hi.opening_number,
+          hardwareCategory: hi.hardware_category,
+          productCode: hi.product_code,
+          requestedQuantity: hi.item_quantity,
+        }),
+      );
+    }
+    return keys;
+  }, [assembledLeafCandidates, looseShippingCandidates]);
+
+  // What the shipping step shows and what finalize submits: draft lines whose candidate is still on
+  // offer. A line can stop being offered because the user stepped back and de-selected its opening,
+  // or because someone else claimed the leaf; it then has no checkbox left to untick, so without
+  // this it would sit invisible on the draft and still be submitted. Derived rather than pruned in
+  // an effect, so re-selecting the opening brings the user's tick back.
+  const effectiveShippingPRDrafts = useMemo(() => {
+    if (purpose !== 'shipping') return shippingPRDrafts;
+    return shippingPRDrafts.map((draft) => {
+      const kept = draft.items.filter((item) => shippingCandidateKeys.has(shippingPRItemKey(item)));
+      return kept.length === draft.items.length ? draft : { ...draft, items: kept };
+    });
+  }, [purpose, shippingPRDrafts, shippingCandidateKeys]);
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
@@ -763,7 +849,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               })
           : null,
       shippingOutPrDrafts: purpose === 'shipping'
-        ? shippingPRDrafts.map((pr) => ({
+        ? effectiveShippingPRDrafts.map((pr) => ({
             requestNumber: pr.requestNumber,
             requestedBy: pr.requestedBy,
             items: pr.items.map((item) => ({
@@ -839,7 +925,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             })
         : null,
     };
-  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, shippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
+  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1252,9 +1338,11 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
           {/* ============ Step: Shipping PRs ============ */}
           {effectiveStepId === 'shipping-prs' && (
             <ShippingPRsStep
-              shippingPRDrafts={shippingPRDrafts}
+              shippingPRDrafts={effectiveShippingPRDrafts}
               assembledLeaves={assembledLeafCandidates}
               looseItems={looseShippingCandidates}
+              leavesLoading={openingItemsLoading}
+              leavesError={openingItemsError !== undefined}
               onAddPR={addShippingPR}
               onRemovePR={removeShippingPR}
               onUpdatePR={updateShippingPR}
@@ -1296,7 +1384,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
                 {purpose === 'shipping' && (
                   <Box sx={{ mb: 1 }}>
                     <Typography variant="body1">
-                      {shippingPRDrafts.filter((d) => d.requestNumber.trim() !== '').length} Shipping
+                      {effectiveShippingPRDrafts.filter((d) => d.requestNumber.trim() !== '').length} Shipping
                       Out Pull Request(s)
                     </Typography>
                   </Box>

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -22,6 +22,10 @@ interface ShippingPRsStepProps {
   assembledLeaves: AssembledLeafCandidate[];
   /** Loose hardware still in inventory for the selected openings. */
   looseItems: AggregatedHardwareItem[];
+  /** The assembled-unit lookup is still in flight, so an empty list means nothing yet. */
+  leavesLoading: boolean;
+  /** The assembled-unit lookup failed; an empty list here is not a real "nothing to ship". */
+  leavesError: boolean;
   onAddPR: () => void;
   onRemovePR: (index: number) => void;
   onUpdatePR: (index: number, field: 'requestNumber' | 'requestedBy', value: string) => void;
@@ -30,18 +34,26 @@ interface ShippingPRsStepProps {
   onBack: () => void;
 }
 
-/** "SG 56 AD8410, HNG-100 +2 more" - what is bolted onto this leaf, for recognising it at a glance. */
+/** "SG 56 AD8410 x2, HNG-100" - what is bolted onto this leaf, for recognising it at a glance. */
 function installedSummary(leaf: AssembledLeafCandidate): string {
-  const codes = leaf.installedHardware.map((h) => h.productCode);
-  if (codes.length === 0) return 'No hardware recorded';
-  const shown = codes.slice(0, 3).join(', ');
-  return codes.length > 3 ? `${shown} +${codes.length - 3} more` : shown;
+  if (leaf.installedHardware.length === 0) return 'No hardware recorded';
+  // Sum per product code: a leaf routinely carries several rows of the same item, and
+  // "HNG-100, HNG-100, HNG-100" tells the user nothing.
+  const byCode = new Map<string, number>();
+  for (const h of leaf.installedHardware) {
+    byCode.set(h.productCode, (byCode.get(h.productCode) ?? 0) + (h.quantity ?? 1));
+  }
+  const parts = Array.from(byCode.entries()).map(([code, qty]) => (qty > 1 ? `${code} x${qty}` : code));
+  const shown = parts.slice(0, 3).join(', ');
+  return parts.length > 3 ? `${shown} +${parts.length - 3} more` : shown;
 }
 
 export default function ShippingPRsStep({
   shippingPRDrafts,
   assembledLeaves,
   looseItems,
+  leavesLoading,
+  leavesError,
   onAddPR,
   onRemovePR,
   onUpdatePR,
@@ -57,13 +69,40 @@ export default function ShippingPRsStep({
     [shippingPRDrafts],
   );
 
-  const nothingToShip = assembledLeaves.length === 0 && looseItems.length === 0;
+  // An assembled leaf is one physical object, so it can sit on exactly one request. Loose hardware
+  // is fungible and is not restricted this way.
+  const leafKeysByDraft = useMemo(
+    () =>
+      shippingPRDrafts.map(
+        (d) => new Set(d.items.filter((i) => i.itemType === 'OPENING_ITEM').map(shippingPRItemKey)),
+      ),
+    [shippingPRDrafts],
+  );
+
+  const nothingToShip =
+    !leavesLoading && !leavesError && assembledLeaves.length === 0 && looseItems.length === 0;
 
   return (
     <Box>
       <Typography variant="h6" sx={{ mb: 2 }}>
         Shipping Pull Requests
       </Typography>
+
+      {/* An empty list has three very different causes, and the failure case must not read as
+          "nothing to ship" - that is the dead end #335 was about. */}
+      {leavesError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Could not load this project's assembled door leaves. Any leaf that is ready to ship is
+          missing from the list below, so go back and retry before creating a request.
+        </Alert>
+      )}
+
+      {nothingToShip && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Nothing on the selected openings is in a shippable state. Assembled leaves already on
+          another shipping request are not listed.
+        </Alert>
+      )}
 
       {shippingPRDrafts.length === 0 && (
         <Alert severity="info" sx={{ mb: 2 }}>
@@ -106,12 +145,6 @@ export default function ShippingPRsStep({
               Select items ({draft.items.length} selected):
             </Typography>
 
-            {nothingToShip && (
-              <Alert severity="warning" sx={{ mb: 1 }}>
-                Nothing on the selected openings is in a shippable state.
-              </Alert>
-            )}
-
             <Box sx={{ maxHeight: 320, overflowY: 'auto' }}>
               {/* Assembled door leaves (#335). Each one ships as itself: the hardware was tagged onto
                   it at shop assembly and left loose inventory then, so this is a move, not a pull
@@ -129,13 +162,16 @@ export default function ShippingPRsStep({
                       leaf: leaf.leaf,
                       requestedQuantity: 1,
                     };
+                    const key = shippingPRItemKey(item);
+                    const onAnotherDraft = leafKeysByDraft.some((keys, i) => i !== prIdx && keys.has(key));
                     return (
                       <FormControlLabel
                         key={leaf.id}
+                        disabled={onAnotherDraft}
                         control={
                           <Checkbox
                             size="small"
-                            checked={selectedKeys.has(shippingPRItemKey(item))}
+                            checked={selectedKeys.has(key)}
                             onChange={() => onTogglePRItem(prIdx, item)}
                           />
                         }
@@ -147,7 +183,9 @@ export default function ShippingPRsStep({
                               {leaf.leaf == null && ' (assembled unit)'}
                             </Typography>
                             <Typography variant="caption" color="text.secondary">
-                              {installedSummary(leaf)}
+                              {onAnotherDraft
+                                ? 'Already on another shipping PR in this session'
+                                : installedSummary(leaf)}
                             </Typography>
                           </Box>
                         }

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -12,23 +12,36 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
-import type { AggregatedHardwareItem, ShippingPRDraft } from './types';
-import { aggregationKey } from './types';
+import type { AggregatedHardwareItem, AssembledLeafCandidate, ShippingPRDraft, ShippingPRItem } from './types';
+import { aggregationKey, shippingPRItemKey } from './types';
+import { leafSuffix } from '../../utils/leaf';
 
 interface ShippingPRsStepProps {
   shippingPRDrafts: ShippingPRDraft[];
-  selectedHardwareItems: AggregatedHardwareItem[];
+  /** Assembled door leaves (OpeningItems) on the selected openings, still in inventory (#335). */
+  assembledLeaves: AssembledLeafCandidate[];
+  /** Loose hardware still in inventory for the selected openings. */
+  looseItems: AggregatedHardwareItem[];
   onAddPR: () => void;
   onRemovePR: (index: number) => void;
   onUpdatePR: (index: number, field: 'requestNumber' | 'requestedBy', value: string) => void;
-  onTogglePRItem: (prIndex: number, hi: AggregatedHardwareItem) => void;
+  onTogglePRItem: (prIndex: number, item: ShippingPRItem) => void;
   onNext: () => void;
   onBack: () => void;
 }
 
+/** "SG 56 AD8410, HNG-100 +2 more" - what is bolted onto this leaf, for recognising it at a glance. */
+function installedSummary(leaf: AssembledLeafCandidate): string {
+  const codes = leaf.installedHardware.map((h) => h.productCode);
+  if (codes.length === 0) return 'No hardware recorded';
+  const shown = codes.slice(0, 3).join(', ');
+  return codes.length > 3 ? `${shown} +${codes.length - 3} more` : shown;
+}
+
 export default function ShippingPRsStep({
   shippingPRDrafts,
-  selectedHardwareItems,
+  assembledLeaves,
+  looseItems,
   onAddPR,
   onRemovePR,
   onUpdatePR,
@@ -44,6 +57,8 @@ export default function ShippingPRsStep({
     [shippingPRDrafts],
   );
 
+  const nothingToShip = assembledLeaves.length === 0 && looseItems.length === 0;
+
   return (
     <Box>
       <Typography variant="h6" sx={{ mb: 2 }}>
@@ -56,71 +71,139 @@ export default function ShippingPRsStep({
         </Alert>
       )}
 
-      {shippingPRDrafts.map((draft, prIdx) => (
-        <Paper key={prIdx} variant="outlined" sx={{ p: 2, mb: 2 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-              Shipping PR #{prIdx + 1}
+      {shippingPRDrafts.map((draft, prIdx) => {
+        const selectedKeys = new Set(draft.items.map(shippingPRItemKey));
+        return (
+          <Paper key={prIdx} variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                Shipping PR #{prIdx + 1}
+              </Typography>
+              <IconButton size="small" color="error" onClick={() => onRemovePR(prIdx)}>
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Box>
+
+            <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+              <TextField
+                label="PR Number"
+                size="small"
+                required
+                value={draft.requestNumber}
+                onChange={(e) => onUpdatePR(prIdx, 'requestNumber', e.target.value)}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Requested By"
+                size="small"
+                value={draft.requestedBy}
+                onChange={(e) => onUpdatePR(prIdx, 'requestedBy', e.target.value)}
+                sx={{ flex: 1 }}
+              />
+            </Box>
+
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              Select items ({draft.items.length} selected):
             </Typography>
-            <IconButton size="small" color="error" onClick={() => onRemovePR(prIdx)}>
-              <DeleteIcon fontSize="small" />
-            </IconButton>
-          </Box>
 
-          <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-            <TextField
-              label="PR Number"
-              size="small"
-              required
-              value={draft.requestNumber}
-              onChange={(e) => onUpdatePR(prIdx, 'requestNumber', e.target.value)}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              label="Requested By"
-              size="small"
-              value={draft.requestedBy}
-              onChange={(e) => onUpdatePR(prIdx, 'requestedBy', e.target.value)}
-              sx={{ flex: 1 }}
-            />
-          </Box>
+            {nothingToShip && (
+              <Alert severity="warning" sx={{ mb: 1 }}>
+                Nothing on the selected openings is in a shippable state.
+              </Alert>
+            )}
 
-          <Typography variant="body2" sx={{ mb: 1 }}>
-            Select items ({draft.items.length} selected):
-          </Typography>
-          <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
-            {selectedHardwareItems.map((hi) => {
-              const isSelected = draft.items.some(
-                (item) =>
-                  item.openingNumber === hi.opening_number &&
-                  item.productCode === hi.product_code &&
-                  item.hardwareCategory === hi.hardware_category,
-              );
-              return (
-                <FormControlLabel
-                  key={aggregationKey(hi)}
-                  control={
-                    <Checkbox
-                      size="small"
-                      checked={isSelected}
-                      onChange={() => onTogglePRItem(prIdx, hi)}
-                    />
-                  }
-                  label={
-                    <Typography variant="body2">
-                      {/* No leaf label: loose PR items are aggregated leaf-agnostically (leaf-collapsed,
-                          first-wins), so a shown leaf would misrepresent qty spanning both leaves. */}
-                      Opening: {hi.opening_number} | Product: {hi.product_code} | Category:{' '}
-                      {hi.hardware_category} | Qty: {hi.item_quantity}
-                    </Typography>
-                  }
-                  sx={{ display: 'block' }}
-                />
-              );
-            })}
-          </Box>
-        </Paper>
-      ))}
+            <Box sx={{ maxHeight: 320, overflowY: 'auto' }}>
+              {/* Assembled door leaves (#335). Each one ships as itself: the hardware was tagged onto
+                  it at shop assembly and left loose inventory then, so this is a move, not a pull
+                  against stock. */}
+              {assembledLeaves.length > 0 && (
+                <>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                    Assembled door leaves
+                  </Typography>
+                  {assembledLeaves.map((leaf) => {
+                    const item: ShippingPRItem = {
+                      itemType: 'OPENING_ITEM',
+                      openingNumber: leaf.openingNumber,
+                      openingItemId: leaf.id,
+                      leaf: leaf.leaf,
+                      requestedQuantity: 1,
+                    };
+                    return (
+                      <FormControlLabel
+                        key={leaf.id}
+                        control={
+                          <Checkbox
+                            size="small"
+                            checked={selectedKeys.has(shippingPRItemKey(item))}
+                            onChange={() => onTogglePRItem(prIdx, item)}
+                          />
+                        }
+                        label={
+                          <Box>
+                            <Typography variant="body2">
+                              Opening {leaf.openingNumber}
+                              {leafSuffix(leaf.leaf)}
+                              {leaf.leaf == null && ' (assembled unit)'}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary">
+                              {installedSummary(leaf)}
+                            </Typography>
+                          </Box>
+                        }
+                        sx={{ display: 'flex', alignItems: 'flex-start', mb: 0.5 }}
+                      />
+                    );
+                  })}
+                </>
+              )}
+
+              {/* Loose hardware. Aggregated leaf-agnostically on purpose: loose stock is fungible and
+                  carries no leaf until a pull tags it onto one. Quantity is what is actually
+                  available, not what the schedule calls for. */}
+              {looseItems.length > 0 && (
+                <>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mt: assembledLeaves.length > 0 ? 1.5 : 0, mb: 0.5 }}
+                  >
+                    Loose hardware
+                  </Typography>
+                  {looseItems.map((hi) => {
+                    const item: ShippingPRItem = {
+                      itemType: 'LOOSE',
+                      openingNumber: hi.opening_number,
+                      hardwareCategory: hi.hardware_category,
+                      productCode: hi.product_code,
+                      requestedQuantity: hi.item_quantity,
+                    };
+                    return (
+                      <FormControlLabel
+                        key={aggregationKey(hi)}
+                        control={
+                          <Checkbox
+                            size="small"
+                            checked={selectedKeys.has(shippingPRItemKey(item))}
+                            onChange={() => onTogglePRItem(prIdx, item)}
+                          />
+                        }
+                        label={
+                          <Typography variant="body2">
+                            Opening: {hi.opening_number} | Product: {hi.product_code} | Category:{' '}
+                            {hi.hardware_category} | Qty: {hi.item_quantity}
+                          </Typography>
+                        }
+                        sx={{ display: 'block' }}
+                      />
+                    );
+                  })}
+                </>
+              )}
+            </Box>
+          </Paper>
+        );
+      })}
 
       <Button startIcon={<AddIcon />} onClick={onAddPR}>
         Add Shipping PR

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -9,7 +9,8 @@ import {
   GET_PROJECT_HARDWARE_SCHEDULE,
   RECONCILE_SCHEDULE,
 } from '../../../graphql/import';
-import { GET_OPENING_ITEMS } from '../../../graphql/warehouse';
+import { GET_OPENING_ITEMS, GET_PULL_REQUESTS } from '../../../graphql/warehouse';
+import { GET_SHIPPING_OUT_REQUESTS } from '../../../graphql/shipping';
 import {
   useHardwareScheduleParser,
   type UseHardwareScheduleParserReturn,
@@ -191,7 +192,33 @@ const emptyOpeningItemsMock: MockedResponse = {
   result: { data: { openingItems: [] } },
 };
 
-const reimportMocks: MockedResponse[] = [...reimportBaseMocks, emptyOpeningItemsMock];
+// The shipping purpose also asks which leaves are already claimed by an open pull or a pending
+// request. Nothing claimed by default.
+function claimMocks(
+  pullRequests: object[] = [],
+  shippingOutRequests: object[] = [],
+): MockedResponse[] {
+  return [
+    {
+      request: {
+        query: GET_PULL_REQUESTS,
+        variables: { projectId: 'proj-1', source: 'SHIPPING_OUT' },
+      },
+      maxUsageCount: Number.POSITIVE_INFINITY,
+      result: { data: { pullRequests } },
+    },
+    {
+      request: {
+        query: GET_SHIPPING_OUT_REQUESTS,
+        variables: { projectId: 'proj-1', status: 'PENDING', reopenableOnly: false },
+      },
+      maxUsageCount: Number.POSITIVE_INFINITY,
+      result: { data: { shippingOutRequests } },
+    },
+  ];
+}
+
+const reimportMocks: MockedResponse[] = [...reimportBaseMocks, emptyOpeningItemsMock, ...claimMocks()];
 
 // --- Shipping-path fixtures (#335) ---
 
@@ -429,7 +456,7 @@ describe('ImportWizard step transitions', () => {
   it('offers assembled door leaves per leaf and drops their hardware from the loose list', async () => {
     renderWizard({
       project: reimportProject,
-      mocks: [...reimportBaseMocks, shippingReconcileMock, shippingOpeningItemsMock],
+      mocks: [...reimportBaseMocks, shippingReconcileMock, shippingOpeningItemsMock, ...claimMocks()],
     });
     await flushApollo();
     clickNext();
@@ -465,6 +492,64 @@ describe('ImportWizard step transitions', () => {
       target: { value: 'SHIP-0019' },
     });
     expect(nextButton()).toBeEnabled();
+  });
+
+  // A leaf stays IN_INVENTORY until its pull completes, so state alone would re-offer it and one
+  // physical leaf would be pulled twice.
+  it('hides an assembled leaf that is already on an open shipping pull', async () => {
+    renderWizard({
+      project: reimportProject,
+      mocks: [
+        ...reimportBaseMocks,
+        shippingReconcileMock,
+        shippingOpeningItemsMock,
+        ...claimMocks([
+          {
+            __typename: 'PullRequest',
+            id: 'pr-1',
+            requestNumber: 'SHIP-EXISTING',
+            projectId: 'proj-1',
+            source: 'SHIPPING_OUT',
+            status: 'IN_PROGRESS',
+            requestedBy: 'someone',
+            assignedTo: 'someone',
+            createdAt: '2026-07-02T00:00:00',
+            updatedAt: '2026-07-02T00:00:00',
+            approvedAt: null,
+            completedAt: null,
+            cancelledAt: null,
+            items: [
+              {
+                __typename: 'PullRequestItem',
+                id: 'pri-1',
+                pullRequestId: 'pr-1',
+                itemType: 'OPENING_ITEM',
+                openingNumber: 'O-1',
+                openingItemId: 'oi-leaf-1',
+                leaf: 1,
+                hardwareCategory: null,
+                productCode: null,
+                requestedQuantity: 1,
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    await flushApollo();
+    clickNext();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Pull Request for Shipping Out/i }));
+    clickNext();
+    fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
+    clickNext();
+    await flushApollo();
+    clickNext();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Shipping PR/i }));
+
+    expect(screen.queryByText('Opening O-1 - Leaf 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Opening O-1 - Leaf 2')).toBeInTheDocument();
   });
 
   it('walks the po path through Reconciliation to Classification and gates on unclassified items', () => {

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -7,7 +7,9 @@ import ImportWizard from '../ImportWizard';
 import {
   GET_PROJECT_EXCLUDED_ITEMS,
   GET_PROJECT_HARDWARE_SCHEDULE,
+  RECONCILE_SCHEDULE,
 } from '../../../graphql/import';
+import { GET_OPENING_ITEMS } from '../../../graphql/warehouse';
 import {
   useHardwareScheduleParser,
   type UseHardwareScheduleParserReturn,
@@ -160,7 +162,7 @@ const reimportProject: Project = { ...firstImportProject, openingCount: 5 };
 // A re-import project eagerly fetches the persisted schedule (null = nothing
 // persisted, so the upload step stays a plain dropzone) and, once parsed items
 // exist, the project's excluded-items list.
-const reimportMocks: MockedResponse[] = [
+const reimportBaseMocks: MockedResponse[] = [
   {
     request: {
       query: GET_PROJECT_HARDWARE_SCHEDULE,
@@ -176,6 +178,109 @@ const reimportMocks: MockedResponse[] = [
     result: { data: { projectExcludedItems: [] } },
   },
 ];
+
+// The shipping purpose reads the project's assembled units (#335). Empty by default so the
+// step-shape tests don't need to care; the shipping walk below swaps in real ones. MockedProvider
+// takes the first matching mock, so this must not be in the list when a populated one is wanted.
+const emptyOpeningItemsMock: MockedResponse = {
+  request: {
+    query: GET_OPENING_ITEMS,
+    variables: { projectId: 'proj-1' },
+  },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+  result: { data: { openingItems: [] } },
+};
+
+const reimportMocks: MockedResponse[] = [...reimportBaseMocks, emptyOpeningItemsMock];
+
+// --- Shipping-path fixtures (#335) ---
+
+// O-1's hinges were consumed into two assembled door leaves; O-2's lock is still loose stock.
+const shippingReconcileMock: MockedResponse = {
+  request: {
+    query: RECONCILE_SCHEDULE,
+    variables: {
+      projectId: 'proj-1',
+      items: [
+        { openingNumber: 'O-1', hardwareCategory: 'Hinges', productCode: 'HNG-100', quantityNeeded: 3 },
+        { openingNumber: 'O-2', hardwareCategory: 'Locks', productCode: 'LCK-200', quantityNeeded: 1 },
+      ],
+    },
+  },
+  result: {
+    data: {
+      reconcileSchedule: [
+        {
+          __typename: 'ReconciliationResult',
+          openingNumber: 'O-1',
+          hardwareCategory: 'Hinges',
+          productCode: 'HNG-100',
+          quantity: 3,
+          status: 'ASSEMBLED',
+        },
+        {
+          __typename: 'ReconciliationResult',
+          openingNumber: 'O-2',
+          hardwareCategory: 'Locks',
+          productCode: 'LCK-200',
+          quantity: 1,
+          status: 'RECEIVED',
+        },
+      ],
+    },
+  },
+};
+
+function makeOpeningItem(id: string, leaf: number | null, state = 'IN_INVENTORY') {
+  return {
+    __typename: 'OpeningItem',
+    id,
+    projectId: 'proj-1',
+    openingId: 'opening-1',
+    openingNumber: 'O-1',
+    building: null,
+    floor: null,
+    location: null,
+    leaf,
+    leafCount: 2,
+    quantity: 1,
+    assemblyCompletedAt: '2026-07-01T00:00:00',
+    state,
+    aisle: null,
+    row: null,
+    bay: null,
+    createdAt: '2026-07-01T00:00:00',
+    updatedAt: '2026-07-01T00:00:00',
+    installedHardware: [
+      {
+        __typename: 'OpeningItemHardware',
+        id: `${id}-hw`,
+        openingItemId: id,
+        productCode: 'HNG-100',
+        hardwareCategory: 'Hinges',
+        quantity: 3,
+      },
+    ],
+  };
+}
+
+const shippingOpeningItemsMock: MockedResponse = {
+  request: {
+    query: GET_OPENING_ITEMS,
+    variables: { projectId: 'proj-1' },
+  },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+  result: {
+    data: {
+      openingItems: [
+        makeOpeningItem('oi-leaf-1', 1),
+        makeOpeningItem('oi-leaf-2', 2),
+        // Already pulled: it waits on the Ship tab, so the wizard must not offer it again.
+        makeOpeningItem('oi-leaf-shipready', 1, 'SHIP_READY'),
+      ],
+    },
+  },
+};
 
 // ---- Harness ----
 
@@ -318,6 +423,48 @@ describe('ImportWizard step transitions', () => {
     clickBack();
     expect(screen.getByRole('heading', { name: 'Hardware Schedule' })).toBeInTheDocument();
     expect(screen.getByText('File parsed successfully!')).toBeInTheDocument();
+  });
+
+  // #335: an assembled leaf ships as itself, not as a request for the loose hardware bolted onto it.
+  it('offers assembled door leaves per leaf and drops their hardware from the loose list', async () => {
+    renderWizard({
+      project: reimportProject,
+      mocks: [...reimportBaseMocks, shippingReconcileMock, shippingOpeningItemsMock],
+    });
+    await flushApollo();
+    clickNext();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Pull Request for Shipping Out/i }));
+    clickNext();
+    fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
+    clickNext();
+    await flushApollo();
+
+    expect(screen.getByRole('heading', { name: 'Reconciliation' })).toBeInTheDocument();
+    clickNext();
+
+    expect(screen.getByRole('heading', { name: 'Shipping Pull Requests' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Add Shipping PR/i }));
+
+    // One row per assembled leaf, and the SHIP_READY unit is not offered.
+    expect(screen.getByText('Opening O-1 - Leaf 1')).toBeInTheDocument();
+    expect(screen.getByText('Opening O-1 - Leaf 2')).toBeInTheDocument();
+    expect(screen.getAllByText(/Opening O-1 - Leaf/)).toHaveLength(2);
+
+    // The hinges live on those leaves now, so they are not offered as loose stock; the lock still is.
+    expect(screen.queryByText(/Product: HNG-100/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Product: LCK-200/)).toBeInTheDocument();
+
+    // Ticking a leaf records a selection on the draft.
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByText('Select items (1 selected):')).toBeInTheDocument();
+    expect(nextButton()).toBeDisabled(); // still needs a PR number
+
+    fireEvent.change(screen.getByRole('textbox', { name: /PR Number/i }), {
+      target: { value: 'SHIP-0019' },
+    });
+    expect(nextButton()).toBeEnabled();
   });
 
   it('walks the po path through Reconciliation to Classification and gates on unclassified items', () => {

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -45,8 +45,7 @@ export interface AssembledLeafCandidate {
   id: string;
   openingNumber: string;
   leaf: number | null;
-  assemblyCompletedAt: string;
-  installedHardware: Array<{ productCode: string; hardwareCategory: string; quantity: number }>;
+  installedHardware: Array<{ productCode: string; quantity: number }>;
 }
 
 export function hardwareItemKey(hi: ParsedHardwareItem) {

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -8,19 +8,45 @@ export function aggregationKey(hi: { opening_number: string; product_code: strin
 
 export type ImportPurpose = 'po' | 'assembly' | 'shipping';
 
+// A line on a shipping pull request draft. The two item types are not variants of the same thing
+// (#335): OPENING_ITEM moves an assembled door leaf that hardware was already tagged onto at shop
+// assembly, so it names an OpeningItem and never touches loose stock. LOOSE tags fungible inventory
+// onto an opening for the first time. See docs/HARDWARE_IDENTITY_LIFECYCLE.md.
 export interface ShippingPRItem {
   itemType: 'OPENING_ITEM' | 'LOOSE';
   openingNumber: string;
   openingItemId?: string;
+  /** Door leaf (#311): set on OPENING_ITEM lines from the assembled unit. Null/absent on LOOSE. */
+  leaf?: number | null;
   hardwareCategory?: string;
   productCode?: string;
   requestedQuantity: number;
+}
+
+/**
+ * Identity of a draft line, for add/remove toggling and checkbox state. An assembled leaf is its
+ * OpeningItem; a loose line is its (opening, category, product) triple, which is leaf-agnostic
+ * because loose stock is fungible.
+ */
+export function shippingPRItemKey(item: ShippingPRItem): string {
+  return item.itemType === 'OPENING_ITEM'
+    ? `OI|${item.openingItemId}`
+    : `LOOSE|${item.openingNumber}|${item.hardwareCategory}|${item.productCode}`;
 }
 
 export interface ShippingPRDraft {
   requestNumber: string;
   requestedBy: string;
   items: ShippingPRItem[];
+}
+
+/** An assembled door leaf (or legacy whole-opening unit) offered for shipping selection (#335). */
+export interface AssembledLeafCandidate {
+  id: string;
+  openingNumber: string;
+  leaf: number | null;
+  assemblyCompletedAt: string;
+  installedHardware: Array<{ productCode: string; hardwareCategory: string; quantity: number }>;
 }
 
 export function hardwareItemKey(hi: ParsedHardwareItem) {

--- a/frontend/src/modules/shipping/ShippingRequestsPage.tsx
+++ b/frontend/src/modules/shipping/ShippingRequestsPage.tsx
@@ -7,11 +7,15 @@ import {
   REJECT_SHIPPING_OUT_REQUEST,
 } from '../../graphql/shipping';
 import RequestsReviewPage from '../../components/RequestsReviewPage';
+import { leafLabel } from '../../utils/leaf';
 
 interface ShippingRequestItem {
   id: string;
   itemType: string;
   openingNumber: string | null;
+  openingItemId: string | null;
+  /** Door leaf (#335): set on assembled-leaf lines, null on loose hardware. */
+  leaf: number | null;
   hardwareCategory: string | null;
   productCode: string | null;
   requestedQuantity: number;
@@ -67,6 +71,9 @@ export default function ShippingRequestsPage({ projectId }: Props) {
             <TableHead>
               <TableRow>
                 <TableCell>Opening</TableCell>
+                {/* #335: an assembled-leaf line names no product, so the leaf is the only thing that
+                    tells a pair's two lines apart before the request is accepted. */}
+                <TableCell>Leaf</TableCell>
                 <TableCell>Product Code</TableCell>
                 <TableCell>Hardware Category</TableCell>
                 <TableCell align="right">Quantity</TableCell>
@@ -76,7 +83,10 @@ export default function ShippingRequestsPage({ projectId }: Props) {
               {req.items.map((item) => (
                 <TableRow key={item.id}>
                   <TableCell>{item.openingNumber || '—'}</TableCell>
-                  <TableCell>{item.productCode || '—'}</TableCell>
+                  <TableCell>{leafLabel(item.leaf) ?? '—'}</TableCell>
+                  <TableCell>
+                    {item.itemType === 'OPENING_ITEM' ? 'Assembled door leaf' : item.productCode || '—'}
+                  </TableCell>
                   <TableCell>{item.hardwareCategory || '—'}</TableCell>
                   <TableCell align="right">{item.requestedQuantity}</TableCell>
                 </TableRow>

--- a/frontend/src/modules/shipping/ShippingRequestsPage.tsx
+++ b/frontend/src/modules/shipping/ShippingRequestsPage.tsx
@@ -28,7 +28,6 @@ interface ShippingRequestItem {
   id: string;
   itemType: string;
   openingNumber: string | null;
-  openingItemId: string | null;
   /** Door leaf (#335): set on assembled-leaf lines, null on loose hardware. */
   leaf: number | null;
   hardwareCategory: string | null;
@@ -121,12 +120,12 @@ export default function ShippingRequestsPage({ projectId }: Props) {
               <TableBody>
                 {req.items.map((item) => (
                   <TableRow key={item.id}>
-                    <TableCell>{item.openingNumber || '—'}</TableCell>
-                    <TableCell>{leafLabel(item.leaf) ?? '—'}</TableCell>
+                    <TableCell>{item.openingNumber || '-'}</TableCell>
+                    <TableCell>{leafLabel(item.leaf) ?? '-'}</TableCell>
                     <TableCell>
-                      {item.itemType === 'OPENING_ITEM' ? 'Assembled door leaf' : item.productCode || '—'}
+                      {item.itemType === 'OPENING_ITEM' ? 'Assembled door leaf' : item.productCode || '-'}
                     </TableCell>
-                    <TableCell>{item.hardwareCategory || '—'}</TableCell>
+                    <TableCell>{item.hardwareCategory || '-'}</TableCell>
                     <TableCell align="right">{item.requestedQuantity}</TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -369,6 +369,9 @@ export default function PullRequestDetailModal({
                       <TableCell>Product Code</TableCell>
                       <TableCell>Hardware Category</TableCell>
                       <TableCell>Opening Number</TableCell>
+                      {/* Shop-assembly pulls are per leaf too (#311), so a pair's two lines read
+                          identically without this. */}
+                      <TableCell>Leaf</TableCell>
                       <TableCell align="right">Requested Qty</TableCell>
                       {isPending && <TableCell align="right">Available Qty</TableCell>}
                       {isPending && <TableCell align="center">Status</TableCell>}
@@ -383,6 +386,7 @@ export default function PullRequestDetailModal({
                           <TableCell>{item.productCode ?? '-'}</TableCell>
                           <TableCell>{item.hardwareCategory ?? '-'}</TableCell>
                           <TableCell>{item.openingNumber}</TableCell>
+                          <TableCell>{leafLabel(item.leaf) ?? '-'}</TableCell>
                           <TableCell align="right">{item.requestedQuantity}</TableCell>
                           {isPending && <TableCell align="right">{availableQty}</TableCell>}
                           {isPending && (

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -22,6 +22,7 @@ import { useToast } from '../../components/Toast';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import type { PullRequest, PullRequestItem } from './PullRequestQueue';
+import { leafLabel } from '../../utils/leaf';
 
 // --- Status config ---
 
@@ -412,6 +413,8 @@ export default function PullRequestDetailModal({
                     <TableRow>
                       <TableCell>Type</TableCell>
                       <TableCell>Opening Number</TableCell>
+                      {/* #335: a pair ships as two lines. Without the leaf they read identically. */}
+                      <TableCell>Leaf</TableCell>
                       <TableCell align="right">Requested Qty</TableCell>
                     </TableRow>
                   </TableHead>
@@ -420,6 +423,7 @@ export default function PullRequestDetailModal({
                       <TableRow key={item.id}>
                         <TableCell>Assembled Opening</TableCell>
                         <TableCell>{item.openingNumber}</TableCell>
+                        <TableCell>{leafLabel(item.leaf) ?? '-'}</TableCell>
                         <TableCell align="right">{item.requestedQuantity}</TableCell>
                       </TableRow>
                     ))}

--- a/frontend/src/modules/warehouse/PullRequestQueue.tsx
+++ b/frontend/src/modules/warehouse/PullRequestQueue.tsx
@@ -15,6 +15,8 @@ export interface PullRequestItem {
   itemType: string;
   openingNumber: string;
   openingItemId: string | null;
+  /** Door leaf this pull line is for (#311): 1 or 2, or null for legacy / leaf-agnostic lines. */
+  leaf: number | null;
   hardwareCategory: string | null;
   productCode: string | null;
   requestedQuantity: number;


### PR DESCRIPTION
fixes #335.

Shipping Out import wizard built every selected line as LOOSE. for an assembled opening the hardware was installed onto a door leaf at shop assembly and left fungible inventory, so the warehouse Shipping Out PR found 0 loose availability -> "Approve and Start" stayed disabled -> leaf never reached SHIP_READY -> Ship tab (SHIP_READY opening items only) showed nothing.

everything downstream of the request already handled per-leaf shipping:
- approve_pull_request collects and locks opening_item_ids for OPENING_ITEM lines, no loose-inventory gate
- complete_pull_request flips SHIPPING_OUT OPENING_ITEM lines to SHIP_READY
- confirm_shipment requires SHIP_READY, snapshots the leaf onto the packing slip

gap was request-creation only. wizard never emitted an OPENING_ITEM line, never learned an OpeningItem id.

- Shipping PRs step now has two sections
- "Assembled door leaves" - one checkbox per OpeningItem still IN_INVENTORY on a selected opening, labelled with its leaf and the hardware installed on it, emits an OPENING_ITEM line naming the OpeningItem
- SHIP_READY units excluded, they are already pulled and waiting on the Ship tab
- "Loose hardware" narrowed to the reconciliation RECEIVED bucket only, quantity clamped to the received quantity. assembled hardware drops out of it entirely, so it cannot be requested twice
- toggleShippingPRItem no longer hard-codes itemType LOOSE. takes a fully-built line, toggles on a new shippingPRItemKey. assembled leaf keyed by its OpeningItem, loose line by its (opening, category, product) triple
- shipping_out_request_items gains a nullable leaf column (migration 058), so the pre-accept Shipping Requests inbox can tell a pair's two lines apart instead of showing two identical rows. #311's migration 056 added leaf to six tables and skipped this one
- accept copies it onto pull_request_items.leaf, batched OpeningItem lookup as fallback for requests written before 058
- finalize_import_session raises ValidationError for an OPENING_ITEM line with no opening_item_id. such a line is inert downstream: approve skips it, complete never flips a leaf
- leaf selected in the pull-request GraphQL documents, shown as a column in the warehouse PR detail Assembled Opening Items table and in the Shipping Requests inbox

domain rule now in docs/HARDWARE_IDENTITY_LIFECYCLE.md, linked from README, with docstrings anchoring it on InventoryLocation, PullRequestItem, OpeningItem.

hardware procured per opening off the TITAN schedule -> identity lost on receipt (InventoryLocation keyed only by project, warehouse, category, product code, no opening or leaf column, inventory fungible on purpose) -> identity regained when a pull request tags a quantity onto a specific door leaf of a specific opening.

both pull request sources, shop assembly and shipping out, are created from the hardware schedule through Start a Task.

a LOOSE pull line tags fungible stock. an OPENING_ITEM pull line moves a leaf already tagged at assembly.

correction to an earlier claim in this description - loose lines are not unguarded. reconcile_schedule moves qty sitting on an open SHIPPING_OUT pull into its own bucket, out of RECEIVED.

assembled leaves were the asymmetric case. an OpeningItem stays IN_INVENTORY for the whole life of an open pull, flips only at complete. now closed:

wizard hides leaves already named by
- a pending shipping request
- an unfinished shipping pull

draft lines whose candidate is no longer offered are derived out. re-selecting the opening brings the tick back. same leaf cannot be ticked on two drafts in one session.

finalize validates the OpeningItem
- exists
- belongs to this project
- IN_INVENTORY

complete_pull_request flips IN_INVENTORY -> SHIP_READY only, so a stale pull cannot walk a shipped leaf back into the ship-ready list.

- assembled-unit load error surfaced
- shippable-state alert renders once
- installed hardware deduped with quantities
- RECEIVED index built once
- loose items table gained the leaf column
- dead fields dropped
- SDL drift fixed on ShippingOutPRDraftItemInput and PullRequestItem
- em dash removed

