### PR TITLE
feat(shop-assembly): slice 3 replacement loop closure + shipping deficiency guard (#341)

### DIFF
--- a/backend/alembic/versions/061_replacement_pending.py
+++ b/backend/alembic/versions/061_replacement_pending.py
@@ -1,0 +1,110 @@
+"""Close the deficiency replacement loop (#341)
+
+Revision ID: 061
+Revises: 060
+Create Date: 2026-07-26
+
+Since #340 a unit found defective at the bench is condemned immediately: it goes back to inventory
+flagged deficient and a PR-REPL pull line is minted for its replacement. Nothing ever brought that
+replacement back to the leaf - `complete_pull_request` looked for openings hanging off the PR-REPL
+pull request, found none (nothing hangs off a replacement PR), and completed as a no-op.
+
+Closing the loop means reducing the leaf's `deficient_quantity` when the replacement arrives. On a
+leaf still on the bench that is enough: the freed unit reappears as remaining work. On a leaf that is
+already COMPLETED it would be corruption - completion's invariant is
+`installed_quantity + deficient_quantity == quantity`, and quietly lowering `deficient_quantity`
+would make a finished leaf read as un-dispositioned.
+
+`shop_assembly_opening_items.replacement_pending_quantity` is the explicit third bucket that makes
+the completed case representable. The three counts partition the line and the check constraint is
+widened to `installed + deficient + replacement_pending <= quantity`, so a completed leaf whose
+replacement has landed still sums to exactly `quantity` - it is complete, with a known unit of work
+outstanding. Installing that unit moves it `replacement_pending -> installed`, again preserving the
+sum, and appends/increments the `OpeningItemHardware` row.
+
+Enum values that come with it:
+- audit_action gains REPLACEMENT_RECEIVED (the pull completed and the expectation came back) and
+  REPLACEMENT_INSTALL (it was fitted to an already-finished leaf).
+- notification_type gains REPLACEMENT_AFTER_SHIPMENT, for a replacement that lands after its leaf
+  has already left the building - the hardware is real and must not be stranded silently.
+
+Downgrade folds any pending replacements back into `deficient_quantity` (the sum is unchanged, so
+the narrower pre-#341 constraint still holds and the pre-#341 reading - "these units are condemned
+and awaiting a replacement pull" - is restored), discards the new audit rows and notifications, and
+recreates the two enums without the new labels, since Postgres cannot drop a label in place.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "061"
+down_revision = "060"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "ck_shop_assembly_opening_items_progress_within_quantity"
+_TABLE = "shop_assembly_opening_items"
+_INDEX = "ix_shop_assembly_opening_items_replacement_pending"
+
+_PROGRESS_WITHOUT_PENDING = (
+    "installed_quantity >= 0 AND deficient_quantity >= 0 AND installed_quantity + deficient_quantity <= quantity"
+)
+_PROGRESS_WITH_PENDING = (
+    "installed_quantity >= 0 AND deficient_quantity >= 0 AND replacement_pending_quantity >= 0 "
+    "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= quantity"
+)
+
+_AUDIT_ACTION_WITHOUT = (
+    "'ADJUSTMENT', 'MOVE', 'UNLOCATE', 'RECEIVE', 'PULL_DEDUCTION', 'SPOT_CHECK', 'PUT_AWAY', "
+    "'DESTOCK', 'ALLOCATE_FROM_STOCK', 'RECLASSIFY', 'REPORT_DEFICIENT', 'RESOLVE_DEFICIENT', "
+    "'TRANSFER', 'RETURN', 'INSTALL_PROGRESS', 'ASSEMBLY_COMPLETE'"
+)
+_NOTIFICATION_TYPE_WITHOUT = (
+    "'PULL_REQUEST_CANCELLED', 'PULL_REQUEST_COMPLETED', 'SHIPMENT_COMPLETED', 'INVENTORY_SHORTFALL'"
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column("replacement_pending_quantity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _PROGRESS_WITH_PENDING)
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["shop_assembly_opening_id"],
+        postgresql_where=sa.text("replacement_pending_quantity > 0"),
+    )
+
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'REPLACEMENT_RECEIVED'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'REPLACEMENT_INSTALL'")
+    op.execute("ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'REPLACEMENT_AFTER_SHIPMENT'")
+
+
+def downgrade() -> None:
+    # Rows first: an enum recast fails on any value that is about to stop existing, and the narrower
+    # check constraint fails on any row still carrying a pending replacement.
+    op.execute(
+        f"UPDATE {_TABLE} SET deficient_quantity = deficient_quantity + replacement_pending_quantity, "
+        "replacement_pending_quantity = 0 WHERE replacement_pending_quantity > 0"
+    )
+    op.execute("DELETE FROM inventory_audit_log WHERE action IN ('REPLACEMENT_RECEIVED', 'REPLACEMENT_INSTALL')")
+    op.execute("DELETE FROM notifications WHERE type = 'REPLACEMENT_AFTER_SHIPMENT'")
+
+    op.execute("ALTER TYPE audit_action RENAME TO audit_action_old")
+    op.execute(f"CREATE TYPE audit_action AS ENUM ({_AUDIT_ACTION_WITHOUT})")
+    op.execute("ALTER TABLE inventory_audit_log ALTER COLUMN action TYPE audit_action USING action::text::audit_action")
+    op.execute("DROP TYPE audit_action_old")
+
+    op.execute("ALTER TYPE notification_type RENAME TO notification_type_old")
+    op.execute(f"CREATE TYPE notification_type AS ENUM ({_NOTIFICATION_TYPE_WITHOUT})")
+    op.execute("ALTER TABLE notifications ALTER COLUMN type TYPE notification_type USING type::text::notification_type")
+    op.execute("DROP TYPE notification_type_old")
+
+    op.drop_index(_INDEX, table_name=_TABLE)
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _PROGRESS_WITHOUT_PENDING)
+    op.drop_column(_TABLE, "replacement_pending_quantity")

--- a/backend/app/graphql/import.graphql
+++ b/backend/app/graphql/import.graphql
@@ -123,6 +123,12 @@ input FinalizeImportSessionInput {
   include_shop_assembly_request: Boolean!
   shop_assembly_request_number: String
   shop_assembly_openings: [SAROpeningInput!]
+  # Shipping deficiency guard (#341). An OPENING_ITEM line naming a leaf whose source shop-assembly
+  # checklist still has units awaiting a replacement is refused with a VALIDATION_ERROR naming every
+  # flagged leaf, unless this is true. Warn + confirm, never silent and never a hard block:
+  # deliberate short-shipping is a real workflow, it just has to be a decision someone made. The
+  # wizard sets it from its "Ship it short" confirmation.
+  acknowledge_incomplete_leaves: Boolean! = false
 }
 
 input ReconciliationItemInput {

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -59,6 +59,40 @@ type ShopAssemblyOpeningItem {
   # client; completion is refused while any line still has remaining > 0.
   installed_quantity: Int!
   deficient_quantity: Int!
+  # Units whose replacement pull has completed but which are not on the leaf yet (#341). Non-zero
+  # only on a COMPLETED opening: while the leaf is still on the bench an arrived replacement just
+  # lowers deficient_quantity and becomes remaining work again. On a finished leaf that would break
+  # the completion invariant, so the unit moves deficient -> replacement_pending instead and
+  # installed + deficient + replacement_pending stays equal to quantity.
+  replacement_pending_quantity: Int!
+}
+
+# One outstanding replacement install on an already-completed leaf (#341). Not a
+# ShopAssemblyOpening: the opening is COMPLETED and stays that way.
+type ReplacementWorkItem {
+  shop_assembly_opening_item_id: ID!
+  shop_assembly_opening_id: ID!
+  project_id: ID!
+  opening_number: String!
+  leaf: Int
+  building: String
+  floor: String
+  hardware_category: String!
+  product_code: String!
+  pending_quantity: Int!
+  assigned_to_user_id: String
+  assigned_to: String
+  opening_item_id: ID
+  # SHIPPED_OUT means the replacement arrived after the leaf left the building: still listed so the
+  # hardware is not silently stranded, but installReplacement refuses it - it needs reallocation.
+  opening_item_state: OpeningItemState
+}
+
+input InstallReplacementInput {
+  shop_assembly_opening_item_id: ID!
+  # Bounded by replacement_pending_quantity, so this can never inflate a leaf.
+  quantity: Int!
+  performed_by: String
 }
 
 input AssignOpeningsInput {
@@ -99,6 +133,10 @@ input CompleteOpeningInput {
 type Query {
   assembleList(projectId: ID!): [ShopAssemblyOpening!]!
   myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
+  # Replacement installs outstanding on already-completed leaves (#341). assignedToUserId scopes it
+  # to one assembler's My Work - the opening keeps the assignment it was completed under, so this
+  # needs no new assignment concept. Rows whose leaf has shipped are included on purpose.
+  replacementWork(assignedToUserId: String, projectId: ID): [ReplacementWorkItem!]!
   # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
   shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus, reopenableOnly: Boolean! = false): [ShopAssemblyRequest!]!
   # Manager assignment picker (#330). Manager-gated (Shop Assembly Manager). ClerkUser in user.graphql.
@@ -123,6 +161,12 @@ type Mutation {
   # (installed + deficient < quantity on some line), or if nothing at all was installed, which would
   # mint an empty assembled leaf. OpeningItemHardware quantities are the recorded installed counts.
   completeOpening(input: CompleteOpeningInput!): OpeningItem!
+  # Fit arrived replacement hardware to a finished leaf (#341) - the one legitimate write to an
+  # assembled leaf's hardware after completion. Appends or increments the leaf's OpeningItemHardware
+  # row for that product and moves the units replacement_pending -> installed on the source line.
+  # VALIDATION_ERROR if more than has arrived; INVALID_STATE_TRANSITION if the leaf is still on the
+  # bench (record it as progress instead) or has already shipped (that is reallocation's problem).
+  installReplacement(input: InstallReplacementInput!): OpeningItem!
   # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
   # display name. Accept re-checks inventory sufficiency and mints the warehouse PullRequest.
   acceptShopAssemblyRequest(id: ID!, acceptedBy: String!): ShopAssemblyRequest!

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -71,6 +71,12 @@ type OpeningItem {
   created_at: DateTime!
   updated_at: DateTime!
   installed_hardware: [OpeningItemHardware!]!
+  # Units this leaf is still owed (#341): condemned-and-unreplaced plus arrived-but-not-fitted,
+  # summed from its source shop-assembly checklist lines. > 0 means the leaf is physically short of
+  # what its hardware list claims, so the shipping wizard flags it and shipping it takes an explicit
+  # acknowledgment. Populated only by openingItems / openingItemDetails / installReplacement; null
+  # elsewhere, which reads as "not evaluated", never as "nothing owed".
+  awaiting_replacement_quantity: Int
 }
 
 type OpeningItemHardware {

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -87,6 +87,10 @@ class NotificationType(str, enum.Enum):
     # PO "couldn't be fulfilled - backfill needed" signal from the inventory-sufficiency gates (#224).
     # Carries the per-combo shortfall detail in its message.
     INVENTORY_SHORTFALL = "INVENTORY_SHORTFALL"
+    # A PR-REPL replacement pull completed for a leaf that had already shipped (#341). The hardware
+    # is real and is owed to an opening that is no longer in the building, so it must not be left to
+    # sit silently in the shop - this is the signal that routes it into reallocation/site shipment.
+    REPLACEMENT_AFTER_SHIPMENT = "REPLACEMENT_AFTER_SHIPMENT"
 
 
 class AuditEntityType(str, enum.Enum):
@@ -118,6 +122,13 @@ class AuditAction(str, enum.Enum):
     # The leaf was called finished and materialized as an OpeningItem (#340). Progress saves are no
     # longer the same call as completion, so the two moments need distinct audit records.
     ASSEMBLY_COMPLETE = "ASSEMBLY_COMPLETE"
+    # A PR-REPL replacement pull completed and gave the leaf its expectation back (#341): the units
+    # left deficient_quantity, either as remaining work (leaf still open) or as
+    # replacement_pending_quantity (leaf already completed).
+    REPLACEMENT_RECEIVED = "REPLACEMENT_RECEIVED"
+    # Replacement hardware was fitted to an already-completed leaf (#341) - the one legitimate write
+    # to an OpeningItem's installed hardware after assembly finished.
+    REPLACEMENT_INSTALL = "REPLACEMENT_INSTALL"
 
 
 class ReturnDisposition(str, enum.Enum):

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -98,11 +98,22 @@ class ShopAssemblyOpeningItem(Base):
             "shop_assembly_opening_id",
         ),
         CheckConstraint("quantity >= 1", name="ck_shop_assembly_opening_items_quantity_positive"),
-        # Progress can never exceed the planned quantity, and neither count can go negative (#340).
+        # Progress can never exceed the planned quantity, and no count can go negative (#340/#341).
+        # The three buckets partition the line: installed + deficient + replacement_pending <=
+        # quantity, and completion requires equality. That is what lets a replacement arriving on an
+        # already-completed leaf move a unit out of `deficient` without the leaf reading as
+        # un-dispositioned - the unit lands in replacement_pending, and the sum is unchanged.
         CheckConstraint(
-            "installed_quantity >= 0 AND deficient_quantity >= 0 "
-            "AND installed_quantity + deficient_quantity <= quantity",
+            "installed_quantity >= 0 AND deficient_quantity >= 0 AND replacement_pending_quantity >= 0 "
+            "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= quantity",
             name="ck_shop_assembly_opening_items_progress_within_quantity",
+        ),
+        # The replacement-install work queue and the shipping deficiency guard both scan for lines
+        # with something outstanding; a partial index keeps that off a full table scan.
+        Index(
+            "ix_shop_assembly_opening_items_replacement_pending",
+            "shop_assembly_opening_id",
+            postgresql_where=text("replacement_pending_quantity > 0"),
         ),
     )
 
@@ -122,5 +133,15 @@ class ShopAssemblyOpeningItem(Base):
     # while any line still has remaining > 0.
     installed_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     deficient_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    # Units whose replacement hardware has arrived but is not on the leaf yet (#341). Only ever
+    # non-zero on a COMPLETED opening: while the leaf is still on the bench a completed PR-REPL pull
+    # simply decrements deficient_quantity, and the unit reappears as remaining work in My Work.
+    # Once the leaf is finished that would break the completion invariant
+    # (installed + deficient == quantity), so the unit moves deficient -> replacement_pending
+    # instead: the sum is unchanged, the leaf stays legitimately complete, and the outstanding unit
+    # stays visible as a replacement-install work item and as the shipping "awaiting replacement"
+    # flag. Installing it moves replacement_pending -> installed and appends/increments the
+    # OpeningItemHardware row - the one legitimate post-completion write.
+    replacement_pending_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     shop_assembly_opening: Mapped["ShopAssemblyOpening"] = relationship(back_populates="items")

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -353,6 +353,7 @@ def finalize_import_session(
     sar_request_number = input_data.get("shop_assembly_request_number")
     sar_openings_input = input_data.get("shop_assembly_openings") or []
     replace_schedule = bool(input_data.get("replace_schedule", False))
+    acknowledge_incomplete_leaves = bool(input_data.get("acknowledge_incomplete_leaves", False))
 
     # 1. Project lookup (must already exist)
     project_stmt = (
@@ -682,6 +683,37 @@ def finalize_import_session(
                     select(OpeningItemModel).where(OpeningItemModel.id.in_(referenced_oi_ids))
                 ).all()
             }
+
+        # Deficiency guard (#341). A leaf whose source checklist still has condemned-and-unreplaced
+        # units - or units whose replacement has arrived but is not fitted yet - is physically short
+        # of the hardware list it ships under. The business decision is warn + confirm, never silent
+        # and never a hard block: deliberate short-shipping is a real workflow (reallocation exists
+        # for it), but it has to be a decision someone made. So it is refused here unless the caller
+        # says explicitly that it knows, and the wizard's confirm is what sets that flag.
+        #
+        # One grouped scalar aggregate for every referenced leaf, not a per-line count.
+        if referenced_oi_ids and not acknowledge_incomplete_leaves:
+            from app.repositories import shop_assembly_repository
+
+            flagged_leaves = shop_assembly_repository.get_awaiting_replacement_quantities(
+                session, list(referenced_oi_ids)
+            )
+            if flagged_leaves:
+                # Name every flagged leaf, not just the first: the user is being asked to make a
+                # decision, and they can only make it once if they can see the whole list.
+                detail = ", ".join(
+                    sorted(
+                        f"{_leaf_label(opening_items_by_id[oi_id])} ({qty} unit(s) awaiting replacement)"
+                        for oi_id, qty in flagged_leaves.items()
+                        if oi_id in opening_items_by_id
+                    )
+                )
+                raise ValidationError(
+                    "These assembled leaves are incomplete - hardware on them is still awaiting a "
+                    f"replacement: {detail}. Confirm you want to ship them short, or wait for the "
+                    "replacements to be installed.",
+                    field="opening_item_id",
+                )
 
         for pr_draft in shipping_pr_drafts:
             # Validate uniqueness against the request entity's own number space.

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -1,10 +1,11 @@
 """Repository for shop assembly data access."""
 
 import uuid
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import (
@@ -35,6 +36,7 @@ from app.models.pull_request import (
 )
 from app.models.shop_assembly import (
     ShopAssemblyOpening,
+    ShopAssemblyOpeningItem,
     ShopAssemblyRequest,
 )
 from app.repositories.stock.common import _log_audit_event
@@ -145,10 +147,27 @@ def assign_openings(
         missing = [str(oid) for oid in opening_ids if oid not in found_ids]
         raise NotFoundError(f"ShopAssemblyOpenings not found: {missing}")
 
+    # A COMPLETED opening is assignable only while it has replacement installs outstanding (#341) -
+    # that is the "reassignable" half of the replacement work item, and it rides the existing manager
+    # flow rather than a second assignment system. One scalar aggregate for the whole batch.
+    completed_ids = {o.id for o in locked if o.assembly_status == AssemblyStatus.COMPLETED}
+    with_pending_replacements: set[uuid.UUID] = set()
+    if completed_ids:
+        with_pending_replacements = set(
+            session.scalars(
+                select(ShopAssemblyOpeningItem.shop_assembly_opening_id)
+                .where(
+                    ShopAssemblyOpeningItem.shop_assembly_opening_id.in_(completed_ids),
+                    ShopAssemblyOpeningItem.replacement_pending_quantity > 0,
+                )
+                .group_by(ShopAssemblyOpeningItem.shop_assembly_opening_id)
+            ).all()
+        )
+
     for opening in locked:
         if opening.pull_status != PullStatus.PULLED:
             raise InvalidStateTransitionError("Opening is not ready for assignment - hardware has not been pulled")
-        if opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
+        if opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES and opening.id not in with_pending_replacements:
             raise InvalidStateTransitionError("Opening assembly is already completed")
         already_held_by_someone_else = (
             opening.assigned_to_user_id is not None and opening.assigned_to_user_id != assigned_to_user_id
@@ -534,6 +553,290 @@ def complete_opening(
         },
     )
 
+    return opening_item
+
+
+def find_assembled_leaf(
+    session: Session,
+    project_id: uuid.UUID,
+    opening_id: uuid.UUID,
+    leaf: int | None,
+) -> OpeningItemModel | None:
+    """The OpeningItem a completed shop-assembly work unit materialized as (#341).
+
+    There is no FK from a ShopAssemblyOpening to the leaf it produced, so this keys it exactly the
+    way find_already_assembled_openings does: (project, opening_id, leaf), with a legacy null leaf
+    matching only a null leaf. A leaf can end up with more than one row over its life (it shipped,
+    then a correction minted another), so a live row wins over a shipped one and the most recently
+    assembled wins among equals - a shipped row is returned only when it is all there is, which is
+    precisely the "replacement arrived after the leaf shipped" case.
+    """
+    rows = list(
+        session.scalars(
+            select(OpeningItemModel).where(
+                OpeningItemModel.project_id == project_id,
+                OpeningItemModel.opening_id == opening_id,
+                OpeningItemModel.leaf.is_not_distinct_from(leaf),
+            )
+        ).all()
+    )
+    if not rows:
+        return None
+    live = [oi for oi in rows if oi.state != OpeningItemState.SHIPPED_OUT]
+    return sorted(live or rows, key=lambda oi: oi.assembly_completed_at)[-1]
+
+
+def get_awaiting_replacement_quantities(
+    session: Session,
+    opening_item_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """Per assembled leaf, how many units of its hardware are still owed (#341): units condemned and
+    not yet replaced, plus units whose replacement has arrived but is not fitted yet.
+
+    This is the shipping deficiency flag. A leaf with a non-zero count is physically short of what
+    its checklist says it carries, so shipping it is a decision, not an accident - the wizard flags
+    it and the shipping-out creation path refuses it without an explicit acknowledgment.
+
+    One grouped scalar aggregate over the whole id set, never a len() over loaded collections
+    (CLAUDE.md perf rules): the shipping selection lists every assembled leaf in a project, and a
+    per-leaf query here would be an N+1 on the heaviest list in the module. Only non-zero entries are
+    returned, so callers can treat a missing key as "nothing outstanding".
+    """
+    ids = list(opening_item_ids)
+    if not ids:
+        return {}
+    outstanding = func.sum(
+        ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity
+    )
+    stmt = (
+        select(OpeningItemModel.id, outstanding.label("outstanding"))
+        .select_from(OpeningItemModel)
+        .join(
+            ShopAssemblyOpening,
+            and_(
+                ShopAssemblyOpening.opening_id == OpeningItemModel.opening_id,
+                ShopAssemblyOpening.leaf.is_not_distinct_from(OpeningItemModel.leaf),
+                ShopAssemblyOpening.assembly_status == AssemblyStatus.COMPLETED,
+            ),
+        )
+        .join(PullRequestModel, PullRequestModel.id == ShopAssemblyOpening.pull_request_id)
+        .join(
+            ShopAssemblyOpeningItem,
+            ShopAssemblyOpeningItem.shop_assembly_opening_id == ShopAssemblyOpening.id,
+        )
+        .where(
+            OpeningItemModel.id.in_(ids),
+            # Scope the join to the leaf's own project: opening_id is a historical stamp, not an FK,
+            # and a re-upload can reissue it.
+            PullRequestModel.project_id == OpeningItemModel.project_id,
+        )
+        .group_by(OpeningItemModel.id)
+        .having(outstanding > 0)
+    )
+    return {row.id: int(row.outstanding) for row in session.execute(stmt).all()}
+
+
+@dataclass(frozen=True)
+class ReplacementWorkItem:
+    """One outstanding replacement install on an already-completed leaf (#341).
+
+    It is deliberately not a ShopAssemblyOpening: the opening is COMPLETED and must stay that way,
+    so this cannot ride in My Work's normal list without either lying about the leaf's status or
+    reopening a finished work unit. It is a separate, narrower unit of work - "fit these N units of
+    this product to a leaf that is otherwise done".
+    """
+
+    shop_assembly_opening_item_id: uuid.UUID
+    shop_assembly_opening_id: uuid.UUID
+    project_id: uuid.UUID
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    hardware_category: str
+    product_code: str
+    pending_quantity: int
+    assigned_to_user_id: str | None
+    assigned_to: str | None
+    opening_item_id: uuid.UUID | None
+    opening_item_state: OpeningItemState | None
+
+
+def get_replacement_work(
+    session: Session,
+    assigned_to_user_id: str | None = None,
+    project_id: uuid.UUID | None = None,
+) -> list[ReplacementWorkItem]:
+    """Outstanding replacement installs (#341), optionally scoped to one assembler.
+
+    The natural assignee is the leaf's last assembler - the ShopAssemblyOpening keeps the assignment
+    it was completed under - so filtering on assigned_to_user_id puts the work in that person's My
+    Work with no new assignment system. A manager can still move it with the existing assign_openings
+    mutation, which allows a COMPLETED opening exactly while it has pending replacements.
+
+    Rows whose leaf has already SHIPPED_OUT are included on purpose: item 4 of #341 is that such a
+    replacement must stay visible rather than be silently stranded. The caller can tell from
+    opening_item_state that it cannot be installed and needs reallocation instead.
+    """
+    stmt = (
+        select(ShopAssemblyOpeningItem, ShopAssemblyOpening, PullRequestModel.project_id)
+        .join(
+            ShopAssemblyOpening,
+            ShopAssemblyOpening.id == ShopAssemblyOpeningItem.shop_assembly_opening_id,
+        )
+        .join(PullRequestModel, PullRequestModel.id == ShopAssemblyOpening.pull_request_id)
+        .where(ShopAssemblyOpeningItem.replacement_pending_quantity > 0)
+        .order_by(ShopAssemblyOpening.opening_number.asc(), ShopAssemblyOpeningItem.product_code.asc())
+    )
+    if assigned_to_user_id is not None:
+        stmt = stmt.where(ShopAssemblyOpening.assigned_to_user_id == assigned_to_user_id)
+    if project_id is not None:
+        stmt = stmt.where(PullRequestModel.project_id == project_id)
+    rows = session.execute(stmt).all()
+    if not rows:
+        return []
+
+    # One batched lookup of the assembled leaves rather than one per row: the pending set is small,
+    # but "small today" is how N+1s get written.
+    leaf_by_key: dict[tuple[uuid.UUID, uuid.UUID, int | None], OpeningItemModel] = {}
+    for _item, opening, proj_id in rows:
+        key = (proj_id, opening.opening_id, opening.leaf)
+        if key not in leaf_by_key:
+            found = find_assembled_leaf(session, proj_id, opening.opening_id, opening.leaf)
+            if found is not None:
+                leaf_by_key[key] = found
+
+    result: list[ReplacementWorkItem] = []
+    for item, opening, proj_id in rows:
+        leaf_row = leaf_by_key.get((proj_id, opening.opening_id, opening.leaf))
+        result.append(
+            ReplacementWorkItem(
+                shop_assembly_opening_item_id=item.id,
+                shop_assembly_opening_id=opening.id,
+                project_id=proj_id,
+                opening_number=opening.opening_number,
+                leaf=opening.leaf,
+                building=opening.building,
+                floor=opening.floor,
+                hardware_category=item.hardware_category,
+                product_code=item.product_code,
+                pending_quantity=item.replacement_pending_quantity,
+                assigned_to_user_id=opening.assigned_to_user_id,
+                assigned_to=opening.assigned_to,
+                opening_item_id=leaf_row.id if leaf_row is not None else None,
+                opening_item_state=leaf_row.state if leaf_row is not None else None,
+            )
+        )
+    return result
+
+
+def install_replacement(
+    session: Session,
+    sa_opening_item_id: uuid.UUID,
+    quantity: int,
+    performed_by: str | None = None,
+) -> OpeningItemModel:
+    """Fit arrived replacement hardware to an already-completed door leaf (#341).
+
+    This is the one legitimate write to an assembled leaf's hardware after completion, and it is
+    narrow on purpose: it can only consume units the replacement pull actually delivered
+    (`replacement_pending_quantity`), so it cannot be used to inflate a leaf.
+
+    The unit moves `replacement_pending -> installed` on the checklist line, which leaves
+    `installed + deficient + replacement_pending == quantity` intact, and the leaf's
+    `OpeningItemHardware` row for that (product_code, hardware_category) is incremented - or created,
+    if the line had nothing installed at completion time. Both cases are real: #339 refuses a
+    completion where *nothing at all* was installed, but a line that was entirely deficient while
+    other lines were fine contributes no row, so the leaf may or may not already carry the product.
+
+    Refused if the leaf has shipped: the hardware cannot be fitted to something that has left the
+    building, and quietly recording it as installed would make the packing slip a lie. That case is
+    already flagged and notified at pull completion, and belongs to reallocation.
+    """
+    if quantity < 1:
+        raise ValidationError("quantity must be >= 1", field="quantity")
+
+    item = session.get(ShopAssemblyOpeningItem, sa_opening_item_id)
+    if item is None:
+        raise NotFoundError(f"ShopAssemblyOpeningItem {sa_opening_item_id} not found")
+
+    # Lock the work unit, then re-read the line under that lock so two installers cannot both spend
+    # the same pending unit.
+    if not lock_rows(session, ShopAssemblyOpening, [item.shop_assembly_opening_id]):
+        raise NotFoundError(f"ShopAssemblyOpening {item.shop_assembly_opening_id} not found")
+    opening = session.get(ShopAssemblyOpening, item.shop_assembly_opening_id)
+    session.refresh(item)
+
+    if opening.assembly_status != AssemblyStatus.COMPLETED:
+        raise InvalidStateTransitionError(
+            "This leaf is still on the bench - record the replacement as installed progress instead"
+        )
+    if item.replacement_pending_quantity < quantity:
+        raise ValidationError(
+            f"Only {item.replacement_pending_quantity} replacement unit(s) of {item.product_code} have "
+            f"arrived for this leaf; cannot install {quantity}",
+            field="quantity",
+        )
+
+    project_id = _opening_project_id(session, opening)
+    if project_id is None:
+        raise NotFoundError(f"ShopAssemblyOpening {opening.id} is not linked to a pull request")
+
+    opening_item = find_assembled_leaf(session, project_id, opening.opening_id, opening.leaf)
+    if opening_item is None:
+        raise NotFoundError(f"No assembled unit found for opening {opening.opening_number}")
+    if opening_item.state == OpeningItemState.SHIPPED_OUT:
+        raise InvalidStateTransitionError(
+            f"Opening {opening.opening_number} has already shipped - this replacement has to be "
+            "routed through reallocation or a site shipment, not installed here"
+        )
+
+    oih = session.scalars(
+        select(OIHModel).where(
+            OIHModel.opening_item_id == opening_item.id,
+            OIHModel.product_code == item.product_code,
+            OIHModel.hardware_category == item.hardware_category,
+        )
+    ).first()
+    previous_installed_on_leaf = oih.quantity if oih is not None else 0
+    if oih is None:
+        # The line was fully deficient when the leaf was completed, so it contributed no row.
+        oih = OIHModel(
+            id=uuid.uuid4(),
+            opening_item_id=opening_item.id,
+            product_code=item.product_code,
+            hardware_category=item.hardware_category,
+            quantity=quantity,
+        )
+        session.add(oih)
+    else:
+        oih.quantity += quantity
+
+    item.replacement_pending_quantity -= quantity
+    item.installed_quantity += quantity
+    opening_item.updated_at = datetime.utcnow()
+
+    _log_audit_event(
+        session,
+        project_id=project_id,
+        entity_type=AuditEntityType.OPENING_ITEM,
+        entity_id=opening_item.id,
+        action=AuditAction.REPLACEMENT_INSTALL,
+        performed_by=performed_by or opening.assigned_to or "Assembler",
+        detail={
+            "shopAssemblyOpeningId": str(opening.id),
+            "shopAssemblyOpeningItemId": str(item.id),
+            "openingNumber": opening.opening_number,
+            "leaf": opening.leaf,
+            "hardwareCategory": item.hardware_category,
+            "productCode": item.product_code,
+            "installedQuantity": quantity,
+            "previousQuantityOnLeaf": previous_installed_on_leaf,
+            "newQuantityOnLeaf": oih.quantity,
+            "remainingPendingQuantity": item.replacement_pending_quantity,
+        },
+    )
+    session.flush()
     return opening_item
 
 

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.errors import InvalidStateTransitionError, NotFoundError
 from app.models.enums import (
+    AssemblyStatus,
     AuditAction,
     AuditEntityType,
     NotificationType,
@@ -248,14 +249,124 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
     return (pr, "APPROVED", None, [])
 
 
+def _apply_replacement_arrivals(session: Session, pr: PullRequestModel) -> None:
+    """Give a door leaf its expectation back when the replacement hardware for a deficient unit
+    actually arrives (#341).
+
+    A PR-REPL pull line carries `sa_opening_item_id` (#339), so completing the pull can find the
+    exact checklist line the unit is owed to. Until now nothing did: the PR-REPL pull is a
+    SHOP_ASSEMBLY pull with no ShopAssemblyOpenings hanging off it, so its completion flipped nothing
+    and the replacement dead-ended in inventory.
+
+    Per line, the arrived quantity is floored at what is genuinely still outstanding
+    (`deficient_quantity`), so an over-delivery - a warehouse operator pulling 3 against a 2-unit
+    line, or a duplicate line - cannot drive the counter negative or breach the progress constraint.
+    Where the freed unit lands depends on whether the leaf is still on the bench:
+
+    - PENDING / IN_PROGRESS: nowhere. `deficient_quantity` simply drops, so
+      `remaining = quantity - installed - deficient` goes back up and the unit reappears as work in
+      My Work. Completion stays blocked until the assembler actually fits it, which is the point.
+    - COMPLETED: the unit moves into `replacement_pending_quantity`. Lowering `deficient_quantity`
+      alone would make a finished leaf read as un-dispositioned (installed + deficient < quantity)
+      and corrupt the completion invariant; moving it keeps the sum at `quantity` while recording
+      that a known unit of work is outstanding on an otherwise-complete leaf.
+
+    If that completed leaf has already SHIPPED_OUT, the replacement cannot be fitted to it at all.
+    The pending state is still recorded (so the unit stays queryable rather than silently stranded)
+    and a notification is raised for the reallocation / site-shipment world to pick up.
+    """
+    # Local import: shop_assembly_repository imports this package's aggregate at call time, so a
+    # module-level import here would close the cycle.
+    from app.models.shop_assembly import ShopAssemblyOpeningItem as SAOpeningItemModel
+    from app.repositories import shop_assembly_repository
+
+    by_item: dict[uuid.UUID, int] = defaultdict(int)
+    for line in pr.items:
+        if line.sa_opening_item_id is not None:
+            by_item[line.sa_opening_item_id] += line.requested_quantity
+    if not by_item:
+        return
+
+    items = list(session.scalars(select(SAOpeningItemModel).where(SAOpeningItemModel.id.in_(by_item.keys()))).all())
+    if not items:
+        return
+    openings = {
+        o.id: o
+        for o in session.scalars(
+            select(ShopAssemblyOpening).where(
+                ShopAssemblyOpening.id.in_({item.shop_assembly_opening_id for item in items})
+            )
+        ).all()
+    }
+
+    for item in items:
+        arrived = by_item[item.id]
+        # Floor at what is actually outstanding: over-delivery restores nothing extra.
+        restored = min(arrived, item.deficient_quantity)
+        if restored <= 0:
+            continue
+        opening = openings.get(item.shop_assembly_opening_id)
+        if opening is None:
+            continue
+
+        item.deficient_quantity -= restored
+        leaf_completed = opening.assembly_status == AssemblyStatus.COMPLETED
+        opening_item = None
+        if leaf_completed:
+            item.replacement_pending_quantity += restored
+            opening_item = shop_assembly_repository.find_assembled_leaf(
+                session, pr.project_id, opening.opening_id, opening.leaf
+            )
+            if opening_item is not None and opening_item.state == OpeningItemState.SHIPPED_OUT:
+                leaf_label = f"Opening {opening.opening_number}"
+                if opening.leaf is not None:
+                    leaf_label += f" Leaf {opening.leaf}"
+                notification_service.create_notification(
+                    session,
+                    project_id=pr.project_id,
+                    recipient_role=notification_service.SHIPPING_RECIPIENT_ROLE,
+                    notification_type=NotificationType.REPLACEMENT_AFTER_SHIPMENT,
+                    message=(
+                        f"{restored} x {item.product_code} replacement arrived on {pr.request_number} for "
+                        f"{leaf_label}, which has already shipped. Route it through reallocation or a "
+                        f"site shipment."
+                    ),
+                )
+
+        _log_audit_event(
+            session,
+            project_id=pr.project_id,
+            entity_type=AuditEntityType.SHOP_ASSEMBLY_OPENING,
+            entity_id=opening.id,
+            action=AuditAction.REPLACEMENT_RECEIVED,
+            performed_by=pr.assigned_to or pr.requested_by or "Warehouse",
+            detail={
+                "pullRequestNumber": pr.request_number,
+                "shopAssemblyOpeningItemId": str(item.id),
+                "hardwareCategory": item.hardware_category,
+                "productCode": item.product_code,
+                "arrivedQuantity": arrived,
+                "restoredQuantity": restored,
+                "deficientQuantity": item.deficient_quantity,
+                "replacementPendingQuantity": item.replacement_pending_quantity,
+                "openingNumber": opening.opening_number,
+                "leaf": opening.leaf,
+                "assemblyStatus": opening.assembly_status.value,
+                "openingItemId": str(opening_item.id) if opening_item is not None else None,
+                "openingItemState": opening_item.state.value if opening_item is not None else None,
+            },
+        )
+
+
 def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestModel:
     """
     Complete a pull request:
     1. Validate status == In_Progress
     2. Set status=Completed, completed_at=now()
     3. Create notification
-    4. If Shipping_Out source: set Opening_Item states to Ship_Ready
-    5. If Shop_Assembly source: update SAR openings pull_status to Pulled
+    4. Restore any leaf expectations the pull's replacement lines are owed to (#341)
+    5. If Shipping_Out source: set Opening_Item states to Ship_Ready
+    6. If Shop_Assembly source: update SAR openings pull_status to Pulled
     """
     stmt = select(PullRequestModel).options(selectinload(PullRequestModel.items)).where(PullRequestModel.id == pr_id)
     pr = session.scalars(stmt).unique().first()
@@ -277,6 +388,11 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestMode
         notification_type=NotificationType.PULL_REQUEST_COMPLETED,
         message=f"Pull Request {pr.request_number} has been fulfilled.",
     )
+
+    # Replacement lines (#341) are keyed on the checklist line they are owed to, not on the PR's
+    # source, so this runs before the source dispatch below. A PR-REPL pull is a SHOP_ASSEMBLY pull
+    # with nothing hanging off it, which is why the SHOP_ASSEMBLY branch alone left it a no-op.
+    _apply_replacement_arrivals(session, pr)
 
     # Source-specific side effects
     if pr.source == PullRequestSource.SHIPPING_OUT:

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -38,6 +38,7 @@ from .types import (
     ReceiveLineItem,
     ReceiveRecord,
     RelayInstallInfo,
+    ReplacementWorkItem,
     ShipmentReturn,
     ShipmentReturnItem,
     ShippingOutRequest,
@@ -428,7 +429,9 @@ def opening_item_hardware_to_type(oih) -> OpeningItemHardware:
     )
 
 
-def opening_item_to_type(oi, *, leaf_count: int | None = None) -> OpeningItem:
+def opening_item_to_type(
+    oi, *, leaf_count: int | None = None, awaiting_replacement_quantity: int | None = None
+) -> OpeningItem:
     return OpeningItem(
         id=strawberry.ID(str(oi.id)),
         project_id=strawberry.ID(str(oi.project_id)),
@@ -449,6 +452,9 @@ def opening_item_to_type(oi, *, leaf_count: int | None = None) -> OpeningItem:
         created_at=oi.created_at,
         updated_at=oi.updated_at,
         installed_hardware=[opening_item_hardware_to_type(h) for h in oi.installed_hardware],
+        # Computed by the caller from one grouped aggregate over the whole list (#341), never
+        # per-row here - this converter runs once per assembled leaf in a project.
+        awaiting_replacement_quantity=awaiting_replacement_quantity,
     )
 
 
@@ -462,6 +468,28 @@ def shop_assembly_opening_item_to_type(item) -> ShopAssemblyOpeningItem:
         # Plain columns on the row the caller already loaded (#340) - reading them triggers no load.
         installed_quantity=item.installed_quantity,
         deficient_quantity=item.deficient_quantity,
+        replacement_pending_quantity=item.replacement_pending_quantity,
+    )
+
+
+def replacement_work_item_to_type(row) -> ReplacementWorkItem:
+    """A repository ReplacementWorkItem dataclass -> the GraphQL type (#341). The dataclass is
+    already flat, so nothing here can trigger a load."""
+    return ReplacementWorkItem(
+        shop_assembly_opening_item_id=strawberry.ID(str(row.shop_assembly_opening_item_id)),
+        shop_assembly_opening_id=strawberry.ID(str(row.shop_assembly_opening_id)),
+        project_id=strawberry.ID(str(row.project_id)),
+        opening_number=row.opening_number,
+        leaf=row.leaf,
+        building=row.building,
+        floor=row.floor,
+        hardware_category=row.hardware_category,
+        product_code=row.product_code,
+        pending_quantity=row.pending_quantity,
+        assigned_to_user_id=row.assigned_to_user_id,
+        assigned_to=row.assigned_to,
+        opening_item_id=(strawberry.ID(str(row.opening_item_id)) if row.opening_item_id else None),
+        opening_item_state=row.opening_item_state,
     )
 
 

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -222,6 +222,7 @@ class ImportMutations:
             if input.shop_assembly_openings
             else None,
             "replace_schedule": input.replace_schedule,
+            "acknowledge_incomplete_leaves": input.acknowledge_incomplete_leaves,
         }
 
         with SessionLocal() as session:

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -174,6 +174,11 @@ class FinalizeImportSessionInput:
     # rows are wiped (including IN_PO ones) and openings absent from the new input
     # are deleted. Downstream POs/receiving/SAR/inventory aggregates are preserved.
     replace_schedule: bool = False
+    # The caller has seen the "incomplete - awaiting replacement" flag on the assembled leaves it is
+    # shipping and wants them on the request anyway (#341). Without it, a flagged leaf is refused
+    # with a VALIDATION_ERROR naming every flagged leaf. Warn + confirm, never silent, never a hard
+    # block - deliberate short-shipping is a real workflow, it just has to be a decision.
+    acknowledge_incomplete_leaves: bool = False
 
 
 @strawberry.input
@@ -461,6 +466,16 @@ class RecordAssemblyProgressInput:
     opening_id: strawberry.ID
     items: list[AssemblyProgressItemInput] = strawberry.field(default_factory=list)
     # The assembler; recorded as the actor on the progress audit rows and on any deficiency return.
+    performed_by: str | None = None
+
+
+@strawberry.input
+class InstallReplacementInput:
+    """Fit arrived replacement hardware to an already-completed leaf (#341). The quantity can only
+    come out of what the replacement pull actually delivered, so this cannot inflate a leaf."""
+
+    shop_assembly_opening_item_id: strawberry.ID
+    quantity: int
     performed_by: str | None = None
 
 

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -14,12 +14,24 @@ from app.services import notification_service
 from .converters import (
     clerk_user_to_type,
     opening_item_to_type,
+    replacement_work_item_to_type,
     shop_assembly_opening_to_type,
     shop_assembly_request_to_type,
 )
 from .enums import ShopAssemblyRequestStatus
-from .inputs import AssignOpeningsInput, CompleteOpeningInput, RecordAssemblyProgressInput
-from .types import ClerkUser, OpeningItem, ShopAssemblyOpening, ShopAssemblyRequest
+from .inputs import (
+    AssignOpeningsInput,
+    CompleteOpeningInput,
+    InstallReplacementInput,
+    RecordAssemblyProgressInput,
+)
+from .types import (
+    ClerkUser,
+    OpeningItem,
+    ReplacementWorkItem,
+    ShopAssemblyOpening,
+    ShopAssemblyRequest,
+)
 
 
 @strawberry.type
@@ -44,6 +56,30 @@ class ShopAssemblyQueries:
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_my_work(session, assigned_to_user_id)
             return [shop_assembly_opening_to_type(sao) for sao in saos]
+
+    @strawberry.field
+    def replacement_work(
+        self,
+        info: strawberry.Info,
+        assigned_to_user_id: str | None = None,
+        project_id: strawberry.ID | None = None,
+    ) -> list[ReplacementWorkItem]:
+        """Replacement installs outstanding on already-completed leaves (#341).
+
+        Scoped to one assembler by assignedToUserId, which is what puts the work in the My Work board
+        of whoever last held the leaf - the ShopAssemblyOpening keeps its assignment through
+        completion, so no new assignment concept is needed. Rows whose leaf has already shipped are
+        included deliberately: that replacement must stay visible rather than be stranded, and the
+        caller can tell from openingItemState that it needs reallocation instead of an install. Open
+        to any signed-in user."""
+        require_user(info)
+        with SessionLocal() as session:
+            rows = shop_assembly_repository.get_replacement_work(
+                session,
+                assigned_to_user_id=assigned_to_user_id,
+                project_id=uuid.UUID(str(project_id)) if project_id else None,
+            )
+            return [replacement_work_item_to_type(r) for r in rows]
 
     @strawberry.field
     def shop_assembly_requests(
@@ -204,6 +240,29 @@ class ShopAssemblyMutations:
             session.commit()
             refreshed = shop_assembly_repository.get_openings_with_items(session, [result.id])[0]
             return shop_assembly_opening_to_type(refreshed)
+
+    @strawberry.mutation
+    def install_replacement(self, info: strawberry.Info, input: InstallReplacementInput) -> OpeningItem:
+        """Fit arrived replacement hardware to an already-completed door leaf (#341).
+
+        The one legitimate write to an assembled leaf's hardware after completion: it appends or
+        increments the leaf's OpeningItemHardware row for that product and moves the units from
+        replacement_pending to installed on the source checklist line, so the completion invariant
+        holds throughout. It can only spend units the replacement pull actually delivered, and it
+        refuses a leaf that has already shipped. Open to any signed-in user - it changes what an
+        assembled leaf is recorded as carrying, so it must not be reachable anonymously."""
+        require_user(info)
+        with SessionLocal() as session:
+            result = shop_assembly_repository.install_replacement(
+                session,
+                uuid.UUID(str(input.shop_assembly_opening_item_id)),
+                input.quantity,
+                performed_by=input.performed_by,
+            )
+            session.commit()
+            refreshed = warehouse_repository.get_opening_item_details(session, result.id)
+            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [refreshed.id])
+            return opening_item_to_type(refreshed, awaiting_replacement_quantity=awaiting.get(refreshed.id, 0))
 
     @strawberry.mutation
     def complete_opening(self, info: strawberry.Info, input: CompleteOpeningInput) -> OpeningItem:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -472,6 +472,12 @@ class OpeningItem:
     created_at: datetime
     updated_at: datetime
     installed_hardware: list[OpeningItemHardware]
+    # Units this leaf is still owed (#341): condemned-and-unreplaced plus arrived-but-not-fitted,
+    # summed from its source shop-assembly checklist lines. > 0 means the leaf is physically short of
+    # what its hardware list claims, so the shipping wizard flags it and shipping it takes an explicit
+    # acknowledgment. Only populated by the resolvers that ask for it (the openingItems list and the
+    # detail view); null everywhere else, which reads as "not evaluated", not as "nothing owed".
+    awaiting_replacement_quantity: int | None = None
 
 
 @strawberry.type
@@ -520,6 +526,40 @@ class ShopAssemblyOpeningItem:
     # while any line still has remaining > 0.
     installed_quantity: int = 0
     deficient_quantity: int = 0
+    # Units whose replacement has arrived but is not on the leaf yet (#341). Non-zero only on a
+    # COMPLETED opening - before completion an arrived replacement just goes back to being remaining
+    # work. installed + deficient + replacement_pending never exceeds quantity.
+    replacement_pending_quantity: int = 0
+
+
+@strawberry.type
+class ReplacementWorkItem:
+    """One outstanding replacement install on an already-completed door leaf (#341).
+
+    Deliberately not a ShopAssemblyOpening: the opening is COMPLETED and stays that way, so this
+    cannot ride in myWork's normal list without either lying about the leaf's status or reopening a
+    finished work unit. It is the narrower unit "fit these N units of this product to a leaf that is
+    otherwise done", assigned to whoever last held the leaf.
+
+    opening_item_state is SHIPPED_OUT when the replacement arrived after the leaf left the building.
+    Those rows are listed on purpose - the hardware is real and must not be silently stranded - but
+    installReplacement refuses them; they belong to reallocation.
+    """
+
+    shop_assembly_opening_item_id: strawberry.ID
+    shop_assembly_opening_id: strawberry.ID
+    project_id: strawberry.ID
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    hardware_category: str
+    product_code: str
+    pending_quantity: int
+    assigned_to_user_id: str | None
+    assigned_to: str | None
+    opening_item_id: strawberry.ID | None
+    opening_item_state: OpeningItemState | None
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -194,7 +194,20 @@ class WarehouseQueries:
             # attached per item so consumers can roll up by opening without an N+1. Computed for the
             # global view too (pid=None) so leafCount isn't null everywhere when project_id is omitted.
             leaf_counts = warehouse_repository.get_opening_leaf_counts(session, pid)
-            return [opening_item_to_type(oi, leaf_count=leaf_counts.get(oi.opening_number)) for oi in ois]
+            # Shipping deficiency flag (#341): one grouped scalar aggregate for the whole list, the
+            # same shape as leaf_counts above - a per-row lookup here would be an N+1 over every
+            # assembled leaf in the project.
+            from app.repositories import shop_assembly_repository
+
+            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [oi.id for oi in ois])
+            return [
+                opening_item_to_type(
+                    oi,
+                    leaf_count=leaf_counts.get(oi.opening_number),
+                    awaiting_replacement_quantity=awaiting.get(oi.id, 0),
+                )
+                for oi in ois
+            ]
 
     @strawberry.field
     def opening_leaf_status(self, project_id: strawberry.ID | None = None) -> list[OpeningLeafStatus]:
@@ -217,8 +230,11 @@ class WarehouseQueries:
     @strawberry.field
     def opening_item_details(self, id: strawberry.ID) -> OpeningItemDetail:
         with SessionLocal() as session:
+            from app.repositories import shop_assembly_repository
+
             oi = warehouse_repository.get_opening_item_details(session, uuid.UUID(str(id)))
-            opening_item = opening_item_to_type(oi)
+            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [oi.id])
+            opening_item = opening_item_to_type(oi, awaiting_replacement_quantity=awaiting.get(oi.id, 0))
             return OpeningItemDetail(
                 opening_item=opening_item,
                 installed_hardware=[opening_item_hardware_to_type(h) for h in oi.installed_hardware],

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -30,6 +30,10 @@ def create_notification(
 # Recipient role for the purchasing officer who backfills short inventory (#224).
 PO_RECIPIENT_ROLE = "PO"
 
+# Recipient role for shipping/reallocation signals (#341): hardware that arrived for a leaf which has
+# already left the building is a shipping problem, not a purchasing one.
+SHIPPING_RECIPIENT_ROLE = "SHIPPING"
+
 
 def format_shortfall_lines(shortfalls) -> str:
     """One human-readable clause per shorted combo, joined by '; '. `shortfalls` is any iterable of

--- a/backend/tests/test_replacement_loop.py
+++ b/backend/tests/test_replacement_loop.py
@@ -1,0 +1,670 @@
+"""The deficiency replacement loop and the shipping deficiency guard (#341).
+
+Since #340 a unit found defective at the bench is condemned on the spot: back to inventory flagged
+deficient, PR-REPL replacement line minted immediately. Nothing ever brought the replacement back -
+`complete_pull_request` looked for ShopAssemblyOpenings hanging off the PR-REPL pull, found none
+(nothing hangs off a replacement PR), and completed as a silent no-op.
+
+Covered here: the arrival restoring the leaf's expectation on a leaf still on the bench, the floor
+that keeps an over-delivery from breaching the progress constraint, the completed-leaf case that has
+to move the unit into `replacement_pending_quantity` rather than corrupt the completion invariant,
+installing that unit onto the finished leaf (both when the product already has an
+OpeningItemHardware row and when the line was entirely deficient at completion and has none), the
+shipping guard's warn-and-confirm, and the shipped-leaf case that must be notified and stay
+queryable rather than stranded.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import InvalidStateTransitionError, ValidationError
+from app.models.audit_log import InventoryAuditLog
+from app.models.enums import (
+    AssemblyStatus,
+    AuditAction,
+    AuditEntityType,
+    NotificationType,
+    OpeningItemState,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.notification import Notification
+from app.models.opening_item import OpeningItemHardware
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
+from app.models.stock_item import StockItem
+from app.repositories import import_repository, shop_assembly_repository, warehouse_admin_repository
+from app.repositories import warehouse as warehouse_repository
+
+HINGE = ("HINGE", "HG-R1")
+LOCK = ("LOCK", "LK-R1")
+
+
+# --- fixtures ----------------------------------------------------------------------------------
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category, code, quantity=0):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _make_pulled_opening(session, project_id, *, request_number, items, leaf=1, assigned_user="user_1"):
+    """A COMPLETED SHOP_ASSEMBLY pull request with one PULLED, assigned, untouched opening."""
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=request_number,
+        project_id=project_id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.COMPLETED,
+        requested_by="tester",
+        completed_at=datetime.utcnow(),
+    )
+    session.add(pr)
+    session.flush()
+
+    opening = ShopAssemblyOpening(
+        id=uuid.uuid4(),
+        pull_request_id=pr.id,
+        opening_id=uuid.uuid4(),
+        opening_number="R01",
+        leaf=leaf,
+        pull_status=PullStatus.PULLED,
+        assigned_to="assembler" if assigned_user else None,
+        assigned_to_user_id=assigned_user,
+        assembly_status=AssemblyStatus.PENDING,
+    )
+    session.add(opening)
+    session.flush()
+
+    sao_items = {}
+    for category, code, qty in items:
+        sao_item = ShopAssemblyOpeningItem(
+            id=uuid.uuid4(),
+            shop_assembly_opening_id=opening.id,
+            hardware_category=category,
+            product_code=code,
+            quantity=qty,
+        )
+        session.add(sao_item)
+        sao_items[code] = sao_item
+    session.flush()
+    return opening, sao_items
+
+
+def _flag_deficient(session, opening, sao_item, quantity, *, reason="Bent"):
+    """Run the real deficiency path so the PR-REPL pull and its stamped line exist for real."""
+    shop_assembly_repository.record_assembly_progress(
+        session,
+        opening.id,
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                shop_assembly_opening_item_id=sao_item.id,
+                flag_deficient_quantity=quantity,
+                deficient_reason=reason,
+            )
+        ],
+        performed_by="ada",
+    )
+    session.flush()
+
+
+def _repl_pull_for(session, sao_item) -> PullRequest:
+    """The PR-REPL pull request holding the replacement line for this checklist item."""
+    line = session.scalars(select(PullRequestItem).where(PullRequestItem.sa_opening_item_id == sao_item.id)).first()
+    assert line is not None, "report_deficiency_at_assembly should have minted a stamped PR-REPL line"
+    return session.get(PullRequest, line.pull_request_id)
+
+
+def _work_the_pull(session, pr, *, status=PullRequestStatus.IN_PROGRESS):
+    pr.status = status
+    session.flush()
+    return pr
+
+
+def _complete(session, opening, sao_items):
+    """Install everything not already condemned, then finish the leaf for real."""
+    updates = [
+        shop_assembly_repository.AssemblyProgressUpdate(
+            shop_assembly_opening_item_id=item.id,
+            installed_quantity=item.quantity - item.deficient_quantity,
+        )
+        for item in sao_items.values()
+    ]
+    shop_assembly_repository.record_assembly_progress(session, opening.id, updates, performed_by="ada")
+    session.flush()
+    return shop_assembly_repository.complete_opening(session, opening.id, "A", "1", "B", completed_by="ada")
+
+
+# --- 1. arrival restores the leaf's expectation --------------------------------------------------
+
+
+def test_repl_completion_restores_expectation_on_an_in_progress_leaf(db_session):
+    """The whole point: the freed unit goes back to being remaining work, and the leaf cannot be
+    called finished until somebody actually fits it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R1", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+
+    _flag_deficient(db_session, opening, item, 2)
+    assert item.deficient_quantity == 2
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    assert item.deficient_quantity == 0
+    # Nothing pending: on an unfinished leaf the unit is just remaining work again.
+    assert item.replacement_pending_quantity == 0
+    assert item.quantity - item.installed_quantity - item.deficient_quantity == 4
+
+    # And completion is still blocked on it.
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+
+
+def test_repl_completion_writes_an_audit_row(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R1A", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    events = list(
+        db_session.scalars(
+            select(InventoryAuditLog).where(
+                InventoryAuditLog.entity_id == opening.id,
+                InventoryAuditLog.action == AuditAction.REPLACEMENT_RECEIVED,
+            )
+        ).all()
+    )
+    assert len(events) == 1
+    assert events[0].entity_type == AuditEntityType.SHOP_ASSEMBLY_OPENING
+    assert events[0].detail["restoredQuantity"] == 2
+    assert events[0].detail["deficientQuantity"] == 0
+    assert events[0].detail["assemblyStatus"] == AssemblyStatus.IN_PROGRESS.value
+
+
+def test_over_delivery_floors_at_what_is_outstanding(db_session):
+    """A line asking for more than is still deficient - a duplicate line, or a hand-edited pull -
+    must not drive the counter negative or breach the progress check constraint."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R2", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+
+    repl = _repl_pull_for(db_session, item)
+    # Second stamped line for the same checklist item, so the pull "delivers" 4 against 1 outstanding.
+    db_session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=repl.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number=opening.opening_number,
+            leaf=opening.leaf,
+            sa_opening_item_id=item.id,
+            hardware_category=HINGE[0],
+            product_code=HINGE[1],
+            requested_quantity=3,
+        )
+    )
+    db_session.flush()
+
+    _work_the_pull(db_session, repl)
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    assert item.deficient_quantity == 0
+    assert item.replacement_pending_quantity == 0
+    assert item.installed_quantity == 0
+
+
+def test_a_second_completed_repl_pull_restores_nothing_extra(db_session):
+    """Idempotence at the outer edge: replaying a completion cannot mint expectation from nothing."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R3", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+    assert item.deficient_quantity == 0
+
+    repl.status = PullRequestStatus.IN_PROGRESS
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+    assert item.deficient_quantity == 0
+    assert item.replacement_pending_quantity == 0
+
+
+# --- 2. the completed leaf ----------------------------------------------------------------------
+
+
+def test_completed_leaf_gets_pending_replacement_not_a_broken_invariant(db_session):
+    """The design problem: lowering deficient_quantity on a finished leaf would make it read as
+    un-dispositioned. The unit moves into replacement_pending instead, so the three counts still
+    sum to exactly quantity and the leaf stays legitimately complete."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R4", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+    _complete(db_session, opening, sao)
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+    assert (item.installed_quantity, item.deficient_quantity) == (3, 1)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    assert item.deficient_quantity == 0
+    assert item.replacement_pending_quantity == 1
+    # Completion invariant intact: nothing is un-dispositioned.
+    assert item.installed_quantity + item.deficient_quantity + item.replacement_pending_quantity == item.quantity
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+
+def test_pending_replacement_surfaces_as_work_for_the_last_assembler(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R5", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+    leaf = _complete(db_session, opening, sao)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    work = shop_assembly_repository.get_replacement_work(db_session, assigned_to_user_id="user_1")
+    assert len(work) == 1
+    assert work[0].shop_assembly_opening_item_id == item.id
+    assert work[0].pending_quantity == 2
+    assert work[0].product_code == HINGE[1]
+    assert work[0].opening_item_id == leaf.id
+    assert work[0].opening_item_state == OpeningItemState.IN_INVENTORY
+
+    # Someone else's board does not show it.
+    assert shop_assembly_repository.get_replacement_work(db_session, assigned_to_user_id="user_2") == []
+
+
+def test_a_manager_can_reassign_a_completed_leaf_that_has_pending_replacements(db_session):
+    """ "Reassignable" rides the existing assign flow: a COMPLETED opening becomes assignable again
+    exactly while it has replacement installs outstanding, and not otherwise."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R6", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+    _complete(db_session, opening, sao)
+
+    # Completed, nothing outstanding yet: still refused.
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob", allow_reassign=True)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_2", "Bob", allow_reassign=True)
+    db_session.flush()
+    assert opening.assigned_to_user_id == "user_2"
+    assert shop_assembly_repository.get_replacement_work(db_session, assigned_to_user_id="user_2")[0].assigned_to == (
+        "Bob"
+    )
+
+
+# --- 3. installing the replacement onto the finished leaf ---------------------------------------
+
+
+def test_install_increments_the_existing_opening_item_hardware_row(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R7", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+    leaf = _complete(db_session, opening, sao)
+    oih = db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == leaf.id)).all()
+    assert [(h.product_code, h.quantity) for h in oih] == [(HINGE[1], 3)]
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    result = shop_assembly_repository.install_replacement(db_session, item.id, 1, performed_by="ada")
+    db_session.flush()
+
+    assert result.id == leaf.id
+    rows = db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == leaf.id)).all()
+    assert [(h.product_code, h.quantity) for h in rows] == [(HINGE[1], 4)]
+    assert item.replacement_pending_quantity == 0
+    assert item.installed_quantity == 4
+    assert item.installed_quantity + item.deficient_quantity + item.replacement_pending_quantity == item.quantity
+    assert shop_assembly_repository.get_replacement_work(db_session) == []
+
+
+def test_install_creates_the_row_when_the_line_had_nothing_installed(db_session):
+    """#339 refuses a completion where *nothing at all* was installed, but a line that was entirely
+    deficient while another line was fine contributes no OpeningItemHardware row - so the install
+    has to be able to create one."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1], quantity=10)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-R8", items=[(*HINGE, 2), (*LOCK, 1)]
+    )
+    lock_item = sao[LOCK[1]]
+    _flag_deficient(db_session, opening, lock_item, 1)
+    leaf = _complete(db_session, opening, sao)
+
+    rows = db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == leaf.id)).all()
+    assert [(h.product_code, h.quantity) for h in rows] == [(HINGE[1], 2)]
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, lock_item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+    shop_assembly_repository.install_replacement(db_session, lock_item.id, 1, performed_by="ada")
+    db_session.flush()
+
+    rows = db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == leaf.id)).all()
+    assert sorted((h.product_code, h.quantity) for h in rows) == [(HINGE[1], 2), (LOCK[1], 1)]
+    assert lock_item.replacement_pending_quantity == 0
+
+
+def test_install_is_audited(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R9", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+    leaf = _complete(db_session, opening, sao)
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    shop_assembly_repository.install_replacement(db_session, item.id, 1, performed_by="ada")
+    db_session.flush()
+
+    events = list(
+        db_session.scalars(
+            select(InventoryAuditLog).where(
+                InventoryAuditLog.entity_id == leaf.id,
+                InventoryAuditLog.action == AuditAction.REPLACEMENT_INSTALL,
+            )
+        ).all()
+    )
+    assert len(events) == 1
+    assert events[0].entity_type == AuditEntityType.OPENING_ITEM
+    assert events[0].performed_by == "ada"
+    assert events[0].detail["installedQuantity"] == 1
+    assert events[0].detail["remainingPendingQuantity"] == 1
+
+
+def test_install_cannot_spend_more_than_arrived(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R10", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+    _complete(db_session, opening, sao)
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.install_replacement(db_session, item.id, 2)
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.install_replacement(db_session, item.id, 0)
+
+
+def test_install_is_refused_while_the_leaf_is_still_on_the_bench(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R11", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.install_replacement(db_session, item.id, 1)
+
+
+# --- 4. the replacement arrives after the leaf shipped ------------------------------------------
+
+
+def test_replacement_after_shipment_notifies_and_stays_queryable(db_session):
+    """Do not strand it silently: the pending state is recorded so the unit stays visible to the
+    reallocation world, and a notification says where it went wrong."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R12", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+    leaf = _complete(db_session, opening, sao)
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    assert item.replacement_pending_quantity == 2
+
+    notes = list(
+        db_session.scalars(
+            select(Notification).where(
+                Notification.project_id == project.id,
+                Notification.type == NotificationType.REPLACEMENT_AFTER_SHIPMENT,
+            )
+        ).all()
+    )
+    assert len(notes) == 1
+    assert "already shipped" in notes[0].message
+    assert HINGE[1] in notes[0].message
+
+    work = shop_assembly_repository.get_replacement_work(db_session)
+    assert len(work) == 1
+    assert work[0].opening_item_state == OpeningItemState.SHIPPED_OUT
+
+    # And it cannot be quietly fitted to a leaf that has left the building.
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.install_replacement(db_session, item.id, 1)
+
+
+def test_no_shipment_notification_for_a_leaf_still_in_inventory(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R13", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 1)
+    _complete(db_session, opening, sao)
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+
+    assert (
+        db_session.scalars(
+            select(Notification).where(
+                Notification.project_id == project.id,
+                Notification.type == NotificationType.REPLACEMENT_AFTER_SHIPMENT,
+            )
+        ).all()
+        == []
+    )
+
+
+# --- 5. the shipping deficiency guard -----------------------------------------------------------
+
+
+def test_awaiting_replacement_counts_condemned_and_arrived_but_unfitted(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1], quantity=10)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-R14", items=[(*HINGE, 4), (*LOCK, 2)]
+    )
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    _flag_deficient(db_session, opening, sao[LOCK[1]], 1)
+    leaf = _complete(db_session, opening, sao)
+
+    # Both still condemned.
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {leaf.id: 2}
+
+    # One replacement arrives: it is still owed to the leaf, just in a different bucket.
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, sao[HINGE[1]]))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {leaf.id: 2}
+
+    # Fitted: the leaf is finally whole and drops out of the flag entirely.
+    shop_assembly_repository.install_replacement(db_session, sao[HINGE[1]].id, 1)
+    db_session.flush()
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {leaf.id: 1}
+
+
+def test_a_whole_leaf_is_not_flagged(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R15", items=[(*HINGE, 2)])
+    leaf = _complete(db_session, opening, sao)
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {}
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, []) == {}
+
+
+def _shipping_finalize(session, project, leaf, *, acknowledge=False, request_number="SOR-R1"):
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [
+                {
+                    "opening_number": leaf.opening_number,
+                    "building": None,
+                    "floor": None,
+                    "location": None,
+                    "location_to": None,
+                    "location_from": None,
+                    "hand": None,
+                    "width": None,
+                    "length": None,
+                    "door_thickness": None,
+                    "jamb_thickness": None,
+                    "door_type": None,
+                    "frame_type": None,
+                    "interior_exterior": None,
+                    "keying": None,
+                    "heading_no": None,
+                    "single_pair": None,
+                    "assignment_multiplier": None,
+                }
+            ],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": request_number,
+                    "requested_by": "tester",
+                    "items": [
+                        {
+                            "item_type": "OPENING_ITEM",
+                            "opening_number": leaf.opening_number,
+                            "opening_item_id": str(leaf.id),
+                            "leaf": leaf.leaf,
+                            "hardware_category": None,
+                            "product_code": None,
+                            "requested_quantity": 1,
+                        }
+                    ],
+                }
+            ],
+            "acknowledge_incomplete_leaves": acknowledge,
+        },
+    )
+
+
+def test_shipping_out_creation_refuses_a_flagged_leaf_without_the_acknowledgment(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R16", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as exc:
+        _shipping_finalize(db_session, project, leaf)
+    # The message has to name the leaves, so the decision can be made once rather than one at a time.
+    assert leaf.opening_number in str(exc.value)
+    assert "awaiting replacement" in str(exc.value)
+    assert exc.value.code == "VALIDATION_ERROR"
+
+
+def test_shipping_out_creation_accepts_a_flagged_leaf_with_the_acknowledgment(db_session):
+    """Warn + confirm, never a hard block: deliberate short-shipping stays possible."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R17", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    result = _shipping_finalize(db_session, project, leaf, acknowledge=True, request_number="SOR-R2")
+    db_session.flush()
+    reqs = result["shipping_out_requests"]
+    assert len(reqs) == 1
+    assert [i.opening_item_id for i in reqs[0].items] == [leaf.id]
+
+
+def test_shipping_out_creation_is_untouched_for_a_whole_leaf(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-R18", items=[(*HINGE, 2)])
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    result = _shipping_finalize(db_session, project, leaf, request_number="SOR-R3")
+    db_session.flush()
+    assert len(result["shipping_out_requests"]) == 1

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -81,6 +81,36 @@ The tag does not become physical all at once. Assembly happens over a shift, uni
 - **Shipping out complete** - the leaf moves to `SHIP_READY`, then a confirmed shipment writes a
   `PackingSlipItem` that snapshots the leaf permanently.
 
+### 4b. The replacement loop closes
+
+Since #341 the round-trip a deficiency starts actually finishes. When the PR-REPL pull completes,
+`complete_pull_request` reads each line's `sa_opening_item_id` and gives the leaf its expectation
+back - floored at what is genuinely still outstanding, so an over-delivery restores nothing extra.
+Where the freed unit lands depends on whether the tag is still being worked:
+
+- **Leaf still PENDING / IN_PROGRESS** - `deficient_quantity` simply drops, `remaining` goes back up,
+  and the unit reappears as work in My Work. Completion stays blocked until somebody fits it.
+- **Leaf already COMPLETED** - the unit moves into `replacement_pending_quantity`. This is the third
+  bucket the line is partitioned into, and it exists because the alternative corrupts the model:
+  lowering `deficient_quantity` alone would make a finished leaf read as un-dispositioned
+  (`installed + deficient < quantity`). Moving it keeps the sum at `quantity` - the leaf is complete,
+  with a known unit of work outstanding - and the check constraint
+  `installed + deficient + replacement_pending <= quantity` is what makes that enforceable rather
+  than merely intended. `install_replacement` then moves it `replacement_pending -> installed` and
+  appends or increments the leaf's `OpeningItemHardware` row: **the one legitimate write to an
+  assembled leaf's hardware after completion**, bounded by what the pull actually delivered.
+- **Leaf already SHIPPED_OUT** - the hardware cannot be fitted to something that has left the
+  building. The pending state is still recorded, so the unit stays queryable rather than silently
+  stranded, and a `REPLACEMENT_AFTER_SHIPMENT` notification hands it to the reallocation /
+  site-shipment world. `install_replacement` refuses it.
+
+**A leaf with anything in `deficient_quantity` or `replacement_pending_quantity` is physically short
+of the hardware list it would ship under.** That sum is `OpeningItem.awaiting_replacement_quantity`,
+and it is what the shipping wizard flags as "incomplete - awaiting replacement". Shipping it anyway
+is allowed and sometimes right - reallocation exists for exactly that - but the shipping-out creation
+path refuses a flagged leaf unless the caller passes an explicit acknowledgment. Warn and confirm,
+never silent, never a hard block.
+
 ## Corollary: LOOSE vs OPENING_ITEM pull lines
 
 Both pull request sources use `pull_request_items`, but the two `item_type` values do fundamentally
@@ -114,4 +144,9 @@ leaf until a pull tags it onto one).
 | Tag worked, incrementally | `backend/app/repositories/shop_assembly_repository.py` (`record_assembly_progress` -> `installed_quantity` / `deficient_quantity`) |
 | Deficient unit returned + replaced | `backend/app/repositories/stock/deficiency.py` (`report_deficiency_at_assembly` -> PR-REPL line) |
 | Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`, quantities = installed) |
+| Replacement arrives, expectation restored | `backend/app/repositories/warehouse/pull_requests.py` (`_apply_replacement_arrivals` -> `deficient_quantity` down, `replacement_pending_quantity` up on a completed leaf) |
+| Replacement fitted to a finished leaf | `backend/app/repositories/shop_assembly_repository.py` (`install_replacement` -> `OpeningItemHardware`) |
+| Leaf is short of its own list | `backend/app/repositories/shop_assembly_repository.py` (`get_awaiting_replacement_quantities`, one grouped aggregate) |
+| Shipping a short leaf takes a decision | `backend/app/repositories/import_repository.py` (`finalize_import_session`, `acknowledge_incomplete_leaves`) |
+| Replacement stranded after shipment | `backend/app/repositories/warehouse/pull_requests.py` (`REPLACEMENT_AFTER_SHIPMENT` notification) |
 | Tag shipped | `backend/app/repositories/shipping_repository.py` (`confirm_shipment` -> `PackingSlipItem.leaf`) |

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -53,3 +53,14 @@ export const ASSEMBLY_PROGRESS_REFETCH_QUERIES = ['GetMyWork'];
 // Evicted. assembleList is read by the other entry point into the same modal, and the two views are
 // never mounted together (separate routes), so whichever one is live repairs its own diff.
 export const ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS = ['assembleList'];
+
+// What installing a replacement onto a finished leaf invalidates (#341). Same disjointness rule.
+//
+// Refetched. GetReplacementWork is the list the install was launched from and is mounted by
+// definition, so refetchQueries reaches it; the row either drops out or its pendingQuantity falls.
+export const REPLACEMENT_INSTALL_REFETCH_QUERIES = ['GetReplacementWork'];
+
+// Evicted. openingItems carries awaitingReplacementQuantity, which the shipping wizard reads to
+// decide whether a leaf is flagged - and the wizard is a different module that is never mounted
+// while an assembler is installing, which is exactly what refetchQueries cannot reach.
+export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems'];

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -38,6 +38,7 @@ export const GET_ASSEMBLE_LIST = gql`
         quantity
         installedQuantity
         deficientQuantity
+        replacementPendingQuantity
       }
     }
   }
@@ -67,6 +68,55 @@ export const GET_MY_WORK = gql`
         quantity
         installedQuantity
         deficientQuantity
+        replacementPendingQuantity
+      }
+    }
+  }
+`;
+
+// Replacement installs outstanding on already-completed leaves (#341). Scoped to one assembler so it
+// lands in the My Work board of whoever last held the leaf - the opening keeps its assignment through
+// completion, so this needs no new assignment concept. Rows whose openingItemState is SHIPPED_OUT are
+// listed deliberately: that replacement must stay visible rather than be stranded, even though it
+// cannot be installed.
+export const GET_REPLACEMENT_WORK = gql`
+  query GetReplacementWork($assignedToUserId: String, $projectId: ID) {
+    replacementWork(assignedToUserId: $assignedToUserId, projectId: $projectId) {
+      shopAssemblyOpeningItemId
+      shopAssemblyOpeningId
+      projectId
+      openingNumber
+      leaf
+      building
+      floor
+      hardwareCategory
+      productCode
+      pendingQuantity
+      assignedToUserId
+      assignedTo
+      openingItemId
+      openingItemState
+    }
+  }
+`;
+
+// Fit arrived replacement hardware to a finished leaf (#341) - the one legitimate write to an
+// assembled leaf's hardware after completion. Returns the leaf so the caller can see its updated
+// installedHardware and whether anything is still owed to it.
+export const INSTALL_REPLACEMENT = gql`
+  mutation InstallReplacement($input: InstallReplacementInput!) {
+    installReplacement(input: $input) {
+      id
+      openingNumber
+      leaf
+      state
+      awaitingReplacementQuantity
+      installedHardware {
+        id
+        openingItemId
+        productCode
+        hardwareCategory
+        quantity
       }
     }
   }
@@ -156,6 +206,7 @@ export const ASSIGN_OPENINGS = gql`
         quantity
         installedQuantity
         deficientQuantity
+        replacementPendingQuantity
       }
     }
   }
@@ -184,6 +235,7 @@ export const REMOVE_OPENING_FROM_USER = gql`
         quantity
         installedQuantity
         deficientQuantity
+        replacementPendingQuantity
       }
     }
   }
@@ -216,6 +268,7 @@ export const RECORD_ASSEMBLY_PROGRESS = gql`
         quantity
         installedQuantity
         deficientQuantity
+        replacementPendingQuantity
       }
     }
   }

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -55,6 +55,7 @@ export const GET_OPENING_ITEMS = gql`
       assemblyCompletedAt state
       aisle row bay
       createdAt updatedAt
+      awaitingReplacementQuantity
       installedHardware {
         id openingItemId productCode hardwareCategory quantity
       }

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -74,6 +74,8 @@ interface OpeningItemResponse {
   leaf: number | null;
   state: string;
   installedHardware: Array<{ productCode: string; quantity: number }>;
+  /** Units still awaiting a replacement (#341); null on a server that predates the field. */
+  awaitingReplacementQuantity: number | null;
 }
 
 /** The slices used to find leaves already claimed by an open request or pull (#335). */
@@ -145,6 +147,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   const [orderAsValues, setOrderAsValues] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
+  // The user has been shown the "incomplete - awaiting replacement" warning on a leaf and chose to
+  // ship it anyway (#341). The backend refuses a flagged leaf without this, so the flag is the
+  // record that a decision was actually made rather than a default that got carried along.
+  const [acknowledgedIncompleteLeaves, setAcknowledgedIncompleteLeaves] = useState(false);
   const [selectedReconItems, setSelectedReconItems] = useState<Set<string>>(new Set());
 
   // Finalize state
@@ -415,6 +421,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         openingNumber: oi.openingNumber,
         leaf: oi.leaf,
         installedHardware: oi.installedHardware ?? [],
+        awaitingReplacementQuantity: oi.awaitingReplacementQuantity ?? 0,
       }))
       .sort((a, b) => a.openingNumber.localeCompare(b.openingNumber) || (a.leaf ?? 0) - (b.leaf ?? 0));
   }, [purpose, openingItemsData, selectedOpenings, claimedOpeningItemIds]);
@@ -869,6 +876,8 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       // schedule (i.e., they did not pick "Use last uploaded schedule"). The backend wipes all
       // existing HardwareItems and openings absent from the new input.
       replaceSchedule: canStartFromLatest && !hydratedFromPersisted,
+      // Only ever true after the user confirmed the warning dialog on a flagged leaf (#341).
+      acknowledgeIncompleteLeaves: acknowledgedIncompleteLeaves,
       shopAssemblyOpenings: purpose === 'assembly'
         ? parsed.openings
             .filter((o) => selectedOpenings.has(o.opening_number))
@@ -925,7 +934,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             })
         : null,
     };
-  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted]);
+  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted, acknowledgedIncompleteLeaves]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1347,6 +1356,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               onRemovePR={removeShippingPR}
               onUpdatePR={updateShippingPR}
               onTogglePRItem={toggleShippingPRItem}
+              onAcknowledgeIncompleteLeaf={() => setAcknowledgedIncompleteLeaves(true)}
               onNext={handleNext}
               onBack={handleBack}
             />

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
   Box,
   Button,
   Checkbox,
+  Chip,
   FormControlLabel,
   IconButton,
   Paper,
@@ -12,6 +13,7 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import type { AggregatedHardwareItem, AssembledLeafCandidate, ShippingPRDraft, ShippingPRItem } from './types';
 import { aggregationKey, shippingPRItemKey } from './types';
 import { leafSuffix } from '../../utils/leaf';
@@ -30,6 +32,11 @@ interface ShippingPRsStepProps {
   onRemovePR: (index: number) => void;
   onUpdatePR: (index: number, field: 'requestNumber' | 'requestedBy', value: string) => void;
   onTogglePRItem: (prIndex: number, item: ShippingPRItem) => void;
+  /**
+   * The user confirmed shipping a leaf that is still awaiting replacement hardware (#341). The
+   * wizard passes this to the backend as the explicit acknowledgment the creation path requires.
+   */
+  onAcknowledgeIncompleteLeaf: () => void;
   onNext: () => void;
   onBack: () => void;
 }
@@ -58,9 +65,38 @@ export default function ShippingPRsStep({
   onRemovePR,
   onUpdatePR,
   onTogglePRItem,
+  onAcknowledgeIncompleteLeaf,
   onNext,
   onBack,
 }: ShippingPRsStepProps) {
+  // Selecting a flagged leaf is gated on a confirm rather than blocked: short-shipping on purpose is
+  // a real workflow (reallocation exists for it), it just must not happen by accident. Held until the
+  // dialog resolves so the checkbox only flips on an actual decision.
+  const [pendingIncomplete, setPendingIncomplete] = useState<{
+    prIndex: number;
+    item: ShippingPRItem;
+    leaf: AssembledLeafCandidate;
+  } | null>(null);
+
+  const handleToggleLeaf = useCallback(
+    (prIndex: number, item: ShippingPRItem, leaf: AssembledLeafCandidate, isSelected: boolean) => {
+      // Only adding a flagged leaf needs a decision. Removing one always just removes it.
+      if (!isSelected && leaf.awaitingReplacementQuantity > 0) {
+        setPendingIncomplete({ prIndex, item, leaf });
+        return;
+      }
+      onTogglePRItem(prIndex, item);
+    },
+    [onTogglePRItem],
+  );
+
+  const confirmIncomplete = useCallback(() => {
+    if (!pendingIncomplete) return;
+    onTogglePRItem(pendingIncomplete.prIndex, pendingIncomplete.item);
+    onAcknowledgeIncompleteLeaf();
+    setPendingIncomplete(null);
+  }, [pendingIncomplete, onTogglePRItem, onAcknowledgeIncompleteLeaf]);
+
   const canProceed = useMemo(
     () =>
       shippingPRDrafts.some(
@@ -164,6 +200,8 @@ export default function ShippingPRsStep({
                     };
                     const key = shippingPRItemKey(item);
                     const onAnotherDraft = leafKeysByDraft.some((keys, i) => i !== prIdx && keys.has(key));
+                    const isSelected = selectedKeys.has(key);
+                    const incomplete = leaf.awaitingReplacementQuantity > 0;
                     return (
                       <FormControlLabel
                         key={leaf.id}
@@ -171,22 +209,40 @@ export default function ShippingPRsStep({
                         control={
                           <Checkbox
                             size="small"
-                            checked={selectedKeys.has(key)}
-                            onChange={() => onTogglePRItem(prIdx, item)}
+                            checked={isSelected}
+                            onChange={() => handleToggleLeaf(prIdx, item, leaf, isSelected)}
                           />
                         }
                         label={
                           <Box>
-                            <Typography variant="body2">
-                              Opening {leaf.openingNumber}
-                              {leafSuffix(leaf.leaf)}
-                              {leaf.leaf == null && ' (assembled unit)'}
-                            </Typography>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <Typography variant="body2">
+                                Opening {leaf.openingNumber}
+                                {leafSuffix(leaf.leaf)}
+                                {leaf.leaf == null && ' (assembled unit)'}
+                              </Typography>
+                              {/* Real system state - the leaf is physically short of its own
+                                  hardware list - so it earns a status colour (#341). */}
+                              {incomplete && (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  color="warning"
+                                  label="Incomplete - awaiting replacement"
+                                />
+                              )}
+                            </Box>
                             <Typography variant="caption" color="text.secondary">
                               {onAnotherDraft
                                 ? 'Already on another shipping PR in this session'
                                 : installedSummary(leaf)}
                             </Typography>
+                            {incomplete && (
+                              <Typography variant="caption" color="warning.main" sx={{ display: 'block' }}>
+                                {leaf.awaitingReplacementQuantity} unit(s) still awaiting replacement
+                                hardware
+                              </Typography>
+                            )}
                           </Box>
                         }
                         sx={{ display: 'flex', alignItems: 'flex-start', mb: 0.5 }}
@@ -246,6 +302,23 @@ export default function ShippingPRsStep({
       <Button startIcon={<AddIcon />} onClick={onAddPR}>
         Add Shipping PR
       </Button>
+
+      <ConfirmDialog
+        open={pendingIncomplete !== null}
+        title="Ship an incomplete leaf?"
+        message={
+          pendingIncomplete
+            ? `Opening ${pendingIncomplete.leaf.openingNumber}${leafSuffix(pendingIncomplete.leaf.leaf)} is ` +
+              `still awaiting replacement hardware for ${pendingIncomplete.leaf.awaitingReplacementQuantity} ` +
+              `unit(s). Shipping it now sends it short of the hardware its list says it carries. ` +
+              `Reallocation can fill the gap later, but the shortfall goes to site either way.`
+            : ''
+        }
+        confirmLabel="Ship it short"
+        cancelLabel="Leave it here"
+        onConfirm={confirmIncomplete}
+        onCancel={() => setPendingIncomplete(null)}
+      />
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
         <Button onClick={onBack}>Back</Button>

--- a/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
+++ b/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ShippingPRsStep from '../ShippingPRsStep';
+import type { AssembledLeafCandidate, ShippingPRDraft } from '../types';
+
+/**
+ * The shipping deficiency guard (#341). A leaf whose hardware is still awaiting a replacement is
+ * physically short of the list it would ship under. The business decision is warn + confirm: never
+ * silent, never a hard block - deliberate short-shipping stays possible, it just has to be a
+ * decision someone made.
+ */
+
+function leaf(overrides: Partial<AssembledLeafCandidate> = {}): AssembledLeafCandidate {
+  return {
+    id: 'oi-1',
+    openingNumber: '0019-EX',
+    leaf: 1,
+    installedHardware: [{ productCode: 'HG-100', quantity: 3 }],
+    awaitingReplacementQuantity: 0,
+    ...overrides,
+  };
+}
+
+const EMPTY_DRAFT: ShippingPRDraft = { requestNumber: 'SOR-1', requestedBy: 'ada', items: [] };
+
+function renderStep(leaves: AssembledLeafCandidate[], overrides: Record<string, unknown> = {}) {
+  const onTogglePRItem = vi.fn();
+  const onAcknowledgeIncompleteLeaf = vi.fn();
+  render(
+    <ShippingPRsStep
+      shippingPRDrafts={[EMPTY_DRAFT]}
+      assembledLeaves={leaves}
+      looseItems={[]}
+      leavesLoading={false}
+      leavesError={false}
+      onAddPR={vi.fn()}
+      onRemovePR={vi.fn()}
+      onUpdatePR={vi.fn()}
+      onTogglePRItem={onTogglePRItem}
+      onAcknowledgeIncompleteLeaf={onAcknowledgeIncompleteLeaf}
+      onNext={vi.fn()}
+      onBack={vi.fn()}
+      {...overrides}
+    />
+  );
+  return { onTogglePRItem, onAcknowledgeIncompleteLeaf };
+}
+
+function leafCheckbox() {
+  // The first checkbox in the assembled-leaves group.
+  return screen.getAllByRole('checkbox')[0];
+}
+
+it('flags a leaf that is still awaiting replacement hardware', () => {
+  renderStep([leaf({ awaitingReplacementQuantity: 2 })]);
+  expect(screen.getByText(/Incomplete - awaiting replacement/i)).toBeInTheDocument();
+  expect(screen.getByText(/2 unit\(s\) still awaiting replacement/i)).toBeInTheDocument();
+});
+
+it('does not flag a whole leaf', () => {
+  renderStep([leaf()]);
+  expect(screen.queryByText(/Incomplete - awaiting replacement/i)).not.toBeInTheDocument();
+});
+
+it('selects a whole leaf immediately, with no confirmation', () => {
+  const { onTogglePRItem, onAcknowledgeIncompleteLeaf } = renderStep([leaf()]);
+  fireEvent.click(leafCheckbox());
+  expect(onTogglePRItem).toHaveBeenCalledTimes(1);
+  // Nothing was acknowledged, because nothing needed acknowledging.
+  expect(onAcknowledgeIncompleteLeaf).not.toHaveBeenCalled();
+});
+
+it('asks before putting a flagged leaf on a request, and does nothing until confirmed', () => {
+  const { onTogglePRItem, onAcknowledgeIncompleteLeaf } = renderStep([
+    leaf({ awaitingReplacementQuantity: 1 }),
+  ]);
+  fireEvent.click(leafCheckbox());
+
+  expect(screen.getByText('Ship an incomplete leaf?')).toBeInTheDocument();
+  // The selection has NOT happened yet - the checkbox must not flip on a question.
+  expect(onTogglePRItem).not.toHaveBeenCalled();
+  expect(onAcknowledgeIncompleteLeaf).not.toHaveBeenCalled();
+});
+
+it('selects the flagged leaf and records the acknowledgment on confirm', () => {
+  const { onTogglePRItem, onAcknowledgeIncompleteLeaf } = renderStep([
+    leaf({ awaitingReplacementQuantity: 1 }),
+  ]);
+  fireEvent.click(leafCheckbox());
+  fireEvent.click(screen.getByRole('button', { name: /ship it short/i }));
+
+  expect(onTogglePRItem).toHaveBeenCalledTimes(1);
+  expect(onTogglePRItem.mock.calls[0][1]).toMatchObject({ itemType: 'OPENING_ITEM', openingItemId: 'oi-1' });
+  // The acknowledgment is what the backend requires; without it the finalize is refused.
+  expect(onAcknowledgeIncompleteLeaf).toHaveBeenCalledTimes(1);
+});
+
+it('leaves the flagged leaf off the request on cancel', async () => {
+  const { onTogglePRItem, onAcknowledgeIncompleteLeaf } = renderStep([
+    leaf({ awaitingReplacementQuantity: 1 }),
+  ]);
+  fireEvent.click(leafCheckbox());
+  fireEvent.click(screen.getByRole('button', { name: /leave it here/i }));
+
+  expect(onTogglePRItem).not.toHaveBeenCalled();
+  expect(onAcknowledgeIncompleteLeaf).not.toHaveBeenCalled();
+  // The dialog unmounts on MUI's close transition, so this has to wait it out.
+  await waitFor(() => expect(screen.queryByText('Ship an incomplete leaf?')).not.toBeInTheDocument());
+});
+
+it('removes an already-selected flagged leaf without asking', () => {
+  const selected: ShippingPRDraft = {
+    requestNumber: 'SOR-1',
+    requestedBy: 'ada',
+    items: [
+      { itemType: 'OPENING_ITEM', openingNumber: '0019-EX', openingItemId: 'oi-1', leaf: 1, requestedQuantity: 1 },
+    ],
+  };
+  const { onTogglePRItem, onAcknowledgeIncompleteLeaf } = renderStep(
+    [leaf({ awaitingReplacementQuantity: 1 })],
+    { shippingPRDrafts: [selected] }
+  );
+  fireEvent.click(leafCheckbox());
+
+  expect(screen.queryByText('Ship an incomplete leaf?')).not.toBeInTheDocument();
+  expect(onTogglePRItem).toHaveBeenCalledTimes(1);
+  expect(onAcknowledgeIncompleteLeaf).not.toHaveBeenCalled();
+});

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -46,6 +46,12 @@ export interface AssembledLeafCandidate {
   openingNumber: string;
   leaf: number | null;
   installedHardware: Array<{ productCode: string; quantity: number }>;
+  /**
+   * Units of this leaf's hardware still owed to it (#341): condemned and not yet replaced, plus
+   * replacements that have arrived but are not fitted. > 0 means the leaf is physically short of the
+   * hardware list it would ship under, so it is flagged and takes an explicit confirm.
+   */
+  awaitingReplacementQuantity: number;
 }
 
 export function hardwareItemKey(hi: ParsedHardwareItem) {

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -5,6 +5,7 @@ import { GET_MY_WORK } from '../../graphql/shop-assembly';
 import { useIdentity } from '../../hooks/useIdentity';
 import DataTable from '../../components/DataTable';
 import AssemblyDetailModal from './AssemblyDetailModal';
+import ReplacementWorkPanel from './ReplacementWorkPanel';
 import { assemblyProgress, assemblyStatusLabel } from './openingFilters';
 import { leafLabel } from '../../utils/leaf';
 import type { GridColDef } from '@mui/x-data-grid';
@@ -120,6 +121,11 @@ export default function MyWorkPage() {
         onRowClick={handleRowClick}
         getRowId={(row: MyWorkOpening) => row.id}
       />
+
+      {/* Leaves this assembler already finished that are owed replacement hardware (#341). Kept out
+          of the grid above because those rows are unfinished openings and these are complete ones -
+          folding them in would mean either reopening a finished work unit or mislabelling it. */}
+      <ReplacementWorkPanel assignedToUserId={userId} performedBy={displayName} />
 
       {selectedOpening && (
         <AssemblyDetailModal

--- a/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useState } from 'react';
+import { Alert, Box, Button, Chip, Paper, Stack, Typography } from '@mui/material';
+import { useMutation, useQuery } from '@apollo/client/react';
+import { GET_REPLACEMENT_WORK, INSTALL_REPLACEMENT } from '../../graphql/shop-assembly';
+import {
+  REPLACEMENT_INSTALL_REFETCH_QUERIES,
+  REPLACEMENT_INSTALL_STALE_ROOT_FIELDS,
+} from '../../graphql/refetch';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useToast } from '../../components/Toast';
+import { leafSuffix } from '../../utils/leaf';
+
+export interface ReplacementWorkRow {
+  shopAssemblyOpeningItemId: string;
+  shopAssemblyOpeningId: string;
+  openingNumber: string;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  hardwareCategory: string;
+  productCode: string;
+  pendingQuantity: number;
+  assignedTo: string | null;
+  openingItemId: string | null;
+  openingItemState: string | null;
+}
+
+interface ReplacementWorkPanelProps {
+  /** The signed-in assembler; the panel shows only the work assigned to them. */
+  assignedToUserId: string | null;
+  /** Recorded as the performer on the install audit row. */
+  performedBy?: string;
+}
+
+/**
+ * Replacement installs outstanding on leaves this assembler already finished (#341).
+ *
+ * These cannot ride in the My Work grid above: those rows are unfinished ShopAssemblyOpenings, and
+ * the leaf here is COMPLETED and stays that way. It is a narrower unit of work - "fit these N units
+ * to a leaf that is otherwise done" - so it gets its own section rather than reopening a finished
+ * work unit or pretending the leaf is in progress.
+ *
+ * A row whose leaf has already shipped is still listed, because the hardware is real and must not be
+ * silently stranded; it just cannot be installed from here.
+ */
+export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: ReplacementWorkPanelProps) {
+  const { showToast } = useToast();
+  const [pending, setPending] = useState<ReplacementWorkRow | null>(null);
+
+  const { data, loading } = useQuery<{ replacementWork: ReplacementWorkRow[] }>(GET_REPLACEMENT_WORK, {
+    variables: { assignedToUserId },
+    skip: !assignedToUserId,
+  });
+
+  const [installReplacement, { loading: installing }] = useMutation(INSTALL_REPLACEMENT, {
+    update(cache) {
+      for (const fieldName of REPLACEMENT_INSTALL_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
+    refetchQueries: REPLACEMENT_INSTALL_REFETCH_QUERIES,
+    onError: (err) => showToast(err.message, 'error'),
+  });
+
+  const confirmInstall = useCallback(async () => {
+    if (!pending) return;
+    const row = pending;
+    setPending(null);
+    const result = await installReplacement({
+      variables: {
+        input: {
+          shopAssemblyOpeningItemId: row.shopAssemblyOpeningItemId,
+          // The whole pending quantity: the units arrived together on one pull line, and splitting
+          // them would be an invented distinction the assembler has no way to act on.
+          quantity: row.pendingQuantity,
+          performedBy,
+        },
+      },
+    });
+    if (result.data) {
+      showToast(
+        `Installed ${row.pendingQuantity} x ${row.productCode} on Opening ${row.openingNumber}${leafSuffix(row.leaf)}`,
+        'success',
+      );
+    }
+  }, [pending, installReplacement, performedBy, showToast]);
+
+  const rows = data?.replacementWork ?? [];
+  if (!assignedToUserId || loading || rows.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant='h6' gutterBottom>
+        Replacement Installs
+      </Typography>
+      <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+        Replacement hardware has arrived for leaves you already finished. Fit it, then record it here
+        so the leaf's hardware list matches what is actually on it.
+      </Typography>
+
+      <Stack spacing={1.5}>
+        {rows.map((row) => {
+          const shipped = row.openingItemState === 'SHIPPED_OUT';
+          return (
+            <Paper key={row.shopAssemblyOpeningItemId} variant='outlined' sx={{ p: 2 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Box>
+                  <Typography variant='subtitle2' sx={{ fontWeight: 600 }}>
+                    Opening {row.openingNumber}
+                    {leafSuffix(row.leaf)}
+                  </Typography>
+                  <Typography variant='body2' color='text.secondary'>
+                    {row.pendingQuantity} x {row.productCode} ({row.hardwareCategory})
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Chip size='small' variant='outlined' label={`${row.pendingQuantity} awaiting install`} />
+                  {shipped ? (
+                    <Chip size='small' variant='outlined' color='warning' label='Leaf already shipped' />
+                  ) : (
+                    <Button
+                      size='small'
+                      variant='contained'
+                      disabled={installing}
+                      onClick={() => setPending(row)}
+                    >
+                      Mark Installed
+                    </Button>
+                  )}
+                </Box>
+              </Box>
+              {shipped && (
+                <Alert severity='warning' sx={{ mt: 1.5 }}>
+                  This leaf shipped before the replacement arrived, so the hardware cannot go on it
+                  here. It needs a reallocation or a site shipment.
+                </Alert>
+              )}
+            </Paper>
+          );
+        })}
+      </Stack>
+
+      <ConfirmDialog
+        open={pending !== null}
+        title='Record replacement as installed?'
+        message={
+          pending
+            ? `This adds ${pending.pendingQuantity} x ${pending.productCode} to Opening ` +
+              `${pending.openingNumber}${leafSuffix(pending.leaf)}'s hardware list. Only do this once the ` +
+              `hardware is physically on the leaf.`
+            : ''
+        }
+        confirmLabel='Mark Installed'
+        onConfirm={confirmInstall}
+        onCancel={() => setPending(null)}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/modules/shop-assembly/__tests__/ReplacementWorkPanel.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/ReplacementWorkPanel.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import ReplacementWorkPanel from '../ReplacementWorkPanel';
+import { GET_REPLACEMENT_WORK, INSTALL_REPLACEMENT } from '../../../graphql/shop-assembly';
+
+/**
+ * The replacement-install work item (#341). A leaf that was finished with a unit condemned gets its
+ * replacement later; fitting it is the one legitimate write to an assembled leaf's hardware after
+ * completion, so it is confirm-gated. A leaf that shipped before the replacement arrived is still
+ * listed - the hardware is real and must not be silently stranded - but cannot be installed.
+ */
+
+vi.setConfig({ testTimeout: 30_000 });
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    shopAssemblyOpeningItemId: 'sai-1',
+    shopAssemblyOpeningId: 'sao-1',
+    projectId: 'p1',
+    openingNumber: '0019-EX',
+    leaf: 1,
+    building: 'A',
+    floor: '2',
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    pendingQuantity: 2,
+    assignedToUserId: 'user_1',
+    assignedTo: 'Ada',
+    openingItemId: 'oi-1',
+    openingItemState: 'IN_INVENTORY',
+    ...overrides,
+  };
+}
+
+function workMock(rows: unknown[]): MockedResponse {
+  return {
+    request: { query: GET_REPLACEMENT_WORK, variables: { assignedToUserId: 'user_1' } },
+    result: { data: { replacementWork: rows } },
+    maxUsageCount: 5,
+  };
+}
+
+function installMock(quantity: number): MockedResponse {
+  return {
+    request: {
+      query: INSTALL_REPLACEMENT,
+      variables: {
+        input: { shopAssemblyOpeningItemId: 'sai-1', quantity, performedBy: 'Ada' },
+      },
+    },
+    result: {
+      data: {
+        installReplacement: {
+          id: 'oi-1',
+          openingNumber: '0019-EX',
+          leaf: 1,
+          state: 'IN_INVENTORY',
+          awaitingReplacementQuantity: 0,
+          installedHardware: [
+            {
+              id: 'h1',
+              openingItemId: 'oi-1',
+              productCode: 'HG-100',
+              hardwareCategory: 'HINGE',
+              quantity: 4,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function renderPanel(mocks: MockedResponse[], userId: string | null = 'user_1') {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <ReplacementWorkPanel assignedToUserId={userId} performedBy='Ada' />
+      </ToastProvider>
+    </MockedProvider>
+  );
+}
+
+it('lists what a finished leaf is still owed', async () => {
+  renderPanel([workMock([row()])]);
+  expect(await screen.findByText(/Replacement Installs/i)).toBeInTheDocument();
+  expect(screen.getByText(/Opening 0019-EX/)).toBeInTheDocument();
+  expect(screen.getByText(/2 x HG-100/)).toBeInTheDocument();
+});
+
+it('renders nothing when there is no replacement work', async () => {
+  const { container } = renderPanel([workMock([])]);
+  await waitFor(() => expect(container.querySelector('h6')).toBeNull());
+  expect(screen.queryByText(/Replacement Installs/i)).not.toBeInTheDocument();
+});
+
+it('confirms before recording the install', async () => {
+  renderPanel([workMock([row()]), installMock(2)]);
+  fireEvent.click(await screen.findByRole('button', { name: /mark installed/i }));
+
+  expect(await screen.findByText('Record replacement as installed?')).toBeInTheDocument();
+  // Nothing has been written yet; the dialog is the decision point.
+  expect(screen.getByText(/Only do this once the hardware is physically on the leaf/i)).toBeInTheDocument();
+});
+
+it('installs the whole arrived quantity on confirm', async () => {
+  renderPanel([workMock([row()]), installMock(2)]);
+  fireEvent.click(await screen.findByRole('button', { name: /mark installed/i }));
+  // Second "Mark Installed" is the dialog's confirm button.
+  const buttons = screen.getAllByRole('button', { name: /mark installed/i });
+  fireEvent.click(buttons[buttons.length - 1]);
+
+  expect(await screen.findByText(/Installed 2 x HG-100 on Opening 0019-EX/)).toBeInTheDocument();
+});
+
+it('does not offer an install for a leaf that already shipped', async () => {
+  renderPanel([workMock([row({ openingItemState: 'SHIPPED_OUT' })])]);
+  expect(await screen.findByText(/Leaf already shipped/i)).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /mark installed/i })).not.toBeInTheDocument();
+  // Still visible, though - that is the whole point of not stranding it.
+  expect(screen.getByText(/2 x HG-100/)).toBeInTheDocument();
+  expect(screen.getByText(/needs a reallocation or a site shipment/i)).toBeInTheDocument();
+});

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -246,12 +246,41 @@ Installed / Deficient / Remaining, with the Installed cell an editable number sp
   a plain user self-claiming cannot take one that is already held - that returns a CONFLICT toast.
   Unassigning an In Progress leaf is allowed and puts it back in the pool with its counts intact.
 
+**Replacement Installs section on My Work (#341).** Below the My Work grid, and only rendered when
+there is something in it, so an empty shop shows nothing at all. It appears when a PR-REPL
+replacement pull is *completed* in the warehouse for a leaf the assembler already finished.
+
+- To produce one end to end: flag a unit deficient in the assembly modal, finish the leaf, then go to
+  Warehouse -> Pull Requests, approve the `PR-REPL-<original PR number>` request and complete it. The
+  card shows up on the assembler's My Work on the next fetch.
+- If the leaf is *not* finished yet, completing the same replacement pull produces **no card** - the
+  unit just goes back to being Remaining in the assembly modal and Mark Complete is blocked again.
+  That is the intended behaviour, not a missing feature.
+- "Mark Installed" is confirm-gated and installs the whole arrived quantity at once. Afterwards the
+  leaf's `installedHardware` carries the extra units; the card disappears.
+- A card whose leaf already shipped shows a "Leaf already shipped" chip and a warning alert instead
+  of the button - it cannot be installed, only reallocated. A `REPLACEMENT_AFTER_SHIPMENT`
+  notification was also raised for the SHIPPING role when the pull completed.
+
 ### Shipping Module
 
 **Entry**: `/app/shipping` -> Project landing page -> ship-ready items browser
 
 - Shows opening items and loose items ready to ship
 - Create packing slips, confirm shipments
+
+**Incomplete-leaf guard in the Start-a-Task shipping wizard (#341).** On the Shipping PRs step, an
+assembled leaf that is still owed hardware carries an amber "Incomplete - awaiting replacement" chip
+and a "<n> unit(s) still awaiting replacement" caption.
+
+- Ticking its checkbox does **not** select it - it opens a "Ship an incomplete leaf?" dialog first.
+  "Ship it short" selects it and records the acknowledgment; "Leave it here" leaves the checkbox
+  clear. Unticking an already-selected flagged leaf never asks.
+- Without that confirmation the finalize is refused by the backend with a VALIDATION_ERROR naming
+  every flagged leaf, so driving the mutation directly (without `acknowledgeIncompleteLeaves: true`)
+  is the way to exercise the guard from GraphQL.
+- The flag is `openingItems { awaitingReplacementQuantity }` - condemned-and-unreplaced plus
+  arrived-but-not-fitted. It only drops to 0 once the replacement is actually installed on the leaf.
 
 ### Admin Module
 


### PR DESCRIPTION
Slice 3 of 6. **Stacked on `feat/sa-slice-2-progress` (PR #346)** — the base is set to that branch so this diff shows only slice 3. Closes #341.

The deficiency flow dead-ended. Since #340 a unit found defective at the bench is condemned on the spot — back to inventory flagged deficient, PR-REPL replacement line minted immediately — but nothing ever brought the replacement back to the leaf. `complete_pull_request` looked for `ShopAssemblyOpening`s hanging off the PR-REPL pull, found none (nothing hangs off a replacement PR), and completed as a silent no-op. The warehouse pulled hardware for a leaf and the leaf never heard about it.

## The design decision: `replacement_pending_quantity`

Closing the loop means lowering `deficient_quantity` when the replacement arrives. On a leaf still on the bench that is the whole fix — the freed unit reappears as remaining work and completion stays blocked until somebody fits it.

On a leaf that is already **COMPLETED** it is corruption. Completion's invariant is `installed + deficient == quantity`; quietly lowering `deficient_quantity` makes a finished leaf read as un-dispositioned, which every later gate would then treat as a half-built leaf.

**Chosen representation: a third counter on the checklist line, not a new work-item table.** `shop_assembly_opening_items.replacement_pending_quantity`, with the check constraint widened to `installed + deficient + replacement_pending <= quantity`. The three counts partition the line, so:

- The completed case is a *move*, not a decrement: `deficient -> replacement_pending`. The sum stays at `quantity`, so the leaf is still legitimately complete, with a known unit of work outstanding.
- Installing it is another move, `replacement_pending -> installed`. The sum is preserved again, and `OpeningItemHardware` picks up the units.
- **Every invariant stays enforceable by the check constraint**, which is the reason to prefer this over a side table. A separate `replacement_work_items` table would have made "the pending units and the line agree" a rule enforced only in Python — and this whole slice exists because a rule that lived only in code got skipped.
- Derivation stays trivial: "what is this leaf still owed" is `deficient + replacement_pending`, one `SUM` over the line rows.

Naming a specific downside taken deliberately: the pending units are per (leaf, product), not per physical unit, so an assembler cannot install 1 of 3 arrived units. They arrived together on one pull line and the UI installs the whole quantity; a per-unit split would be a distinction nobody at the bench can act on. A future un-install / correction flow reuses the same two moves in reverse, which is what #341 asked the state to leave room for.

## Migration `061_replacement_pending` (revises 060)

Adds the column (`int NOT NULL DEFAULT 0`), swaps the progress check constraint for the three-way one, adds a partial index on `replacement_pending_quantity > 0` (both the work queue and the shipping guard scan for outstanding lines). `audit_action` gains `REPLACEMENT_RECEIVED` / `REPLACEMENT_INSTALL`; `notification_type` gains `REPLACEMENT_AFTER_SHIPMENT`.

**Downgrade** folds pending replacements back into `deficient_quantity` — the sum is unchanged, so the narrower pre-#341 constraint still holds and the pre-#341 reading ("condemned, awaiting a replacement pull") is restored — then discards the new audit rows and notifications and recreates both enums without the new labels. Verified against a live cluster with rows using every new value present, not just an empty schema.

## Backend

**1. Arrival restores the expectation.** `_apply_replacement_arrivals` runs in `complete_pull_request` *before* the source dispatch, because a replacement line is keyed on the checklist line it is owed to, not on the PR's source — which is exactly why the `SHOP_ASSEMBLY` branch alone left it a no-op. Per line the arrived quantity is floored at what is genuinely still outstanding, so an over-delivery (a duplicate line, a hand-edited pull) cannot drive the counter negative or breach the constraint; a replayed completion restores nothing extra.

**2. Install on a completed leaf.** `install_replacement` is the one legitimate write to an assembled leaf's hardware after completion, and it is narrow on purpose: it can only spend units the pull actually delivered. It finds the leaf's `OpeningItemHardware` row by `(product_code, hardware_category)` and increments it — or creates it, because #339 refuses a completion where *nothing at all* was installed, but a line that was entirely deficient while another line was fine contributes no row. Both paths are tested. `require_user`, audited as `REPLACEMENT_INSTALL` against the `OpeningItem`.

Surfaced as `replacementWork(assignedToUserId, projectId)`. The assignee falls out of the existing model — the `ShopAssemblyOpening` keeps the assignment it was completed under — and `assign_openings` now accepts a COMPLETED opening **exactly while it has pending replacements**, so a manager reassigns it through the flow that already exists rather than a second assignment system.

**3. Shipping guard — warn + confirm, never silent, never a hard block.** `get_awaiting_replacement_quantities` sums `deficient + replacement_pending` per assembled leaf in **one grouped scalar aggregate** with a `HAVING > 0`, joined `opening_items -> shop_assembly_openings` on `(opening_id, leaf IS NOT DISTINCT FROM leaf, COMPLETED)` and scoped to the leaf's own project. Never a `len()` over loaded collections — the shipping selection lists every assembled leaf in a project, so a per-leaf lookup here is an N+1 on the heaviest list in the module. Exposed as `OpeningItem.awaitingReplacementQuantity` (populated only by the resolvers that compute it; null elsewhere reads as "not evaluated", never "nothing owed").

`finalize_import_session` refuses a flagged `OPENING_ITEM` line with a typed `ValidationError` **naming every flagged leaf at once** — the user is being asked to make a decision and can only make it once if they can see the whole list — unless `acknowledgeIncompleteLeaves` is set. Deliberate short-shipping stays possible; reallocation exists for it.

**4. Replacement after shipment.** If the leaf is `SHIPPED_OUT` at PR-REPL completion the pending state is still recorded, so the unit stays queryable rather than silently stranded, and a `REPLACEMENT_AFTER_SHIPMENT` notification goes to the SHIPPING role. `install_replacement` refuses it — fitting hardware to something that left the building would make the packing slip a lie. Routing is out of scope; visibility is not.

`find_assembled_leaf` keys the leaf exactly the way `find_already_assembled_openings` does (`project`, `opening_id`, `leaf`, null matching only null), with a live row winning over a shipped one — so the "arrived after shipment" case is detected rather than inferred.

## Frontend

- **Shipping PRs step**: a flagged leaf carries an amber "Incomplete — awaiting replacement" chip and a unit count. Ticking it does not select it — it opens a "Ship an incomplete leaf?" confirm first; "Ship it short" selects it *and* sets the acknowledgment the backend requires. Unticking never asks. The checkbox not flipping on a question is the point: the guard has to be a decision, not a dialog you click through.
- **My Work** gains a **Replacement Installs** section (`ReplacementWorkPanel`), rendered only when there is something in it. Confirm-gated "Mark Installed"; a card whose leaf already shipped shows a warning alert instead of the button. It is deliberately not folded into the My Work grid — those rows are unfinished openings and these are complete ones, so folding them in would mean either reopening a finished work unit or mislabelling it.
- `refetch.ts` gains a disjoint refetch/evict pair for the install (`GetReplacementWork` refetched, `openingItems` evicted — the shipping wizard reads the flag from a module that is never mounted while an assembler is installing).

## Verification

Ran against a throwaway PostgreSQL 16 cluster (EDB portable binaries, `initdb` into a scratch dir, stopped afterwards):

- **301 backend tests pass** (was 282 pre-slice; 19 new in `tests/test_replacement_loop.py`), all DB-backed.
- Full CI migration-integrity cycle on a clean database: `upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean). Downgrade separately re-verified with a completed opening carrying `replacement_pending_quantity = 1` and rows using every new enum value: it folded 1 pending + 1 deficient into `deficient_quantity = 2`, as designed.
- `uvx ruff check .` / `uvx ruff format --check .` clean (poetry is not installed on this box).
- Frontend: `npm run lint` (0 errors, 17 warnings — the pre-existing set, unchanged), `npm run test:run` **186 pass** (11 new: 6 for the shipping confirm flow, 5 for the replacement work item), `npm run build` clean.
- Printed SDL checked for the new fields; `ReplacementWorkItem`, `installReplacement`, `replacementWork`, `awaitingReplacementQuantity`, `acknowledgeIncompleteLeaves` all present and additive.
- SDL reference docs, `docs/HARDWARE_IDENTITY_LIFECYCLE.md` (new §4b plus six rows in the enforcement table) and `testing/CLAUDE.md` updated.

## Deviations from the issue spec

- Added `AuditAction.REPLACEMENT_RECEIVED` alongside the specified install audit. The arrival and the install are different moments with different actors (warehouse vs assembler), and the arrival is the one that can silently do nothing when a leaf has shipped — it needs its own record.
- `install_replacement` takes the whole pending quantity from the UI rather than offering a partial split, for the reason given above. The repository accepts any quantity ≤ pending, so a partial install is available to a non-UI caller and to a future correction flow.
- Reassignment of a completed-with-pending leaf is enabled at the data layer and reachable through the existing `assignOpenings` mutation, but the manager Assignment Board's assignable pool is unchanged — surfacing completed openings there would have muddied a board about unfinished work. The natural assignee (the last assembler) needs no action, so this only affects the rarer hand-off.
