### PR TITLE
feat(shop-assembly): slice 2 persisted assembly progress (#340)

### DIFF
--- a/backend/alembic/versions/060_assembly_progress.py
+++ b/backend/alembic/versions/060_assembly_progress.py
@@ -1,0 +1,104 @@
+"""Persisted per-item assembly progress (#340)
+
+Revision ID: 060
+Revises: 059
+Create Date: 2026-07-26
+
+Assembly used to be an atomic, ephemeral event: the assembler's checklist lived only in the browser
+until Mark Complete posted it, so a leaf half-built at the end of a shift lost everything. This adds
+the two counters completion now reads instead:
+
+- shop_assembly_opening_items.installed_quantity - units actually fitted to the leaf.
+- shop_assembly_opening_items.deficient_quantity - units found defective and already sent through the
+  deficiency flow (returned to inventory flagged deficient + a PR-REPL replacement pull).
+
+Both default to 0, so every existing row starts un-dispositioned; a check constraint keeps them
+non-negative and keeps their sum inside the planned quantity, which is what makes
+`remaining = quantity - installed - deficient` safe to derive rather than store.
+
+Three enum values come with it:
+- assembly_status gains IN_PROGRESS - an opening with saved progress that is not finished.
+- audit_action gains INSTALL_PROGRESS and ASSEMBLY_COMPLETE, and audit_entity_type gains
+  SHOP_ASSEMBLY_OPENING, so a progress save is auditable against the work unit. Progress cannot hang
+  off OPENING_ITEM - no OpeningItem exists until completion - and because saving progress and
+  finishing the leaf are no longer the same call, the two moments need distinct actions.
+
+Downgrade folds IN_PROGRESS openings back to PENDING (their saved counters go away with the columns,
+which is exactly the pre-#340 behaviour), discards the progress audit rows, and recreates the three
+enums without the new values - Postgres cannot drop an enum label in place.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "060"
+down_revision = "059"
+branch_labels = None
+depends_on = None
+
+_ASSEMBLY_STATUS_WITHOUT = "'PENDING', 'COMPLETED'"
+_AUDIT_ACTION_WITHOUT = (
+    "'ADJUSTMENT', 'MOVE', 'UNLOCATE', 'RECEIVE', 'PULL_DEDUCTION', 'SPOT_CHECK', 'PUT_AWAY', "
+    "'DESTOCK', 'ALLOCATE_FROM_STOCK', 'RECLASSIFY', 'REPORT_DEFICIENT', 'RESOLVE_DEFICIENT', "
+    "'TRANSFER', 'RETURN'"
+)
+_AUDIT_ENTITY_TYPE_WITHOUT = "'INVENTORY_LOCATION', 'OPENING_ITEM', 'STOCK_ITEM'"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shop_assembly_opening_items",
+        sa.Column("installed_quantity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "shop_assembly_opening_items",
+        sa.Column("deficient_quantity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_check_constraint(
+        "ck_shop_assembly_opening_items_progress_within_quantity",
+        "shop_assembly_opening_items",
+        "installed_quantity >= 0 AND deficient_quantity >= 0 AND installed_quantity + deficient_quantity <= quantity",
+    )
+
+    op.execute("ALTER TYPE assembly_status ADD VALUE IF NOT EXISTS 'IN_PROGRESS'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'INSTALL_PROGRESS'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'ASSEMBLY_COMPLETE'")
+    op.execute("ALTER TYPE audit_entity_type ADD VALUE IF NOT EXISTS 'SHOP_ASSEMBLY_OPENING'")
+
+
+def downgrade() -> None:
+    # Rows first: an enum recast fails on any value that is about to stop existing. A half-built
+    # opening becomes PENDING again, which is the only state pre-#340 code knows for unfinished work.
+    op.execute("UPDATE shop_assembly_openings SET assembly_status = 'PENDING' WHERE assembly_status = 'IN_PROGRESS'")
+    op.execute("DELETE FROM inventory_audit_log WHERE action IN ('INSTALL_PROGRESS', 'ASSEMBLY_COMPLETE')")
+    op.execute("DELETE FROM inventory_audit_log WHERE entity_type = 'SHOP_ASSEMBLY_OPENING'")
+
+    op.execute("ALTER TYPE assembly_status RENAME TO assembly_status_old")
+    op.execute(f"CREATE TYPE assembly_status AS ENUM ({_ASSEMBLY_STATUS_WITHOUT})")
+    op.execute(
+        "ALTER TABLE shop_assembly_openings ALTER COLUMN assembly_status "
+        "TYPE assembly_status USING assembly_status::text::assembly_status"
+    )
+    op.execute("DROP TYPE assembly_status_old")
+
+    op.execute("ALTER TYPE audit_action RENAME TO audit_action_old")
+    op.execute(f"CREATE TYPE audit_action AS ENUM ({_AUDIT_ACTION_WITHOUT})")
+    op.execute("ALTER TABLE inventory_audit_log ALTER COLUMN action TYPE audit_action USING action::text::audit_action")
+    op.execute("DROP TYPE audit_action_old")
+
+    op.execute("ALTER TYPE audit_entity_type RENAME TO audit_entity_type_old")
+    op.execute(f"CREATE TYPE audit_entity_type AS ENUM ({_AUDIT_ENTITY_TYPE_WITHOUT})")
+    op.execute(
+        "ALTER TABLE inventory_audit_log ALTER COLUMN entity_type "
+        "TYPE audit_entity_type USING entity_type::text::audit_entity_type"
+    )
+    op.execute("DROP TYPE audit_entity_type_old")
+
+    op.drop_constraint(
+        "ck_shop_assembly_opening_items_progress_within_quantity",
+        "shop_assembly_opening_items",
+        type_="check",
+    )
+    op.drop_column("shop_assembly_opening_items", "deficient_quantity")
+    op.drop_column("shop_assembly_opening_items", "installed_quantity")

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -43,6 +43,8 @@ enum PullStatus {
 
 enum AssemblyStatus {
   PENDING
+  # Some hardware is recorded against the leaf but it is not fully dispositioned yet (#340).
+  IN_PROGRESS
   COMPLETED
 }
 
@@ -51,7 +53,12 @@ type ShopAssemblyOpeningItem {
   shop_assembly_opening_id: ID!
   hardware_category: String!
   product_code: String!
+  # Units pulled for this leaf - the plan.
   quantity: Int!
+  # Persisted assembly progress (#340). Remaining = quantity - installed - deficient, derived on the
+  # client; completion is refused while any line still has remaining > 0.
+  installed_quantity: Int!
+  deficient_quantity: Int!
 }
 
 input AssignOpeningsInput {
@@ -60,18 +67,30 @@ input AssignOpeningsInput {
   assigned_to: String!
 }
 
-input CompleteOpeningItemResultInput {
+input AssemblyProgressItemInput {
   shop_assembly_opening_item_id: ID!
-  installed: Boolean! = true
+  # ABSOLUTE running total of units fitted to the leaf; omit to leave the line's count alone.
+  # Re-sending the same value is a no-op, so a retried save cannot double-count.
+  installed_quantity: Int
+  # INCREMENTAL - units condemned now, on top of any already flagged. Each is returned to inventory
+  # flagged deficient and given a PR-REPL replacement line immediately, so it is one-way and a
+  # deficient_reason is required with it.
+  flag_deficient_quantity: Int
   deficient_reason: String
 }
 
+input RecordAssemblyProgressInput {
+  opening_id: ID!
+  items: [AssemblyProgressItemInput!]
+  performed_by: String
+}
+
+# No item_results since #340: completion reads the persisted per-item progress instead.
 input CompleteOpeningInput {
   opening_id: ID!
   aisle: String
   row: String
   bay: String
-  item_results: [CompleteOpeningItemResultInput!]
   completed_by: String
 }
 
@@ -89,11 +108,20 @@ type Query {
 type Mutation {
   # Self-assignment is open to any signed-in user; assigning to *another* user additionally
   # requires the Shop Assembly Manager role (#330).
+  # A manager (the require_role branch) may reassign an opening someone else is holding, including an
+  # IN_PROGRESS one - progress is persisted, so the handoff is lossless (#340). A self-claim never
+  # can: it takes the is-self branch, which does not pass allow_reassign.
   assignOpenings(input: AssignOpeningsInput!): [ShopAssemblyOpening!]!
+  # PENDING or IN_PROGRESS only (#340); a completed opening cannot be unassigned.
   removeOpeningFromUser(openingId: ID!): ShopAssemblyOpening!
-  # Refuses (#339) if a live OpeningItem already exists for this (opening, leaf) - CONFLICT - or if
-  # every checklist item is flagged deficient, which would mint an empty assembled leaf -
-  # VALIDATION_ERROR. Neither case records any deficiency; the opening stays pending.
+  # Save partial assembly progress without finishing (#340). Requires the opening to be PULLED,
+  # assigned, and not completed. First save flips it PENDING -> IN_PROGRESS. Flagged units are
+  # returned to inventory flagged deficient and given a PR-REPL replacement line immediately.
+  recordAssemblyProgress(input: RecordAssemblyProgressInput!): ShopAssemblyOpening!
+  # Refuses (#339) if a live OpeningItem already exists for this (opening, leaf) - CONFLICT.
+  # Refuses (#340) with VALIDATION_ERROR while any unit is still unaccounted for
+  # (installed + deficient < quantity on some line), or if nothing at all was installed, which would
+  # mint an empty assembled leaf. OpeningItemHardware quantities are the recorded installed counts.
   completeOpening(input: CompleteOpeningInput!): OpeningItem!
   # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
   # display name. Accept re-checks inventory sufficiency and mints the warehouse PullRequest.

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -65,6 +65,10 @@ class PullStatus(str, enum.Enum):
 
 class AssemblyStatus(str, enum.Enum):
     PENDING = "PENDING"
+    # Some hardware has been recorded against the leaf but it is not fully dispositioned yet (#340).
+    # An IN_PROGRESS opening is still the assembler's work: it stays in My Work and can be handed to
+    # someone else by a manager, because every unit counted so far is persisted on the item rows.
+    IN_PROGRESS = "IN_PROGRESS"
     COMPLETED = "COMPLETED"
 
 
@@ -89,6 +93,9 @@ class AuditEntityType(str, enum.Enum):
     INVENTORY_LOCATION = "INVENTORY_LOCATION"
     OPENING_ITEM = "OPENING_ITEM"
     STOCK_ITEM = "STOCK_ITEM"
+    # The assembly work unit (one door leaf) an INSTALL_PROGRESS event is recorded against (#340).
+    # Progress happens before any OpeningItem exists, so it cannot hang off OPENING_ITEM.
+    SHOP_ASSEMBLY_OPENING = "SHOP_ASSEMBLY_OPENING"
 
 
 class AuditAction(str, enum.Enum):
@@ -106,6 +113,11 @@ class AuditAction(str, enum.Enum):
     RESOLVE_DEFICIENT = "RESOLVE_DEFICIENT"
     TRANSFER = "TRANSFER"
     RETURN = "RETURN"
+    # An assembler recorded how many units of a checklist line are installed on a leaf (#340).
+    INSTALL_PROGRESS = "INSTALL_PROGRESS"
+    # The leaf was called finished and materialized as an OpeningItem (#340). Progress saves are no
+    # longer the same call as completion, so the two moments need distinct audit records.
+    ASSEMBLY_COMPLETE = "ASSEMBLY_COMPLETE"
 
 
 class ReturnDisposition(str, enum.Enum):

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -98,6 +98,12 @@ class ShopAssemblyOpeningItem(Base):
             "shop_assembly_opening_id",
         ),
         CheckConstraint("quantity >= 1", name="ck_shop_assembly_opening_items_quantity_positive"),
+        # Progress can never exceed the planned quantity, and neither count can go negative (#340).
+        CheckConstraint(
+            "installed_quantity >= 0 AND deficient_quantity >= 0 "
+            "AND installed_quantity + deficient_quantity <= quantity",
+            name="ck_shop_assembly_opening_items_progress_within_quantity",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -105,5 +111,16 @@ class ShopAssemblyOpeningItem(Base):
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Per-item assembly progress (#340). The assembler records these incrementally at the bench;
+    # completion reads them rather than taking an ephemeral checklist as input.
+    #   installed_quantity - units physically fitted to the leaf. Absolute, editable both directions
+    #     until the opening is completed, then frozen as the OpeningItemHardware quantity.
+    #   deficient_quantity - units found defective and already handed to the deficiency flow
+    #     (returned to inventory flagged deficient + a PR-REPL replacement line). Only ever grows;
+    #     undoing a deficiency is deficiency review's job, not the assembler's.
+    # Remaining (quantity - installed - deficient) is derived, never stored; completion is refused
+    # while any line still has remaining > 0.
+    installed_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    deficient_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     shop_assembly_opening: Mapped["ShopAssemblyOpening"] = relationship(back_populates="items")

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -16,6 +16,8 @@ from app.errors import (
 )
 from app.models.enums import (
     AssemblyStatus,
+    AuditAction,
+    AuditEntityType,
     OpeningItemState,
     PullRequestItemType,
     PullRequestSource,
@@ -35,15 +37,32 @@ from app.models.shop_assembly import (
     ShopAssemblyOpening,
     ShopAssemblyRequest,
 )
+from app.repositories.stock.common import _log_audit_event
 from app.services.locking import lock_rows
+
+MAX_DEFICIENT_REASON_LENGTH = 500
+
+# Assembly statuses an opening can still be worked in (#340). COMPLETED is terminal.
+_WORKABLE_ASSEMBLY_STATUSES = (AssemblyStatus.PENDING, AssemblyStatus.IN_PROGRESS)
 
 
 @dataclass
-class OpeningItemResult:
-    """One line of the completion-time deficiency checklist (#225)."""
+class AssemblyProgressUpdate:
+    """One line of a progress save (#340).
+
+    installed_quantity is ABSOLUTE - the total number of units of this line now fitted to the leaf.
+    Sending the same value twice is a no-op, so a retried save cannot double-count, and a miscount can
+    be corrected downward right up until the opening is completed. None leaves it untouched.
+
+    flag_deficient_quantity is INCREMENTAL - units being condemned *now*, on top of whatever was
+    already flagged. It is not absolute because flagging is not a state the assembler owns: each unit
+    is immediately returned to inventory flagged deficient and given a PR-REPL replacement line, and
+    unwinding that is deficiency review's job. A reason is required with it.
+    """
 
     shop_assembly_opening_item_id: uuid.UUID
-    installed: bool = True
+    installed_quantity: int | None = None
+    flag_deficient_quantity: int | None = None
     deficient_reason: str | None = None
 
 
@@ -73,8 +92,9 @@ def get_my_work(
     session: Session,
     assigned_to_user_id: str,
 ) -> list[ShopAssemblyOpening]:
-    """Query ShopAssemblyOpenings claimed by a user (by stable Clerk user id, #324) with Pending
-    assembly_status."""
+    """Query ShopAssemblyOpenings claimed by a user (by stable Clerk user id, #324) that are still
+    unfinished - PENDING or, since progress is persisted (#340), IN_PROGRESS. A leaf the assembler
+    saved partial progress on has to stay in My Work or the work would be unreachable."""
     stmt = (
         select(ShopAssemblyOpening)
         .join(
@@ -84,7 +104,7 @@ def get_my_work(
         .options(selectinload(ShopAssemblyOpening.items))
         .where(
             ShopAssemblyOpening.assigned_to_user_id == assigned_to_user_id,
-            ShopAssemblyOpening.assembly_status == AssemblyStatus.PENDING,
+            ShopAssemblyOpening.assembly_status.in_(_WORKABLE_ASSEMBLY_STATUSES),
             PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
             PullRequestModel.status == PullRequestStatus.COMPLETED,
         )
@@ -98,9 +118,19 @@ def assign_openings(
     opening_ids: list[uuid.UUID],
     assigned_to_user_id: str,
     assigned_to_name: str,
+    allow_reassign: bool = False,
 ) -> list[ShopAssemblyOpening]:
     """Assign ShopAssemblyOpenings to a user with pessimistic locking. Keyed on the stable Clerk
-    user id (#324); assigned_to_name is the display name stored alongside for the UI."""
+    user id (#324); assigned_to_name is the display name stored alongside for the UI.
+
+    allow_reassign (#340) is the data-layer half of the reassignment rule. Progress is persisted on
+    the item rows now, so moving a half-built leaf to another assembler is safe - the new owner opens
+    it and sees exactly what the last one recorded - but "safe" is not "anyone's to take". Only the
+    manager branch of the resolver passes allow_reassign=True; a self-claim never does, so a user
+    cannot take an opening off the person holding it by claiming it themselves. Re-claiming an
+    opening already assigned to the same user stays a no-op either way (it only refreshes the display
+    name), so a stale UI does not turn a double-click into an error.
+    """
     if not opening_ids:
         raise ValidationError("opening_ids must not be empty", field="opening_ids")
     if not assigned_to_user_id:
@@ -118,9 +148,12 @@ def assign_openings(
     for opening in locked:
         if opening.pull_status != PullStatus.PULLED:
             raise InvalidStateTransitionError("Opening is not ready for assignment - hardware has not been pulled")
-        if opening.assembly_status != AssemblyStatus.PENDING:
+        if opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
             raise InvalidStateTransitionError("Opening assembly is already completed")
-        if opening.assigned_to_user_id is not None:
+        already_held_by_someone_else = (
+            opening.assigned_to_user_id is not None and opening.assigned_to_user_id != assigned_to_user_id
+        )
+        if already_held_by_someone_else and not allow_reassign:
             raise ConflictError(f"Opening already assigned to {opening.assigned_to}")
         opening.assigned_to_user_id = assigned_to_user_id
         opening.assigned_to = assigned_to_name
@@ -132,7 +165,12 @@ def remove_opening_from_user(
     session: Session,
     opening_id: uuid.UUID,
 ) -> ShopAssemblyOpening:
-    """Unassign a ShopAssemblyOpening."""
+    """Unassign a ShopAssemblyOpening.
+
+    Allowed while the opening is PENDING or IN_PROGRESS (#340): saved progress lives on the item rows,
+    not on the assignment, so returning a half-built leaf to the pool loses nothing - the next person
+    to claim it picks up where the last one stopped. COMPLETED is terminal and refused.
+    """
     stmt = (
         select(ShopAssemblyOpening)
         .options(selectinload(ShopAssemblyOpening.items))
@@ -142,7 +180,7 @@ def remove_opening_from_user(
     if opening is None:
         raise NotFoundError(f"ShopAssemblyOpening {opening_id} not found")
 
-    if opening.assembly_status != AssemblyStatus.PENDING:
+    if opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
         raise InvalidStateTransitionError("Cannot unassign a completed opening")
     if opening.assigned_to_user_id is None:
         raise ValidationError("Opening is not assigned to anyone", field="assigned_to_user_id")
@@ -152,37 +190,203 @@ def remove_opening_from_user(
     return opening
 
 
+def _load_workable_opening(session: Session, opening_id: uuid.UUID) -> ShopAssemblyOpening:
+    """Lock a ShopAssemblyOpening and re-read it with its items eager-loaded.
+
+    lock_rows takes the row lock; the second read is what populates `items` (SELECT ... FOR UPDATE
+    cannot be combined with the selectinload without locking the child rows too, which nothing here
+    needs). Both statements hit the same identity map, so this is one row, locked.
+    """
+    if not lock_rows(session, ShopAssemblyOpening, [opening_id]):
+        raise NotFoundError(f"ShopAssemblyOpening {opening_id} not found")
+    stmt = (
+        select(ShopAssemblyOpening)
+        .options(selectinload(ShopAssemblyOpening.items))
+        .where(ShopAssemblyOpening.id == opening_id)
+    )
+    return session.scalars(stmt).unique().first()
+
+
+def _opening_project_id(session: Session, sa_opening: ShopAssemblyOpening) -> uuid.UUID | None:
+    """The project an opening belongs to, via its shop-assembly PullRequest. Audit rows want it and
+    a legacy opening may not have a PR yet, so this returns None rather than raising."""
+    if sa_opening.pull_request_id is None:
+        return None
+    return session.scalar(select(PullRequestModel.project_id).where(PullRequestModel.id == sa_opening.pull_request_id))
+
+
+def record_assembly_progress(
+    session: Session,
+    opening_id: uuid.UUID,
+    updates: list[AssemblyProgressUpdate],
+    performed_by: str | None = None,
+) -> ShopAssemblyOpening:
+    """Record what an assembler has actually fitted to a door leaf so far (#340).
+
+    This is the write that makes assembly resumable. Before it, the checklist existed only in the
+    browser until Mark Complete posted it, so a leaf half-built at the end of a shift lost everything
+    and a defect found at 9am was not visible to the warehouse until the leaf was finished.
+
+    Two kinds of update, deliberately asymmetric (see AssemblyProgressUpdate):
+
+    - installed_quantity is set absolutely, so a save is idempotent and a miscount stays correctable
+      in both directions right up until completion. Nothing leaves inventory here: the hardware was
+      already deducted when the pull was approved, so counting it onto the leaf is work-tracking, not
+      a stock movement.
+    - flag_deficient_quantity condemns units immediately - report_deficiency_at_assembly returns them
+      to project inventory flagged deficient and appends a PR-REPL replacement line the moment the
+      defect is found, not at completion. That is the whole point of moving it here: the warehouse can
+      start sourcing the replacement while the leaf is still on the bench. It is one-way from the
+      assembler's side; deficiency review owns the undo.
+
+    Nothing else is decremented for a deficient unit - deficient_quantity on the item is the record
+    that those units are spoken for, and the remaining-must-be-zero gate at completion is what makes
+    that count load-bearing.
+
+    The first save flips the opening PENDING -> IN_PROGRESS. Returns the opening with items loaded.
+    """
+    if not updates:
+        raise ValidationError("updates must not be empty", field="updates")
+
+    sa_opening = _load_workable_opening(session, opening_id)
+
+    if sa_opening.pull_status != PullStatus.PULLED:
+        raise InvalidStateTransitionError("Opening hardware has not been pulled - there is nothing to assemble yet")
+    if sa_opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
+        raise InvalidStateTransitionError("Opening assembly is already completed")
+    if sa_opening.assigned_to_user_id is None:
+        raise ValidationError(
+            "Opening must be assigned before progress can be recorded",
+            field="assigned_to_user_id",
+        )
+
+    item_by_id = {item.id: item for item in sa_opening.items}
+    seen: set[uuid.UUID] = set()
+    for update in updates:
+        if update.shop_assembly_opening_item_id not in item_by_id:
+            raise ValidationError(
+                f"Item {update.shop_assembly_opening_item_id} does not belong to opening {opening_id}",
+                field="shop_assembly_opening_item_id",
+            )
+        # Two updates for one line would make the absolute installed_quantity order-dependent, which
+        # is exactly the ambiguity "absolute" is meant to remove. Refuse rather than pick a winner.
+        if update.shop_assembly_opening_item_id in seen:
+            raise ValidationError(
+                f"Item {update.shop_assembly_opening_item_id} appears more than once in one save",
+                field="shop_assembly_opening_item_id",
+            )
+        seen.add(update.shop_assembly_opening_item_id)
+
+    from app.repositories import stock as stock_repository
+
+    actor = performed_by or "Assembler"
+    project_id = _opening_project_id(session, sa_opening)
+    now = datetime.utcnow()
+
+    # Validate every line before writing any of them, so a bad line at the end cannot leave the first
+    # few lines applied (and, worse, their deficiencies already returned to inventory).
+    planned: list[tuple] = []
+    for update in updates:
+        item = item_by_id[update.shop_assembly_opening_item_id]
+        flagged = update.flag_deficient_quantity or 0
+        reason: str | None = None
+        if flagged:
+            if flagged < 1:
+                raise ValidationError("flag_deficient_quantity must be >= 1", field="flag_deficient_quantity")
+            reason = (update.deficient_reason or "").strip()
+            if not reason:
+                raise ValidationError(
+                    "A deficiency reason is required when flagging units deficient",
+                    field="deficient_reason",
+                )
+            if len(reason) > MAX_DEFICIENT_REASON_LENGTH:
+                raise ValidationError(
+                    f"Deficiency reason must be {MAX_DEFICIENT_REASON_LENGTH} characters or fewer",
+                    field="deficient_reason",
+                )
+
+        new_installed = item.installed_quantity if update.installed_quantity is None else update.installed_quantity
+        new_deficient = item.deficient_quantity + flagged
+        if new_installed < 0:
+            raise ValidationError("installed_quantity must be >= 0", field="installed_quantity")
+        if new_installed + new_deficient > item.quantity:
+            raise ValidationError(
+                f"{item.product_code}: {new_installed} installed + {new_deficient} deficient exceeds the "
+                f"{item.quantity} unit(s) pulled for this leaf",
+                field="installed_quantity",
+            )
+        planned.append((item, new_installed, new_deficient, flagged, reason))
+
+    changed = False
+    for item, new_installed, new_deficient, flagged, reason in planned:
+        previous_installed = item.installed_quantity
+        if new_installed == previous_installed and not flagged:
+            continue
+        changed = True
+        item.installed_quantity = new_installed
+        item.deficient_quantity = new_deficient
+
+        if flagged:
+            # Immediate, not deferred to completion: the unit goes back to inventory flagged deficient
+            # and the replacement pull is minted now.
+            stock_repository.report_deficiency_at_assembly(
+                session,
+                sa_opening_item_id=item.id,
+                quantity=flagged,
+                reason_text=reason,
+                performed_by=actor,
+            )
+
+        _log_audit_event(
+            session,
+            project_id=project_id,
+            entity_type=AuditEntityType.SHOP_ASSEMBLY_OPENING,
+            entity_id=sa_opening.id,
+            action=AuditAction.INSTALL_PROGRESS,
+            performed_by=actor,
+            detail={
+                "shopAssemblyOpeningItemId": str(item.id),
+                "hardwareCategory": item.hardware_category,
+                "productCode": item.product_code,
+                "plannedQuantity": item.quantity,
+                "previousInstalledQuantity": previous_installed,
+                "installedQuantity": new_installed,
+                "flaggedDeficientQuantity": flagged,
+                "deficientQuantity": new_deficient,
+                "remainingQuantity": item.quantity - new_installed - new_deficient,
+                "reasonText": reason,
+                "openingNumber": sa_opening.opening_number,
+                "leaf": sa_opening.leaf,
+                "recordedAt": now.isoformat(),
+            },
+        )
+
+    if changed and sa_opening.assembly_status == AssemblyStatus.PENDING:
+        sa_opening.assembly_status = AssemblyStatus.IN_PROGRESS
+
+    return sa_opening
+
+
 def complete_opening(
     session: Session,
     opening_id: uuid.UUID,
     aisle: str | None,
     row: str | None,
     bay: str | None,
-    item_results: list[OpeningItemResult] | None = None,
     completed_by: str | None = None,
 ) -> OpeningItemModel:
     """Mark an opening's assembly as complete. Creates OpeningItem + OpeningItemHardware records.
 
-    Completion-time deficiency checklist (#225): only items marked installed are snapshotted as
-    OpeningItemHardware. Items marked not-installed are flagged deficient - the unit is returned to
-    inventory flagged deficient and a PR-REPL replacement pull is appended (via
-    stock_repository.report_deficiency_at_assembly). An empty/omitted item_results treats every
-    item as installed, preserving pre-checklist behaviour.
+    Completion takes no checklist any more (#340). It reads the per-item counters
+    record_assembly_progress has been persisting, so what is snapshotted onto the assembled leaf is
+    what the assembler actually recorded fitting, unit by unit - not a claim made in the same call.
+    Deficiencies were already returned to inventory and replaced when they were flagged, so this
+    function no longer writes any of that.
     """
     # 1. Load and validate ShopAssemblyOpening (with pessimistic lock)
-    locked = lock_rows(session, ShopAssemblyOpening, [opening_id])
-    if not locked:
-        raise NotFoundError(f"ShopAssemblyOpening {opening_id} not found")
-    sa_opening = locked[0]
-    # Eager-load items
-    stmt = (
-        select(ShopAssemblyOpening)
-        .options(selectinload(ShopAssemblyOpening.items))
-        .where(ShopAssemblyOpening.id == opening_id)
-    )
-    sa_opening = session.scalars(stmt).unique().first()
+    sa_opening = _load_workable_opening(session, opening_id)
 
-    if sa_opening.assembly_status != AssemblyStatus.PENDING:
+    if sa_opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
         raise InvalidStateTransitionError("Opening assembly is already completed")
     if sa_opening.assigned_to is None:
         raise ValidationError(
@@ -223,43 +427,34 @@ def complete_opening(
             field="opening_id",
         )
 
-    # 4. Resolve the per-item installed/deficient checklist (#225). The checklist is keyed on
-    #    ShopAssemblyOpeningItem ids (what the assembler sees in the modal). Any item without a
-    #    result row defaults to installed, so an empty checklist preserves the old snapshot-all path.
-    item_by_id = {item.id: item for item in sa_opening.items}
-    deficient_reason_by_id: dict[uuid.UUID, str | None] = {}
-    for res in item_results or []:
-        if res.shop_assembly_opening_item_id not in item_by_id:
-            raise ValidationError(
-                f"Checklist item {res.shop_assembly_opening_item_id} does not belong to opening {opening_id}",
-                field="item_results",
-            )
-        if not res.installed:
-            reason = (res.deficient_reason or "").strip()
-            if not reason:
-                raise ValidationError(
-                    "A deficiency reason is required for items not installed",
-                    field="deficient_reason",
-                )
-            if len(reason) > 500:
-                raise ValidationError(
-                    "Deficiency reason must be 500 characters or fewer",
-                    field="deficient_reason",
-                )
-            deficient_reason_by_id[res.shop_assembly_opening_item_id] = reason
-
-    # 4b. Refuse an all-deficient completion (#339). If every checklist item is flagged deficient the
-    #     OpeningItem would be minted with zero OpeningItemHardware rows - an "assembled" leaf that
-    #     had nothing installed on it, which then reads as ship-ready inventory. Nothing was
-    #     assembled, so the opening stays PENDING and no deficiency is recorded: the caller's
-    #     transaction is abandoned whole, so the flagged units are neither returned to inventory nor
-    #     given a PR-REPL line. Report the deficiencies through the warehouse deficiency flow, or
-    #     re-complete once at least one item is installed.
-    if sa_opening.items and all(item.id in deficient_reason_by_id for item in sa_opening.items):
+    # 4. Every unit must be accounted for (#340). Business decision: block, never auto-default. An
+    #    unrecorded unit is an unanswered question - was it fitted, is it still on the cart, is it
+    #    missing? - and silently treating it as installed is what would put hardware on a leaf that
+    #    was never there, while silently treating it as deficient would mint replacement pulls nobody
+    #    asked for. Name the lines so the assembler knows exactly which ones to go finish.
+    undispositioned = [
+        f"{item.product_code} ({item.quantity - item.installed_quantity - item.deficient_quantity} of "
+        f"{item.quantity} unrecorded)"
+        for item in sa_opening.items
+        if item.installed_quantity + item.deficient_quantity != item.quantity
+    ]
+    if undispositioned:
         raise ValidationError(
-            "Cannot complete an opening with every item flagged deficient - nothing would be "
-            "assembled. Leave the opening pending and report the deficiencies instead.",
-            field="item_results",
+            "Cannot complete assembly while hardware is unaccounted for. Record each unit as "
+            "installed or flag it deficient first: " + ", ".join(undispositioned),
+            field="items",
+        )
+
+    # 4b. Refuse an all-deficient completion (#339). If every unit was flagged deficient the
+    #     OpeningItem would be minted with zero OpeningItemHardware rows - an "assembled" leaf that
+    #     had nothing installed on it, which then reads as ship-ready inventory. The deficiencies
+    #     themselves stand (they were recorded when they were found, #340); what is refused is calling
+    #     the leaf assembled. It stays IN_PROGRESS until at least one unit is installed on it.
+    if sa_opening.items and all(item.installed_quantity == 0 for item in sa_opening.items):
+        raise ValidationError(
+            "Cannot complete an opening with every unit flagged deficient - nothing would be "
+            "assembled. Leave the opening open until replacement hardware is installed.",
+            field="items",
         )
 
     # 5. Create OpeningItem (snapshot opening identity from the ShopAssemblyOpening row)
@@ -288,33 +483,56 @@ def complete_opening(
     session.add(opening_item)
     session.flush()  # Get opening_item.id for OpeningItemHardware FK
 
-    # 6. Snapshot only INSTALLED items as OpeningItemHardware; flag the rest deficient.
-    from app.repositories import stock as stock_repository
-
-    performed_by = completed_by or "Assembler"
+    # 6. Snapshot what was actually installed (#340): the recorded installed_quantity, not the
+    #    planned quantity. A line whose units were all flagged deficient contributes no row at all -
+    #    the leaf must not claim hardware that is sitting in the deficiency queue awaiting a
+    #    replacement pull.
     for item in sa_opening.items:
-        if item.id in deficient_reason_by_id:
-            # Not installed -> return the unit to inventory flagged deficient + append PR-REPL pull.
-            stock_repository.report_deficiency_at_assembly(
-                session,
-                sa_opening_item_id=item.id,
-                quantity=item.quantity,
-                reason_text=deficient_reason_by_id[item.id],
-                performed_by=performed_by,
-            )
+        if item.installed_quantity <= 0:
             continue
         oih = OIHModel(
             id=uuid.uuid4(),
             opening_item_id=opening_item.id,
             product_code=item.product_code,
             hardware_category=item.hardware_category,
-            quantity=item.quantity,
+            quantity=item.installed_quantity,
         )
         session.add(oih)
 
     # 7. Mark ShopAssemblyOpening as Completed
     sa_opening.assembly_status = AssemblyStatus.COMPLETED
     sa_opening.completed_at = now
+
+    # 8. Record the moment the tag became physical (#340). Progress saves and completion are separate
+    #    calls now, so completion needs its own audit row - and it is the only place completed_by is
+    #    written down, the assignment holding the name of whoever claimed the leaf, not who finished it.
+    _log_audit_event(
+        session,
+        project_id=pr.project_id,
+        entity_type=AuditEntityType.OPENING_ITEM,
+        entity_id=opening_item.id,
+        action=AuditAction.ASSEMBLY_COMPLETE,
+        performed_by=completed_by or sa_opening.assigned_to or "Assembler",
+        detail={
+            "shopAssemblyOpeningId": str(sa_opening.id),
+            "openingNumber": sa_opening.opening_number,
+            "leaf": sa_opening.leaf,
+            "assignedTo": sa_opening.assigned_to,
+            "installedHardware": [
+                {
+                    "productCode": item.product_code,
+                    "hardwareCategory": item.hardware_category,
+                    "plannedQuantity": item.quantity,
+                    "installedQuantity": item.installed_quantity,
+                    "deficientQuantity": item.deficient_quantity,
+                }
+                for item in sa_opening.items
+            ],
+            "aisle": aisle,
+            "row": row,
+            "bay": bay,
+        },
+    )
 
     return opening_item
 

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -459,6 +459,9 @@ def shop_assembly_opening_item_to_type(item) -> ShopAssemblyOpeningItem:
         hardware_category=item.hardware_category,
         product_code=item.product_code,
         quantity=item.quantity,
+        # Plain columns on the row the caller already loaded (#340) - reading them triggers no load.
+        installed_quantity=item.installed_quantity,
+        deficient_quantity=item.deficient_quantity,
     )
 
 

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -438,14 +438,30 @@ class AssignOpeningsInput:
 
 
 @strawberry.input
-class CompleteOpeningItemResultInput:
-    """One line of the completion-time deficiency checklist (#225). Identifies a
-    ShopAssemblyOpeningItem and whether the assembler installed it. Not-installed lines
-    are flagged deficient with an optional reason."""
+class AssemblyProgressItemInput:
+    """One line of a progress save (#340).
+
+    installed_quantity is the ABSOLUTE running total of units fitted to the leaf, so re-sending it is
+    a no-op and a miscount can be corrected in either direction until the opening is completed. Omit
+    it to leave the line's installed count alone.
+
+    flag_deficient_quantity is INCREMENTAL - units being condemned now, on top of any already flagged.
+    Each one is immediately returned to inventory flagged deficient and given a PR-REPL replacement
+    pull line, which is why it is one-way and why a reason is required with it.
+    """
 
     shop_assembly_opening_item_id: strawberry.ID
-    installed: bool = True
+    installed_quantity: int | None = None
+    flag_deficient_quantity: int | None = None
     deficient_reason: str | None = None
+
+
+@strawberry.input
+class RecordAssemblyProgressInput:
+    opening_id: strawberry.ID
+    items: list[AssemblyProgressItemInput] = strawberry.field(default_factory=list)
+    # The assembler; recorded as the actor on the progress audit rows and on any deficiency return.
+    performed_by: str | None = None
 
 
 @strawberry.input
@@ -454,10 +470,6 @@ class CompleteOpeningInput:
     aisle: str | None = None
     row: str | None = None
     bay: str | None = None
-    # Per-item installed/deficient checklist (#225). Empty -> every item treated as installed
-    # (preserves pre-checklist behaviour). Only installed items are snapshotted as
-    # OpeningItemHardware; deficient items are returned to inventory flagged deficient.
-    item_results: list[CompleteOpeningItemResultInput] = strawberry.field(default_factory=list)
     completed_by: str | None = None
 
 

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -18,7 +18,7 @@ from .converters import (
     shop_assembly_request_to_type,
 )
 from .enums import ShopAssemblyRequestStatus
-from .inputs import AssignOpeningsInput, CompleteOpeningInput
+from .inputs import AssignOpeningsInput, CompleteOpeningInput, RecordAssemblyProgressInput
 from .types import ClerkUser, OpeningItem, ShopAssemblyOpening, ShopAssemblyRequest
 
 
@@ -38,7 +38,8 @@ class ShopAssemblyQueries:
 
     @strawberry.field
     def my_work(self, info: strawberry.Info, assigned_to_user_id: str) -> list[ShopAssemblyOpening]:
-        """An assembler's claimed, still-pending openings. Open to any signed-in user."""
+        """An assembler's claimed, unfinished openings - PENDING or IN_PROGRESS (#340), so a leaf with
+        saved partial progress stays reachable. Open to any signed-in user."""
         require_user(info)
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_my_work(session, assigned_to_user_id)
@@ -133,14 +134,28 @@ class ShopAssemblyMutations:
     def assign_openings(self, info: strawberry.Info, input: AssignOpeningsInput) -> list[ShopAssemblyOpening]:
         """Assign pulled openings to a user (#330). Any signed-in user may self-assign (the "Assign to
         me" board); assigning to *another* user is Shop Assembly Manager-gated, so the manager-only
-        guarantee holds at the data layer, not just the UI."""
+        guarantee holds at the data layer, not just the UI.
+
+        Reassignment (#340) rides on that same distinction. Progress is persisted per item now, so
+        handing a half-built leaf to someone else loses nothing - but only the manager branch may take
+        an opening off whoever is holding it, so allow_reassign is passed exactly when the caller has
+        already been through require_role. A self-claim can never steal: it takes the is_self branch,
+        which passes allow_reassign=False, and the repository refuses on a conflicting holder. That
+        also means a manager claiming work *for themselves* must unassign it first - the safer read of
+        an ambiguous action, and one keystroke, not a hole.
+        """
         auth = require_user(info)
-        if input.assigned_to_user_id != auth["user_id"]:
+        is_self = input.assigned_to_user_id == auth["user_id"]
+        if not is_self:
             require_role(info, SHOP_ASSEMBLY_MANAGER_ROLE)
         opening_ids = [uuid.UUID(str(oid)) for oid in input.opening_ids]
         with SessionLocal() as session:
             result = shop_assembly_repository.assign_openings(
-                session, opening_ids, input.assigned_to_user_id, input.assigned_to
+                session,
+                opening_ids,
+                input.assigned_to_user_id,
+                input.assigned_to,
+                allow_reassign=not is_self,
             )
             session.commit()
             saos = shop_assembly_repository.get_openings_with_items(session, [o.id for o in result])
@@ -148,7 +163,9 @@ class ShopAssemblyMutations:
 
     @strawberry.mutation
     def remove_opening_from_user(self, info: strawberry.Info, opening_id: strawberry.ID) -> ShopAssemblyOpening:
-        """Unassign a pending opening. Open to any signed-in user (the board's Unassign action)."""
+        """Unassign an unfinished opening. Allowed while it is PENDING or IN_PROGRESS (#340) - saved
+        progress lives on the item rows, so returning a half-built leaf to the pool loses nothing.
+        Open to any signed-in user (the board's Unassign action)."""
         require_user(info)
         with SessionLocal() as session:
             result = shop_assembly_repository.remove_opening_from_user(session, uuid.UUID(str(opening_id)))
@@ -157,26 +174,52 @@ class ShopAssemblyMutations:
             return shop_assembly_opening_to_type(refreshed)
 
     @strawberry.mutation
+    def record_assembly_progress(
+        self, info: strawberry.Info, input: RecordAssemblyProgressInput
+    ) -> ShopAssemblyOpening:
+        """Save what an assembler has fitted to a leaf so far (#340), without finishing it.
+
+        This is what makes assembly resumable: the counts land on the ShopAssemblyOpeningItem rows,
+        the opening flips to IN_PROGRESS on the first save and stays in the assembler's My Work, and
+        any units flagged deficient are returned to inventory and given a replacement pull line
+        immediately rather than waiting for completion. Open to any signed-in user - it moves
+        inventory when a deficiency is flagged, so it must not be reachable anonymously."""
+        require_user(info)
+        updates = [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                shop_assembly_opening_item_id=uuid.UUID(str(item.shop_assembly_opening_item_id)),
+                installed_quantity=item.installed_quantity,
+                flag_deficient_quantity=item.flag_deficient_quantity,
+                deficient_reason=item.deficient_reason,
+            )
+            for item in input.items
+        ]
+        with SessionLocal() as session:
+            result = shop_assembly_repository.record_assembly_progress(
+                session,
+                uuid.UUID(str(input.opening_id)),
+                updates,
+                performed_by=input.performed_by,
+            )
+            session.commit()
+            refreshed = shop_assembly_repository.get_openings_with_items(session, [result.id])[0]
+            return shop_assembly_opening_to_type(refreshed)
+
+    @strawberry.mutation
     def complete_opening(self, info: strawberry.Info, input: CompleteOpeningInput) -> OpeningItem:
         """Complete an opening's assembly, materializing the assembled leaf as an OpeningItem (#339).
-        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously."""
+
+        Takes no checklist (#340): completion reads the per-item counts recordAssemblyProgress has
+        been persisting, and is refused while any unit is still unaccounted for. Open to any signed-in
+        user - it writes inventory, so it must not be reachable anonymously."""
         require_user(info)
         with SessionLocal() as session:
-            item_results = [
-                shop_assembly_repository.OpeningItemResult(
-                    shop_assembly_opening_item_id=uuid.UUID(str(r.shop_assembly_opening_item_id)),
-                    installed=r.installed,
-                    deficient_reason=r.deficient_reason,
-                )
-                for r in input.item_results
-            ]
             result = shop_assembly_repository.complete_opening(
                 session,
                 uuid.UUID(str(input.opening_id)),
                 input.aisle,
                 input.row,
                 input.bay,
-                item_results=item_results,
                 completed_by=input.completed_by,
             )
             session.commit()

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -514,6 +514,12 @@ class ShopAssemblyOpeningItem:
     hardware_category: str
     product_code: str
     quantity: int
+    # Persisted assembly progress (#340). installed_quantity is what the assembler has recorded
+    # fitting to the leaf; deficient_quantity is what has already been condemned and replaced.
+    # Remaining is quantity - installed - deficient, derived on the client - completion is refused
+    # while any line still has remaining > 0.
+    installed_quantity: int = 0
+    deficient_quantity: int = 0
 
 
 @strawberry.type

--- a/backend/tests/test_assembly_progress.py
+++ b/backend/tests/test_assembly_progress.py
@@ -1,0 +1,543 @@
+"""Persisted per-item assembly progress (#340).
+
+Assembly used to be atomic and ephemeral: the checklist lived in the browser until Mark Complete
+posted it, so a leaf half-built at the end of a shift lost everything and a defect found at 9am was
+invisible to the warehouse until the leaf was finished. record_assembly_progress makes the counts
+durable, and completion reads them instead of taking a claim as input.
+
+Covered here: save/resume, partial quantities per line, immediate PR-REPL mint, the disposition gate
+at completion, OpeningItemHardware quantities matching what was installed rather than what was
+planned, and the assignment rules that let a manager - and only a manager - hand a half-built leaf to
+somebody else.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import ConflictError, InvalidStateTransitionError, ValidationError
+from app.models.audit_log import InventoryAuditLog
+from app.models.enums import (
+    AssemblyStatus,
+    AuditAction,
+    AuditEntityType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.opening_item import OpeningItemHardware
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
+from app.models.stock_item import StockItem
+from app.repositories import shop_assembly_repository, warehouse_admin_repository
+
+HINGE = ("HINGE", "HG-P1")
+LOCK = ("LOCK", "LK-P1")
+
+Update = shop_assembly_repository.AssemblyProgressUpdate
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category, code, quantity=0):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _make_pulled_opening(
+    session,
+    project_id,
+    *,
+    request_number,
+    items,
+    leaf=1,
+    assigned_user="user_1",
+    pull_status=PullStatus.PULLED,
+):
+    """A COMPLETED SHOP_ASSEMBLY pull request with one PULLED, assigned, untouched opening."""
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=request_number,
+        project_id=project_id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.COMPLETED,
+        requested_by="tester",
+        completed_at=datetime.utcnow(),
+    )
+    session.add(pr)
+    session.flush()
+
+    opening = ShopAssemblyOpening(
+        id=uuid.uuid4(),
+        pull_request_id=pr.id,
+        opening_id=uuid.uuid4(),
+        opening_number="A01",
+        leaf=leaf,
+        pull_status=pull_status,
+        assigned_to="assembler" if assigned_user else None,
+        assigned_to_user_id=assigned_user,
+        assembly_status=AssemblyStatus.PENDING,
+    )
+    session.add(opening)
+    session.flush()
+
+    sao_items = {}
+    for category, code, qty in items:
+        sao_item = ShopAssemblyOpeningItem(
+            id=uuid.uuid4(),
+            shop_assembly_opening_id=opening.id,
+            hardware_category=category,
+            product_code=code,
+            quantity=qty,
+        )
+        session.add(sao_item)
+        sao_items[code] = sao_item
+    session.flush()
+    return opening, sao_items
+
+
+# --- 1. save and resume ------------------------------------------------------------------------
+
+
+def test_first_save_flips_to_in_progress_and_persists(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P1", items=[(*HINGE, 4)])
+    assert opening.assembly_status == AssemblyStatus.PENDING
+
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)], performed_by="ada"
+    )
+    db_session.flush()
+
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+    assert sao[HINGE[1]].installed_quantity == 2
+    assert sao[HINGE[1]].deficient_quantity == 0
+
+
+def test_progress_resumes_and_is_editable_in_both_directions(db_session):
+    """installed_quantity is absolute: a second save continues the count, and a miscount can be
+    walked back down while the leaf is still open."""
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P2", items=[(*HINGE, 4)])
+    item_id = sao[HINGE[1]].id
+
+    shop_assembly_repository.record_assembly_progress(db_session, opening.id, [Update(item_id, installed_quantity=2)])
+    shop_assembly_repository.record_assembly_progress(db_session, opening.id, [Update(item_id, installed_quantity=3)])
+    db_session.flush()
+    assert sao[HINGE[1]].installed_quantity == 3
+
+    # Correction downward.
+    shop_assembly_repository.record_assembly_progress(db_session, opening.id, [Update(item_id, installed_quantity=1)])
+    db_session.flush()
+    assert sao[HINGE[1]].installed_quantity == 1
+
+
+def test_resending_the_same_count_is_idempotent(db_session):
+    """A retried save must not double-count - which is the whole reason installed is absolute."""
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P3", items=[(*HINGE, 4)])
+    item_id = sao[HINGE[1]].id
+
+    for _ in range(3):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(item_id, installed_quantity=2)]
+        )
+    db_session.flush()
+    assert sao[HINGE[1]].installed_quantity == 2
+
+    # Only the first save was a change, so only it wrote an audit row.
+    events = list(
+        db_session.scalars(
+            select(InventoryAuditLog).where(
+                InventoryAuditLog.entity_id == opening.id,
+                InventoryAuditLog.action == AuditAction.INSTALL_PROGRESS,
+            )
+        ).all()
+    )
+    assert len(events) == 1
+    assert events[0].entity_type == AuditEntityType.SHOP_ASSEMBLY_OPENING
+    assert events[0].detail["installedQuantity"] == 2
+    assert events[0].detail["remainingQuantity"] == 2
+
+
+# --- 2. partial quantities per line ------------------------------------------------------------
+
+
+def test_partial_quantities_are_tracked_per_line(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P4", items=[(*HINGE, 8), (*LOCK, 2)]
+    )
+
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [
+            Update(sao[HINGE[1]].id, installed_quantity=5),
+            Update(sao[LOCK[1]].id, installed_quantity=1),
+        ],
+    )
+    db_session.flush()
+
+    assert sao[HINGE[1]].installed_quantity == 5
+    assert sao[LOCK[1]].installed_quantity == 1
+
+
+def test_installed_plus_deficient_cannot_exceed_the_pulled_quantity(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P5", items=[(*HINGE, 4)])
+    item_id = sao[HINGE[1]].id
+
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(item_id, installed_quantity=5)]
+        )
+
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(item_id, flag_deficient_quantity=2, deficient_reason="bent")]
+    )
+    db_session.flush()
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(item_id, installed_quantity=3)]
+        )
+
+
+def test_negative_installed_quantity_is_refused(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P6", items=[(*HINGE, 4)])
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=-1)]
+        )
+
+
+def test_one_line_twice_in_a_single_save_is_refused(db_session):
+    """Two absolute values for one line in one call would be order-dependent - refuse it."""
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P7", items=[(*HINGE, 4)])
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session,
+            opening.id,
+            [
+                Update(sao[HINGE[1]].id, installed_quantity=1),
+                Update(sao[HINGE[1]].id, installed_quantity=2),
+            ],
+        )
+
+
+# --- 3. deficiency is minted immediately -------------------------------------------------------
+
+
+def test_mid_assembly_deficiency_mints_the_replacement_pull_at_once(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P8", items=[(*HINGE, 2), (*LOCK, 3)], leaf=2
+    )
+
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [Update(sao[LOCK[1]].id, flag_deficient_quantity=2, deficient_reason="seized")],
+        performed_by="ada",
+    )
+    db_session.flush()
+
+    # Recorded on the line...
+    assert sao[LOCK[1]].deficient_quantity == 2
+    assert sao[LOCK[1]].installed_quantity == 0
+
+    # ...returned to inventory flagged deficient (available unchanged)...
+    il = db_session.scalars(
+        select(InventoryLocation).where(
+            InventoryLocation.project_id == project.id, InventoryLocation.product_code == LOCK[1]
+        )
+    ).first()
+    assert il.quantity == 2
+    assert il.deficient_quantity == 2
+
+    # ...and the replacement pull exists now, with the leaf and source line stamped on it, while the
+    # rest of the leaf is still unbuilt.
+    repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-P8")).first()
+    assert repl is not None
+    lines = list(db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == repl.id)).all())
+    assert len(lines) == 1
+    assert lines[0].requested_quantity == 2
+    assert lines[0].leaf == 2
+    assert lines[0].sa_opening_item_id == sao[LOCK[1]].id
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+    assert sao[HINGE[1]].installed_quantity == 0
+
+
+def test_flagging_more_than_remains_is_refused_and_nothing_is_written(db_session):
+    """Validation runs over every line before any of them is applied, so a bad line cannot leave an
+    earlier line's deficiency already returned to inventory."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P9", items=[(*HINGE, 2), (*LOCK, 1)]
+    )
+
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session,
+            opening.id,
+            [
+                Update(sao[HINGE[1]].id, flag_deficient_quantity=1, deficient_reason="bent"),
+                Update(sao[LOCK[1]].id, flag_deficient_quantity=5, deficient_reason="seized"),
+            ],
+        )
+
+    assert sao[HINGE[1]].deficient_quantity == 0
+    assert (
+        db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-P9")).first() is None
+    )
+
+
+# --- 4. state guards on the save ---------------------------------------------------------------
+
+
+def test_progress_refused_when_hardware_is_not_pulled(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-P10",
+        items=[(*HINGE, 2)],
+        pull_status=PullStatus.PARTIAL,
+    )
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=1)]
+        )
+
+
+def test_progress_refused_when_unassigned(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P11", items=[(*HINGE, 2)], assigned_user=None
+    )
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=1)]
+        )
+
+
+def test_progress_refused_once_completed(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P12", items=[(*HINGE, 2)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
+    )
+    shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=1)]
+        )
+
+
+# --- 5. completion reads the persisted state ---------------------------------------------------
+
+
+def test_completion_blocked_while_units_are_unaccounted_for(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P13", items=[(*HINGE, 4), (*LOCK, 1)]
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [Update(sao[HINGE[1]].id, installed_quantity=3), Update(sao[LOCK[1]].id, installed_quantity=1)],
+    )
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    # The message names the line that is short so the assembler knows where to go back to.
+    assert HINGE[1] in str(excinfo.value)
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+
+
+def test_untouched_opening_cannot_be_completed(db_session):
+    """The pre-#340 shortcut - complete with no checklist and snapshot everything as installed - is
+    gone. Nothing recorded means nothing to complete."""
+    project = _make_project(db_session)
+    opening, _ = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P14", items=[(*HINGE, 2)])
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+
+
+def test_opening_item_hardware_quantities_are_the_installed_counts(db_session):
+    """The snapshot records what went on the leaf, not what was pulled for it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-P15", items=[(*HINGE, 4), (*LOCK, 2)]
+    )
+
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [
+            # 3 of 4 hinges fitted, the fourth condemned.
+            Update(sao[HINGE[1]].id, installed_quantity=3, flag_deficient_quantity=1, deficient_reason="bent"),
+            # Both locks condemned - the line contributes no hardware row at all.
+            Update(sao[LOCK[1]].id, flag_deficient_quantity=2, deficient_reason="seized"),
+        ],
+        performed_by="ada",
+    )
+    db_session.flush()
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "1", "1", completed_by="ada")
+    db_session.flush()
+
+    hw = list(
+        db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == result.id)).all()
+    )
+    assert {h.product_code: h.quantity for h in hw} == {HINGE[1]: 3}
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+    # Completion is audited against the minted leaf, naming who finished it.
+    completion_events = list(
+        db_session.scalars(
+            select(InventoryAuditLog).where(
+                InventoryAuditLog.entity_id == result.id,
+                InventoryAuditLog.action == AuditAction.ASSEMBLY_COMPLETE,
+            )
+        ).all()
+    )
+    assert len(completion_events) == 1
+    assert completion_events[0].performed_by == "ada"
+
+
+# --- 6. assignment and handoff -----------------------------------------------------------------
+
+
+def test_my_work_includes_in_progress_openings(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P16", items=[(*HINGE, 4)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=1)]
+    )
+    db_session.flush()
+
+    mine = shop_assembly_repository.get_my_work(db_session, "user_1")
+    assert [o.id for o in mine] == [opening.id]
+
+
+def test_manager_can_reassign_an_in_progress_opening_keeping_the_progress(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P17", items=[(*HINGE, 4)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
+    )
+    db_session.flush()
+
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob", allow_reassign=True)
+    db_session.flush()
+
+    assert opening.assigned_to_user_id == "user_2"
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+    # The handoff is lossless - that is what makes it safe.
+    assert sao[HINGE[1]].installed_quantity == 2
+    assert [o.id for o in shop_assembly_repository.get_my_work(db_session, "user_2")] == [opening.id]
+    assert shop_assembly_repository.get_my_work(db_session, "user_1") == []
+
+
+def test_self_claim_cannot_steal_someone_elses_opening(db_session):
+    """allow_reassign defaults to False, which is what the self-claim resolver branch passes."""
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P18", items=[(*HINGE, 4)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
+    )
+    db_session.flush()
+
+    with pytest.raises(ConflictError):
+        shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob")
+    assert opening.assigned_to_user_id == "user_1"
+
+
+def test_reclaiming_your_own_opening_is_a_no_op(db_session):
+    """A double-click on Assign to me must not error out."""
+    project = _make_project(db_session)
+    opening, _ = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P19", items=[(*HINGE, 4)])
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_1", "Ada")
+    db_session.flush()
+    assert opening.assigned_to_user_id == "user_1"
+    assert opening.assigned_to == "Ada"
+
+
+def test_unassigning_in_progress_work_is_allowed_and_keeps_it_assignable(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P20", items=[(*HINGE, 4)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
+    )
+    db_session.flush()
+
+    shop_assembly_repository.remove_opening_from_user(db_session, opening.id)
+    db_session.flush()
+    assert opening.assigned_to_user_id is None
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+
+    # Back in the pool, and a plain self-claim can pick it up with its progress intact.
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob")
+    db_session.flush()
+    assert opening.assigned_to_user_id == "user_2"
+    assert sao[HINGE[1]].installed_quantity == 2
+
+
+def test_completed_openings_cannot_be_unassigned_or_reassigned(db_session):
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P21", items=[(*HINGE, 2)])
+    shop_assembly_repository.record_assembly_progress(
+        db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
+    )
+    shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.remove_opening_from_user(db_session, opening.id)
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob", allow_reassign=True)

--- a/backend/tests/test_completion_deficiency_checklist.py
+++ b/backend/tests/test_completion_deficiency_checklist.py
@@ -1,9 +1,13 @@
-"""Tests for the completion-time deficiency checklist (#225).
+"""Tests for the assembly deficiency path (#225, reworked for #340).
 
-complete_opening snapshots only INSTALLED checklist items as OpeningItemHardware. Items flagged
-not-installed are returned to project inventory flagged deficient (quantity AND deficient_quantity
-both bumped on an existing row) and get a PR-REPL replacement pull appended. An empty checklist
-snapshots every item (pre-checklist behaviour). The assembled opening returns to inventory.
+Flagging a deficient unit used to be an argument to complete_opening. It is now its own act, recorded
+through record_assembly_progress the moment the defect is found at the bench: the unit is returned to
+project inventory flagged deficient (quantity AND deficient_quantity both bumped on an existing row)
+and a PR-REPL replacement pull is appended straight away, so the warehouse can start sourcing the
+replacement while the leaf is still being built.
+
+Completion then only snapshots what was actually installed. These tests cover the deficiency half of
+that split; the progress and gating half is in test_assembly_progress.py.
 """
 
 import uuid
@@ -31,6 +35,8 @@ from app.repositories import shop_assembly_repository, warehouse_admin_repositor
 
 INSTALLED = ("HINGE", "HG-INST")
 DEFICIENT = ("LOCK", "LK-DEF")
+
+Update = shop_assembly_repository.AssemblyProgressUpdate
 
 
 def _make_project(session) -> Project:
@@ -77,7 +83,7 @@ def _make_pulled_opening(session, project_id, *, request_number, items):
     """A completed SHOP_ASSEMBLY PR with a single PULLED opening (assembly PENDING, assigned).
 
     `items` is a list of (category, code, qty). Mirrors the import: one LOOSE PR item and one
-    ShopAssemblyOpeningItem per line. Returns (pr, opening, {code: ShopAssemblyOpeningItem}).
+    ShopAssemblyOpeningItem per line, all at zero recorded progress. Returns (pr, opening, {code: item}).
     """
     pr = PullRequest(
         id=uuid.uuid4(),
@@ -101,6 +107,7 @@ def _make_pulled_opening(session, project_id, *, request_number, items):
         location="L1",
         pull_status=PullStatus.PULLED,
         assigned_to="assembler",
+        assigned_to_user_id="user_1",
         assembly_status=AssemblyStatus.PENDING,
     )
     session.add(opening)
@@ -138,7 +145,7 @@ def _installed_hardware(session, opening_item_id):
     )
 
 
-def test_completion_snapshots_only_installed_and_flags_deficient(db_session):
+def test_deficiency_returns_unit_and_mints_replacement_before_completion(db_session):
     project = _make_project(db_session)
     # Row for the deficient product is at quantity 0, i.e. fully pulled - the deficient unit still
     # has an existing row to be returned onto.
@@ -150,31 +157,19 @@ def test_completion_snapshots_only_installed_and_flags_deficient(db_session):
         items=[(*INSTALLED, 1), (*DEFICIENT, 1)],
     )
 
-    result = shop_assembly_repository.complete_opening(
+    shop_assembly_repository.record_assembly_progress(
         db_session,
         opening.id,
-        "A",
-        "2",
-        "3",
-        item_results=[
-            shop_assembly_repository.OpeningItemResult(sao[INSTALLED[1]].id, installed=True),
-            shop_assembly_repository.OpeningItemResult(
-                sao[DEFICIENT[1]].id, installed=False, deficient_reason="bent tab"
-            ),
+        [
+            Update(sao[INSTALLED[1]].id, installed_quantity=1),
+            Update(sao[DEFICIENT[1]].id, flag_deficient_quantity=1, deficient_reason="bent tab"),
         ],
-        completed_by="assembler",
+        performed_by="assembler",
     )
     db_session.flush()
 
-    # Assembled opening returns to inventory.
-    assert result.state == OpeningItemState.IN_INVENTORY
-    assert result.aisle == "A" and result.row == "2" and result.bay == "3"
-
-    # Only the installed item is snapshotted as hardware.
-    hw = _installed_hardware(db_session, result.id)
-    assert {h.product_code for h in hw} == {INSTALLED[1]}
-
-    # The deficient unit is returned to inventory flagged deficient (both counts bumped together).
+    # The deficient unit is returned to inventory flagged deficient (both counts bumped together),
+    # and the replacement pull exists BEFORE the leaf is finished - the point of moving it here.
     def_il = db_session.scalars(
         select(InventoryLocation).where(
             InventoryLocation.project_id == project.id,
@@ -184,7 +179,6 @@ def test_completion_snapshots_only_installed_and_flags_deficient(db_session):
     assert def_il.quantity == 1
     assert def_il.deficient_quantity == 1
 
-    # A replacement pull was appended for the deficient product.
     repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-CHK1")).first()
     assert repl is not None
     assert repl.status == PullRequestStatus.PENDING
@@ -196,33 +190,53 @@ def test_completion_snapshots_only_installed_and_flags_deficient(db_session):
     assert repl_items[0].requested_quantity == 1
     assert repl_items[0].opening_number == "A01"
 
-    # Opening is marked completed.
+    # ...and the opening is now in progress, not pending.
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "2", "3", completed_by="assembler")
+    db_session.flush()
+
+    # Assembled leaf returns to inventory carrying only what was installed.
+    assert result.state == OpeningItemState.IN_INVENTORY
+    assert result.aisle == "A" and result.row == "2" and result.bay == "3"
+    hw = _installed_hardware(db_session, result.id)
+    assert {h.product_code for h in hw} == {INSTALLED[1]}
+
     db_session.refresh(opening)
     assert opening.assembly_status == AssemblyStatus.COMPLETED
     assert opening.completed_at is not None
 
 
-def test_empty_checklist_snapshots_all_items(db_session):
+def test_no_deficiency_means_no_replacement_pull(db_session):
+    """Installing everything mints nothing extra - a replacement PR only exists if a defect is found."""
     project = _make_project(db_session)
-    _, opening, _sao = _make_pulled_opening(
+    _, opening, sao = _make_pulled_opening(
         db_session,
         project.id,
         request_number="PR-SA-CHK2",
         items=[(*INSTALLED, 2), (*DEFICIENT, 1)],
     )
 
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [
+            Update(sao[INSTALLED[1]].id, installed_quantity=2),
+            Update(sao[DEFICIENT[1]].id, installed_quantity=1),
+        ],
+        performed_by="assembler",
+    )
     result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
     db_session.flush()
 
     hw = _installed_hardware(db_session, result.id)
-    assert {h.product_code for h in hw} == {INSTALLED[1], DEFICIENT[1]}
+    assert {h.product_code: h.quantity for h in hw} == {INSTALLED[1]: 2, DEFICIENT[1]: 1}
 
-    # No replacement pull created when nothing is flagged deficient.
     repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-CHK2")).first()
     assert repl is None
 
 
-def test_checklist_item_must_belong_to_opening(db_session):
+def test_progress_item_must_belong_to_opening(db_session):
     project = _make_project(db_session)
     _, opening, _sao = _make_pulled_opening(
         db_session,
@@ -232,24 +246,19 @@ def test_checklist_item_must_belong_to_opening(db_session):
     )
 
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(
+        shop_assembly_repository.record_assembly_progress(
             db_session,
             opening.id,
-            None,
-            None,
-            None,
-            item_results=[
-                shop_assembly_repository.OpeningItemResult(uuid.uuid4(), installed=False, deficient_reason="x")
-            ],
+            [Update(uuid.uuid4(), flag_deficient_quantity=1, deficient_reason="x")],
         )
 
 
-def test_completion_creates_inventory_row_when_deleted(db_session):
-    """#227(2): a deficient flag still completes when the source inventory row was hard-deleted.
+def test_deficiency_creates_inventory_row_when_deleted(db_session):
+    """#227(2): a deficient flag still lands when the source inventory row was hard-deleted.
 
     Simulates a replace-schedule re-upload that removed the InventoryLocation row after the unit
     was pulled. report_deficiency_at_assembly re-materializes the row instead of aborting, so the
-    installed items' snapshots are preserved.
+    rest of the leaf can still be built and completed.
     """
     project = _make_project(db_session)
     il = _seed_inventory(db_session, project.id, category=DEFICIENT[0], code=DEFICIENT[1], quantity=0)
@@ -263,20 +272,16 @@ def test_completion_creates_inventory_row_when_deleted(db_session):
         items=[(*INSTALLED, 1), (*DEFICIENT, 1)],
     )
 
-    result = shop_assembly_repository.complete_opening(
+    shop_assembly_repository.record_assembly_progress(
         db_session,
         opening.id,
-        "A",
-        "2",
-        "3",
-        item_results=[
-            shop_assembly_repository.OpeningItemResult(sao[INSTALLED[1]].id, installed=True),
-            shop_assembly_repository.OpeningItemResult(
-                sao[DEFICIENT[1]].id, installed=False, deficient_reason="bent tab"
-            ),
+        [
+            Update(sao[INSTALLED[1]].id, installed_quantity=1),
+            Update(sao[DEFICIENT[1]].id, flag_deficient_quantity=1, deficient_reason="bent tab"),
         ],
-        completed_by="assembler",
+        performed_by="assembler",
     )
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "2", "3", completed_by="assembler")
     db_session.flush()
 
     # Installed item is still snapshotted despite the missing deficient-product row.
@@ -295,14 +300,13 @@ def test_completion_creates_inventory_row_when_deleted(db_session):
     assert def_il.deficient_quantity == 1
     assert def_il.stock_item_id is not None
 
-    # Replacement pull is still appended.
     repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-CHK4")).first()
     assert repl is not None
     assert opening.assembly_status == AssemblyStatus.COMPLETED
 
 
 def test_deficient_item_requires_reason(db_session):
-    """#227(3): complete_opening rejects a not-installed item with a missing/blank reason."""
+    """#227(3): a flagged unit with a missing/blank reason is rejected."""
     project = _make_project(db_session)
     _, opening, sao = _make_pulled_opening(
         db_session,
@@ -313,22 +317,15 @@ def test_deficient_item_requires_reason(db_session):
 
     for bad_reason in (None, "   "):
         with pytest.raises(ValidationError):
-            shop_assembly_repository.complete_opening(
+            shop_assembly_repository.record_assembly_progress(
                 db_session,
                 opening.id,
-                None,
-                None,
-                None,
-                item_results=[
-                    shop_assembly_repository.OpeningItemResult(
-                        sao[DEFICIENT[1]].id, installed=False, deficient_reason=bad_reason
-                    )
-                ],
+                [Update(sao[DEFICIENT[1]].id, flag_deficient_quantity=1, deficient_reason=bad_reason)],
             )
 
 
 def test_deficient_reason_length_capped(db_session):
-    """#227(3): complete_opening rejects a deficiency reason over 500 characters."""
+    """#227(3): a deficiency reason over 500 characters is rejected."""
     project = _make_project(db_session)
     _, opening, sao = _make_pulled_opening(
         db_session,
@@ -338,15 +335,8 @@ def test_deficient_reason_length_capped(db_session):
     )
 
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(
+        shop_assembly_repository.record_assembly_progress(
             db_session,
             opening.id,
-            None,
-            None,
-            None,
-            item_results=[
-                shop_assembly_repository.OpeningItemResult(
-                    sao[DEFICIENT[1]].id, installed=False, deficient_reason="x" * 501
-                )
-            ],
+            [Update(sao[DEFICIENT[1]].id, flag_deficient_quantity=1, deficient_reason="x" * 501)],
         )

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -859,6 +859,9 @@ def test_complete_opening_stamps_leaf(db_session):
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
     sao.pull_status = PullStatus.PULLED
     sao.assigned_to = "tester"
+    # Every unit has to be dispositioned before completion is allowed (#340).
+    for item in sao.items:
+        item.installed_quantity = item.quantity
     db_session.flush()
 
     opening_item = shop_assembly_repository.complete_opening(db_session, sao.id, "A", "1", "1", completed_by="tester")

--- a/backend/tests/test_shop_assembly_completion_guards.py
+++ b/backend/tests/test_shop_assembly_completion_guards.py
@@ -26,7 +26,7 @@ from app.models.enums import (
     PullStatus,
 )
 from app.models.inventory import InventoryLocation
-from app.models.opening_item import OpeningItem
+from app.models.opening_item import OpeningItem, OpeningItemHardware
 from app.models.project import Project
 from app.models.pull_request import PullRequest, PullRequestItem
 from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
@@ -73,10 +73,15 @@ def _seed_inventory(session, project_id, *, category, code, quantity=0):
     return il
 
 
-def _make_pulled_opening(session, project_id, *, request_number, items, leaf=None, opening_id=None):
+def _make_pulled_opening(session, project_id, *, request_number, items, leaf=None, opening_id=None, install_all=True):
     """A COMPLETED SHOP_ASSEMBLY pull request with one PULLED, assigned, still-pending opening.
 
     `items` is a list of (category, code, qty). Returns (opening, {code: ShopAssemblyOpeningItem}).
+
+    install_all seeds every line as fully installed, the state persisted progress would be in by the
+    time an assembler presses Mark Complete (#340). These tests are about the *other* completion
+    guards, so they want a leaf that is otherwise completable; the disposition gate itself is covered
+    in test_assembly_progress.py.
     """
     pr = PullRequest(
         id=uuid.uuid4(),
@@ -112,6 +117,7 @@ def _make_pulled_opening(session, project_id, *, request_number, items, leaf=Non
             hardware_category=category,
             product_code=code,
             quantity=qty,
+            installed_quantity=qty if install_all else 0,
         )
         session.add(sao_item)
         sao_items[code] = sao_item
@@ -254,51 +260,63 @@ def test_duplicate_guard_is_project_scoped(db_session):
 # --- 2. all-deficient completion ---------------------------------------------------------------
 
 
+def _flag_all_deficient(session, opening, sao_items):
+    """Condemn every unit of every line through the progress path (#340)."""
+    shop_assembly_repository.record_assembly_progress(
+        session,
+        opening.id,
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                shop_assembly_opening_item_id=item.id,
+                installed_quantity=0,
+                flag_deficient_quantity=item.quantity,
+                deficient_reason="bent",
+            )
+            for item in sao_items.values()
+        ],
+        performed_by="assembler",
+    )
+    session.flush()
+
+
 def test_all_deficient_completion_is_refused(db_session):
-    """Every item flagged deficient would mint an empty assembled leaf - refuse the whole call."""
+    """Every unit flagged deficient would mint an empty assembled leaf - refuse to call it complete.
+
+    Since #340 the deficiencies themselves were recorded when they were found, so unlike the #339
+    version of this guard they are NOT rolled back - the units are already in the deficiency queue
+    with a replacement pull against them, which is the correct state. What is refused is the claim
+    that the leaf is assembled.
+    """
     project = _make_project(db_session)
-    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
     opening, sao = _make_pulled_opening(
         db_session,
         project.id,
         request_number="PR-SA-ALLDEF",
         items=[(*HINGE, 1), (*LOCK, 1)],
         leaf=1,
+        install_all=False,
     )
+    _flag_all_deficient(db_session, opening, sao)
 
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(
-            db_session,
-            opening.id,
-            None,
-            None,
-            None,
-            item_results=[
-                shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=False, deficient_reason="bent"),
-                shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
-            ],
-            completed_by="assembler",
-        )
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None, completed_by="assembler")
     db_session.flush()
 
-    # The opening stays pending, no assembled unit exists...
-    assert opening.assembly_status == AssemblyStatus.PENDING
+    # No assembled unit exists and the leaf stays open (IN_PROGRESS - it has recorded work on it).
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
     assert opening.completed_at is None
     assert db_session.scalars(select(OpeningItem).where(OpeningItem.opening_id == opening.opening_id)).first() is None
 
-    # ...and no deficiency was recorded: the refusal happens before any unit is returned to
-    # inventory or any PR-REPL line is appended, so the call fails whole.
-    assert (
-        db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-ALLDEF")).first()
-        is None
-    )
-    db_session.refresh(il)
-    assert il.quantity == 0
-    assert il.deficient_quantity == 0
+    # The deficiencies stand: they were reported at the bench, not at completion.
+    repl = db_session.scalars(select(PullRequest).where(PullRequest.request_number == "PR-REPL-PR-SA-ALLDEF")).first()
+    assert repl is not None
+    assert len(list(db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == repl.id)))) == 2
 
 
 def test_partially_deficient_completion_still_succeeds(db_session):
-    """One installed item is enough - the guard only fires when nothing at all is installed."""
+    """One installed unit is enough - the guard only fires when nothing at all was installed."""
     project = _make_project(db_session)
     _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
     opening, sao = _make_pulled_opening(
@@ -307,22 +325,31 @@ def test_partially_deficient_completion_still_succeeds(db_session):
         request_number="PR-SA-PARTDEF",
         items=[(*HINGE, 1), (*LOCK, 1)],
         leaf=1,
+        install_all=False,
     )
-
-    result = shop_assembly_repository.complete_opening(
+    shop_assembly_repository.record_assembly_progress(
         db_session,
         opening.id,
-        None,
-        None,
-        None,
-        item_results=[
-            shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=True),
-            shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(sao[HINGE[1]].id, installed_quantity=1),
+            shop_assembly_repository.AssemblyProgressUpdate(
+                sao[LOCK[1]].id, flag_deficient_quantity=1, deficient_reason="seized"
+            ),
         ],
-        completed_by="assembler",
+        performed_by="assembler",
+    )
+    db_session.flush()
+
+    result = shop_assembly_repository.complete_opening(
+        db_session, opening.id, None, None, None, completed_by="assembler"
     )
     db_session.flush()
     assert result.state == OpeningItemState.IN_INVENTORY
+    # Only the installed line is snapshotted onto the leaf.
+    hw = list(
+        db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == result.id)).all()
+    )
+    assert {h.product_code: h.quantity for h in hw} == {HINGE[1]: 1}
 
 
 def test_opening_with_no_items_still_completes(db_session):
@@ -346,7 +373,10 @@ def test_opening_with_no_items_still_completes(db_session):
 
 
 def test_replacement_pull_line_carries_leaf_and_source_item(db_session):
-    """#339: the PR-REPL line is stamped with the leaf and the deficient ShopAssemblyOpeningItem."""
+    """#339: the PR-REPL line is stamped with the leaf and the deficient ShopAssemblyOpeningItem.
+
+    Minted at the moment the defect is flagged since #340, not at completion.
+    """
     project = _make_project(db_session)
     _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1])
     opening, sao = _make_pulled_opening(
@@ -355,19 +385,19 @@ def test_replacement_pull_line_carries_leaf_and_source_item(db_session):
         request_number="PR-SA-REPL",
         items=[(*HINGE, 1), (*LOCK, 1)],
         leaf=2,
+        install_all=False,
     )
 
-    shop_assembly_repository.complete_opening(
+    shop_assembly_repository.record_assembly_progress(
         db_session,
         opening.id,
-        None,
-        None,
-        None,
-        item_results=[
-            shop_assembly_repository.OpeningItemResult(sao[HINGE[1]].id, installed=True),
-            shop_assembly_repository.OpeningItemResult(sao[LOCK[1]].id, installed=False, deficient_reason="seized"),
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(sao[HINGE[1]].id, installed_quantity=1),
+            shop_assembly_repository.AssemblyProgressUpdate(
+                sao[LOCK[1]].id, flag_deficient_quantity=1, deficient_reason="seized"
+            ),
         ],
-        completed_by="assembler",
+        performed_by="assembler",
     )
     db_session.flush()
 

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -58,9 +58,26 @@ cannot answer that question, because it deliberately forgot.
 
 ### 4. The tag materializes
 
-- **Shop assembly complete** - the tag becomes physical. An `OpeningItem` row is created per leaf
-  (`opening_items.leaf`), with `OpeningItemHardware` recording what was actually installed on it.
-  From here the leaf is a real object with its own state and warehouse location.
+The tag does not become physical all at once. Assembly happens over a shift, unit by unit, and since
+#340 the system records it that way.
+
+- **Assembly progress** - `shop_assembly_opening_items.installed_quantity` / `deficient_quantity`
+  count what the assembler has actually fitted and what has been condemned. This is *work-tracking on
+  the tag*, not a materialization: no `OpeningItem` exists yet, nothing has left or entered fungible
+  inventory (the hardware was deducted when the pull was approved), and the leaf can be handed to
+  another assembler without losing a unit of it. The opening sits at `IN_PROGRESS` while this is
+  happening. Remaining is `quantity - installed - deficient`, derived, never stored.
+- **A unit found defective** goes back the moment it is found, not at completion:
+  `report_deficiency_at_assembly` returns it to project inventory flagged deficient and appends a
+  PR-REPL replacement pull line carrying the leaf and the source `ShopAssemblyOpeningItem`. That is
+  the identity round-trip in miniature - the unit loses its leaf on the way back into inventory, and
+  the replacement line is what re-tags a fresh one.
+- **Shop assembly complete** - *this* is where the tag becomes physical. An `OpeningItem` row is
+  created per leaf (`opening_items.leaf`), with one `OpeningItemHardware` row per line that had units
+  installed, at the **installed** quantity, not the planned one. Completion is refused while any unit
+  is still unaccounted for (`installed + deficient < quantity`), and refused if nothing at all was
+  installed - an assembled leaf with no hardware on it would read as ship-ready inventory. From here
+  the leaf is a real object with its own state and warehouse location.
 - **Shipping out complete** - the leaf moves to `SHIP_READY`, then a confirmed shipment writes a
   `PackingSlipItem` that snapshots the leaf permanently.
 
@@ -94,5 +111,7 @@ leaf until a pull tags it onto one).
 | Tag written, shop assembly | `backend/app/repositories/shop_assembly_repository.py` (`accept_shop_assembly_request`) |
 | Tag written, shipping out | `backend/app/repositories/shipping_repository.py` (`accept_shipping_out_request`) |
 | Tag consumes stock | `backend/app/repositories/warehouse/pull_requests.py` (`approve_pull_request`, FIFO deduction) |
-| Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`) |
+| Tag worked, incrementally | `backend/app/repositories/shop_assembly_repository.py` (`record_assembly_progress` -> `installed_quantity` / `deficient_quantity`) |
+| Deficient unit returned + replaced | `backend/app/repositories/stock/deficiency.py` (`report_deficiency_at_assembly` -> PR-REPL line) |
+| Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`, quantities = installed) |
 | Tag shipped | `backend/app/repositories/shipping_repository.py` (`confirm_shipment` -> `PackingSlipItem.leaf`) |

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -38,3 +38,18 @@ export const SHIPPING_REFETCH_QUERIES = ['GetOpeningLeafStatus'];
 // goes to the network) and notifications (NotificationBell polls every 30s and mounts two instances
 // with different variables, so listing it costs two round-trips for a badge that self-corrects).
 export const SHIPPING_STALE_ROOT_FIELDS = ['shipReadyItems', 'openingItems'];
+
+// What a shop-assembly progress save invalidates (#340). Same disjointness rule as above: a root
+// field that is evicted must not also be refetched by name, or Apollo fires a repair fetch for the
+// incomplete cache diff on top of the explicit refetch.
+//
+// Refetched. GetMyWork is the assembler's own board and is mounted whenever they are saving from My
+// Work; refetchQueries reaches only mounted instances, so this is a no-op when the save came from
+// the Assemble List instead. Note that recordAssemblyProgress already returns the updated opening
+// with its items, so the modal itself needs neither of these - these lists exist for the *lists*
+// behind it, whose status chip and "5/8 units" column would otherwise sit stale.
+export const ASSEMBLY_PROGRESS_REFETCH_QUERIES = ['GetMyWork'];
+
+// Evicted. assembleList is read by the other entry point into the same modal, and the two views are
+// never mounted together (separate routes), so whichever one is live repairs its own diff.
+export const ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS = ['assembleList'];

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -36,6 +36,8 @@ export const GET_ASSEMBLE_LIST = gql`
         hardwareCategory
         productCode
         quantity
+        installedQuantity
+        deficientQuantity
       }
     }
   }
@@ -63,6 +65,8 @@ export const GET_MY_WORK = gql`
         hardwareCategory
         productCode
         quantity
+        installedQuantity
+        deficientQuantity
       }
     }
   }
@@ -150,6 +154,8 @@ export const ASSIGN_OPENINGS = gql`
         hardwareCategory
         productCode
         quantity
+        installedQuantity
+        deficientQuantity
       }
     }
   }
@@ -176,11 +182,47 @@ export const REMOVE_OPENING_FROM_USER = gql`
         hardwareCategory
         productCode
         quantity
+        installedQuantity
+        deficientQuantity
       }
     }
   }
 `;
 
+// Save partial assembly progress without finishing the leaf (#340). Returns the opening so the modal
+// can re-hydrate from what the server actually stored - installedQuantity is absolute, and a
+// flagDeficientQuantity line has already minted a replacement pull by the time this resolves.
+export const RECORD_ASSEMBLY_PROGRESS = gql`
+  mutation RecordAssemblyProgress($input: RecordAssemblyProgressInput!) {
+    recordAssemblyProgress(input: $input) {
+      id
+      shopAssemblyRequestId
+      pullRequestId
+      openingId
+      pullStatus
+      assignedToUserId
+      assignedTo
+      assemblyStatus
+      completedAt
+      openingNumber
+      building
+      floor
+      leaf
+      items {
+        id
+        shopAssemblyOpeningId
+        hardwareCategory
+        productCode
+        quantity
+        installedQuantity
+        deficientQuantity
+      }
+    }
+  }
+`;
+
+// CompleteOpeningInput has no itemResults since #340 - completion reads the persisted per-item
+// progress, so the client no longer restates what was installed at the moment it finishes.
 export const COMPLETE_OPENING = gql`
   mutation CompleteOpening($input: CompleteOpeningInput!) {
     completeOpening(input: $input) {

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -23,6 +23,7 @@ import OpeningLeafStatusPanel from '../../components/OpeningLeafStatusPanel';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import AssemblyDetailModal from './AssemblyDetailModal';
+import { assemblyProgress, assemblyStatusLabel } from './openingFilters';
 
 // --- Types ---
 
@@ -32,6 +33,8 @@ interface AssembleOpeningItem {
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  installedQuantity: number;
+  deficientQuantity: number;
 }
 
 interface AssembleOpening {
@@ -70,7 +73,9 @@ const PULL_STATUS_SECTIONS: PullStatusSection[] = [
 export default function AssembleListPage() {
   const { displayName, userId } = useIdentity();
   const { showToast } = useToast();
-  const [completing, setCompleting] = useState<AssembleOpening | null>(null);
+  // The id, not the row: the modal saves progress and this list re-reads, and holding the object
+  // would pin the modal to the pre-save snapshot (#340).
+  const [completingId, setCompletingId] = useState<string | null>(null);
 
   const {
     data,
@@ -78,7 +83,11 @@ export default function AssembleListPage() {
     refetch,
   } = useQuery<{ assembleList: AssembleOpening[] }>(GET_ASSEMBLE_LIST);
 
-  const openings = data?.assembleList ?? [];
+  const openings = useMemo(() => data?.assembleList ?? [], [data]);
+  const completing = useMemo(
+    () => openings.find((o) => o.id === completingId) ?? null,
+    [openings, completingId]
+  );
 
   const [assignOpenings] = useMutation(ASSIGN_OPENINGS, {
     onCompleted: () => {
@@ -129,8 +138,8 @@ export default function AssembleListPage() {
       if (opening.assignedToUserId === userId) {
         return (
           <Stack direction="row" spacing={1}>
-            <Button size="small" variant="contained" onClick={() => setCompleting(opening)}>
-              Complete assembly
+            <Button size="small" variant="contained" onClick={() => setCompletingId(opening.id)}>
+              {opening.assemblyStatus === 'IN_PROGRESS' ? 'Continue assembly' : 'Start assembly'}
             </Button>
             <Button
               size="small"
@@ -216,10 +225,11 @@ export default function AssembleListPage() {
               ) : (
                 sectionOpenings.map((opening) => {
                   const actions = renderActions(opening);
+                  const progress = assemblyProgress(opening.items ?? []);
                   return (
                     <Accordion key={opening.id} variant="outlined" sx={{ mb: 1 }}>
                       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Stack direction="row" spacing={2} alignItems="center">
+                        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
                           <Typography fontWeight="bold">
                             Opening: {opening.openingNumber || opening.openingId}
                             {leafSuffix(opening.leaf)}
@@ -230,6 +240,17 @@ export default function AssembleListPage() {
                             size="small"
                             variant="outlined"
                           />
+                          {/* Assembly state is separate from pull state - a leaf can be fully pulled
+                              and half built (#340). */}
+                          <Chip
+                            label={assemblyStatusLabel(opening.assemblyStatus)}
+                            color={opening.assemblyStatus === 'IN_PROGRESS' ? 'info' : 'default'}
+                            size="small"
+                            variant="outlined"
+                          />
+                          <Typography variant="body2" color="text.secondary">
+                            {progress.installed + progress.deficient}/{progress.planned} units
+                          </Typography>
                         </Stack>
                       </AccordionSummary>
                       <AccordionDetails>
@@ -240,7 +261,9 @@ export default function AssembleListPage() {
                               <TableRow>
                                 <TableCell>Product Code</TableCell>
                                 <TableCell>Hardware Category</TableCell>
-                                <TableCell align="right">Quantity</TableCell>
+                                <TableCell align="right">Pulled</TableCell>
+                                <TableCell align="right">Installed</TableCell>
+                                <TableCell align="right">Deficient</TableCell>
                               </TableRow>
                             </TableHead>
                             <TableBody>
@@ -249,6 +272,8 @@ export default function AssembleListPage() {
                                   <TableCell>{item.productCode}</TableCell>
                                   <TableCell>{item.hardwareCategory}</TableCell>
                                   <TableCell align="right">{item.quantity}</TableCell>
+                                  <TableCell align="right">{item.installedQuantity}</TableCell>
+                                  <TableCell align="right">{item.deficientQuantity}</TableCell>
                                 </TableRow>
                               ))}
                             </TableBody>
@@ -270,11 +295,13 @@ export default function AssembleListPage() {
 
       {completing && (
         <AssemblyDetailModal
+          // Keyed on the leaf so switching openings remounts and re-seeds the draft counts.
+          key={completing.id}
           open={!!completing}
           opening={completing}
-          onClose={() => setCompleting(null)}
+          onClose={() => setCompletingId(null)}
           onCompleted={() => {
-            setCompleting(null);
+            setCompletingId(null);
             refetch();
           }}
           completedBy={displayName}

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -10,14 +10,24 @@ import {
   TableCell,
   Button,
   Stack,
-  Checkbox,
+  Chip,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import { useMutation } from '@apollo/client/react';
-import { COMPLETE_OPENING } from '../../graphql/shop-assembly';
+import { COMPLETE_OPENING, RECORD_ASSEMBLY_PROGRESS } from '../../graphql/shop-assembly';
+import {
+  ASSEMBLY_PROGRESS_REFETCH_QUERIES,
+  ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS,
+} from '../../graphql/refetch';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
 import { leafSuffix } from '../../utils/leaf';
+import { assemblyProgress } from './openingFilters';
 
 interface OpeningItem {
   id: string;
@@ -25,6 +35,8 @@ interface OpeningItem {
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  installedQuantity: number;
+  deficientQuantity: number;
 }
 
 interface MyWorkOpening {
@@ -40,11 +52,14 @@ interface AssemblyDetailModalProps {
   open: boolean;
   opening: MyWorkOpening;
   onClose: () => void;
+  // Called once the leaf is finished and minted as an OpeningItem - the caller closes and refetches.
   onCompleted: () => void;
-  // The logged-in assembler; recorded as the performer on the completion and on any
-  // deficiency return so the audit trail names a real user, not the generic "Assembler".
+  // The logged-in assembler; recorded as the performer on progress saves, on the completion, and on
+  // any deficiency return so the audit trail names a real user, not the generic "Assembler".
   completedBy?: string;
 }
+
+const MAX_REASON_LENGTH = 500;
 
 export default function AssemblyDetailModal({
   open,
@@ -58,24 +73,41 @@ export default function AssemblyDetailModal({
   const [row, setRow] = useState('');
   const [bay, setBay] = useState('');
   const [confirmOpen, setConfirmOpen] = useState(false);
-  // Per-item checklist. Missing key -> installed (default). Reasons keyed by item id.
-  const [installed, setInstalled] = useState<Record<string, boolean>>({});
-  const [reasons, setReasons] = useState<Record<string, string>>({});
 
-  const isInstalled = (id: string): boolean => installed[id] ?? true;
-  const reasonFor = (id: string): string => reasons[id] ?? '';
+  // Draft installed counts, keyed by item id, held as strings so a half-typed field is not coerced to
+  // 0 under the assembler's fingers. Seeded once, on mount, from what the server has stored - which
+  // is what makes a half-built leaf resumable (#340). Both callers mount this modal only while an
+  // opening is selected and key it on that opening's id, so opening a different leaf remounts and
+  // re-seeds; there is no re-seeding effect to fight with, and a save that replaces the item objects
+  // therefore cannot stomp on whatever else the assembler is part-way through typing.
+  //
+  // Deficient counts are deliberately NOT drafted: flagging is immediate and irreversible, so it is
+  // always read straight off the server.
+  const [draftInstalled, setDraftInstalled] = useState<Record<string, string>>(() =>
+    Object.fromEntries(opening.items.map((item) => [item.id, String(item.installedQuantity)]))
+  );
+  // The line a deficiency is being reported against, if the flag dialog is open.
+  const [flagging, setFlagging] = useState<OpeningItem | null>(null);
+  const [flagQuantity, setFlagQuantity] = useState('1');
+  const [flagReason, setFlagReason] = useState('');
 
-  const [completeOpening, { loading }] = useMutation(COMPLETE_OPENING, {
+  const [recordProgress, { loading: saving }] = useMutation(RECORD_ASSEMBLY_PROGRESS, {
+    update(cache) {
+      for (const fieldName of ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
+    refetchQueries: ASSEMBLY_PROGRESS_REFETCH_QUERIES,
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const [completeOpening, { loading: completing }] = useMutation(COMPLETE_OPENING, {
     onCompleted: () => {
-      showToast(
-        `Opening ${opening.openingNumber || 'item'} marked complete`,
-        'success'
-      );
+      showToast(`Opening ${opening.openingNumber || 'item'} marked complete`, 'success');
       onCompleted();
     },
-    onError: (err) => {
-      showToast(err.message, 'error');
-    },
+    onError: (err) => showToast(err.message, 'error'),
   });
 
   const validateField = (value: string): boolean => {
@@ -83,33 +115,86 @@ export default function AssemblyDetailModal({
     return value.length >= 1 && value.length <= 20;
   };
 
-  // Every not-installed item must carry a deficiency reason before completion.
-  const deficientMissingReason = opening.items.some(
-    (item) => !isInstalled(item.id) && reasonFor(item.id).trim() === ''
+  // The most a line can be marked installed: everything not already condemned.
+  const maxInstalled = (item: OpeningItem): number => item.quantity - item.deficientQuantity;
+
+  const draftFor = (item: OpeningItem): string =>
+    draftInstalled[item.id] ?? String(item.installedQuantity);
+
+  // null means "not a usable number yet" - blank, non-integer, or out of range.
+  const parsedDraft = (item: OpeningItem): number | null => {
+    const raw = draftFor(item).trim();
+    if (raw === '') return null;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 0 || n > maxInstalled(item)) return null;
+    return n;
+  };
+
+  const allDraftsValid = opening.items.every((item) => parsedDraft(item) !== null);
+
+  // Progress as the assembler currently has it on screen: server-stored deficient counts plus the
+  // draft installed counts. Mark Complete is gated on this rather than on the stored values so the
+  // button turns on the moment the last unit is typed; the save that precedes completion is what
+  // then makes it true on the server.
+  const draftProgress = useMemo(
+    () =>
+      assemblyProgress(
+        opening.items.map((item) => ({
+          quantity: item.quantity,
+          installedQuantity: parsedDraft(item) ?? item.installedQuantity,
+          deficientQuantity: item.deficientQuantity,
+        }))
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [opening.items, draftInstalled]
   );
-  const deficientCount = opening.items.filter(
-    (item) => !isInstalled(item.id)
-  ).length;
 
-  const isValid =
-    validateField(aisle) &&
-    validateField(row) &&
-    validateField(bay) &&
-    !deficientMissingReason;
+  const dirty = opening.items.some((item) => parsedDraft(item) !== item.installedQuantity);
+  const locationValid = validateField(aisle) && validateField(row) && validateField(bay);
+  const busy = saving || completing;
 
-  const toggleInstalled = (id: string, checked: boolean) => {
-    setInstalled((prev) => ({ ...prev, [id]: checked }));
-  };
-  const setReason = (id: string, value: string) => {
-    setReasons((prev) => ({ ...prev, [id]: value }));
-  };
+  // Mirrors the backend's completion gate exactly - every unit installed or condemned, and at least
+  // one actually installed - so the button explains itself instead of failing on submit.
+  const canComplete =
+    allDraftsValid && draftProgress.complete && draftProgress.installed > 0 && locationValid;
 
-  const handleMarkComplete = useCallback(() => {
-    setConfirmOpen(true);
-  }, []);
+  const progressPayload = useCallback(
+    () =>
+      opening.items
+        .filter((item) => parsedDraft(item) !== item.installedQuantity)
+        .map((item) => ({
+          shopAssemblyOpeningItemId: item.id,
+          installedQuantity: parsedDraft(item),
+        })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [opening.items, draftInstalled]
+  );
 
-  const handleConfirm = useCallback(() => {
+  const handleSaveProgress = useCallback(async () => {
+    const items = progressPayload();
+    if (items.length === 0) {
+      showToast('No changes to save', 'info');
+      return;
+    }
+    const result = await recordProgress({
+      variables: { input: { openingId: opening.id, items, performedBy: completedBy || null } },
+    });
+    if (result.data) showToast('Progress saved', 'success');
+    // The modal deliberately stays open: a save is a checkpoint mid-job, not the end of it, and the
+    // leaf stays in My Work as In Progress.
+  }, [progressPayload, recordProgress, opening.id, completedBy, showToast]);
+
+  const handleConfirmComplete = useCallback(async () => {
     setConfirmOpen(false);
+    // Completion reads persisted state, so anything still in the draft has to land first. One save,
+    // then complete - if the save fails its error surfaces and nothing is completed on stale counts.
+    const items = progressPayload();
+    if (items.length > 0) {
+      const saved = await recordProgress({
+        variables: { input: { openingId: opening.id, items, performedBy: completedBy || null } },
+      });
+      if (!saved.data) return;
+    }
     completeOpening({
       variables: {
         input: {
@@ -117,19 +202,58 @@ export default function AssemblyDetailModal({
           aisle: aisle || null,
           row: row || null,
           bay: bay || null,
-          itemResults: opening.items.map((item) => ({
-            shopAssemblyOpeningItemId: item.id,
-            installed: isInstalled(item.id),
-            deficientReason: isInstalled(item.id)
-              ? null
-              : reasonFor(item.id).trim(),
-          })),
           completedBy: completedBy || null,
         },
       },
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [completeOpening, opening.id, opening.items, aisle, row, bay, installed, reasons, completedBy]);
+  }, [progressPayload, recordProgress, completeOpening, opening.id, aisle, row, bay, completedBy]);
+
+  // --- deficiency flagging -------------------------------------------------------------------
+
+  const openFlagDialog = (item: OpeningItem) => {
+    setFlagging(item);
+    setFlagQuantity('1');
+    setFlagReason('');
+  };
+
+  const flagRemaining = flagging
+    ? flagging.quantity - flagging.installedQuantity - flagging.deficientQuantity
+    : 0;
+  const flagQuantityValue = Number(flagQuantity);
+  const flagQuantityValid =
+    Number.isInteger(flagQuantityValue) &&
+    flagQuantityValue >= 1 &&
+    flagQuantityValue <= flagRemaining;
+  const flagReasonValid =
+    flagReason.trim().length > 0 && flagReason.trim().length <= MAX_REASON_LENGTH;
+
+  const handleFlagDeficient = useCallback(async () => {
+    if (!flagging) return;
+    const item = flagging;
+    const result = await recordProgress({
+      variables: {
+        input: {
+          openingId: opening.id,
+          items: [
+            {
+              shopAssemblyOpeningItemId: item.id,
+              flagDeficientQuantity: Number(flagQuantity),
+              deficientReason: flagReason.trim(),
+            },
+          ],
+          performedBy: completedBy || null,
+        },
+      },
+    });
+    if (result.data) {
+      setFlagging(null);
+      showToast(
+        `${flagQuantity} x ${item.productCode} flagged deficient - replacement pull requested`,
+        'success'
+      );
+    }
+  }, [flagging, recordProgress, opening.id, flagQuantity, flagReason, completedBy, showToast]);
+
   return (
     <>
       <Modal
@@ -137,89 +261,116 @@ export default function AssemblyDetailModal({
         onClose={onClose}
         title={`Assembly: ${opening.openingNumber || 'Opening'}${leafSuffix(opening.leaf)}`}
         actions={
-          <Stack direction='row' spacing={1}>
-            <Button onClick={onClose}>Cancel</Button>
+          <Stack direction="row" spacing={1}>
+            <Button onClick={onClose}>Close</Button>
             <Button
-              variant='contained'
-              onClick={handleMarkComplete}
-              disabled={!isValid || loading}
+              variant="outlined"
+              onClick={handleSaveProgress}
+              disabled={!allDraftsValid || !dirty || busy}
             >
-              {loading ? 'Completing...' : 'Mark Complete'}
+              {saving ? 'Saving...' : 'Save Progress'}
+            </Button>
+            <Button
+              variant="contained"
+              onClick={() => setConfirmOpen(true)}
+              disabled={!canComplete || busy}
+            >
+              {completing ? 'Completing...' : 'Mark Complete'}
             </Button>
           </Stack>
         }
       >
         <Box>
-          <Stack direction='row' spacing={2} sx={{ mb: 2 }}>
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }} alignItems="center" flexWrap="wrap">
             {opening.building && (
-              <Typography variant='body2' color='text.secondary'>
+              <Typography variant="body2" color="text.secondary">
                 Building: {opening.building}
               </Typography>
             )}
             {opening.floor && (
-              <Typography variant='body2' color='text.secondary'>
+              <Typography variant="body2" color="text.secondary">
                 Floor: {opening.floor}
               </Typography>
             )}
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`${draftProgress.installed + draftProgress.deficient}/${draftProgress.planned} units accounted for`}
+            />
           </Stack>
 
-          <Typography variant='subtitle1' sx={{ mb: 0.5, fontWeight: 'bold' }}>
+          <Typography variant="subtitle1" sx={{ mb: 0.5, fontWeight: 'bold' }}>
             Shop Hardware Checklist
           </Typography>
-          <Typography
-            variant='caption'
-            color='text.secondary'
-            sx={{ mb: 1, display: 'block' }}
-          >
-            Uncheck any item not installed to flag it deficient - a reason is
-            required. Only installed items are recorded on the assembled opening.
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+            Enter how many units of each line you have fitted. Save Progress as often as you like -
+            the leaf stays in My Work until you mark it complete. Every unit has to be either
+            installed or flagged deficient before the leaf can be completed.
           </Typography>
 
           {opening.items.length > 0 ? (
-            <Table size='small' sx={{ mb: 3 }}>
+            <Table size="small" sx={{ mb: 3 }}>
               <TableHead>
                 <TableRow>
-                  <TableCell padding='checkbox'>Installed</TableCell>
                   <TableCell>Product Code</TableCell>
                   <TableCell>Hardware Category</TableCell>
-                  <TableCell align='right'>Quantity</TableCell>
-                  <TableCell>Deficiency reason</TableCell>
+                  <TableCell align="right">Pulled</TableCell>
+                  <TableCell align="right">Installed</TableCell>
+                  <TableCell align="right">Deficient</TableCell>
+                  <TableCell align="right">Remaining</TableCell>
+                  <TableCell align="right">Action</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {opening.items.map((item) => {
-                  const installedNow = isInstalled(item.id);
+                  const parsed = parsedDraft(item);
+                  const storedRemaining =
+                    item.quantity - item.installedQuantity - item.deficientQuantity;
+                  const remaining =
+                    parsed === null ? storedRemaining : item.quantity - parsed - item.deficientQuantity;
                   return (
                     <TableRow key={item.id}>
-                      <TableCell padding='checkbox'>
-                        <Checkbox
-                          checked={installedNow}
+                      <TableCell>{item.productCode}</TableCell>
+                      <TableCell>{item.hardwareCategory}</TableCell>
+                      <TableCell align="right">{item.quantity}</TableCell>
+                      <TableCell align="right">
+                        <TextField
+                          size="small"
+                          type="number"
+                          value={draftFor(item)}
                           onChange={(e) =>
-                            toggleInstalled(item.id, e.target.checked)
+                            setDraftInstalled((prev) => ({ ...prev, [item.id]: e.target.value }))
                           }
+                          error={parsed === null}
+                          disabled={busy}
                           inputProps={{
-                            'aria-label': `Installed: ${item.productCode}`,
+                            min: 0,
+                            max: maxInstalled(item),
+                            step: 1,
+                            'aria-label': `Installed units: ${item.productCode}`,
+                            style: { textAlign: 'right', width: '4rem' },
                           }}
                         />
                       </TableCell>
-                      <TableCell>{item.productCode}</TableCell>
-                      <TableCell>{item.hardwareCategory}</TableCell>
-                      <TableCell align='right'>{item.quantity}</TableCell>
-                      <TableCell>
-                        <TextField
-                          size='small'
-                          fullWidth
-                          placeholder={
-                            installedNow ? '-' : 'Reason (required)'
-                          }
-                          value={reasonFor(item.id)}
-                          onChange={(e) => setReason(item.id, e.target.value)}
-                          disabled={installedNow}
-                          error={
-                            !installedNow && reasonFor(item.id).trim() === ''
-                          }
-                          inputProps={{ maxLength: 500 }}
-                        />
+                      <TableCell align="right">{item.deficientQuantity}</TableCell>
+                      <TableCell align="right">
+                        {parsed !== null && remaining === 0 ? (
+                          <Chip size="small" label="Done" variant="outlined" />
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">
+                            {parsed === null ? '-' : remaining}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell align="right">
+                        <Button
+                          size="small"
+                          variant="text"
+                          disabled={busy || storedRemaining <= 0}
+                          onClick={() => openFlagDialog(item)}
+                        >
+                          Flag deficient
+                        </Button>
                       </TableCell>
                     </TableRow>
                   );
@@ -227,22 +378,22 @@ export default function AssemblyDetailModal({
               </TableBody>
             </Table>
           ) : (
-            <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
               No hardware items.
             </Typography>
           )}
 
-          <Typography variant='subtitle1' sx={{ mb: 1, fontWeight: 'bold' }}>
+          <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
             Store completed Opening Item at:
           </Typography>
-          <Typography variant='caption' color='text.secondary' sx={{ mb: 2, display: 'block' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
             Leave blank for Unlocated
           </Typography>
 
-          <Stack direction='row' spacing={2}>
+          <Stack direction="row" spacing={2}>
             <TextField
-              label='Aisle'
-              size='small'
+              label="Aisle"
+              size="small"
               value={aisle}
               onChange={(e) => setAisle(e.target.value)}
               error={!validateField(aisle)}
@@ -250,8 +401,8 @@ export default function AssemblyDetailModal({
               inputProps={{ maxLength: 20 }}
             />
             <TextField
-              label='Row'
-              size='small'
+              label="Row"
+              size="small"
               value={row}
               onChange={(e) => setRow(e.target.value)}
               error={!validateField(row)}
@@ -259,8 +410,8 @@ export default function AssemblyDetailModal({
               inputProps={{ maxLength: 20 }}
             />
             <TextField
-              label='Bay'
-              size='small'
+              label="Bay"
+              size="small"
               value={bay}
               onChange={(e) => setBay(e.target.value)}
               error={!validateField(bay)}
@@ -268,19 +419,81 @@ export default function AssemblyDetailModal({
               inputProps={{ maxLength: 20 }}
             />
           </Stack>
+
+          {opening.items.length > 0 && !draftProgress.complete && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+              {draftProgress.remaining} unit(s) still unaccounted for - Mark Complete stays disabled
+              until every unit is installed or flagged deficient.
+            </Typography>
+          )}
+          {opening.items.length > 0 && draftProgress.complete && draftProgress.installed === 0 && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+              Every unit was flagged deficient, so there is nothing assembled to complete. The leaf
+              stays open until replacement hardware arrives and is installed.
+            </Typography>
+          )}
         </Box>
       </Modal>
 
+      {/* Flagging is irreversible from the bench and moves inventory the moment it is confirmed, so
+          it gets its own dialog and its own confirm rather than an inline control. */}
+      <Dialog open={flagging !== null} onClose={() => setFlagging(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Flag deficient: {flagging?.productCode}</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            This cannot be undone here. The units are returned to inventory flagged deficient and a
+            replacement pull is requested immediately - reversing it is a deficiency review.
+          </Alert>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Units deficient"
+              size="small"
+              type="number"
+              value={flagQuantity}
+              onChange={(e) => setFlagQuantity(e.target.value)}
+              error={!flagQuantityValid}
+              helperText={
+                flagQuantityValid ? `${flagRemaining} unrecorded` : `Enter 1 to ${flagRemaining}`
+              }
+              inputProps={{ min: 1, max: flagRemaining, step: 1, 'aria-label': 'Units deficient' }}
+            />
+            <TextField
+              label="Reason"
+              size="small"
+              fullWidth
+              multiline
+              minRows={2}
+              value={flagReason}
+              onChange={(e) => setFlagReason(e.target.value)}
+              error={flagReason.length > 0 && !flagReasonValid}
+              helperText="Required - what is wrong with the hardware"
+              inputProps={{ maxLength: MAX_REASON_LENGTH, 'aria-label': 'Deficiency reason' }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFlagging(null)}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleFlagDeficient}
+            disabled={!flagQuantityValid || !flagReasonValid || busy}
+          >
+            Flag deficient
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <ConfirmDialog
         open={confirmOpen}
-        title='Complete Assembly'
+        title="Complete Assembly"
         message={
-          deficientCount > 0
-            ? `Mark opening ${opening.openingNumber || 'item'} as assembled? ${deficientCount} item(s) will be flagged deficient and a replacement pull requested. This action cannot be undone.`
-            : `Mark opening ${opening.openingNumber || 'item'} as assembled? This action cannot be undone.`
+          draftProgress.deficient > 0
+            ? `Mark opening ${opening.openingNumber || 'item'} as assembled with ${draftProgress.installed} unit(s) installed? ${draftProgress.deficient} unit(s) were flagged deficient and already have a replacement pull. This action cannot be undone.`
+            : `Mark opening ${opening.openingNumber || 'item'} as assembled with ${draftProgress.installed} unit(s) installed? This action cannot be undone.`
         }
-        confirmLabel='Mark Complete'
-        onConfirm={handleConfirm}
+        confirmLabel="Mark Complete"
+        onConfirm={handleConfirmComplete}
         onCancel={() => setConfirmOpen(false)}
       />
     </>

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -35,6 +35,8 @@ interface OpeningItem {
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  installedQuantity: number;
+  deficientQuantity: number;
 }
 
 interface AssembleOpening {
@@ -164,7 +166,9 @@ export default function AssignmentBoard() {
   const isManager = hasRole('Shop Assembly Manager');
   const [activeOpening, setActiveOpening] = useState<AssembleOpening | null>(null);
   // Opening whose completion modal is open (reuses the same checklist modal as My Work).
-  const [completing, setCompleting] = useState<AssembleOpening | null>(null);
+  // The id, not the row: the modal saves progress and this board re-reads, and holding the object
+  // would pin the modal to the pre-save snapshot (#340).
+  const [completingId, setCompletingId] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -195,19 +199,26 @@ export default function AssignmentBoard() {
     },
   });
 
-  const openings = data?.assembleList ?? [];
+  // Memoized so the three derived lists below don't recompute on every render off a fresh [] literal.
+  const openings = useMemo(() => data?.assembleList ?? [], [data]);
 
   const available = useMemo(() => openings.filter(isAvailableForAssignment), [openings]);
 
+  const completing = useMemo(
+    () => openings.find((o) => o.id === completingId) ?? null,
+    [openings, completingId]
+  );
+
   // "Assigned" shows only what THIS user has claimed (keyed on the stable user id, #324),
-  // not everything assigned to anyone.
+  // not everything assigned to anyone. Unfinished, not "pending": a leaf with saved progress is
+  // IN_PROGRESS and is precisely the work the board should still be showing (#340).
   const assigned = useMemo(
     () =>
       openings.filter(
         (o) =>
           o.pullStatus === 'PULLED' &&
           o.assignedToUserId === userId &&
-          o.assemblyStatus === 'PENDING'
+          o.assemblyStatus !== 'COMPLETED'
       ),
     [openings, userId]
   );
@@ -298,7 +309,7 @@ export default function AssignmentBoard() {
               color='action.hover'
               renderActions={(opening) => (
                 <Stack direction='row' spacing={1}>
-                  <Button size='small' variant='contained' onClick={() => setCompleting(opening)}>
+                  <Button size='small' variant='contained' onClick={() => setCompletingId(opening.id)}>
                     Complete
                   </Button>
                   <Button
@@ -323,11 +334,13 @@ export default function AssignmentBoard() {
 
       {completing && (
         <AssemblyDetailModal
+          // Keyed on the leaf so switching openings remounts and re-seeds the draft counts.
+          key={completing.id}
           open={!!completing}
           opening={completing}
-          onClose={() => setCompleting(null)}
+          onClose={() => setCompletingId(null)}
           onCompleted={() => {
-            setCompleting(null);
+            setCompletingId(null);
             refetch();
           }}
           completedBy={displayName}

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useCallback } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Chip } from '@mui/material';
 import { useQuery } from '@apollo/client/react';
 import { GET_MY_WORK } from '../../graphql/shop-assembly';
 import { useIdentity } from '../../hooks/useIdentity';
 import DataTable from '../../components/DataTable';
 import AssemblyDetailModal from './AssemblyDetailModal';
+import { assemblyProgress, assemblyStatusLabel } from './openingFilters';
 import { leafLabel } from '../../utils/leaf';
 import type { GridColDef } from '@mui/x-data-grid';
 
@@ -14,6 +15,8 @@ interface OpeningItem {
   hardwareCategory: string;
   productCode: string;
   quantity: number;
+  installedQuantity: number;
+  deficientQuantity: number;
 }
 
 interface MyWorkOpening {
@@ -43,16 +46,45 @@ const columns: GridColDef[] = [
   { field: 'building', headerName: 'Building', flex: 1 },
   { field: 'floor', headerName: 'Floor', flex: 1 },
   {
+    field: 'assemblyStatus',
+    headerName: 'Status',
+    flex: 0.9,
+    // Assembly status is real system state, so it earns a status chip. In Progress is the one that
+    // matters here: it says the leaf has saved work on it and can be picked straight back up (#340).
+    renderCell: (params) => (
+      <Chip
+        size='small'
+        variant='outlined'
+        label={assemblyStatusLabel(params.row.assemblyStatus)}
+        color={params.row.assemblyStatus === 'IN_PROGRESS' ? 'info' : 'default'}
+      />
+    ),
+  },
+  {
+    field: 'progress',
+    headerName: 'Progress',
+    flex: 0.9,
+    // Units, not lines: a line of 8 hinges with 5 fitted is most of the job, and a line count would
+    // report it as untouched.
+    valueGetter: (_value: unknown, row: MyWorkOpening) => {
+      const { installed, deficient, planned } = assemblyProgress(row.items ?? []);
+      return `${installed + deficient}/${planned} units`;
+    },
+  },
+  {
     field: 'itemCount',
     headerName: 'Hardware Items',
-    flex: 1,
+    flex: 0.8,
     valueGetter: (_value: unknown, row: MyWorkOpening) => row.items?.length ?? 0,
   },
 ];
 
 export default function MyWorkPage() {
   const { displayName, userId } = useIdentity();
-  const [selectedOpening, setSelectedOpening] = useState<MyWorkOpening | null>(null);
+  // Hold the id, not the row. The modal writes progress and the list refetches; keeping the object
+  // would pin the modal to a snapshot taken before the save, so a just-flagged deficiency would not
+  // appear in it.
+  const [selectedOpeningId, setSelectedOpeningId] = useState<string | null>(null);
 
   const { data, loading, refetch } = useQuery<{ myWork: MyWorkOpening[] }>(GET_MY_WORK, {
     // Filter on the stable Clerk user id (#324); skip until Clerk has resolved it.
@@ -61,19 +93,19 @@ export default function MyWorkPage() {
   });
 
   const rows = useMemo(() => data?.myWork ?? [], [data]);
-
-  const handleRowClick = useCallback(
-    (params: { row: MyWorkOpening }) => {
-      setSelectedOpening(params.row);
-    },
-    []
+  const selectedOpening = useMemo(
+    () => rows.find((r) => r.id === selectedOpeningId) ?? null,
+    [rows, selectedOpeningId]
   );
 
+  const handleRowClick = useCallback((params: { row: MyWorkOpening }) => {
+    setSelectedOpeningId(params.row.id);
+  }, []);
+
   const handleCompleted = useCallback(() => {
-    setSelectedOpening(null);
+    setSelectedOpeningId(null);
     refetch();
   }, [refetch]);
-
 
   return (
     <Box>
@@ -91,9 +123,12 @@ export default function MyWorkPage() {
 
       {selectedOpening && (
         <AssemblyDetailModal
+          // Keyed on the leaf so switching openings remounts and re-seeds the draft counts from the
+          // newly-selected opening's stored progress.
+          key={selectedOpening.id}
           open={!!selectedOpening}
           opening={selectedOpening}
-          onClose={() => setSelectedOpening(null)}
+          onClose={() => setSelectedOpeningId(null)}
           onCompleted={handleCompleted}
           completedBy={displayName}
         />

--- a/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import AssemblyDetailModal from '../AssemblyDetailModal';
+import { RECORD_ASSEMBLY_PROGRESS, COMPLETE_OPENING } from '../../../graphql/shop-assembly';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// The modal is a progress editor since #340: it hydrates from persisted per-item counts, saves them
+// absolutely, and only lets the leaf be completed once every unit is either installed or condemned.
+
+function item(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'i1',
+    shopAssemblyOpeningId: 'o1',
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    quantity: 4,
+    installedQuantity: 0,
+    deficientQuantity: 0,
+    ...overrides,
+  };
+}
+
+function opening(items: ReturnType<typeof item>[]) {
+  return {
+    id: 'o1',
+    openingNumber: '0019-EX',
+    building: 'A',
+    floor: '2',
+    leaf: 1,
+    items,
+  };
+}
+
+function renderModal(
+  items: ReturnType<typeof item>[],
+  mocks: MockedResponse[] = [],
+  onCompleted = vi.fn()
+) {
+  const view = render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <AssemblyDetailModal
+          open
+          opening={opening(items)}
+          onClose={vi.fn()}
+          onCompleted={onCompleted}
+          completedBy="Ada"
+        />
+      </ToastProvider>
+    </MockedProvider>
+  );
+  return { ...view, onCompleted };
+}
+
+const installedInput = (productCode = 'HG-100') =>
+  screen.getByLabelText(`Installed units: ${productCode}`) as HTMLInputElement;
+
+describe('AssemblyDetailModal progress editor', () => {
+  it('hydrates the installed input from the persisted count', () => {
+    renderModal([item({ installedQuantity: 3 })]);
+    expect(installedInput().value).toBe('3');
+  });
+
+  it('keeps Mark Complete disabled while units are unaccounted for', () => {
+    renderModal([item({ quantity: 4, installedQuantity: 1 })]);
+
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
+    expect(screen.getByText(/3 unit\(s\) still unaccounted for/i)).toBeInTheDocument();
+  });
+
+  it('enables Mark Complete once every unit is installed or deficient', () => {
+    // 1 already condemned, so typing 3 accounts for all 4.
+    renderModal([item({ quantity: 4, installedQuantity: 0, deficientQuantity: 1 })]);
+
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
+    fireEvent.change(installedInput(), { target: { value: '3' } });
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeEnabled();
+  });
+
+  it('refuses to enable Mark Complete when every unit was flagged deficient', () => {
+    // Fully dispositioned but nothing installed - completing would mint an empty assembled leaf.
+    renderModal([item({ quantity: 2, installedQuantity: 0, deficientQuantity: 2 })]);
+
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
+    expect(screen.getByText(/nothing assembled to complete/i)).toBeInTheDocument();
+  });
+
+  it('rejects an installed count above what is left after deficiencies', () => {
+    renderModal([item({ quantity: 4, installedQuantity: 0, deficientQuantity: 1 })]);
+
+    fireEvent.change(installedInput(), { target: { value: '4' } });
+    expect(screen.getByRole('button', { name: /save progress/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
+  });
+
+  it('Save Progress is disabled until something changes, then sends the absolute count', async () => {
+    const saveMock: MockedResponse = {
+      request: {
+        query: RECORD_ASSEMBLY_PROGRESS,
+        variables: {
+          input: {
+            openingId: 'o1',
+            items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
+            performedBy: 'Ada',
+          },
+        },
+      },
+      result: {
+        data: {
+          recordAssemblyProgress: {
+            __typename: 'ShopAssemblyOpening',
+            id: 'o1',
+            shopAssemblyRequestId: null,
+            pullRequestId: 'pr1',
+            openingId: 'op1',
+            pullStatus: 'PULLED',
+            assignedToUserId: 'u1',
+            assignedTo: 'Ada',
+            assemblyStatus: 'IN_PROGRESS',
+            completedAt: null,
+            openingNumber: '0019-EX',
+            building: 'A',
+            floor: '2',
+            leaf: 1,
+            items: [
+              {
+                __typename: 'ShopAssemblyOpeningItem',
+                ...item({ installedQuantity: 2 }),
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    renderModal([item({ quantity: 4 })], [saveMock]);
+
+    expect(screen.getByRole('button', { name: /save progress/i })).toBeDisabled();
+    fireEvent.change(installedInput(), { target: { value: '2' } });
+    expect(screen.getByRole('button', { name: /save progress/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /save progress/i }));
+    await waitFor(() => expect(screen.getByText(/progress saved/i)).toBeInTheDocument());
+  });
+
+  it('saves outstanding progress before completing, then reports completion', async () => {
+    const saveMock: MockedResponse = {
+      request: {
+        query: RECORD_ASSEMBLY_PROGRESS,
+        variables: {
+          input: {
+            openingId: 'o1',
+            items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
+            performedBy: 'Ada',
+          },
+        },
+      },
+      result: {
+        data: {
+          recordAssemblyProgress: {
+            __typename: 'ShopAssemblyOpening',
+            id: 'o1',
+            shopAssemblyRequestId: null,
+            pullRequestId: 'pr1',
+            openingId: 'op1',
+            pullStatus: 'PULLED',
+            assignedToUserId: 'u1',
+            assignedTo: 'Ada',
+            assemblyStatus: 'IN_PROGRESS',
+            completedAt: null,
+            openingNumber: '0019-EX',
+            building: 'A',
+            floor: '2',
+            leaf: 1,
+            items: [
+              { __typename: 'ShopAssemblyOpeningItem', ...item({ quantity: 2, installedQuantity: 2 }) },
+            ],
+          },
+        },
+      },
+    };
+    const completeMock: MockedResponse = {
+      request: {
+        query: COMPLETE_OPENING,
+        variables: {
+          input: {
+            openingId: 'o1',
+            aisle: null,
+            row: null,
+            bay: null,
+            completedBy: 'Ada',
+          },
+        },
+      },
+      result: {
+        data: {
+          completeOpening: {
+            __typename: 'OpeningItem',
+            id: 'oi1',
+            projectId: 'p1',
+            openingId: 'op1',
+            openingNumber: '0019-EX',
+            building: 'A',
+            floor: '2',
+            location: null,
+            leaf: 1,
+            quantity: 1,
+            assemblyCompletedAt: '2026-07-26T00:00:00',
+            state: 'IN_INVENTORY',
+            aisle: null,
+            row: null,
+            bay: null,
+            createdAt: '2026-07-26T00:00:00',
+            updatedAt: '2026-07-26T00:00:00',
+            installedHardware: [],
+          },
+        },
+      },
+    };
+
+    const { onCompleted } = renderModal([item({ quantity: 2 })], [saveMock, completeMock]);
+
+    fireEvent.change(installedInput(), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: /mark complete/i }));
+    // Confirm dialog guards the irreversible step.
+    fireEvent.click(screen.getByRole('button', { name: /^mark complete$/i, hidden: false }));
+
+    await waitFor(() => expect(onCompleted).toHaveBeenCalled());
+  });
+
+  it('requires a reason before a deficiency can be flagged', async () => {
+    renderModal([item({ quantity: 2 })]);
+
+    fireEvent.click(screen.getByRole('button', { name: /flag deficient/i }));
+    const confirm = await screen.findByRole('button', { name: /^flag deficient$/i });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Deficiency reason'), {
+      target: { value: 'bent tab' },
+    });
+    expect(screen.getByRole('button', { name: /^flag deficient$/i })).toBeEnabled();
+  });
+
+  it('will not let more units be flagged deficient than are left unrecorded', async () => {
+    renderModal([item({ quantity: 3, installedQuantity: 2 })]);
+
+    fireEvent.click(screen.getByRole('button', { name: /flag deficient/i }));
+    fireEvent.change(await screen.findByLabelText('Deficiency reason'), {
+      target: { value: 'seized' },
+    });
+    fireEvent.change(screen.getByLabelText('Units deficient'), { target: { value: '2' } });
+
+    expect(screen.getByRole('button', { name: /^flag deficient$/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/modules/shop-assembly/openingFilters.ts
+++ b/frontend/src/modules/shop-assembly/openingFilters.ts
@@ -7,7 +7,45 @@ interface AssignableFields {
   assemblyStatus: string;
 }
 
-/** A pulled opening not yet claimed by anyone and still pending assembly - the assignable pool. */
+/** A pulled opening not yet claimed by anyone and not finished - the assignable pool.
+ *
+ * Unfinished, not "pending" (#340): an opening someone started and then returned to the pool is
+ * IN_PROGRESS with its counts saved on the item rows, and it is exactly as assignable as an untouched
+ * one - the next person opens it and continues. Only COMPLETED leaves the pool for good. The backend
+ * enforces the same rule, so a stale client cannot widen it.
+ */
 export function isAvailableForAssignment(o: AssignableFields): boolean {
-  return o.pullStatus === 'PULLED' && o.assignedToUserId === null && o.assemblyStatus === 'PENDING';
+  return o.pullStatus === 'PULLED' && o.assignedToUserId === null && o.assemblyStatus !== 'COMPLETED';
+}
+
+/** Progress rollup for one opening: units installed, condemned, and still unaccounted for.
+ *
+ * The whole gating story reduces to `remaining === 0`. Kept here rather than in a component so the
+ * modal's Mark Complete gate and the lists' "5/8 units" column cannot drift apart.
+ */
+export function assemblyProgress(items: ProgressFields[]): {
+  planned: number;
+  installed: number;
+  deficient: number;
+  remaining: number;
+  complete: boolean;
+} {
+  const planned = items.reduce((sum, i) => sum + i.quantity, 0);
+  const installed = items.reduce((sum, i) => sum + i.installedQuantity, 0);
+  const deficient = items.reduce((sum, i) => sum + i.deficientQuantity, 0);
+  const remaining = planned - installed - deficient;
+  return { planned, installed, deficient, remaining, complete: remaining === 0 };
+}
+
+interface ProgressFields {
+  quantity: number;
+  installedQuantity: number;
+  deficientQuantity: number;
+}
+
+/** Chip label for an opening's assembly status. */
+export function assemblyStatusLabel(status: string): string {
+  if (status === 'IN_PROGRESS') return 'In Progress';
+  if (status === 'COMPLETED') return 'Completed';
+  return 'Pending';
 }

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -223,6 +223,29 @@ Both entry points open a "Transfer <productCode>" MUI dialog with: an "X availab
 - Approved SARs generate pull requests for warehouse
 - Users get assigned openings, pull hardware, assemble, mark complete
 
+**Assembly modal is a progress editor, not a one-shot checklist (#340).** Clicking a row in My Work
+(or "Start assembly" / "Continue assembly" on the Assemble List) opens it. Per line it shows Pulled /
+Installed / Deficient / Remaining, with the Installed cell an editable number spinbutton labelled
+`Installed units: <productCode>`.
+
+- **Save Progress** persists the counts and leaves the modal open; the leaf stays in My Work and its
+  status chip flips Pending -> In Progress. Reopening rehydrates from the saved counts, so this is the
+  thing to exercise when checking resumability.
+- **Mark Complete** stays disabled until every unit on every line is either installed or flagged
+  deficient (the modal spells out how many are unaccounted for underneath the location fields), and
+  also stays disabled if everything was flagged deficient. It saves any outstanding draft first, then
+  completes, so pressing it fires *two* mutations.
+- **Flag deficient** opens a nested dialog (quantity + reason, both required) with a warning alert.
+  Confirming it is irreversible from this screen: the units go back to inventory flagged deficient and
+  a PR-REPL replacement pull is minted immediately, before the leaf is finished. Watch for the
+  spinbutton-append gotcha on the quantity field - clear it before typing.
+- Both number inputs are MUI spinbuttons, so the usual "fill appends to the existing value" trap
+  applies; the deficiency quantity is capped at the line's remaining units and the flag button stays
+  disabled if you exceed it.
+- Assignment: a manager may reassign an In Progress leaf to someone else (progress travels with it);
+  a plain user self-claiming cannot take one that is already held - that returns a CONFLICT toast.
+  Unassigning an In Progress leaf is allowed and puts it back in the pool with its counts intact.
+
 ### Shipping Module
 
 **Entry**: `/app/shipping` -> Project landing page -> ship-ready items browser


### PR DESCRIPTION
Slice 2 of 6. **Stacked on `feat/sa-slice-1-safety` (PR #345)** — the base is set to that branch so this diff shows only slice 2. Closes #340.

Assembly was atomic and ephemeral: the checklist lived in the browser until Mark Complete posted it. A leaf half-built at the end of a shift lost everything, and a defect found at 9am stayed invisible to the warehouse until the leaf was finished. Progress is now persisted per item, and completion reads it instead of taking a claim as input.

## Migration `060_assembly_progress` (revises 059)

- `shop_assembly_opening_items.installed_quantity` / `deficient_quantity` — `int NOT NULL DEFAULT 0`, under `ck_shop_assembly_opening_items_progress_within_quantity` (both non-negative, sum ≤ `quantity`). That constraint is what makes `remaining = quantity - installed - deficient` safe to derive rather than store.
- `assembly_status` gains `IN_PROGRESS`.
- `audit_action` gains `INSTALL_PROGRESS` and `ASSEMBLY_COMPLETE`; `audit_entity_type` gains `SHOP_ASSEMBLY_OPENING`. Progress cannot hang off `OPENING_ITEM` — no `OpeningItem` exists until completion.

Additive, no backfill: every existing row starts un-dispositioned. **Downgrade** folds `IN_PROGRESS` openings back to `PENDING`, deletes the new audit rows, and recreates the three enums without the new labels (Postgres cannot drop a label in place), then drops the constraint and columns. Verified against a live cluster with rows using every new enum value present, not just an empty schema.

## Backend

**`record_assembly_progress(session, opening_id, updates, performed_by)`** — requires `PULLED`, `PENDING|IN_PROGRESS`, and an assignment. The two update kinds are deliberately asymmetric:

- `installed_quantity` is **absolute**, so a retried save cannot double-count and a miscount stays correctable in both directions until the leaf is finished. Nothing moves in inventory — the hardware was deducted when the pull was approved, so counting it onto the leaf is work-tracking.
- `flag_deficient_quantity` is **incremental** and one-way: each unit goes straight to `report_deficiency_at_assembly`, returned to inventory flagged deficient with a PR-REPL replacement line minted *on the spot*, so the warehouse can start sourcing while the leaf is still on the bench. Undo belongs to deficiency review.

Every line is validated before any is applied, so a bad line at the end cannot leave an earlier line's deficiency already committed. First save flips the opening to `IN_PROGRESS`. Audited per changed line via the existing `_log_audit_event` pattern.

**`complete_opening` drops `item_results`** (and `CompleteOpeningItemResultInput` goes away). It refuses with a typed `ValidationError` while any unit is unaccounted for, naming the short lines — block, never auto-default, because an unrecorded unit is an unanswered question and silently calling it installed would put hardware on a leaf that never had it. `OpeningItemHardware.quantity` is the **installed** count, not the planned one, and a line with nothing installed contributes no row at all. The #339 duplicate-completion and all-deficient guards still hold; the all-deficient refusal no longer unwinds the deficiencies, because since this slice they were correctly recorded at the moment they were found.

**GraphQL**: new `recordAssemblyProgress` mutation (`require_user`) in `ShopAssemblyMutations`; `ShopAssemblyOpeningItem` gains `installedQuantity` / `deficientQuantity` (plain columns on an already-loaded row — the converter triggers no load). SDL reference docs updated.

**Guard sweep**: `myWork` returns `IN_PROGRESS` work too, or a half-built leaf would be unreachable. `remove_opening_from_user` allows `PENDING` and `IN_PROGRESS`, refuses `COMPLETED`.

### Reassignment authorization

`assign_openings` takes `allow_reassign`, and the resolver passes it **exactly when the caller has already been through `require_role(SHOP_ASSEMBLY_MANAGER_ROLE)`** — i.e. only on the not-self branch it already had for #330. A self-claim takes the is-self branch, passes `allow_reassign=False`, and the repository still raises `ConflictError` on a conflicting holder, so a user cannot steal work by claiming it themselves. Re-claiming an opening already held by the *same* user is a no-op either way, so a stale UI does not turn a double-click into an error. The gate lives in the repository, not the resolver, so it is not bypassable by a non-UI caller. One consequence, taken deliberately: a manager claiming a held leaf *for themselves* must unassign it first — the safer read of an ambiguous action, and one keystroke rather than a hole.

## Frontend

`AssemblyDetailModal` is now a progress editor: per-line installed spinbutton bounded by what is not already condemned, a confirm-gated **Flag deficient** dialog (quantity + reason, warning alert, error-toned confirm — it is irreversible and mints a replacement pull), **Save Progress** that keeps the modal open and the leaf in My Work, and **Mark Complete** gated on the same rule the backend enforces. Mark Complete saves any outstanding draft first, so completion never runs on stale counts. Persisted counts hydrate on open.

My Work and the Assemble List gain a status chip (Pending / In Progress / Completed) and a `5/8 units` progress column; both now hold the selected opening **by id** so the modal is not pinned to a pre-save snapshot. `openingFilters.ts` keeps the assignable pool at PULLED + unassigned + not COMPLETED (an unassigned `IN_PROGRESS` leaf is exactly as claimable as an untouched one), and `refetch.ts` gains a disjoint refetch/evict pair for the new mutation.

## Verification

Ran locally against a throwaway PostgreSQL 16 cluster (EDB portable binaries, `initdb` into a scratch dir, dropped and stopped afterwards):

- `alembic upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean).
- Downgrade re-verified with `IN_PROGRESS` and new-enum audit rows present.
- **282 backend tests pass** (was 261 pre-slice; 27 of them in the reworked/new assembly files).
- `uvx ruff check .` and `uvx ruff format --check .` clean (poetry is not installed on this box).
- Frontend: `npm run lint` (0 errors, 17 warnings — two fewer than the pre-existing 19), `npm run test:run` **174 tests pass** (9 new for modal gating), `npm run build` clean.

## Deviations from the issue spec

- Added `AuditAction.ASSEMBLY_COMPLETE` alongside the specified `INSTALL_PROGRESS`, and an `AuditEntityType.SHOP_ASSEMBLY_OPENING`. Progress and completion are no longer the same call, so they need distinct audit records, and `completed_by` had no persistent record at all once the deficiency reporting moved out of `complete_opening` — this keeps it load-bearing rather than a dead parameter.
- The progress input field is named `flagDeficientQuantity` rather than `deficientQuantity`, to make it unmistakable at the call site that it is an incremental action and not an absolute target (unlike `installedQuantity` right beside it).
- `AssignmentBoard.tsx` picked up the same id-based-selection and `IN_PROGRESS` treatment as the other two views; it renders the same modal, so leaving it out would have made it the one place a half-built leaf disappeared.
