### PR TITLE
fix(shop-assembly): slice 1 correctness & safety fixes (#339)

### DIFF
--- a/backend/alembic/versions/059_pull_request_item_sa_opening_item.py
+++ b/backend/alembic/versions/059_pull_request_item_sa_opening_item.py
@@ -1,0 +1,46 @@
+"""Replacement pull lines link back to the deficient assembly item (#339)
+
+Revision ID: 059
+Revises: 058
+Create Date: 2026-07-26
+
+Issue #339: report_deficiency_at_assembly mints a PR-REPL replacement pull line for a checklist item
+flagged deficient at the bench, but the line carried nothing pointing back at the item that failed.
+Add a nullable FK so a replacement can be traced to its ShopAssemblyOpeningItem - the hook the
+replacement-loop closure hangs off - plus an index for the reverse lookup.
+
+Additive and nullable, no backfill: pre-#339 replacement lines stay null (untraceable, as they are
+today), and every non-replacement pull line stays null forever. The FK is created inline with the
+column, so dropping the column in downgrade drops it too.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "059"
+down_revision = "058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pull_request_items",
+        sa.Column(
+            "sa_opening_item_id",
+            sa.Uuid(),
+            sa.ForeignKey("shop_assembly_opening_items.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_pull_request_items_sa_opening_item",
+        "pull_request_items",
+        ["sa_opening_item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pull_request_items_sa_opening_item", table_name="pull_request_items")
+    op.drop_column("pull_request_items", "sa_opening_item_id")

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -75,6 +75,8 @@ input CompleteOpeningInput {
   completed_by: String
 }
 
+# Every field below is gated on an authenticated caller (require_user, #339) except where a
+# stronger role gate is noted. Adding the gate did not change any field's arguments.
 type Query {
   assembleList(projectId: ID!): [ShopAssemblyOpening!]!
   myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
@@ -85,8 +87,13 @@ type Query {
 }
 
 type Mutation {
+  # Self-assignment is open to any signed-in user; assigning to *another* user additionally
+  # requires the Shop Assembly Manager role (#330).
   assignOpenings(input: AssignOpeningsInput!): [ShopAssemblyOpening!]!
   removeOpeningFromUser(openingId: ID!): ShopAssemblyOpening!
+  # Refuses (#339) if a live OpeningItem already exists for this (opening, leaf) - CONFLICT - or if
+  # every checklist item is flagged deficient, which would mint an empty assembled leaf -
+  # VALIDATION_ERROR. Neither case records any deficiency; the opening stays pending.
   completeOpening(input: CompleteOpeningInput!): OpeningItem!
   # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
   # display name. Accept re-checks inventory sufficiency and mints the warehouse PullRequest.

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -108,6 +108,9 @@ type PullRequestItem {
   item_type: PullRequestItemType!
   opening_number: String!
   opening_item_id: ID
+  # Deficient ShopAssemblyOpeningItem this line replaces (#339). Set only on PR-REPL replacement
+  # lines minted at assembly completion; null on every other line.
+  sa_opening_item_id: ID
   # Door leaf this pull line is for (#311). Null = legacy / leaf-agnostic.
   leaf: Int
   hardware_category: String

--- a/backend/app/models/pull_request.py
+++ b/backend/app/models/pull_request.py
@@ -58,6 +58,7 @@ class PullRequestItem(Base):
     __table_args__ = (
         Index("ix_pull_request_items_pull_request", "pull_request_id"),
         Index("ix_pull_request_items_opening_item", "opening_item_id"),
+        Index("ix_pull_request_items_sa_opening_item", "sa_opening_item_id"),
         CheckConstraint("requested_quantity >= 1", name="ck_pull_request_items_requested_quantity_positive"),
     )
 
@@ -73,6 +74,12 @@ class PullRequestItem(Base):
     )
     opening_number: Mapped[str] = mapped_column(String, nullable=False)
     opening_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("opening_items.id"), nullable=True)
+    # The deficient shop-assembly checklist item this line replaces (#339). Set only on PR-REPL
+    # replacement lines minted by report_deficiency_at_assembly, so a replacement pull can be traced
+    # back to the exact ShopAssemblyOpeningItem that failed at the bench. Null on every other line.
+    sa_opening_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("shop_assembly_opening_items.id"), nullable=True
+    )
     # Door leaf this pull line is for (#311): SHOP_ASSEMBLY LOOSE from ShopAssemblyOpening.leaf,
     # SHIPPING_OUT OPENING_ITEM from OpeningItem.leaf. Snapshot so a leaf-1 pull reads distinct from
     # a leaf-2 pull. Null = legacy / leaf-agnostic.

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -206,6 +206,23 @@ def complete_opening(
     if pr is None:
         raise NotFoundError(f"Completed shop-assembly pull request for opening {opening_id} not found")
 
+    # 3. Duplicate-completion guard (#339). Two shop-assembly openings can name the same
+    #    (opening_id, leaf) - e.g. a request was reopened and re-imported, or the same leaf was sent
+    #    to the shop twice - and completing both would mint a second assembled unit for one physical
+    #    door leaf, double-counting inventory and letting the same leaf ship twice. Refuse if a live
+    #    OpeningItem already exists for this leaf, using exactly the keying the pre-request REQ-5
+    #    guard uses (find_already_assembled_openings: any state except SHIPPED_OUT, and a legacy
+    #    null-leaf unit matches only a null-leaf spec).
+    if find_already_assembled_openings(
+        session, pr.project_id, [(sa_opening.opening_number, sa_opening.opening_id, sa_opening.leaf)]
+    ):
+        leaf_suffix = f" leaf {sa_opening.leaf}" if sa_opening.leaf is not None else ""
+        raise ConflictError(
+            f"Opening {sa_opening.opening_number}{leaf_suffix} has already been assembled - "
+            "an assembled unit for it is still in the system",
+            field="opening_id",
+        )
+
     # 4. Resolve the per-item installed/deficient checklist (#225). The checklist is keyed on
     #    ShopAssemblyOpeningItem ids (what the assembler sees in the modal). Any item without a
     #    result row defaults to installed, so an empty checklist preserves the old snapshot-all path.
@@ -230,6 +247,20 @@ def complete_opening(
                     field="deficient_reason",
                 )
             deficient_reason_by_id[res.shop_assembly_opening_item_id] = reason
+
+    # 4b. Refuse an all-deficient completion (#339). If every checklist item is flagged deficient the
+    #     OpeningItem would be minted with zero OpeningItemHardware rows - an "assembled" leaf that
+    #     had nothing installed on it, which then reads as ship-ready inventory. Nothing was
+    #     assembled, so the opening stays PENDING and no deficiency is recorded: the caller's
+    #     transaction is abandoned whole, so the flagged units are neither returned to inventory nor
+    #     given a PR-REPL line. Report the deficiencies through the warehouse deficiency flow, or
+    #     re-complete once at least one item is installed.
+    if sa_opening.items and all(item.id in deficient_reason_by_id for item in sa_opening.items):
+        raise ValidationError(
+            "Cannot complete an opening with every item flagged deficient - nothing would be "
+            "assembled. Leave the opening pending and report the deficiencies instead.",
+            field="item_results",
+        )
 
     # 5. Create OpeningItem (snapshot opening identity from the ShopAssemblyOpening row)
     now = datetime.utcnow()

--- a/backend/app/repositories/stock/deficiency.py
+++ b/backend/app/repositories/stock/deficiency.py
@@ -246,6 +246,13 @@ def report_deficiency_at_assembly(
         pull_request_id=replacement_pr.id,
         item_type=PullRequestItemType.LOOSE,
         opening_number=opening_number,
+        # Restore the identity the replacement is owed to (#339). Without these the replacement was
+        # a bare (opening, product) line: the warehouse could not tell a pair's leaf-1 replacement
+        # from its leaf-2 one, and nothing tied the pulled unit back to the checklist item that
+        # failed. leaf comes from the ShopAssemblyOpening (the assembly work unit is one leaf);
+        # sa_opening_item_id is the direct link the replacement-loop closure reads.
+        leaf=sa_opening.leaf,
+        sa_opening_item_id=sa_oi.id,
         hardware_category=il.hardware_category,
         product_code=il.product_code,
         requested_quantity=quantity,

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -539,6 +539,7 @@ def pull_request_item_to_type(item) -> PullRequestItem:
         item_type=item.item_type,
         opening_number=item.opening_number,
         opening_item_id=strawberry.ID(str(item.opening_item_id)) if item.opening_item_id else None,
+        sa_opening_item_id=(strawberry.ID(str(item.sa_opening_item_id)) if item.sa_opening_item_id else None),
         leaf=item.leaf,
         hardware_category=item.hardware_category,
         product_code=item.product_code,

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -25,7 +25,11 @@ from .types import ClerkUser, OpeningItem, ShopAssemblyOpening, ShopAssemblyRequ
 @strawberry.type
 class ShopAssemblyQueries:
     @strawberry.field
-    def assemble_list(self, project_id: strawberry.ID | None = None) -> list[ShopAssemblyOpening]:
+    def assemble_list(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[ShopAssemblyOpening]:
+        """Openings whose shop-assembly pull is complete (#222). Open to any signed-in user."""
+        require_user(info)
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_assemble_list(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -33,7 +37,9 @@ class ShopAssemblyQueries:
             return [shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.field
-    def my_work(self, assigned_to_user_id: str) -> list[ShopAssemblyOpening]:
+    def my_work(self, info: strawberry.Info, assigned_to_user_id: str) -> list[ShopAssemblyOpening]:
+        """An assembler's claimed, still-pending openings. Open to any signed-in user."""
+        require_user(info)
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_my_work(session, assigned_to_user_id)
             return [shop_assembly_opening_to_type(sao) for sao in saos]
@@ -41,13 +47,15 @@ class ShopAssemblyQueries:
     @strawberry.field
     def shop_assembly_requests(
         self,
+        info: strawberry.Info,
         project_id: strawberry.ID | None = None,
         status: ShopAssemblyRequestStatus | None = None,
         reopenable_only: bool = False,
     ) -> list[ShopAssemblyRequest]:
         """Accept UI (#293): shop-assembly requests for a project, PENDING by default. reopenableOnly
         (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
-        view uses it so it lists only requests Reopen can still act on."""
+        view uses it so it lists only requests Reopen can still act on. Open to any signed-in user."""
+        require_user(info)
         with SessionLocal() as session:
             reqs = shop_assembly_repository.get_shop_assembly_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
@@ -139,7 +147,9 @@ class ShopAssemblyMutations:
             return [shop_assembly_opening_to_type(sao) for sao in saos]
 
     @strawberry.mutation
-    def remove_opening_from_user(self, opening_id: strawberry.ID) -> ShopAssemblyOpening:
+    def remove_opening_from_user(self, info: strawberry.Info, opening_id: strawberry.ID) -> ShopAssemblyOpening:
+        """Unassign a pending opening. Open to any signed-in user (the board's Unassign action)."""
+        require_user(info)
         with SessionLocal() as session:
             result = shop_assembly_repository.remove_opening_from_user(session, uuid.UUID(str(opening_id)))
             session.commit()
@@ -147,7 +157,10 @@ class ShopAssemblyMutations:
             return shop_assembly_opening_to_type(refreshed)
 
     @strawberry.mutation
-    def complete_opening(self, input: CompleteOpeningInput) -> OpeningItem:
+    def complete_opening(self, info: strawberry.Info, input: CompleteOpeningInput) -> OpeningItem:
+        """Complete an opening's assembly, materializing the assembled leaf as an OpeningItem (#339).
+        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously."""
+        require_user(info)
         with SessionLocal() as session:
             item_results = [
                 shop_assembly_repository.OpeningItemResult(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -481,6 +481,8 @@ class PullRequestItem:
     item_type: PullRequestItemType
     opening_number: str
     opening_item_id: strawberry.ID | None
+    # Deficient shop-assembly checklist item this line replaces (#339). Set only on PR-REPL lines.
+    sa_opening_item_id: strawberry.ID | None
     # Door leaf this pull line is for (#311): 1 or 2, or null (legacy / leaf-agnostic).
     leaf: int | None
     hardware_category: str | None

--- a/backend/tests/test_shop_assembly_completion_guards.py
+++ b/backend/tests/test_shop_assembly_completion_guards.py
@@ -1,0 +1,384 @@
+"""Completion-time correctness guards for shop assembly (#339).
+
+Three things complete_opening now refuses or records that it previously did not:
+
+1. Duplicate completion - a live OpeningItem already exists for this (opening_id, leaf), so
+   completing again would mint a second assembled unit for one physical door leaf.
+2. All-deficient completion - every checklist item flagged deficient would mint an OpeningItem with
+   zero installed hardware, an "assembled" leaf that reads as ship-ready inventory.
+3. Replacement-line identity - the PR-REPL line minted for a deficient item now carries the leaf and
+   a FK back to the ShopAssemblyOpeningItem that failed.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import ConflictError, ValidationError
+from app.models.enums import (
+    AssemblyStatus,
+    OpeningItemState,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.opening_item import OpeningItem
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
+from app.models.stock_item import StockItem
+from app.repositories import shop_assembly_repository, warehouse_admin_repository
+
+HINGE = ("HINGE", "HG-G1")
+LOCK = ("LOCK", "LK-G1")
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category, code, quantity=0):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _make_pulled_opening(session, project_id, *, request_number, items, leaf=None, opening_id=None):
+    """A COMPLETED SHOP_ASSEMBLY pull request with one PULLED, assigned, still-pending opening.
+
+    `items` is a list of (category, code, qty). Returns (opening, {code: ShopAssemblyOpeningItem}).
+    """
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=request_number,
+        project_id=project_id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.COMPLETED,
+        requested_by="tester",
+        completed_at=datetime.utcnow(),
+    )
+    session.add(pr)
+    session.flush()
+
+    opening = ShopAssemblyOpening(
+        id=uuid.uuid4(),
+        pull_request_id=pr.id,
+        opening_id=opening_id or uuid.uuid4(),
+        opening_number="A01",
+        leaf=leaf,
+        pull_status=PullStatus.PULLED,
+        assigned_to="assembler",
+        assigned_to_user_id="user_1",
+        assembly_status=AssemblyStatus.PENDING,
+    )
+    session.add(opening)
+    session.flush()
+
+    sao_items = {}
+    for category, code, qty in items:
+        sao_item = ShopAssemblyOpeningItem(
+            id=uuid.uuid4(),
+            shop_assembly_opening_id=opening.id,
+            hardware_category=category,
+            product_code=code,
+            quantity=qty,
+        )
+        session.add(sao_item)
+        sao_items[code] = sao_item
+    session.flush()
+    return opening, sao_items
+
+
+def _make_assembled_unit(session, project_id, opening_id, *, leaf, state=OpeningItemState.IN_INVENTORY):
+    oi = OpeningItem(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        opening_id=opening_id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
+        opening_number="A01",
+        leaf=leaf,
+        quantity=1,
+        assembly_completed_at=datetime.utcnow(),
+        state=state,
+    )
+    session.add(oi)
+    session.flush()
+    return oi
+
+
+# --- 1. duplicate-completion guard -------------------------------------------------------------
+
+
+def test_completion_refused_when_leaf_already_assembled(db_session):
+    """A live OpeningItem for the same (opening_id, leaf) blocks a second completion."""
+    project = _make_project(db_session)
+    opening_id = uuid.uuid4()
+    _make_assembled_unit(db_session, project.id, opening_id, leaf=1)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP1",
+        items=[(*HINGE, 2)],
+        leaf=1,
+        opening_id=opening_id,
+    )
+
+    with pytest.raises(ConflictError):
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+
+    # Nothing was minted and the opening stays workable.
+    db_session.flush()
+    assert opening.assembly_status == AssemblyStatus.PENDING
+    minted = db_session.scalars(select(OpeningItem).where(OpeningItem.opening_id == opening_id)).all()
+    assert len(minted) == 1
+
+
+def test_completion_allowed_when_only_the_other_leaf_is_assembled(db_session):
+    """Leaf keying (#311): assembling leaf 1 must not block leaf 2 of the same opening."""
+    project = _make_project(db_session)
+    opening_id = uuid.uuid4()
+    _make_assembled_unit(db_session, project.id, opening_id, leaf=1)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP2",
+        items=[(*HINGE, 2)],
+        leaf=2,
+        opening_id=opening_id,
+    )
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+    assert result.leaf == 2
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+
+def test_completion_allowed_when_prior_unit_shipped_out(db_session):
+    """SHIPPED_OUT units are not live - the leaf can be assembled again (a replacement build)."""
+    project = _make_project(db_session)
+    opening_id = uuid.uuid4()
+    _make_assembled_unit(db_session, project.id, opening_id, leaf=1, state=OpeningItemState.SHIPPED_OUT)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP3",
+        items=[(*HINGE, 2)],
+        leaf=1,
+        opening_id=opening_id,
+    )
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+    assert result.state == OpeningItemState.IN_INVENTORY
+
+
+def test_legacy_null_leaf_unit_only_blocks_a_null_leaf_completion(db_session):
+    """Legacy whole-opening units carry a null leaf and match only a null-leaf work unit."""
+    project = _make_project(db_session)
+    opening_id = uuid.uuid4()
+    _make_assembled_unit(db_session, project.id, opening_id, leaf=None)
+
+    leafed, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP4",
+        items=[(*HINGE, 2)],
+        leaf=1,
+        opening_id=opening_id,
+    )
+    shop_assembly_repository.complete_opening(db_session, leafed.id, None, None, None)
+    db_session.flush()
+
+    legacy, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP5",
+        items=[(*HINGE, 2)],
+        leaf=None,
+        opening_id=opening_id,
+    )
+    with pytest.raises(ConflictError):
+        shop_assembly_repository.complete_opening(db_session, legacy.id, None, None, None)
+
+
+def test_duplicate_guard_is_project_scoped(db_session):
+    """The same historical opening_id under a different project does not block completion."""
+    other_project = _make_project(db_session)
+    project = _make_project(db_session)
+    opening_id = uuid.uuid4()
+    _make_assembled_unit(db_session, other_project.id, opening_id, leaf=1)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-DUP6",
+        items=[(*HINGE, 2)],
+        leaf=1,
+        opening_id=opening_id,
+    )
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+    assert result.project_id == project.id
+
+
+# --- 2. all-deficient completion ---------------------------------------------------------------
+
+
+def test_all_deficient_completion_is_refused(db_session):
+    """Every item flagged deficient would mint an empty assembled leaf - refuse the whole call."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-ALLDEF",
+        items=[(*HINGE, 1), (*LOCK, 1)],
+        leaf=1,
+    )
+
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.complete_opening(
+            db_session,
+            opening.id,
+            None,
+            None,
+            None,
+            item_results=[
+                shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=False, deficient_reason="bent"),
+                shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
+            ],
+            completed_by="assembler",
+        )
+    db_session.flush()
+
+    # The opening stays pending, no assembled unit exists...
+    assert opening.assembly_status == AssemblyStatus.PENDING
+    assert opening.completed_at is None
+    assert db_session.scalars(select(OpeningItem).where(OpeningItem.opening_id == opening.opening_id)).first() is None
+
+    # ...and no deficiency was recorded: the refusal happens before any unit is returned to
+    # inventory or any PR-REPL line is appended, so the call fails whole.
+    assert (
+        db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-ALLDEF")).first()
+        is None
+    )
+    db_session.refresh(il)
+    assert il.quantity == 0
+    assert il.deficient_quantity == 0
+
+
+def test_partially_deficient_completion_still_succeeds(db_session):
+    """One installed item is enough - the guard only fires when nothing at all is installed."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-PARTDEF",
+        items=[(*HINGE, 1), (*LOCK, 1)],
+        leaf=1,
+    )
+
+    result = shop_assembly_repository.complete_opening(
+        db_session,
+        opening.id,
+        None,
+        None,
+        None,
+        item_results=[
+            shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=True),
+            shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
+        ],
+        completed_by="assembler",
+    )
+    db_session.flush()
+    assert result.state == OpeningItemState.IN_INVENTORY
+
+
+def test_opening_with_no_items_still_completes(db_session):
+    """The guard is 'nothing installed out of something', not 'nothing installed'."""
+    project = _make_project(db_session)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-NOITEMS",
+        items=[],
+        leaf=1,
+    )
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+    assert result.state == OpeningItemState.IN_INVENTORY
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+
+# --- 3. replacement-line identity --------------------------------------------------------------
+
+
+def test_replacement_pull_line_carries_leaf_and_source_item(db_session):
+    """#339: the PR-REPL line is stamped with the leaf and the deficient ShopAssemblyOpeningItem."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-REPL",
+        items=[(*HINGE, 1), (*LOCK, 1)],
+        leaf=2,
+    )
+
+    shop_assembly_repository.complete_opening(
+        db_session,
+        opening.id,
+        None,
+        None,
+        None,
+        item_results=[
+            shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=True),
+            shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
+        ],
+        completed_by="assembler",
+    )
+    db_session.flush()
+
+    repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-REPL")).first()
+    assert repl is not None
+    lines = list(db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == repl.id)).all())
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.item_type == PullRequestItemType.LOOSE
+    assert line.product_code == LOCK[1]
+    assert line.opening_number == "A01"
+    # Identity restored on the replacement tag: which leaf, and which checklist item it replaces.
+    assert line.leaf == 2
+    assert line.sa_opening_item_id == sao[LOCK[1]].id


### PR DESCRIPTION
Slice 1 of 6 of the shop-assembly completion plan: purely defensive fixes that every later slice builds on. Backend only — no frontend changes were needed.

Closes #339

## 1. Auth sweep of the shop-assembly resolvers

`completeOpening` had **no auth gate at all**, so an unauthenticated caller could mint assembled inventory. Every query and mutation in `backend/app/schemas/shop_assembly.py` now calls `require_user(info)`:

| Resolver | Before | After |
| --- | --- | --- |
| `assembleList` | ungated | `require_user` |
| `myWork` | ungated | `require_user` |
| `shopAssemblyRequests` | ungated | `require_user` |
| `shopAssemblyMembers` | `require_role(Shop Assembly Manager)` | unchanged |
| `assignOpenings` | `require_user` + manager role to assign to another user | unchanged |
| `removeOpeningFromUser` | ungated | `require_user` |
| `completeOpening` | **ungated** | `require_user` |
| accept / reject / reopen | `require_user` | unchanged |

The gated resolvers gained an `info: strawberry.Info` parameter. Strawberry does not expose `info` as a GraphQL argument, so **the client contract is unchanged** — verified by building the schema and diffing the printed SDL, and `frontend/src/graphql/shop-assembly.ts` needs no edit.

## 2. Duplicate-completion guard

`complete_opening` never checked whether the leaf had already been assembled, so completing the same work unit twice minted a second `OpeningItem` for one physical door leaf — double-counted inventory that could then ship twice.

It now raises `ConflictError` (`extensions.code = CONFLICT`) when a live `OpeningItem` exists for `(project_id, opening_id, leaf)`. The check *calls* `find_already_assembled_openings` rather than reimplementing it, so the keying is identical to the pre-request REQ-5 guard by construction: any state except `SHIPPED_OUT` counts as live, and a legacy null-leaf unit matches only a null-leaf work unit. Assembling leaf 1 still does not block leaf 2 (#311).

## 3. PR-REPL replacement pull lines regain their identity

`report_deficiency_at_assembly` minted the replacement `PullRequestItem` with no `leaf` and nothing pointing back at the deficient `ShopAssemblyOpeningItem` — a bare (opening, product) line the warehouse could not attribute to a pair's leaf 1 vs leaf 2. That is a hole in the identity lifecycle (`docs/HARDWARE_IDENTITY_LIFECYCLE.md`: a pull line *is* the tag).

- New nullable `pull_request_items.sa_opening_item_id` FK → `shop_assembly_opening_items.id`, plus `ix_pull_request_items_sa_opening_item` for the reverse lookup (model + **migration `059`**, additive, no backfill, working `downgrade`).
- The replacement line is now stamped with `leaf` (from the `ShopAssemblyOpening`) and `sa_opening_item_id`.
- Exposed as `saOpeningItemId` on the `PullRequestItem` GraphQL type so the SDL reference docs stay truthful. Purely additive for clients.

This is the hook slice 3 (replacement-loop closure) hangs off.

## 4. Refuse an all-deficient completion

If every checklist item was flagged deficient, completion created an `OpeningItem` with **zero** `OpeningItemHardware` rows — an "assembled" leaf with nothing on it, sitting in inventory reading as ship-ready.

It now raises `ValidationError` (`extensions.code = VALIDATION_ERROR`) before anything is written, so the call fails whole: no unit is returned to inventory flagged deficient, no PR-REPL line is appended, and the opening stays `PENDING`. The guard is "nothing installed out of something" — an opening with no items at all still completes, and one installed item is enough.

## Verification

Run locally against a real Postgres 16 (the suite skips entirely without `DATABASE_URL`):

- `pytest` — **261 passed**, including 9 new DB-backed repository tests in `backend/tests/test_shop_assembly_completion_guards.py` covering duplicate/leaf/SHIPPED_OUT/legacy-null-leaf/cross-project keying, the all-deficient refusal (asserting no deficiency was recorded), the partial and no-items cases, and the stamped replacement line.
- `ruff check .` and `ruff format --check .` — clean.
- Full CI migration-integrity cycle: `upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean).
- Strawberry schema builds; printed SDL confirms no argument changes and the new `saOpeningItemId` field.
