### PR TITLE
fix(shipping): refetch and evict the Ship view after Confirm Shipment (#337)

### DIFF
--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -17,30 +17,24 @@ export const WAREHOUSE_REFETCH_QUERIES = [
   'GetProjectProgressByProduct',
 ];
 
-// Everything confirmShipment invalidates (#337). It flips OpeningItems to Shipped_Out and creates a
-// packing slip, which contradicts four cached reads. Two lists because they heal different things:
+// What confirmShipment invalidates (#337). The two lists are deliberately DISJOINT: evicting a root
+// field that a mounted query also refetches makes Apollo fire a repair fetch for the incomplete
+// cache diff on top of the explicit refetch, so the heaviest shipping resolvers would run twice
+// concurrently - the pool-starvation pattern the perf rules in CLAUDE.md warn about.
 //
-// - SHIPPING_REFETCH_QUERIES heals what is MOUNTED. Apollo's refetchQueries only touches active
-//   queries, which is what fixes the reported bug: the Ship view sits open behind the packing-slip
-//   dialog, so GetShipReadyItems (cache-first) and GetOpeningLeafStatus never re-run on their own
-//   and keep rendering the just-shipped leaf as Ship_Ready.
-// - SHIPPING_STALE_ROOT_FIELDS heals what is NOT. Warehouse Opening Items and the Returns tab live
-//   in other routes, so refetchQueries skips them and their next mount would serve a pre-shipment
-//   cache-first snapshot. Evicting the root fields forces that mount to go to the network.
-//
-// GetNotifications is deliberately absent: NotificationBell mounts two instances with different
-// variables and already polls every 30s, so listing it costs two round-trips per shipment for a
-// badge that self-corrects.
-export const SHIPPING_REFETCH_QUERIES = [
-  'GetShipReadyItems',
-  'GetOpeningLeafStatus',
-  'GetPackingSlips',
-  'GetOpeningItems',
-];
+// Refetched. GetOpeningLeafStatus is cache-and-network but stays mounted for the whole flow, so
+// nothing re-triggers it on its own and the rollup keeps its pre-shipment count.
+export const SHIPPING_REFETCH_QUERIES = ['GetOpeningLeafStatus'];
 
-export const SHIPPING_STALE_ROOT_FIELDS = [
-  'shipReadyItems',
-  'openingLeafStatus',
-  'packingSlips',
-  'openingItems',
-];
+// Evicted. Both are read cache-first by a query that may not be active when a shipment is confirmed,
+// which is precisely what refetchQueries cannot reach:
+// - shipReadyItems: the Ship view is usually mounted behind the dialog, and eviction makes its
+//   watcher re-run (an incomplete cache diff repairs itself by refetching). But the cart drawer is
+//   rendered outside <Routes>, so a shipment can also be confirmed from the Requests/Returns tab
+//   with the Ship view unmounted - refetchQueries would silently skip it there.
+// - openingItems: warehouse Opening Items is another module entirely, never active at ship time.
+//
+// Absent on purpose: packingSlips (ShipmentsList reads cache-and-network, so its next mount already
+// goes to the network) and notifications (NotificationBell polls every 30s and mounts two instances
+// with different variables, so listing it costs two round-trips for a badge that self-corrects).
+export const SHIPPING_STALE_ROOT_FIELDS = ['shipReadyItems', 'openingItems'];

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -16,3 +16,31 @@ export const WAREHOUSE_REFETCH_QUERIES = [
   'GetWarehouseDashboard',
   'GetProjectProgressByProduct',
 ];
+
+// Everything confirmShipment invalidates (#337). It flips OpeningItems to Shipped_Out and creates a
+// packing slip, which contradicts four cached reads. Two lists because they heal different things:
+//
+// - SHIPPING_REFETCH_QUERIES heals what is MOUNTED. Apollo's refetchQueries only touches active
+//   queries, which is what fixes the reported bug: the Ship view sits open behind the packing-slip
+//   dialog, so GetShipReadyItems (cache-first) and GetOpeningLeafStatus never re-run on their own
+//   and keep rendering the just-shipped leaf as Ship_Ready.
+// - SHIPPING_STALE_ROOT_FIELDS heals what is NOT. Warehouse Opening Items and the Returns tab live
+//   in other routes, so refetchQueries skips them and their next mount would serve a pre-shipment
+//   cache-first snapshot. Evicting the root fields forces that mount to go to the network.
+//
+// GetNotifications is deliberately absent: NotificationBell mounts two instances with different
+// variables and already polls every 30s, so listing it costs two round-trips per shipment for a
+// badge that self-corrects.
+export const SHIPPING_REFETCH_QUERIES = [
+  'GetShipReadyItems',
+  'GetOpeningLeafStatus',
+  'GetPackingSlips',
+  'GetOpeningItems',
+];
+
+export const SHIPPING_STALE_ROOT_FIELDS = [
+  'shipReadyItems',
+  'openingLeafStatus',
+  'packingSlips',
+  'openingItems',
+];

--- a/frontend/src/modules/shipping/PackingSlipForm.tsx
+++ b/frontend/src/modules/shipping/PackingSlipForm.tsx
@@ -11,6 +11,7 @@ import { useToast } from '../../components/Toast';
 import { useNavigate } from 'react-router-dom';
 import { CONFIRM_SHIPMENT } from '../../graphql/shipping';
 import { SHIPPING_REFETCH_QUERIES, SHIPPING_STALE_ROOT_FIELDS } from '../../graphql/refetch';
+import { extractGpError } from '../../graphql/gpError';
 import PackingSlipDocument from './PackingSlipDocument';
 
 interface PackingSlipFormProps {
@@ -44,13 +45,23 @@ interface ShipmentResult {
 
 const SLIP_NUMBER_PATTERN = /^[a-zA-Z0-9_-]{1,50}$/;
 
-// The backend rejects an opening item that already shipped with an id-bearing state-transition
-// string ("Opening item <uuid> is not Ship_Ready (current: Shipped_Out)"). That only reaches a user
-// whose grid was stale, so pair the readable message with the refetch that unsticks them (#337).
-const STALE_SHIP_READY_ERROR = /not Ship_Ready/i;
-const STALE_SHIP_READY_MESSAGE =
-  'One or more items are no longer ship-ready - they may already have shipped. ' +
-  'The list has been refreshed; please review your cart.';
+// Both ways a confirm can fail because the grid the user acted on disagrees with the server (#337).
+// Keyed on extensions.code, not the message text: the backend wording carries a raw uuid and no test
+// pins it, so a reword would silently drop us back to showing that string.
+const STALE_CART_CODES = new Set(['INVALID_STATE_TRANSITION', 'VALIDATION_ERROR']);
+const REFRESHED_SUFFIX = ' The list has been refreshed - please review your cart.';
+
+// "Opening item <uuid> is not Ship_Ready (current: Shipped_Out)" says nothing to a shipper. The
+// insufficient-loose-hardware message does (it names the product and the counts), so that one is
+// kept and only annotated.
+function describeConfirmError(err: unknown): string {
+  const gp = extractGpError(err);
+  if (!gp) return 'Failed to confirm shipment';
+  if (gp.code === 'INVALID_STATE_TRANSITION') {
+    return `One or more items are no longer ship-ready - they may already have shipped.${REFRESHED_SUFFIX}`;
+  }
+  return STALE_CART_CODES.has(gp.code ?? '') ? `${gp.message}${REFRESHED_SUFFIX}` : gp.message;
+}
 
 export default function PackingSlipForm({ open, onClose, onShipped, projectId, projectName }: PackingSlipFormProps) {
   const { displayName } = useIdentity();
@@ -71,10 +82,15 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
   const openingItemCount = items.filter((i) => i.itemType === 'Opening_Item').length;
   const looseItemCount = items.filter((i) => i.itemType === 'Loose').length;
 
-  // A shipment contradicts every cached read of ship-ready stock, the leaf rollup, the slip list and
-  // the warehouse opening-item states. Evict those root fields so routes that aren't mounted refetch
-  // on their next visit, and refetch the mounted ones before the success view replaces the form -
-  // otherwise the Ship view behind this dialog keeps offering the leaf that just left (#337).
+  // A shipment contradicts the cached ship-ready stock, the leaf rollup and the warehouse
+  // opening-item states, and none of those re-read on their own - which is why the Ship view behind
+  // this dialog kept offering the leaf that just left (#337).
+  //
+  // Not awaited. `awaitRefetchQueries` folds the refetches into the mutate promise
+  // (QueryInfo.markMutationResult -> Promise.all), so one slow or failed refetch would reject a
+  // shipment that already committed: no success view, no packing-slip PDF, and a retry that can only
+  // fail on the duplicate slip number. The shipment is the thing that must be reported truthfully;
+  // the grid behind the modal can catch up on its own.
   const [confirmShipment, { loading: confirming }] = useMutation<ShipmentResult>(CONFIRM_SHIPMENT, {
     update(cache) {
       for (const fieldName of SHIPPING_STALE_ROOT_FIELDS) {
@@ -83,7 +99,6 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
       cache.gc();
     },
     refetchQueries: SHIPPING_REFETCH_QUERIES,
-    awaitRefetchQueries: true,
   });
 
   const handleConfirm = useCallback(async () => {
@@ -91,6 +106,14 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
 
     if (!SLIP_NUMBER_PATTERN.test(packingSlipNumber)) {
       setError('Packing slip number must be 1-50 characters (alphanumeric, hyphens, underscores).');
+      return;
+    }
+
+    // ConfirmShipmentInput.projectId is ID! but the shipping module leaves it undefined in its
+    // "All Projects" mode, where the Ship view still lists items and lets them into the cart. Say so
+    // here rather than shipping an undefined variable and surfacing a coercion error.
+    if (!projectId) {
+      setError('Select a single project before shipping - "All Projects" cannot create a packing slip.');
       return;
     }
 
@@ -134,12 +157,18 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
         showToast('Shipment confirmed successfully!', 'success');
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to confirm shipment';
-      const stale = STALE_SHIP_READY_ERROR.test(message);
-      setError(stale ? STALE_SHIP_READY_MESSAGE : message);
-      // A rejection means the view the user acted on disagrees with the server, so reconcile it here
-      // too - the mutation's own refetch never runs on the error path.
-      void client.refetchQueries({ include: SHIPPING_REFETCH_QUERIES });
+      // A rejection means the view the user acted on disagrees with the server, and the mutation's
+      // own invalidation never runs on the error path. Reconcile BEFORE showing the message, so the
+      // "list has been refreshed" it may carry is true by the time it is read. A refetch that fails
+      // in turn must not replace the error that actually explains the rejection.
+      try {
+        client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'shipReadyItems' });
+        client.cache.gc();
+        await client.refetchQueries({ include: SHIPPING_REFETCH_QUERIES });
+      } catch {
+        /* keep the original failure */
+      }
+      setError(describeConfirmError(err));
     }
   }, [confirmShipment, items, packingSlipNumber, projectId, displayName, showToast, clearCart, client]);
 
@@ -187,24 +216,27 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
     }
   }, [result, projectName, showToast]);
 
-  // Both exits from the success view only reset local form state - the cart was already emptied when
-  // the shipment succeeded, not deferred to whichever button the user happens to press.
+  // The cart is emptied the moment the shipment succeeds rather than here, so the Ship view never
+  // shows a shipped leaf as still carted. These calls stay as the backstop for any path that reaches
+  // the success view without that clear having run; clearCart is idempotent.
   const handleShipMore = useCallback(() => {
+    clearCart();
     setView('form');
     setPackingSlipNumber('');
     setError(null);
     setResult(null);
     onShipped();
-  }, [onShipped]);
+  }, [clearCart, onShipped]);
 
   const handleReturnHome = useCallback(() => {
+    clearCart();
     setView('form');
     setPackingSlipNumber('');
     setError(null);
     setResult(null);
     onClose();
     navigate('/app');
-  }, [navigate, onClose]);
+  }, [clearCart, navigate, onClose]);
 
   const handleClose = () => {
     if (view === 'form') {

--- a/frontend/src/modules/shipping/PackingSlipForm.tsx
+++ b/frontend/src/modules/shipping/PackingSlipForm.tsx
@@ -3,13 +3,14 @@ import {
   Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
   Typography, Box, CircularProgress, Alert, List, ListItem, ListItemText,
 } from '@mui/material';
-import { useMutation } from '@apollo/client/react';
+import { useMutation, useApolloClient } from '@apollo/client/react';
 import { pdf } from '@react-pdf/renderer';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useCart, type CartItem } from '../../contexts/CartContext';
 import { useToast } from '../../components/Toast';
 import { useNavigate } from 'react-router-dom';
 import { CONFIRM_SHIPMENT } from '../../graphql/shipping';
+import { SHIPPING_REFETCH_QUERIES, SHIPPING_STALE_ROOT_FIELDS } from '../../graphql/refetch';
 import PackingSlipDocument from './PackingSlipDocument';
 
 interface PackingSlipFormProps {
@@ -43,11 +44,20 @@ interface ShipmentResult {
 
 const SLIP_NUMBER_PATTERN = /^[a-zA-Z0-9_-]{1,50}$/;
 
+// The backend rejects an opening item that already shipped with an id-bearing state-transition
+// string ("Opening item <uuid> is not Ship_Ready (current: Shipped_Out)"). That only reaches a user
+// whose grid was stale, so pair the readable message with the refetch that unsticks them (#337).
+const STALE_SHIP_READY_ERROR = /not Ship_Ready/i;
+const STALE_SHIP_READY_MESSAGE =
+  'One or more items are no longer ship-ready - they may already have shipped. ' +
+  'The list has been refreshed; please review your cart.';
+
 export default function PackingSlipForm({ open, onClose, onShipped, projectId, projectName }: PackingSlipFormProps) {
   const { displayName } = useIdentity();
   const { items, clearCart } = useCart();
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const client = useApolloClient();
 
   const [view, setView] = useState<'form' | 'success'>('form');
   const [packingSlipNumber, setPackingSlipNumber] = useState('');
@@ -61,7 +71,20 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
   const openingItemCount = items.filter((i) => i.itemType === 'Opening_Item').length;
   const looseItemCount = items.filter((i) => i.itemType === 'Loose').length;
 
-  const [confirmShipment, { loading: confirming }] = useMutation<ShipmentResult>(CONFIRM_SHIPMENT);
+  // A shipment contradicts every cached read of ship-ready stock, the leaf rollup, the slip list and
+  // the warehouse opening-item states. Evict those root fields so routes that aren't mounted refetch
+  // on their next visit, and refetch the mounted ones before the success view replaces the form -
+  // otherwise the Ship view behind this dialog keeps offering the leaf that just left (#337).
+  const [confirmShipment, { loading: confirming }] = useMutation<ShipmentResult>(CONFIRM_SHIPMENT, {
+    update(cache) {
+      for (const fieldName of SHIPPING_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
+    refetchQueries: SHIPPING_REFETCH_QUERIES,
+    awaitRefetchQueries: true,
+  });
 
   const handleConfirm = useCallback(async () => {
     setError(null);
@@ -106,12 +129,19 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
       if (data?.confirmShipment) {
         setResult(data.confirmShipment);
         setView('success');
+        // These items have shipped - the cart must not still hold them behind the success view.
+        clearCart();
         showToast('Shipment confirmed successfully!', 'success');
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to confirm shipment');
+      const message = err instanceof Error ? err.message : 'Failed to confirm shipment';
+      const stale = STALE_SHIP_READY_ERROR.test(message);
+      setError(stale ? STALE_SHIP_READY_MESSAGE : message);
+      // A rejection means the view the user acted on disagrees with the server, so reconcile it here
+      // too - the mutation's own refetch never runs on the error path.
+      void client.refetchQueries({ include: SHIPPING_REFETCH_QUERIES });
     }
-  }, [confirmShipment, items, packingSlipNumber, projectId, displayName, showToast]);
+  }, [confirmShipment, items, packingSlipNumber, projectId, displayName, showToast, clearCart, client]);
 
   const handleViewPdf = useCallback(async () => {
     if (!result) return;
@@ -157,24 +187,24 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
     }
   }, [result, projectName, showToast]);
 
+  // Both exits from the success view only reset local form state - the cart was already emptied when
+  // the shipment succeeded, not deferred to whichever button the user happens to press.
   const handleShipMore = useCallback(() => {
-    clearCart();
     setView('form');
     setPackingSlipNumber('');
     setError(null);
     setResult(null);
     onShipped();
-  }, [clearCart, onShipped]);
+  }, [onShipped]);
 
   const handleReturnHome = useCallback(() => {
-    clearCart();
     setView('form');
     setPackingSlipNumber('');
     setError(null);
     setResult(null);
     onClose();
     navigate('/app');
-  }, [clearCart, navigate, onClose]);
+  }, [navigate, onClose]);
 
   const handleClose = () => {
     if (view === 'form') {

--- a/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useRef } from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, configure } from '@testing-library/react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
 import { InMemoryCache } from '@apollo/client/cache';
+import { useQuery } from '@apollo/client/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../../../components/Toast';
 import { CartProvider, useCart, type CartItem } from '../../../contexts/CartContext';
 import PackingSlipForm from '../PackingSlipForm';
 import { CONFIRM_SHIPMENT, GET_SHIP_READY_ITEMS } from '../../../graphql/shipping';
 
+// MUI Dialog under jsdom is slow, and slower still when the whole suite runs in parallel - the same
+// budget lift ReceiveModal/LocationActionDialog need. In isolation these three finish in under a second.
 vi.setConfig({ testTimeout: 30_000 });
+configure({ asyncUtilTimeout: 10_000 });
 
 vi.mock('../../../hooks/useIdentity', () => ({
   useIdentity: () => ({
@@ -56,6 +60,29 @@ const CONFIRM_VARS = {
   },
 };
 
+function shipReadyLeaf() {
+  return {
+    __typename: 'OpeningItem',
+    id: 'oi-1',
+    projectId: PROJECT_ID,
+    openingId: 'op-1',
+    openingNumber: '0019-EX',
+    building: 'A',
+    floor: '1',
+    location: 'Rm 101',
+    leaf: 1,
+    quantity: 1,
+    assemblyCompletedAt: '2026-07-24T00:00:00Z',
+    state: 'SHIP_READY',
+    aisle: null,
+    row: null,
+    bay: null,
+    createdAt: '2026-07-24T00:00:00Z',
+    updatedAt: '2026-07-24T00:00:00Z',
+    installedHardware: [],
+  };
+}
+
 function confirmMock(): MockedResponse {
   return {
     request: { query: CONFIRM_SHIPMENT, variables: CONFIRM_VARS },
@@ -88,6 +115,19 @@ function confirmMock(): MockedResponse {
   };
 }
 
+// The server's post-shipment answer: get_ship_ready_items filters on state == SHIP_READY, so the
+// leaf that just shipped is simply gone.
+function shipReadyAfterShipmentMock(): MockedResponse {
+  return {
+    request: { query: GET_SHIP_READY_ITEMS, variables: { projectId: PROJECT_ID } },
+    result: {
+      data: {
+        shipReadyItems: { __typename: 'ShipReadyItems', openingItems: [], looseItems: [] },
+      },
+    },
+  };
+}
+
 // Seeds one opening item into the cart on mount and exposes the live count, so a test can assert the
 // cart emptied without reaching into the context internals.
 function CartProbe() {
@@ -101,6 +141,15 @@ function CartProbe() {
   return <div data-testid="cart-count">{items.length}</div>;
 }
 
+// Stands in for ShipReadyBrowser: the same query, mounted behind the dialog, read cache-first.
+function ShipReadyProbe() {
+  const { data } = useQuery<{ shipReadyItems: { openingItems: { id: string }[] } }>(
+    GET_SHIP_READY_ITEMS,
+    { variables: { projectId: PROJECT_ID } },
+  );
+  return <div data-testid="ship-ready-count">{data ? data.shipReadyItems.openingItems.length : -1}</div>;
+}
+
 // A cache holding what the Ship view read before the shipment - the snapshot that must not survive.
 function seededCache() {
   const cache = new InMemoryCache();
@@ -110,28 +159,7 @@ function seededCache() {
     data: {
       shipReadyItems: {
         __typename: 'ShipReadyItems',
-        openingItems: [
-          {
-            __typename: 'OpeningItem',
-            id: 'oi-1',
-            projectId: PROJECT_ID,
-            openingId: 'op-1',
-            openingNumber: '0019-EX',
-            building: 'A',
-            floor: '1',
-            location: 'Rm 101',
-            leaf: 1,
-            quantity: 1,
-            assemblyCompletedAt: '2026-07-24T00:00:00Z',
-            state: 'SHIP_READY',
-            aisle: null,
-            row: null,
-            bay: null,
-            createdAt: '2026-07-24T00:00:00Z',
-            updatedAt: '2026-07-24T00:00:00Z',
-            installedHardware: [],
-          },
-        ],
+        openingItems: [shipReadyLeaf()],
         looseItems: [],
       },
     },
@@ -139,19 +167,18 @@ function seededCache() {
   return cache;
 }
 
-function renderForm(mocks: MockedResponse[], cache: InMemoryCache) {
-  const onShipped = vi.fn();
-  const onClose = vi.fn();
+function renderForm(mocks: MockedResponse[], cache: InMemoryCache, withShipReadyProbe = false) {
   render(
     <MockedProvider mocks={mocks} cache={cache}>
       <MemoryRouter>
         <ToastProvider>
           <CartProvider>
             <CartProbe />
+            {withShipReadyProbe && <ShipReadyProbe />}
             <PackingSlipForm
               open
-              onClose={onClose}
-              onShipped={onShipped}
+              onClose={vi.fn()}
+              onShipped={vi.fn()}
               projectId={PROJECT_ID}
               projectName="TUBC 80003"
             />
@@ -160,20 +187,30 @@ function renderForm(mocks: MockedResponse[], cache: InMemoryCache) {
       </MemoryRouter>
     </MockedProvider>,
   );
-  return { onShipped, onClose };
 }
 
-async function submitShipment(mocks: MockedResponse[], cache: InMemoryCache) {
-  const handles = renderForm(mocks, cache);
+async function submitShipment(
+  mocks: MockedResponse[],
+  cache: InMemoryCache,
+  withShipReadyProbe = false,
+) {
+  renderForm(mocks, cache, withShipReadyProbe);
   await waitFor(() => expect(screen.getByTestId('cart-count')).toHaveTextContent('1'));
   fireEvent.change(screen.getByLabelText(/Packing Slip Number/i), {
     target: { value: 'PS-0019-L1' },
   });
   fireEvent.click(screen.getByRole('button', { name: /Confirm Shipment/i }));
-  return handles;
 }
 
 describe('PackingSlipForm', () => {
+  // The bug in #337: the Ship view sat behind this dialog still offering the shipped leaf.
+  it('refreshes a mounted ship-ready consumer so the shipped leaf leaves the grid', async () => {
+    await submitShipment([confirmMock(), shipReadyAfterShipmentMock()], seededCache(), true);
+
+    await waitFor(() => expect(screen.getByText('Shipment Confirmed')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('ship-ready-count')).toHaveTextContent('0'));
+  });
+
   it('empties the cart as soon as the shipment succeeds, not on the next button press', async () => {
     await submitShipment([confirmMock()], seededCache());
 
@@ -184,23 +221,53 @@ describe('PackingSlipForm', () => {
 
   it('evicts the pre-shipment root fields so unmounted views refetch instead of reusing them', async () => {
     const cache = seededCache();
-    expect(Object.keys(cache.extract().ROOT_QUERY ?? {}).some((k) => k.startsWith('shipReadyItems'))).toBe(true);
+    const shipReadyKeys = () =>
+      Object.keys(cache.extract().ROOT_QUERY ?? {}).filter((k) => k.startsWith('shipReadyItems'));
+    expect(shipReadyKeys()).not.toHaveLength(0);
 
     await submitShipment([confirmMock()], cache);
 
     await waitFor(() => expect(screen.getByText('Shipment Confirmed')).toBeInTheDocument());
-    expect(Object.keys(cache.extract().ROOT_QUERY ?? {}).some((k) => k.startsWith('shipReadyItems'))).toBe(false);
+    expect(shipReadyKeys()).toHaveLength(0);
   });
 
+  // Keyed on extensions.code, so this asserts the real CombinedGraphQLErrors shape the backend's
+  // ErrorHandlerExtension produces - not a bare network Error.
   it('replaces the raw state-transition error with a readable one', async () => {
     const rejected: MockedResponse = {
       request: { query: CONFIRM_SHIPMENT, variables: CONFIRM_VARS },
-      error: new Error('Opening item 9f2 is not Ship_Ready (current: Shipped_Out)'),
+      result: {
+        errors: [
+          {
+            message: 'Opening item 9f2 is not Ship_Ready (current: Shipped_Out)',
+            extensions: { code: 'INVALID_STATE_TRANSITION' },
+          },
+        ],
+      },
     };
-    await submitShipment([rejected], seededCache());
+    await submitShipment([rejected, shipReadyAfterShipmentMock()], seededCache());
 
     await waitFor(() => expect(screen.getByText(/no longer ship-ready/i)).toBeInTheDocument());
     expect(screen.queryByText(/not Ship_Ready \(current/)).not.toBeInTheDocument();
     expect(screen.queryByText('Shipment Confirmed')).not.toBeInTheDocument();
+  });
+
+  it('keeps the insufficiency detail and notes the refresh', async () => {
+    const rejected: MockedResponse = {
+      request: { query: CONFIRM_SHIPMENT, variables: CONFIRM_VARS },
+      result: {
+        errors: [
+          {
+            message:
+              'Insufficient loose hardware: AD8406 (Locksets) for opening 0019-EX - requested 4, available 1',
+            extensions: { code: 'VALIDATION_ERROR', field: 'items' },
+          },
+        ],
+      },
+    };
+    await submitShipment([rejected, shipReadyAfterShipmentMock()], seededCache());
+
+    await waitFor(() => expect(screen.getByText(/requested 4, available 1/)).toBeInTheDocument());
+    expect(screen.getByText(/list has been refreshed/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useRef } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { InMemoryCache } from '@apollo/client/cache';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../../../components/Toast';
+import { CartProvider, useCart, type CartItem } from '../../../contexts/CartContext';
+import PackingSlipForm from '../PackingSlipForm';
+import { CONFIRM_SHIPMENT, GET_SHIP_READY_ITEMS } from '../../../graphql/shipping';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Me',
+    userId: 'me',
+    roles: [],
+    hasRole: () => false,
+    isAdmin: false,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+// The real renderer pulls a font/layout stack that jsdom can't run, and none of these tests exercise
+// the PDF path - PackingSlipDocument only needs the primitives to import.
+vi.mock('@react-pdf/renderer', () => ({
+  pdf: () => ({ toBlob: () => Promise.resolve(new Blob()) }),
+  Document: () => null,
+  Page: () => null,
+  Text: () => null,
+  View: () => null,
+  StyleSheet: { create: (s: unknown) => s },
+}));
+
+const PROJECT_ID = 'proj-1';
+
+const CART_ITEM: CartItem = {
+  id: 'oi-1',
+  itemType: 'Opening_Item',
+  openingItemId: 'oi-1',
+  openingNumber: '0019-EX',
+  leaf: 1,
+  quantity: 1,
+  building: 'A',
+  floor: '1',
+  location: 'Rm 101',
+};
+
+const CONFIRM_VARS = {
+  input: {
+    projectId: PROJECT_ID,
+    packingSlipNumber: 'PS-0019-L1',
+    shippedBy: 'Me',
+    items: [{ itemType: 'OPENING_ITEM', openingItemId: 'oi-1', quantity: 1 }],
+  },
+};
+
+function confirmMock(): MockedResponse {
+  return {
+    request: { query: CONFIRM_SHIPMENT, variables: CONFIRM_VARS },
+    result: {
+      data: {
+        confirmShipment: {
+          __typename: 'PackingSlip',
+          id: 'ps-1',
+          packingSlipNumber: 'PS-0019-L1',
+          projectId: PROJECT_ID,
+          shippedBy: 'Me',
+          shippedAt: '2026-07-24T00:00:00Z',
+          createdAt: '2026-07-24T00:00:00Z',
+          items: [
+            {
+              __typename: 'PackingSlipItem',
+              id: 'psi-1',
+              packingSlipId: 'ps-1',
+              itemType: 'OPENING_ITEM',
+              openingItemId: 'oi-1',
+              openingNumber: '0019-EX',
+              productCode: 'AD8406',
+              hardwareCategory: 'Locksets',
+              quantity: 1,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+// Seeds one opening item into the cart on mount and exposes the live count, so a test can assert the
+// cart emptied without reaching into the context internals.
+function CartProbe() {
+  const { items, addItem } = useCart();
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current) return;
+    seeded.current = true;
+    addItem(CART_ITEM);
+  }, [addItem]);
+  return <div data-testid="cart-count">{items.length}</div>;
+}
+
+// A cache holding what the Ship view read before the shipment - the snapshot that must not survive.
+function seededCache() {
+  const cache = new InMemoryCache();
+  cache.writeQuery({
+    query: GET_SHIP_READY_ITEMS,
+    variables: { projectId: PROJECT_ID },
+    data: {
+      shipReadyItems: {
+        __typename: 'ShipReadyItems',
+        openingItems: [
+          {
+            __typename: 'OpeningItem',
+            id: 'oi-1',
+            projectId: PROJECT_ID,
+            openingId: 'op-1',
+            openingNumber: '0019-EX',
+            building: 'A',
+            floor: '1',
+            location: 'Rm 101',
+            leaf: 1,
+            quantity: 1,
+            assemblyCompletedAt: '2026-07-24T00:00:00Z',
+            state: 'SHIP_READY',
+            aisle: null,
+            row: null,
+            bay: null,
+            createdAt: '2026-07-24T00:00:00Z',
+            updatedAt: '2026-07-24T00:00:00Z',
+            installedHardware: [],
+          },
+        ],
+        looseItems: [],
+      },
+    },
+  });
+  return cache;
+}
+
+function renderForm(mocks: MockedResponse[], cache: InMemoryCache) {
+  const onShipped = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <MockedProvider mocks={mocks} cache={cache}>
+      <MemoryRouter>
+        <ToastProvider>
+          <CartProvider>
+            <CartProbe />
+            <PackingSlipForm
+              open
+              onClose={onClose}
+              onShipped={onShipped}
+              projectId={PROJECT_ID}
+              projectName="TUBC 80003"
+            />
+          </CartProvider>
+        </ToastProvider>
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+  return { onShipped, onClose };
+}
+
+async function submitShipment(mocks: MockedResponse[], cache: InMemoryCache) {
+  const handles = renderForm(mocks, cache);
+  await waitFor(() => expect(screen.getByTestId('cart-count')).toHaveTextContent('1'));
+  fireEvent.change(screen.getByLabelText(/Packing Slip Number/i), {
+    target: { value: 'PS-0019-L1' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Confirm Shipment/i }));
+  return handles;
+}
+
+describe('PackingSlipForm', () => {
+  it('empties the cart as soon as the shipment succeeds, not on the next button press', async () => {
+    await submitShipment([confirmMock()], seededCache());
+
+    await waitFor(() => expect(screen.getByText('Shipment Confirmed')).toBeInTheDocument());
+    // Still on the success view - no "Ship More Items" / "Return to Home" click yet.
+    expect(screen.getByTestId('cart-count')).toHaveTextContent('0');
+  });
+
+  it('evicts the pre-shipment root fields so unmounted views refetch instead of reusing them', async () => {
+    const cache = seededCache();
+    expect(Object.keys(cache.extract().ROOT_QUERY ?? {}).some((k) => k.startsWith('shipReadyItems'))).toBe(true);
+
+    await submitShipment([confirmMock()], cache);
+
+    await waitFor(() => expect(screen.getByText('Shipment Confirmed')).toBeInTheDocument());
+    expect(Object.keys(cache.extract().ROOT_QUERY ?? {}).some((k) => k.startsWith('shipReadyItems'))).toBe(false);
+  });
+
+  it('replaces the raw state-transition error with a readable one', async () => {
+    const rejected: MockedResponse = {
+      request: { query: CONFIRM_SHIPMENT, variables: CONFIRM_VARS },
+      error: new Error('Opening item 9f2 is not Ship_Ready (current: Shipped_Out)'),
+    };
+    await submitShipment([rejected], seededCache());
+
+    await waitFor(() => expect(screen.getByText(/no longer ship-ready/i)).toBeInTheDocument());
+    expect(screen.queryByText(/not Ship_Ready \(current/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Shipment Confirmed')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
fixes #337.

confirmShipment declared bare - no refetchQueries, no update, no cache eviction. GetShipReadyItems is cache-first and GetOpeningLeafStatus stays mounted behind the packing-slip dialog, so neither re-ran on its own.

frontend/src/graphql/refetch.ts

SHIPPING_STALE_ROOT_FIELDS, evicted
shipReadyItems
openingItems

SHIPPING_REFETCH_QUERIES, refetched
GetOpeningLeafStatus

the two lists are disjoint on purpose. evicting a root field that a mounted query also refetches makes Apollo fire a repair fetch for the incomplete cache diff on top of the explicit refetch, so the two heaviest shipping resolvers would run twice concurrently. shipReadyItems is evicted rather than refetched because the cart drawer renders outside Routes, so a shipment can be confirmed from the Requests or Returns tab with the Ship view unmounted, where refetchQueries silently skips it. openingItems is warehouse Opening Items, another module, never active at ship time. packingSlips needs neither, ShipmentsList reads cache-and-network and already refetches directly when a return completes.

frontend/src/modules/shipping/PackingSlipForm.tsx
- update(cache) evicts the stale root fields plus cache.gc(), refetchQueries covers the mounted rollup.
- no awaitRefetchQueries. it folds the refetches into the mutate promise via QueryInfo.markMutationResult and Promise.all, so a slow or failed refetch would reject a shipment that already committed: no success view, no packing-slip PDF, and a retry that can only fail on the duplicate slip number.
- cart clears the moment the shipment succeeds, clearCart stays in the success-view exits as an idempotent backstop.
- stale-cart failures classified on extensions.code via extractGpError instead of regex on the backend wording. INVALID_STATE_TRANSITION replaces the uuid-bearing string, VALIDATION_ERROR for insufficient loose hardware keeps its detail and gains the refresh note.
- error path evicts and awaits the refetch inside its own try/catch, so "the list has been refreshed" is true by the time it is read and a failed refetch cannot mask the real error.
- All Projects mode guarded. projectId is undefined there against a non-null ID!, so confirm died on variable coercion.

frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx, new file
- mounted ship-ready consumer refreshes after confirm and the leaf leaves the grid. confirmed failing without the invalidation.
- cart empties on success
- pre-shipment root fields evicted from cache
- INVALID_STATE_TRANSITION shows the readable message, asserted against the real CombinedGraphQLErrors shape
- VALIDATION_ERROR keeps the insufficiency detail and notes the refresh

no backend change. get_ship_ready_items filters state == SHIP_READY, so a refetch drops the shipped leaf on its own.

deferred to its own issue and one consistent fix - reloading /shipping/browse drops project context back to the project picker, repo-wide pattern. selectedProject held in local useState
ShippingModule
import/index.tsx
warehouse InventoryView
warehouse DeliveriesView
