### PR TITLE
feat(inventory): slice 4 inventory reservations at request creation (#342)

### DIFF
--- a/backend/alembic/versions/062_inventory_reservations.py
+++ b/backend/alembic/versions/062_inventory_reservations.py
@@ -1,0 +1,251 @@
+"""Inventory reservations at request creation (#342)
+
+Revision ID: 062
+Revises: 061
+Create Date: 2026-07-26
+
+Creating a shop-assembly or shipping-out request now RESERVES the hardware it needs, so
+
+    available = on-hand - deficient - active reservations
+
+The creator is held to what is genuinely free at creation time (they refine the selection when it
+does not fit); accept becomes a pure human gate with no inventory re-check; and approving the pull
+consumes the claim and deducts FIFO in one transaction. That kills the accept-vs-pull TOCTOU race
+and the "blocked pull waiting on backfill" limbo for normal requests.
+
+`inventory_reservations` is aggregate-level - (project, hardware_category, product_code) - and
+deliberately carries no opening, no leaf, and no `inventory_location_id`. A hinge is a hinge
+(docs/HARDWARE_IDENTITY_LIFECYCLE.md), and pinning a claim to specific rows would fight the FIFO
+deduction, which is unchanged: the reservation governs *how much* is free, never *which* row.
+
+Also here: `integrity_note` on both request tables. One nullable message, two writers, because the
+acceptor's question is the same either way - "can I still trust this request?". A `replace_schedule`
+re-upload landing under an in-flight request writes one; so does this migration's backfill when it
+cannot cover a request.
+
+## Backfill policy
+
+Existing in-flight requests were created before reservations existed, so they hold no claim. Left
+alone, the first request created after this migration would reserve stock the older ones are already
+counting on, and the older pull would come up short at approval - exactly the failure the slice
+removes. So they are backfilled, **oldest first** (the queue everybody already understands):
+
+- A shop-assembly request is in flight when it is PENDING, or APPROVED while the PullRequest it
+  minted (matched on the shared, unique `request_number`) is still PENDING. A shipping-out request,
+  the same, via `pull_request_id`. Once the pull is IN_PROGRESS or COMPLETED the inventory has
+  already moved and there is nothing left to reserve.
+- Shipping-out OPENING_ITEM lines reserve nothing - an assembled leaf left fungible inventory when
+  it was built.
+- Where the remaining stock covers a request, its reservation is written and it behaves from now on
+  exactly like one created after this slice.
+- Where it does not, **nothing partial is written** and the request is flagged via `integrity_note`.
+  A half-reservation would be the worst of both: it reads as covered while the pull is still short.
+  Flagged-and-unreserved is honest - the request keeps the pre-#342 behaviour (its pull can come up
+  short and go to PO backfill) and the acceptor is told so before they act on it.
+
+Downgrade drops the table and both columns. Verified against a live cluster holding reservation rows
+and flagged requests, not just an empty schema - the drop is unconditional, so the claims simply
+cease to exist and availability reverts to on-hand minus deficient, which is what the pre-#342 code
+computes.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "062"
+down_revision = "061"
+branch_labels = None
+depends_on = None
+
+_TABLE = "inventory_reservations"
+
+_BACKFILL_NOTE = (
+    "Created before inventory reservations existed, and stock could not cover it at the time of "
+    "the upgrade, so it holds no reservation. Its pull can still come up short."
+)
+
+
+def upgrade() -> None:
+    reservation_source = postgresql.ENUM(
+        "SHOP_ASSEMBLY_REQUEST",
+        "SHIPPING_OUT_REQUEST",
+        name="reservation_source",
+        create_type=False,
+    )
+    reservation_source.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("hardware_category", sa.String(), nullable=False),
+        sa.Column("product_code", sa.String(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("source", reservation_source, nullable=False),
+        sa.Column("shop_assembly_request_id", sa.Uuid(), nullable=True),
+        sa.Column("shipping_out_request_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"]),
+        sa.ForeignKeyConstraint(["shop_assembly_request_id"], ["shop_assembly_requests.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["shipping_out_request_id"], ["shipping_out_requests.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("quantity >= 1", name="ck_inventory_reservations_quantity_positive"),
+        sa.CheckConstraint(
+            "(source = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
+            "AND shipping_out_request_id IS NULL) "
+            "OR (source = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
+            "AND shop_assembly_request_id IS NULL)",
+            name="ck_inventory_reservations_source_matches_request",
+        ),
+    )
+    op.create_index(
+        "ix_inventory_reservations_project_combo",
+        _TABLE,
+        ["project_id", "hardware_category", "product_code"],
+    )
+    op.create_index("ix_inventory_reservations_shop_assembly_request", _TABLE, ["shop_assembly_request_id"])
+    op.create_index("ix_inventory_reservations_shipping_out_request", _TABLE, ["shipping_out_request_id"])
+
+    op.add_column("shop_assembly_requests", sa.Column("integrity_note", sa.String(length=500), nullable=True))
+    op.add_column("shipping_out_requests", sa.Column("integrity_note", sa.String(length=500), nullable=True))
+
+    _backfill_reservations()
+
+
+def _backfill_reservations() -> None:
+    """Reserve for existing in-flight requests where stock allows; flag them where it does not."""
+    conn = op.get_bind()
+
+    # (created_at, kind, request_id, project_id) for every in-flight request, oldest first. Ordering
+    # is what makes the outcome deterministic and defensible: the queue the warehouse already works.
+    in_flight = conn.execute(
+        sa.text(
+            """
+            SELECT sar.created_at AS created_at,
+                   'SHOP_ASSEMBLY_REQUEST' AS kind,
+                   sar.id AS request_id,
+                   sar.project_id AS project_id
+              FROM shop_assembly_requests sar
+              LEFT JOIN pull_requests pr ON pr.request_number = sar.request_number
+             WHERE sar.status = 'PENDING'
+                OR (sar.status = 'APPROVED' AND (pr.id IS NULL OR pr.status = 'PENDING'))
+            UNION ALL
+            SELECT sor.created_at, 'SHIPPING_OUT_REQUEST', sor.id, sor.project_id
+              FROM shipping_out_requests sor
+              LEFT JOIN pull_requests pr ON pr.id = sor.pull_request_id
+             WHERE sor.status = 'PENDING'
+                OR (sor.status = 'APPROVED' AND (pr.id IS NULL OR pr.status = 'PENDING'))
+             ORDER BY created_at, request_id
+            """
+        )
+    ).fetchall()
+    if not in_flight:
+        return
+
+    sa_demand = sa.text(
+        """
+        SELECT saoi.hardware_category AS hardware_category,
+               saoi.product_code AS product_code,
+               SUM(saoi.quantity) AS quantity
+          FROM shop_assembly_opening_items saoi
+          JOIN shop_assembly_openings sao ON sao.id = saoi.shop_assembly_opening_id
+         WHERE sao.shop_assembly_request_id = :request_id
+         GROUP BY saoi.hardware_category, saoi.product_code
+        """
+    )
+    # OPENING_ITEM lines are excluded: the assembled leaf ships as itself and claims no loose stock.
+    so_demand = sa.text(
+        """
+        SELECT hardware_category, product_code, SUM(requested_quantity) AS quantity
+          FROM shipping_out_request_items
+         WHERE shipping_out_request_id = :request_id
+           AND item_type = 'LOOSE'
+           AND hardware_category IS NOT NULL
+           AND product_code IS NOT NULL
+         GROUP BY hardware_category, product_code
+        """
+    )
+    available_sql = sa.text(
+        """
+        SELECT COALESCE(SUM(quantity - deficient_quantity), 0)
+          FROM inventory_locations
+         WHERE project_id = :project_id
+           AND hardware_category = :hardware_category
+           AND product_code = :product_code
+        """
+    )
+    reserved_sql = sa.text(
+        """
+        SELECT COALESCE(SUM(quantity), 0)
+          FROM inventory_reservations
+         WHERE project_id = :project_id
+           AND hardware_category = :hardware_category
+           AND product_code = :product_code
+        """
+    )
+    insert_sql = sa.text(
+        """
+        INSERT INTO inventory_reservations
+            (id, project_id, hardware_category, product_code, quantity, source,
+             shop_assembly_request_id, shipping_out_request_id, created_at)
+        VALUES (gen_random_uuid(), :project_id, :hardware_category, :product_code, :quantity, :source,
+                :sa_request_id, :so_request_id, NOW())
+        """
+    )
+
+    for row in in_flight:
+        kind = row.kind
+        demand = conn.execute(
+            sa_demand if kind == "SHOP_ASSEMBLY_REQUEST" else so_demand,
+            {"request_id": row.request_id},
+        ).fetchall()
+        if not demand:
+            continue
+
+        covered = True
+        for line in demand:
+            params = {
+                "project_id": row.project_id,
+                "hardware_category": line.hardware_category,
+                "product_code": line.product_code,
+            }
+            on_hand = conn.execute(available_sql, params).scalar() or 0
+            reserved = conn.execute(reserved_sql, params).scalar() or 0
+            if on_hand - reserved < line.quantity:
+                covered = False
+                break
+
+        if not covered:
+            table = "shop_assembly_requests" if kind == "SHOP_ASSEMBLY_REQUEST" else "shipping_out_requests"
+            conn.execute(
+                sa.text(f"UPDATE {table} SET integrity_note = :note WHERE id = :id"),
+                {"note": _BACKFILL_NOTE, "id": row.request_id},
+            )
+            continue
+
+        for line in demand:
+            conn.execute(
+                insert_sql,
+                {
+                    "project_id": row.project_id,
+                    "hardware_category": line.hardware_category,
+                    "product_code": line.product_code,
+                    "quantity": int(line.quantity),
+                    "source": kind,
+                    "sa_request_id": row.request_id if kind == "SHOP_ASSEMBLY_REQUEST" else None,
+                    "so_request_id": row.request_id if kind == "SHIPPING_OUT_REQUEST" else None,
+                },
+            )
+
+
+def downgrade() -> None:
+    op.drop_column("shipping_out_requests", "integrity_note")
+    op.drop_column("shop_assembly_requests", "integrity_note")
+
+    op.drop_index("ix_inventory_reservations_shipping_out_request", table_name=_TABLE)
+    op.drop_index("ix_inventory_reservations_shop_assembly_request", table_name=_TABLE)
+    op.drop_index("ix_inventory_reservations_project_combo", table_name=_TABLE)
+    op.drop_table(_TABLE)
+    op.execute("DROP TYPE IF EXISTS reservation_source")

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -36,6 +36,8 @@ type ShippingOutRequest {
   createdAt: DateTime!
   approvedAt: DateTime
   rejectedAt: DateTime
+  # See ShopAssemblyRequest.integrity_note (#342).
+  integrityNote: String
   pullRequestId: ID
   items: [ShippingOutRequestItem!]!
 }

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -13,6 +13,9 @@ type ShopAssemblyRequest {
   created_at: DateTime!
   approved_at: DateTime
   rejected_at: DateTime
+  # Something happened to this request after it was created that the acceptor must know about
+  # (#342): a schedule re-upload landed under it, or the reservations backfill could not cover it.
+  integrity_note: String
   openings: [ShopAssemblyOpening!]!
 }
 

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -141,8 +141,23 @@ type InventoryShortfall {
   hardware_category: String!
   product_code: String!
   requested: Int!
+  # available = on-hand - deficient - OTHER requests' reservations (#342), so a zero here can mean
+  # "the stock is present but claimed". `reserved` is that number, separately.
   available: Int!
   short: Int!
+  reserved: Int!
+}
+
+# What one product in a project can still be CLAIMED for (#342): available = on_hand - deficient -
+# reserved. Distinct from InventoryHierarchyNode's availability (on-hand minus deficient), which
+# answers "what is physically unspoken-for in the building".
+type InventoryAvailability {
+  hardware_category: String!
+  product_code: String!
+  on_hand_quantity: Int!
+  deficient_quantity: Int!
+  reserved_quantity: Int!
+  available_quantity: Int!
 }
 
 type ShipReadyItems {
@@ -302,6 +317,7 @@ type ProjectProgressByProduct {
 type Query {
   openPOs(projectId: ID): [PurchaseOrder!]!
   poReceivingDetails(poId: ID!): PurchaseOrder!
+  projectInventoryAvailability(projectId: ID!): [InventoryAvailability!]!
   inventoryHierarchy(projectId: ID!): [InventoryHierarchyNode!]!
   inventoryItems(projectId: ID!, category: String!, productCode: String!): [InventoryItemDetail!]!
   unlocatedInventory(projectId: ID): [InventoryItemDetail!]!

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from .deficiency_review import DeficiencyReview  # noqa: E402, F401
 from .gp_write import GpWriteIdempotency  # noqa: E402, F401
 from .hardware import HardwareItem  # noqa: E402, F401
 from .inventory import InventoryLocation  # noqa: E402, F401
+from .inventory_reservation import InventoryReservation  # noqa: E402, F401
 from .manufacturer_vendor_map import ManufacturerVendorMap  # noqa: E402, F401
 from .notification import Notification  # noqa: E402, F401
 from .opening_item import OpeningItem, OpeningItemHardware  # noqa: E402, F401

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -57,6 +57,15 @@ class ShippingOutRequestStatus(str, enum.Enum):
     REJECTED = "REJECTED"
 
 
+class ReservationSource(str, enum.Enum):
+    """Which kind of request an InventoryReservation is held for (#342). The discriminator is
+    explicit rather than inferred from whichever FK is populated, so a query can filter on it
+    without an OR over nullable columns."""
+
+    SHOP_ASSEMBLY_REQUEST = "SHOP_ASSEMBLY_REQUEST"
+    SHIPPING_OUT_REQUEST = "SHIPPING_OUT_REQUEST"
+
+
 class PullStatus(str, enum.Enum):
     NOT_PULLED = "NOT_PULLED"
     PARTIAL = "PARTIAL"

--- a/backend/app/models/inventory_reservation.py
+++ b/backend/app/models/inventory_reservation.py
@@ -1,0 +1,75 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+from .enums import ReservationSource
+
+
+class InventoryReservation(Base):
+    """A request's claim on a quantity of one product in one project, held from the moment the
+    request is created until the pull that spends it is approved (#342).
+
+    Creating a shop-assembly or shipping-out request reserves the hardware it needs, so
+    **available = on-hand - deficient - active reservations**. That is what makes the creator abide
+    by what is really free at creation time (they refine the selection when it does not fit) instead
+    of discovering a shortfall at accept, and it is what removed the accept-vs-pull TOCTOU race: by
+    the time the warehouse approves the pull, the units it is about to deduct were already spoken
+    for by this very request.
+
+    Note what is NOT here, deliberately:
+
+    - **No opening, no door leaf.** Same rule as `InventoryLocation` - a hinge is a hinge
+      (docs/HARDWARE_IDENTITY_LIFECYCLE.md). A reservation is a claim on fungible stock, and the
+      identity is re-attached later by the pull line that tags the units onto a leaf.
+    - **No `inventory_location_id`.** Reservations are aggregate-level, per
+      (project, hardware_category, product_code). Pinning a claim to specific rows would fight FIFO
+      deduction, which stays exactly as it was: at approval the pull walks the project's rows
+      oldest-first, and the reservation only ever governed *how much* was free, never *which* row.
+
+    Exactly one of `shop_assembly_request_id` / `shipping_out_request_id` is set, matching `source`.
+    """
+
+    __tablename__ = "inventory_reservations"
+    __table_args__ = (
+        # The availability sum is per project + combo, and it runs on every request creation and
+        # every pull approval.
+        Index(
+            "ix_inventory_reservations_project_combo",
+            "project_id",
+            "hardware_category",
+            "product_code",
+        ),
+        # Release and consumption are both "every reservation of this request".
+        Index("ix_inventory_reservations_shop_assembly_request", "shop_assembly_request_id"),
+        Index("ix_inventory_reservations_shipping_out_request", "shipping_out_request_id"),
+        CheckConstraint("quantity >= 1", name="ck_inventory_reservations_quantity_positive"),
+        # The discriminator and the FKs cannot disagree, and a reservation can never be orphaned
+        # from its request (which is what would strand a claim nothing can ever release).
+        CheckConstraint(
+            "(source = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
+            "AND shipping_out_request_id IS NULL) "
+            "OR (source = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
+            "AND shop_assembly_request_id IS NULL)",
+            name="ck_inventory_reservations_source_matches_request",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), nullable=False)
+    hardware_category: Mapped[str] = mapped_column(String, nullable=False)
+    product_code: Mapped[str] = mapped_column(String, nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    source: Mapped[ReservationSource] = mapped_column(
+        Enum(ReservationSource, name="reservation_source", create_constraint=True),
+        nullable=False,
+    )
+    shop_assembly_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("shop_assembly_requests.id", ondelete="CASCADE"), nullable=True
+    )
+    shipping_out_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("shipping_out_requests.id", ondelete="CASCADE"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)

--- a/backend/app/models/shipping_out_request.py
+++ b/backend/app/models/shipping_out_request.py
@@ -32,6 +32,9 @@ class ShippingOutRequest(Base):
     approved_by: Mapped[str | None] = mapped_column(String, nullable=True)
     rejected_by: Mapped[str | None] = mapped_column(String, nullable=True)
     rejection_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # See ShopAssemblyRequest.integrity_note (#342): a schedule re-upload landed under this request,
+    # or the reservations backfill could not cover it. Null = nothing has happened to it.
+    integrity_note: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
     approved_at: Mapped[datetime | None] = mapped_column(nullable=True)
     rejected_at: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -27,6 +27,15 @@ class ShopAssemblyRequest(Base):
     approved_by: Mapped[str | None] = mapped_column(String, nullable=True)
     rejected_by: Mapped[str | None] = mapped_column(String, nullable=True)
     rejection_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Something happened to this request after it was created that the acceptor has to know about
+    # before they act on it (#342). Two writers, one field, because the acceptor's question is the
+    # same either way - "can I still trust this request?":
+    #   - a `replace_schedule=True` re-upload landed while the request was in flight, so its bill of
+    #     hardware may no longer match the schedule (and any openings that vanished were dropped);
+    #   - the reservations backfill could not cover it, so it holds no claim on inventory and the
+    #     pull can still come up short.
+    # Null means nothing has happened to it. Surfaced as `integrityNote` on the accept UI.
+    integrity_note: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
     approved_at: Mapped[datetime | None] = mapped_column(nullable=True)
     rejected_at: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -2,13 +2,14 @@
 
 import uuid
 from collections import defaultdict
+from datetime import datetime
 from decimal import Decimal
 from math import floor
 
-from sqlalchemy import delete, func, select, tuple_
+from sqlalchemy import and_, delete, func, or_, select, tuple_
 from sqlalchemy.orm import Session, selectinload
 
-from app.errors import ConflictError, NotFoundError, ValidationError
+from app.errors import ConflictError, InventoryShortfallError, NotFoundError, ValidationError
 from app.models.enums import (
     AssemblyStatus,
     Classification,
@@ -19,6 +20,7 @@ from app.models.enums import (
     PullRequestSource,
     PullRequestStatus,
     PullStatus,
+    ReservationSource,
     ShippingOutRequestStatus,
     ShopAssemblyRequestStatus,
 )
@@ -314,6 +316,217 @@ def _leaf_label(oi: OpeningItemModel) -> str:
     return f"Opening {oi.opening_number} Leaf {oi.leaf}" if oi.leaf is not None else f"Opening {oi.opening_number}"
 
 
+def _opening_leaf_label(opening_number: str, leaf: int | None) -> str:
+    """Same label, built from the raw pair rather than from a materialized OpeningItem."""
+    return f"Opening {opening_number} Leaf {leaf}" if leaf is not None else f"Opening {opening_number}"
+
+
+# The note stamped on a live in-flight request when a full-schedule re-upload lands underneath it.
+SCHEDULE_CHANGED_NOTE = (
+    "The hardware schedule was re-uploaded after this request was created, so its bill of hardware "
+    "may no longer match the schedule. Review it before accepting."
+)
+SCHEDULE_CHANGED_DROPPED_NOTE = (
+    "The hardware schedule was re-uploaded after this request was created and some of its openings "
+    "no longer exist; those were dropped and their inventory reservations released. Review what is "
+    "left before accepting."
+)
+
+
+def _gate_on_available_inventory(
+    session: Session,
+    project_id: uuid.UUID,
+    needs: list[tuple[str, str, int]],
+    *,
+    label: str,
+    request_number: str | None,
+) -> None:
+    """The creation-time inventory gate (#342). Refuses the whole finalize with a typed
+    `InventoryShortfallError` naming every short combo if the selection does not fit inside
+
+        available = on-hand - deficient - active reservations
+
+    Whole-request, never partial: the creator is being asked to make one decision about one
+    selection, so they get the entire list of what does not fit and refine the selection once. This
+    replaces the shortfall that used to surface at accept, where nobody could do anything about it.
+
+    The inventory rows are locked (`lock=True`) for the rest of the finalize transaction, so two
+    creators racing for the last hinge serialise: the second one sees the first one's reservation
+    rather than both passing on the same stock.
+    """
+    from app.repositories import warehouse as warehouse_repository
+    from app.services import notification_service
+
+    result = warehouse_repository.check_inventory_sufficiency(
+        session, project_id, needs, lock=True, reservation_aware=True
+    )
+    if not result.sufficient:
+        raise InventoryShortfallError(
+            f"Cannot create this {label} - the hardware it needs is not available. "
+            + notification_service.format_shortfall_lines(result.shortfalls)
+            + ". Reduce the selection, or wait for stock to be received or another request to be released.",
+            shortfalls=result.shortfalls,
+            project_id=project_id,
+            request_number=request_number,
+        )
+
+
+def _live_shop_assembly_requests(session: Session, project_id: uuid.UUID) -> list[SARModel]:
+    """Shop-assembly requests in a project that are still in flight: PENDING, or APPROVED while the
+    pull they minted has not been worked (PENDING). Once the warehouse approves the pull, inventory
+    has moved and the request is no longer something a re-upload may quietly rewrite."""
+    return list(
+        session.scalars(
+            select(SARModel)
+            .options(selectinload(SARModel.openings).selectinload(SAOModel.items))
+            .outerjoin(PullRequestModel, SARModel.request_number == PullRequestModel.request_number)
+            .where(
+                SARModel.project_id == project_id,
+                or_(
+                    SARModel.status == ShopAssemblyRequestStatus.PENDING,
+                    and_(
+                        SARModel.status == ShopAssemblyRequestStatus.APPROVED,
+                        or_(
+                            PullRequestModel.id.is_(None),
+                            PullRequestModel.status == PullRequestStatus.PENDING,
+                        ),
+                    ),
+                ),
+            )
+        )
+        .unique()
+        .all()
+    )
+
+
+def _live_shipping_out_requests(session: Session, project_id: uuid.UUID) -> list[ShippingOutRequestModel]:
+    """Shipping-out requests still in flight, on the same definition as their shop-assembly twin."""
+    return list(
+        session.scalars(
+            select(ShippingOutRequestModel)
+            .options(selectinload(ShippingOutRequestModel.items))
+            .outerjoin(PullRequestModel, ShippingOutRequestModel.pull_request_id == PullRequestModel.id)
+            .where(
+                ShippingOutRequestModel.project_id == project_id,
+                or_(
+                    ShippingOutRequestModel.status == ShippingOutRequestStatus.PENDING,
+                    and_(
+                        ShippingOutRequestModel.status == ShippingOutRequestStatus.APPROVED,
+                        or_(
+                            PullRequestModel.id.is_(None),
+                            PullRequestModel.status == PullRequestStatus.PENDING,
+                        ),
+                    ),
+                ),
+            )
+        )
+        .unique()
+        .all()
+    )
+
+
+def _handle_schedule_replacement(
+    session: Session,
+    project: ProjectModel,
+    new_opening_numbers: set[str],
+) -> None:
+    """Re-upload policy for in-flight requests (#342), run just before a `replace_schedule=True`
+    finalize deletes the openings that are gone from the new schedule.
+
+    **The re-upload is not blocked.** Replacing the schedule is how a real revision reaches the
+    system, and refusing it whenever any request is open would mean the revision waits on the
+    warehouse - the wrong way round. Instead the requests are made to tell the truth about
+    themselves:
+
+    - **PENDING requests are rewritten to what survived.** Work units and lines whose opening is
+      gone are deleted, and the request's reservations are rebuilt from what is left - which
+      releases exactly the claim the vanished openings were holding, no more. A request left with
+      nothing at all is auto-REJECTED (which releases the rest by the ordinary reject path), because
+      an empty request is not something anybody can accept.
+    - **APPROVED requests are left alone.** Their pull already exists and is the authority on what
+      the warehouse will hand over; silently shrinking it underneath the puller would be worse than
+      a stale bill of hardware.
+    - **Every live request is flagged** with `integrity_note`, not just the ones that lost openings,
+      because a full-schedule replacement can change the hardware on an opening it kept. The
+      acceptor sees the flag and can reject-and-recreate.
+
+    Deliberately *not* done: re-deriving a surviving request's items from the new schedule. The
+    request is a snapshot somebody made a decision about; rewriting its contents under them would
+    make the flag a lie.
+    """
+    from app.repositories import warehouse as warehouse_repository
+
+    vanished_ids = {o.id for o in project.openings if o.opening_number not in new_opening_numbers}
+    vanished_numbers = {o.opening_number for o in project.openings if o.opening_number not in new_opening_numbers}
+
+    for sar in _live_shop_assembly_requests(session, project.id):
+        pending = sar.status == ShopAssemblyRequestStatus.PENDING
+        lost = [o for o in sar.openings if o.opening_id in vanished_ids] if pending else []
+        if lost:
+            lost_ids = [o.id for o in lost]
+            session.execute(delete(SAOItemModel).where(SAOItemModel.shop_assembly_opening_id.in_(lost_ids)))
+            session.execute(delete(SAOModel).where(SAOModel.id.in_(lost_ids)))
+            session.flush()
+            session.refresh(sar, attribute_names=["openings"])
+
+        if pending and not sar.openings:
+            # Nothing left to assemble: reject it (which releases every remaining reservation) rather
+            # than leave an empty request on the accept board.
+            sar.status = ShopAssemblyRequestStatus.REJECTED
+            sar.rejected_by = "Hardware Schedule Import"
+            sar.rejection_reason = "All of this request's openings were removed by a hardware schedule re-upload."
+            sar.rejected_at = datetime.utcnow()
+            warehouse_repository.release_reservations(session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id)
+            continue
+
+        if lost:
+            # Rebuild from what survived. Replace-in-place rather than a per-opening decrement: the
+            # reservation rows are aggregates over the whole request, so "what it should hold now" is
+            # the only number that is unambiguous.
+            warehouse_repository.release_reservations(session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id)
+            warehouse_repository.create_reservations(
+                session,
+                sar.project_id,
+                ReservationSource.SHOP_ASSEMBLY_REQUEST,
+                sar.id,
+                [(item.hardware_category, item.product_code, item.quantity) for o in sar.openings for item in o.items],
+            )
+        sar.integrity_note = SCHEDULE_CHANGED_DROPPED_NOTE if lost else SCHEDULE_CHANGED_NOTE
+
+    for req in _live_shipping_out_requests(session, project.id):
+        pending = req.status == ShippingOutRequestStatus.PENDING
+        lost = [i for i in req.items if i.opening_number in vanished_numbers] if pending else []
+        if lost:
+            session.execute(
+                delete(ShippingOutRequestItemModel).where(ShippingOutRequestItemModel.id.in_([i.id for i in lost]))
+            )
+            session.flush()
+            session.refresh(req, attribute_names=["items"])
+
+        if pending and not req.items:
+            req.status = ShippingOutRequestStatus.REJECTED
+            req.rejected_by = "Hardware Schedule Import"
+            req.rejection_reason = "All of this request's lines were removed by a hardware schedule re-upload."
+            req.rejected_at = datetime.utcnow()
+            warehouse_repository.release_reservations(session, ReservationSource.SHIPPING_OUT_REQUEST, req.id)
+            continue
+
+        if lost:
+            warehouse_repository.release_reservations(session, ReservationSource.SHIPPING_OUT_REQUEST, req.id)
+            warehouse_repository.create_reservations(
+                session,
+                req.project_id,
+                ReservationSource.SHIPPING_OUT_REQUEST,
+                req.id,
+                [
+                    (i.hardware_category, i.product_code, i.requested_quantity)
+                    for i in req.items
+                    if i.item_type == PullRequestItemType.LOOSE and i.hardware_category and i.product_code
+                ],
+            )
+        req.integrity_note = SCHEDULE_CHANGED_DROPPED_NOTE if lost else SCHEDULE_CHANGED_NOTE
+
+
 def _apply_opening_fields(opening: OpeningModel, opening_input: dict) -> None:
     """Copy mutable fields from input dict onto an Opening model."""
     opening.building = opening_input.get("building")
@@ -341,7 +554,18 @@ def finalize_import_session(
     session: Session,
     input_data: dict,
 ) -> dict:
-    """Finalize an import session: attach openings/POs/PRs/SAR to an existing project atomically."""
+    """Finalize an import session: attach openings/POs/PRs/SAR to an existing project atomically.
+
+    Since #342 this is also where inventory is **reserved**: creating a shop-assembly or
+    shipping-out request gates on `available = on-hand - deficient - active reservations` and, if it
+    fits, writes the request's claim in the same transaction. A short selection raises
+    `InventoryShortfallError` and nothing at all is created - the creator refines the selection,
+    which is the only place in the flow where that is still a cheap thing to do.
+    """
+    # Local import: warehouse re-exports the reservation helpers, and importing it at module level
+    # would close a cycle (warehouse -> shop_assembly_repository -> ... -> import_repository).
+    from app.repositories import warehouse as warehouse_repository
+
     project_id = uuid.UUID(input_data["project_id"])
     openings_input = input_data.get("openings", [])
     hardware_items_input = input_data.get("hardware_items") or []
@@ -383,6 +607,9 @@ def finalize_import_session(
         session.flush()
 
         new_opening_numbers = {o["opening_number"] for o in openings_input}
+        # #342: reconcile in-flight requests with the new schedule BEFORE the openings they point at
+        # are deleted - drop what vanished, release the reservations it was holding, flag the rest.
+        _handle_schedule_replacement(session, project, new_opening_numbers)
         # ORM-aware delete so identity map / project.openings stay consistent.
         for opening in list(project.openings):
             if opening.opening_number not in new_opening_numbers:
@@ -715,7 +942,92 @@ def finalize_import_session(
                     field="opening_item_id",
                 )
 
+        # --- request-integrity guards (#342) ---------------------------------------------------
+        # Degenerate request: a request with no lines has nothing to accept, nothing to pull, and
+        # nothing to reserve. It is refused at creation rather than left on the accept board.
         for pr_draft in shipping_pr_drafts:
+            if not pr_draft.get("items"):
+                raise ValidationError(
+                    f"Shipping-out request {pr_draft['request_number']} has no items - "
+                    "select at least one assembled leaf or loose line.",
+                    field="items",
+                )
+
+        # Duplicate in-flight guard: one physical leaf can sit on exactly one live request. The
+        # wizard already hides claimed leaves, but a stale tab or a non-UI caller must not be able to
+        # send the same leaf out twice.
+        from app.repositories import shipping_repository as _shipping_repository
+        from app.repositories import shop_assembly_repository as _sa_repository
+
+        if referenced_oi_ids:
+            claims = _shipping_repository.find_live_shipping_claims(
+                session, project.id, opening_item_ids=list(referenced_oi_ids)
+            )["by_opening_item"]
+            if claims:
+                detail = ", ".join(
+                    sorted(
+                        f"{_leaf_label(opening_items_by_id[oi_id])} (on {request_number})"
+                        for oi_id, request_number in claims.items()
+                        if oi_id in opening_items_by_id
+                    )
+                )
+                raise ValidationError(
+                    f"These assembled leaves are already on a live shipping-out request: {detail}. "
+                    "Reject or complete that request first.",
+                    field="opening_item_id",
+                )
+
+            # Cross-request-type conflict: the same leaf cannot be on its way out the door and still
+            # inside a live shop-assembly work unit.
+            leaf_specs = [
+                (oi.opening_number, oi.opening_id, oi.leaf)
+                for oi in opening_items_by_id.values()
+                if oi.project_id == project.id
+            ]
+            in_assembly = _sa_repository.find_in_flight_assembly_leaves(session, leaf_specs)
+            if in_assembly:
+                detail = ", ".join(
+                    sorted(
+                        f"{_opening_leaf_label(num, leaf)}"
+                        + (f" (on shop-assembly request {request_number})" if request_number else "")
+                        for num, leaf, request_number in in_assembly
+                    )
+                )
+                raise ValidationError(
+                    f"These leaves are still in shop assembly: {detail}. They cannot be shipped "
+                    "until that work unit is finished or its request is rejected.",
+                    field="opening_item_id",
+                )
+
+        # Reservation gate: LOOSE lines claim fungible stock, so they must fit inside what is
+        # actually free right now (on-hand - deficient - other requests' reservations). OPENING_ITEM
+        # lines claim nothing - an assembled leaf left fungible inventory when it was built, and it
+        # ships as itself (docs/HARDWARE_IDENTITY_LIFECYCLE.md). Checked across every draft in this
+        # finalize at once, because they are all created in one transaction and therefore compete.
+        loose_needs_by_draft: dict[int, list[tuple[str, str, int]]] = {}
+        for idx, pr_draft in enumerate(shipping_pr_drafts):
+            loose_needs_by_draft[idx] = [
+                (
+                    item["hardware_category"],
+                    item["product_code"],
+                    item.get("requested_quantity", 1),
+                )
+                for item in pr_draft.get("items", [])
+                if PullRequestItemType(item["item_type"]) == PullRequestItemType.LOOSE
+                and item.get("hardware_category")
+                and item.get("product_code")
+            ]
+        all_loose_needs = [need for needs in loose_needs_by_draft.values() for need in needs]
+        if all_loose_needs:
+            _gate_on_available_inventory(
+                session,
+                project.id,
+                all_loose_needs,
+                label="shipping-out request",
+                request_number=shipping_pr_drafts[0]["request_number"],
+            )
+
+        for draft_index, pr_draft in enumerate(shipping_pr_drafts):
             # Validate uniqueness against the request entity's own number space.
             existing_req = session.scalars(
                 select(ShippingOutRequestModel).where(
@@ -777,13 +1089,24 @@ def finalize_import_session(
                 )
                 session.add(req_item)
 
+            # The request now holds its claim on loose stock until the pull that spends it is
+            # approved (#342). Nothing for the OPENING_ITEM lines - see the gate above.
+            warehouse_repository.create_reservations(
+                session,
+                project.id,
+                ReservationSource.SHIPPING_OUT_REQUEST,
+                req.id,
+                loose_needs_by_draft[draft_index],
+            )
+
             created_shipping_requests.append(req)
 
     # 7. Shop-assembly request + openings (#293)
-    # Start a Task mints a PENDING ShopAssemblyRequest (NO PullRequest, NO approval-time sufficiency
-    # gate). The ShopAssemblyOpening/Item rows hang off the SAR via shop_assembly_request_id; their
-    # pull_request_id stays NULL until a signed-in user accepts the request (accept mints the PR and
-    # backfills pull_request_id). Sufficiency is enforced at accept, not here.
+    # Start a Task mints a PENDING ShopAssemblyRequest (NO PullRequest). The ShopAssemblyOpening/Item
+    # rows hang off the SAR via shop_assembly_request_id; their pull_request_id stays NULL until a
+    # signed-in user accepts the request (accept mints the PR and backfills pull_request_id).
+    # Since #342 the inventory gate lives HERE, at creation, and creating the request reserves the
+    # hardware. Accept is a pure human gate and re-checks nothing.
     sar = None
     if include_sar and sar_request_number:
         # Validate uniqueness against the SAR number space.
@@ -794,9 +1117,17 @@ def finalize_import_session(
                 field="shop_assembly_request_number",
             )
 
-        # REQ-5 guard (#293): an opening that already has an assembled OpeningItem for this project
-        # (any state except SHIPPED_OUT) can't be sent to shop assembly again.
+        from app.repositories import shipping_repository as _shipping_repository
         from app.repositories import shop_assembly_repository
+
+        # Degenerate request validation (#342). A request with no work units, or a work unit with no
+        # hardware on it, is unacceptable and unpullable - and a zero-item opening would reach shop
+        # assembly as a leaf with an empty checklist, which #339 already refuses to complete.
+        if not sar_openings_input:
+            raise ValidationError(
+                "A shop-assembly request must include at least one opening.",
+                field="shop_assembly_openings",
+            )
 
         opening_id_by_number: dict[str, uuid.UUID] = {}
         # Guard per (opening, leaf) (#311): assembling Leaf 1 must not block sending Leaf 2.
@@ -806,6 +1137,12 @@ def finalize_import_session(
             opening_id = opening_map.get(opening_number)
             if opening_id is None:
                 raise NotFoundError(f"Opening {opening_number} not found in project")
+            if not sa_opening_input.get("items"):
+                raise ValidationError(
+                    f"{_opening_leaf_label(opening_number, sa_opening_input.get('leaf'))} has no hardware on it, "
+                    "so it cannot be sent to shop assembly.",
+                    field="shop_assembly_openings",
+                )
             opening_id_by_number[opening_number] = opening_id
             opening_leaf_specs.append((opening_number, opening_id, sa_opening_input.get("leaf")))
 
@@ -818,6 +1155,59 @@ def finalize_import_session(
                 f"Opening {labels} is already assembled and cannot be sent to shop assembly.",
                 field="shop_assembly_openings",
             )
+
+        # Duplicate in-flight guard (#342): the already-assembled guard above catches a leaf that has
+        # been *built*; this catches one that is still on its way - requested, pulled, or half-built.
+        # Two live requests for one leaf both reserve and both pull, and the second lot of hardware
+        # has nowhere to go.
+        in_flight = shop_assembly_repository.find_in_flight_assembly_leaves(session, opening_leaf_specs)
+        if in_flight:
+            labels = ", ".join(
+                sorted(
+                    _opening_leaf_label(num, leaf) + (f" (on {request_number})" if request_number else "")
+                    for num, leaf, request_number in in_flight
+                )
+            )
+            raise ValidationError(
+                f"These leaves are already in a live shop-assembly request: {labels}. "
+                "Reject that request first, or pick different openings.",
+                field="shop_assembly_openings",
+            )
+
+        # Cross-request-type conflict: a leaf a live shipping-out request has claimed is on its way
+        # out of the building and cannot also be sent back to the bench.
+        shipping_claims = _shipping_repository.find_live_shipping_claims(
+            session,
+            project.id,
+            opening_leaf_specs=[(num, leaf) for num, _, leaf in opening_leaf_specs],
+        )["by_opening_leaf"]
+        if shipping_claims:
+            labels = ", ".join(
+                sorted(
+                    f"{_opening_leaf_label(num, leaf)} (on shipping-out request {request_number})"
+                    for (num, leaf), request_number in shipping_claims.items()
+                )
+            )
+            raise ValidationError(
+                f"These leaves are claimed by a live shipping-out request: {labels}. "
+                "Resolve that request before sending them to shop assembly.",
+                field="shop_assembly_openings",
+            )
+
+        # Reservation gate: every checklist line claims fungible stock, so the whole request must fit
+        # inside what is available right now.
+        sar_needs = [
+            (item["hardware_category"], item["product_code"], item["quantity"])
+            for sa_opening_input in sar_openings_input
+            for item in sa_opening_input.get("items", [])
+        ]
+        _gate_on_available_inventory(
+            session,
+            project.id,
+            sar_needs,
+            label="shop-assembly request",
+            request_number=sar_request_number,
+        )
 
         sar = SARModel(
             id=uuid.uuid4(),
@@ -860,6 +1250,16 @@ def finalize_import_session(
                         quantity=item_input["quantity"],
                     )
                 )
+
+        # The request holds its claim from here until the warehouse approves the pull that spends it
+        # (#342). One row per combo across the whole request, not per opening.
+        warehouse_repository.create_reservations(
+            session,
+            project.id,
+            ReservationSource.SHOP_ASSEMBLY_REQUEST,
+            sar.id,
+            sar_needs,
+        )
 
     session.flush()
 

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -4,7 +4,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
@@ -16,6 +16,7 @@ from app.models.enums import (
     PullRequestItemType,
     PullRequestSource,
     PullRequestStatus,
+    ReservationSource,
     ReturnDisposition,
     ShippingOutRequestStatus,
 )
@@ -35,6 +36,7 @@ from app.models.shipping import (
 )
 from app.models.shipping_out_request import (
     ShippingOutRequest,
+    ShippingOutRequestItem,
 )
 from app.models.warehouse import Warehouse
 from app.repositories.stock import _find_or_create_stock_row, _log_audit_event
@@ -572,6 +574,67 @@ def get_shipping_out_requests(
     return list(session.scalars(stmt).unique().all())
 
 
+def find_live_shipping_claims(
+    session: Session,
+    project_id: uuid.UUID,
+    *,
+    opening_item_ids: list[uuid.UUID] | None = None,
+    opening_leaf_specs: list[tuple[str, int | None]] | None = None,
+) -> dict:
+    """Assembled leaves a still-live shipping-out request has already claimed (#342).
+
+    Returns `{"by_opening_item": {opening_item_id: request_number},
+              "by_opening_leaf": {(opening_number, leaf): request_number}}` - the first for the
+    "this leaf is already on a shipping request" duplicate guard, the second for the cross-type
+    conflict a shop-assembly creation has to see (the same physical leaf cannot be both on its way
+    out the door and back on the assembly bench).
+
+    Live is defined by the *pull*, not by the request status, because a shipping-out request stays
+    APPROVED forever once accepted: PENDING, or APPROVED while its minted PullRequest is still
+    PENDING/IN_PROGRESS. A request whose pull has completed has shipped its leaves, which is a
+    different state that the OpeningItem's own `state` already refuses. One query, outer-joined to
+    the pull so an APPROVED request whose PR was discarded by a reopen still reads as live (it is
+    back to PENDING and still holding).
+    """
+    result: dict = {"by_opening_item": {}, "by_opening_leaf": {}}
+    if not opening_item_ids and not opening_leaf_specs:
+        return result
+
+    live_request = or_(
+        ShippingOutRequest.status == ShippingOutRequestStatus.PENDING,
+        and_(
+            ShippingOutRequest.status == ShippingOutRequestStatus.APPROVED,
+            or_(
+                PullRequestModel.id.is_(None),
+                PullRequestModel.status.in_([PullRequestStatus.PENDING, PullRequestStatus.IN_PROGRESS]),
+            ),
+        ),
+    )
+    stmt = (
+        select(
+            ShippingOutRequestItem.opening_item_id,
+            ShippingOutRequestItem.opening_number,
+            ShippingOutRequestItem.leaf,
+            ShippingOutRequest.request_number,
+        )
+        .join(ShippingOutRequest, ShippingOutRequestItem.shipping_out_request_id == ShippingOutRequest.id)
+        .outerjoin(PullRequestModel, ShippingOutRequest.pull_request_id == PullRequestModel.id)
+        .where(
+            ShippingOutRequest.project_id == project_id,
+            ShippingOutRequestItem.item_type == PullRequestItemType.OPENING_ITEM,
+            live_request,
+        )
+    )
+    wanted_items = set(opening_item_ids or [])
+    wanted_leaves = set(opening_leaf_specs or [])
+    for opening_item_id, opening_number, leaf, request_number in session.execute(stmt).all():
+        if opening_item_id is not None and opening_item_id in wanted_items:
+            result["by_opening_item"][opening_item_id] = request_number
+        if (opening_number, leaf) in wanted_leaves:
+            result["by_opening_leaf"][(opening_number, leaf)] = request_number
+    return result
+
+
 def accept_shipping_out_request(
     session: Session,
     request_id: uuid.UUID,
@@ -579,8 +642,12 @@ def accept_shipping_out_request(
 ) -> ShippingOutRequest:
     """Accept a PENDING shipping-out request (#293): mint the warehouse PullRequest (SHIPPING_OUT,
     PENDING) copying this request's items into PullRequestItems, flip the request to APPROVED, and
-    stamp pull_request_id. No sufficiency gate here - the warehouse approve handles shortfalls for
-    the shipping path (it re-checks and leaves the PR PENDING if short, #224)."""
+    stamp pull_request_id.
+
+    A pure human approval gate (#342), like its shop-assembly twin: the request's LOOSE lines
+    reserved their hardware when the request was created and still hold that claim, so there is
+    nothing to re-check here and nothing to release. The claim is spent when the warehouse approves
+    the pull."""
     stmt = (
         select(ShippingOutRequest)
         .options(selectinload(ShippingOutRequest.items))
@@ -645,7 +712,14 @@ def reject_shipping_out_request(
     rejected_by: str,
     reason: str | None,
 ) -> ShippingOutRequest:
-    """Reject a PENDING shipping-out request (#293). Mints no PullRequest."""
+    """Reject a PENDING shipping-out request (#293). Mints no PullRequest, and **releases the
+    request's inventory reservations** (#342): its LOOSE lines have been holding a claim on loose
+    stock since creation, and a dead request must not keep it. OPENING_ITEM lines never reserved
+    anything (an assembled leaf left fungible inventory at assembly), so there is nothing of theirs
+    to release. Also the recovery path after a reopen - a reopened request is PENDING and still
+    holding, and this is what finally lets go."""
+    from app.repositories import warehouse as warehouse_repository
+
     stmt = (
         select(ShippingOutRequest)
         .options(selectinload(ShippingOutRequest.items))
@@ -661,6 +735,7 @@ def reject_shipping_out_request(
     req.rejected_by = rejected_by
     req.rejection_reason = (reason or "").strip() or None
     req.rejected_at = datetime.utcnow()
+    warehouse_repository.release_reservations(session, ReservationSource.SHIPPING_OUT_REQUEST, req.id)
     return req
 
 

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -5,13 +5,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import (
     ConflictError,
     InvalidStateTransitionError,
-    InventoryShortfallError,
     NotFoundError,
     ValidationError,
 )
@@ -24,6 +23,7 @@ from app.models.enums import (
     PullRequestSource,
     PullRequestStatus,
     PullStatus,
+    ReservationSource,
     ShopAssemblyRequestStatus,
 )
 from app.models.opening_item import OpeningItem as OpeningItemModel
@@ -884,6 +884,52 @@ def find_already_assembled_openings(
     return [(num, leaf) for num, oid, leaf in opening_leaf_specs if (oid, leaf) in assembled]
 
 
+def find_in_flight_assembly_leaves(
+    session: Session,
+    opening_leaf_specs: list[tuple[str, uuid.UUID, int | None]],
+) -> list[tuple[str, int | None, str | None]]:
+    """Duplicate in-flight guard (#342): the (opening_number, leaf, request_number) triples whose
+    leaf is already inside a **live** shop-assembly work unit.
+
+    `find_already_assembled_openings` catches the leaf that has already been *built*. This catches
+    the one that is on its way there - requested, accepted, pulled, or half-assembled on somebody's
+    bench - which the pre-#342 creation path let through: two requests for the same leaf both
+    reserved and both pulled hardware, and the second one had nowhere to put it.
+
+    Live means the work unit is not finished and its request is not dead:
+
+    - `assembly_status != COMPLETED` (a completed leaf is the already-assembled guard's business,
+      and re-requesting it is legitimate only after the assembled unit ships);
+    - the parent ShopAssemblyRequest is not REJECTED - or there is no parent at all, which is the
+      legacy #222 shape where the opening hangs straight off a PullRequest.
+
+    Scoping is by `opening_id`, which is a project's own Opening UUID, so this is project-scoped by
+    construction without joining a table whose rows a re-upload may have deleted. One query, and the
+    request_number comes back with the row so the refusal can name what is holding the leaf.
+    """
+    if not opening_leaf_specs:
+        return []
+    opening_ids = [oid for _, oid, _ in opening_leaf_specs]
+    rows = session.execute(
+        select(
+            ShopAssemblyOpening.opening_id,
+            ShopAssemblyOpening.leaf,
+            ShopAssemblyRequest.request_number,
+        )
+        .outerjoin(ShopAssemblyRequest, ShopAssemblyOpening.shop_assembly_request_id == ShopAssemblyRequest.id)
+        .where(
+            ShopAssemblyOpening.opening_id.in_(opening_ids),
+            ShopAssemblyOpening.assembly_status != AssemblyStatus.COMPLETED,
+            or_(
+                ShopAssemblyRequest.id.is_(None),
+                ShopAssemblyRequest.status != ShopAssemblyRequestStatus.REJECTED,
+            ),
+        )
+    ).all()
+    claimed = {(opening_id, leaf): request_number for opening_id, leaf, request_number in rows}
+    return [(num, leaf, claimed[(oid, leaf)]) for num, oid, leaf in opening_leaf_specs if (oid, leaf) in claimed]
+
+
 def get_shop_assembly_requests(
     session: Session,
     project_id: uuid.UUID | None = None,
@@ -918,18 +964,19 @@ def accept_shop_assembly_request(
     request_id: uuid.UUID,
     accepted_by: str,
 ) -> ShopAssemblyRequest:
-    """Accept a PENDING shop-assembly request (#293).
+    """Accept a PENDING shop-assembly request (#293). Since #342 this is a **pure human approval
+    gate**: it flips the request to APPROVED and mints the warehouse PullRequest (SHOP_ASSEMBLY,
+    PENDING) with one LOOSE item per opening item, then repoints the request's ShopAssemblyOpenings
+    at that PR (pull_request_id) so the unchanged warehouse pull/complete flow works as before.
 
-    Re-runs the shared inventory-sufficiency gate over the request's openings' items. If short,
-    raises InventoryShortfallError WITHOUT minting anything - the resolver rolls back, notifies the
-    PO in a fresh session, and re-raises so the shortfall reaches the caller inline. If covered,
-    flips the request to APPROVED and mints the warehouse PullRequest (SHOP_ASSEMBLY, PENDING) with
-    one LOOSE item per opening item, then repoints the request's ShopAssemblyOpenings at that PR
-    (pull_request_id) so the unchanged warehouse pull/complete flow works exactly as before.
+    The reactive inventory-sufficiency re-check that used to live here is gone. The hardware was
+    reserved when the request was created, so it is already this request's; re-checking at accept
+    could only ever fail for stock that was never free to begin with, and it made the accept step a
+    second place a shortfall could surface - with no action the acceptor could take about it. The
+    check now happens once, at creation (where the creator can still refine the selection), and the
+    claim is spent at pull approval. Accepting does not touch the reservations: the request keeps
+    holding them, exactly as it did while PENDING.
     """
-    from app.repositories import warehouse as warehouse_repository
-    from app.services import notification_service
-
     stmt = (
         select(ShopAssemblyRequest)
         .options(selectinload(ShopAssemblyRequest.openings).selectinload(ShopAssemblyOpening.items))
@@ -940,19 +987,6 @@ def accept_shop_assembly_request(
         raise NotFoundError(f"Shop-assembly request {request_id} not found")
     if sar.status != ShopAssemblyRequestStatus.PENDING:
         raise InvalidStateTransitionError(f"Shop-assembly request must be Pending to accept, got {sar.status.value}")
-
-    needs = [
-        (item.hardware_category, item.product_code, item.quantity) for opening in sar.openings for item in opening.items
-    ]
-    sufficiency = warehouse_repository.check_inventory_sufficiency(session, sar.project_id, needs)
-    if not sufficiency.sufficient:
-        raise InventoryShortfallError(
-            "Cannot accept shop-assembly request - insufficient inventory. "
-            + notification_service.format_shortfall_lines(sufficiency.shortfalls),
-            shortfalls=sufficiency.shortfalls,
-            project_id=sar.project_id,
-            request_number=sar.request_number,
-        )
 
     now = datetime.utcnow()
     sar.status = ShopAssemblyRequestStatus.APPROVED
@@ -996,7 +1030,14 @@ def reject_shop_assembly_request(
     rejected_by: str,
     reason: str | None,
 ) -> ShopAssemblyRequest:
-    """Reject a PENDING shop-assembly request (#293). Mints no PullRequest."""
+    """Reject a PENDING shop-assembly request (#293). Mints no PullRequest, and **releases the
+    request's inventory reservations** (#342) - the request is dead, so the hardware it has been
+    holding since creation goes back to the available pool for whoever asks next.
+
+    This is also the recovery path for a reopened request: reopen returns it to PENDING still
+    holding its claim, and rejecting it from there runs exactly this code."""
+    from app.repositories import warehouse as warehouse_repository
+
     stmt = (
         select(ShopAssemblyRequest)
         .options(selectinload(ShopAssemblyRequest.openings).selectinload(ShopAssemblyOpening.items))
@@ -1012,6 +1053,7 @@ def reject_shop_assembly_request(
     sar.rejected_by = rejected_by
     sar.rejection_reason = (reason or "").strip() or None
     sar.rejected_at = datetime.utcnow()
+    warehouse_repository.release_reservations(session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id)
     return sar
 
 

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -1,6 +1,6 @@
 """Warehouse repository package - split by sub-domain (#265).
 
-Sub-modules: receiving, locations, inventory, pull_requests, audit, progress.
+Sub-modules: receiving, locations, inventory, reservations, pull_requests, audit, progress.
 The package re-exports the full public API so callers keep a single import surface.
 """
 
@@ -48,6 +48,7 @@ from .pull_requests import (
     check_inventory_sufficiency,
     complete_pull_request,
     discard_pending_pull_request,
+    find_reservation_holder,
     get_pull_request_details,
     get_pull_requests,
 )
@@ -58,6 +59,12 @@ from .receiving import (
     get_po_receiving_details,
     get_recent_receive_records,
     validate_receive_eligibility,
+)
+from .reservations import (
+    create_reservations,
+    get_project_availability,
+    get_reserved_quantities,
+    release_reservations,
 )
 
 __all__ = [
@@ -73,7 +80,9 @@ __all__ = [
     "check_inventory_sufficiency",
     "complete_pull_request",
     "create_receive",
+    "create_reservations",
     "discard_pending_pull_request",
+    "find_reservation_holder",
     "get_audit_log",
     "get_back_ordered_items",
     "get_distinct_location_values",
@@ -90,10 +99,12 @@ __all__ = [
     "get_opening_leaf_counts",
     "get_opening_leaf_status",
     "get_po_receiving_details",
+    "get_project_availability",
     "get_project_progress_by_product",
     "get_pull_request_details",
     "get_pull_requests",
     "get_recent_receive_records",
+    "get_reserved_quantities",
     "get_unlocated_inventory",
     "get_warehouse_dashboard",
     "mark_inventory_unlocated",
@@ -103,5 +114,6 @@ __all__ = [
     "move_opening_item_location",
     "normalize_location_value",
     "override_inventory_quantity",
+    "release_reservations",
     "validate_receive_eligibility",
 ]

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -20,15 +20,19 @@ from app.models.enums import (
     PullRequestSource,
     PullRequestStatus,
     PullStatus,
+    ReservationSource,
 )
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.pull_request import PullRequest as PullRequestModel
 from app.models.pull_request import PullRequestItem as PullRequestItemModel
+from app.models.shipping_out_request import ShippingOutRequest as ShippingOutRequestModel
 from app.models.shop_assembly import ShopAssemblyOpening
+from app.models.shop_assembly import ShopAssemblyRequest as ShopAssemblyRequestModel
 from app.services import notification_service
 from app.services.locking import lock_rows
 
+from . import reservations
 from .audit import _log_audit_event
 
 
@@ -82,14 +86,19 @@ def get_pull_request_details(session: Session, pr_id: uuid.UUID) -> PullRequestM
 @dataclass(frozen=True)
 class Shortfall:
     """One shorted (hardware_category, product_code) combo: how much was requested, how much is
-    available (quantity - deficient_quantity), and the gap. Emitted by the shared sufficiency gate
-    and surfaced verbatim to the creator/approver and to the PO backfill notification."""
+    available, and the gap. Emitted by the shared sufficiency gate and surfaced verbatim to the
+    creator/approver and to the PO backfill notification.
+
+    Since #342 `available` is net of other requests' reservations as well as deficient units, so
+    "available: 0" can mean "the stock is here but spoken for". `reserved` carries that number
+    separately, which is the difference between "order more" and "release or refine a request"."""
 
     hardware_category: str
     product_code: str
     requested: int
     available: int
     short: int
+    reserved: int = 0
 
 
 @dataclass
@@ -112,13 +121,32 @@ def check_inventory_sufficiency(
     needs: Iterable[tuple[str, str, int]],
     *,
     lock: bool = False,
+    reservation_aware: bool = False,
+    exclude_reservations_of: tuple[ReservationSource, uuid.UUID] | None = None,
 ) -> SufficiencyResult:
-    """Shared hard inventory-sufficiency gate (#224). Aggregates `needs` (an iterable of
-    (hardware_category, product_code, quantity)) by combo, compares each against available
-    inventory in the project, and returns a Shortfall per combo that can't be fully covered - no
-    partial fulfilment. available = quantity - deficient_quantity, the same rule
-    approve_pull_request deducts under. With lock=True the inventory rows are SELECT ... FOR UPDATE
-    and returned grouped by combo so the caller can pull FIFO against exactly what was checked."""
+    """Shared hard inventory-sufficiency gate (#224, reservation-aware since #342).
+
+    Aggregates `needs` (an iterable of (hardware_category, product_code, quantity)) by combo,
+    compares each against available inventory in the project, and returns a Shortfall per combo
+    that can't be fully covered - no partial fulfilment.
+
+    - Base availability is `quantity - deficient_quantity`, the same rule approve_pull_request
+      deducts under. A deficiency reported at the bench bumps the inventory row's `quantity` and
+      `deficient_quantity` together, so it nets to zero here - a condemned unit is back in the
+      building but is not available, and it is not double-counted against anything.
+    - `reservation_aware=True` also subtracts active reservations, giving
+      `available = on-hand - deficient - reservations`. This is what request creation gates on and
+      what pull approval re-checks: stock another request has already claimed is not free.
+    - `exclude_reservations_of=(source, request_id)` is **self-coverage**. Approving request R's
+      pull spends R's own reservations, so R's claim must not be counted against R - otherwise a
+      request that reserved exactly what it needs could never be approved. Everyone else's claims
+      still count, which is what stops a PR-REPL replacement pull (which holds no reservations of
+      its own, because a deficiency cannot be foreseen) from eating stock somebody reserved.
+
+    With lock=True the inventory rows are SELECT ... FOR UPDATE and returned grouped by combo so the
+    caller can pull FIFO against exactly what was checked. Creation locks too: two creators racing
+    for the last hinge serialise on those rows, so the second one sees the first one's reservation.
+    """
     needed_combos: dict[tuple[str, str], int] = defaultdict(int)
     for cat, code, qty in needs:
         needed_combos[(cat, code)] += qty
@@ -145,14 +173,59 @@ def check_inventory_sufficiency(
         for il in session.scalars(stmt).all():
             inv_by_combo[(il.hardware_category, il.product_code)].append(il)
 
+    reserved_by_combo: dict[tuple[str, str], int] = {}
+    if reservation_aware and needed_combos:
+        exclude_source, exclude_request_id = exclude_reservations_of or (None, None)
+        reserved_by_combo = reservations.get_reserved_quantities(
+            session,
+            project_id,
+            needed_combos.keys(),
+            exclude_source=exclude_source,
+            exclude_request_id=exclude_request_id,
+        )
+
     shortfalls: list[Shortfall] = []
     for (cat, code), requested in needed_combos.items():
-        available = sum(il.quantity - (il.deficient_quantity or 0) for il in inv_by_combo.get((cat, code), []))
+        on_hand = sum(il.quantity - (il.deficient_quantity or 0) for il in inv_by_combo.get((cat, code), []))
+        reserved = reserved_by_combo.get((cat, code), 0)
+        available = max(0, on_hand - reserved)
         if available < requested:
-            shortfalls.append(Shortfall(cat, code, requested, available, requested - available))
+            shortfalls.append(Shortfall(cat, code, requested, available, requested - available, reserved))
     shortfalls.sort(key=lambda s: (s.hardware_category, s.product_code))
 
     return SufficiencyResult(shortfalls=shortfalls, inventory_by_combo=dict(inv_by_combo))
+
+
+def find_reservation_holder(session: Session, pr: PullRequestModel) -> tuple[ReservationSource, uuid.UUID] | None:
+    """The request whose reservations this pull is going to spend, or None if it has none (#342).
+
+    A shop-assembly accept stamps the minted PR with the request's own `request_number` (unique on
+    both tables), and a shipping-out accept stamps `pull_request_id` on the request - so each hop
+    is a single indexed lookup, no string parsing.
+
+    None is the honest answer for three real cases, and they all behave identically downstream (the
+    pull is checked against on-hand minus *everyone's* reservations, and consumes nothing):
+
+    - a **PR-REPL replacement pull**. Nobody can reserve for a deficiency that has not happened yet,
+      so a replacement genuinely holds no claim; it keeps the reactive check and the PO-backfill
+      loop, and it must not be able to eat stock other requests have reserved.
+    - a pull whose source request was **rejected/reopened** after the accept - the claim is gone by
+      design.
+    - a **legacy pull** minted before this table existed, or one created directly by a non-UI caller.
+    """
+    if pr.source == PullRequestSource.SHOP_ASSEMBLY:
+        sar_id = session.scalar(
+            select(ShopAssemblyRequestModel.id).where(ShopAssemblyRequestModel.request_number == pr.request_number)
+        )
+        if sar_id is not None:
+            return (ReservationSource.SHOP_ASSEMBLY_REQUEST, sar_id)
+    elif pr.source == PullRequestSource.SHIPPING_OUT:
+        sor_id = session.scalar(
+            select(ShippingOutRequestModel.id).where(ShippingOutRequestModel.pull_request_id == pr.id)
+        )
+        if sor_id is not None:
+            return (ReservationSource.SHIPPING_OUT_REQUEST, sor_id)
+    return None
 
 
 def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -> tuple:
@@ -163,6 +236,21 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
     where outcome_string is "APPROVED" or "INSUFFICIENT". On INSUFFICIENT the PR is left PENDING
     (the pull is blocked, not cancelled - #224), `notification_or_none` is the PO backfill signal,
     and `shortfalls` lists the shorted combos. On APPROVED `shortfalls` is empty.
+
+    Since #342 this is where a request's reservation is **consumed**: the claim it has held since
+    creation turns into the actual FIFO deduction, atomically, under the same row locks. Two rules
+    make that safe:
+
+    - **Self-coverage.** The availability check excludes this request's own reservations. They are
+      what backs the deduction; counting them as competing demand would make a correctly-reserved
+      request permanently unapprovable.
+    - **Consume only on success.** A pull that comes up short keeps its claim and stays PENDING, so
+      the blocked request does not quietly hand its hardware to whoever asks next.
+
+    A shortfall on a pull that *did* hold reservations is not normal flow - it means stock vanished
+    under a live claim (an admin write-off or quantity override). It is reported the same way so the
+    approver and the PO see it, but it is additionally recorded as an integrity event, because the
+    reserved path is supposed to be un-shortfallable.
     """
     # 1. Lock PR
     locked_prs = lock_rows(session, PullRequestModel, [pr_id])
@@ -186,10 +274,21 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
 
     now = datetime.utcnow()
 
-    # 3. Re-run the shared sufficiency gate, locking the rows we'd pull from.
-    result = check_inventory_sufficiency(session, pr.project_id, needs, lock=True)
+    # 3. Re-run the shared sufficiency gate, locking the rows we'd pull from. Reservation-aware, with
+    #    this request's own claim excluded (self-coverage) - so it pulls from
+    #    on-hand - deficient - *other* requests' reservations, plus whatever it reserved itself.
+    holder = find_reservation_holder(session, pr)
+    result = check_inventory_sufficiency(
+        session,
+        pr.project_id,
+        needs,
+        lock=True,
+        reservation_aware=True,
+        exclude_reservations_of=holder,
+    )
 
-    # 4. If short: leave the PR PENDING (blocked, not cancelled) and notify the PO for backfill.
+    # 4. If short: leave the PR PENDING (blocked, not cancelled), keep the reservations (the claim
+    #    outlives the blocked attempt), and notify the PO for backfill.
     if not result.sufficient:
         notif = notification_service.notify_po_shortfall(
             session,
@@ -197,9 +296,42 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
             request_number=pr.request_number,
             shortfalls=result.shortfalls,
         )
+        if holder is not None:
+            # The reserved path is not supposed to be able to come up short. Record it against the
+            # pull so the discrepancy is investigable rather than indistinguishable from the normal
+            # PR-REPL / legacy shortfall the approver sees.
+            _log_audit_event(
+                session,
+                project_id=pr.project_id,
+                entity_type=AuditEntityType.INVENTORY_LOCATION,
+                entity_id=pr.id,
+                action=AuditAction.PULL_DEDUCTION,
+                performed_by=approved_by,
+                detail={
+                    "integrityError": "RESERVED_PULL_SHORT",
+                    "pullRequestNumber": pr.request_number,
+                    "reservationSource": holder[0].value,
+                    "reservationRequestId": str(holder[1]),
+                    "shortfalls": [
+                        {
+                            "hardwareCategory": s.hardware_category,
+                            "productCode": s.product_code,
+                            "requested": s.requested,
+                            "available": s.available,
+                            "short": s.short,
+                        }
+                        for s in result.shortfalls
+                    ],
+                },
+            )
         return (pr, "INSUFFICIENT", notif, result.shortfalls)
 
-    # 5. If sufficient: approve and deduct FIFO
+    # 5. If sufficient: consume the source request's claim and deduct FIFO, in this transaction.
+    #    Consumption happens before the deduction so the two can never be observed apart: a reader
+    #    between them would otherwise see the units both reserved and already gone.
+    if holder is not None:
+        reservations.release_reservations(session, holder[0], holder[1])
+
     pr.status = PullRequestStatus.IN_PROGRESS
     pr.assigned_to = approved_by
     pr.approved_at = now

--- a/backend/app/repositories/warehouse/reservations.py
+++ b/backend/app/repositories/warehouse/reservations.py
@@ -1,0 +1,225 @@
+"""Inventory reservations: the claim a request holds on stock between creation and the pull (#342).
+
+Creating a shop-assembly or shipping-out request reserves what it needs, so
+
+    available = on-hand - deficient - active reservations
+
+and the creator is held to what is genuinely free at creation time. Approving the pull *consumes*
+the source request's reservations and deducts FIFO in the same transaction; every other way a
+request can die *releases* them. Both are the same DB operation - delete the request's rows - and
+the two names exist because the two moments mean opposite things (`release_reservations` documents
+the whole table).
+
+Everything here aggregates with `func.sum`; there is no path that loads reservation rows to count
+them in Python (CLAUDE.md perf rules).
+"""
+
+import uuid
+from collections.abc import Iterable
+
+from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy.orm import Session
+
+from app.models.enums import ReservationSource
+from app.models.inventory import InventoryLocation as InventoryLocationModel
+from app.models.inventory_reservation import InventoryReservation as InventoryReservationModel
+
+# The FK column each source discriminator writes to / filters on.
+_SOURCE_COLUMN = {
+    ReservationSource.SHOP_ASSEMBLY_REQUEST: InventoryReservationModel.shop_assembly_request_id,
+    ReservationSource.SHIPPING_OUT_REQUEST: InventoryReservationModel.shipping_out_request_id,
+}
+
+
+def _combo_filter(combos: Iterable[tuple[str, str]] | None, category_col, code_col):
+    """OR of (hardware_category, product_code) equality pairs, or None for "no filter"."""
+    if combos is None:
+        return None
+    pairs = list(combos)
+    if not pairs:
+        # An explicit empty set means "nothing", not "everything".
+        return category_col.is_(None) & category_col.is_not(None)
+    return or_(*[and_(category_col == cat, code_col == code) for cat, code in pairs])
+
+
+def get_reserved_quantities(
+    session: Session,
+    project_id: uuid.UUID,
+    combos: Iterable[tuple[str, str]] | None = None,
+    *,
+    exclude_source: ReservationSource | None = None,
+    exclude_request_id: uuid.UUID | None = None,
+) -> dict[tuple[str, str], int]:
+    """Active reserved quantity per (hardware_category, product_code) in one project.
+
+    One grouped scalar aggregate - never a `len()` or a Python sum over loaded rows. `combos`
+    narrows it to the combos a caller actually cares about (an empty iterable returns `{}`; `None`
+    means every combo in the project).
+
+    `exclude_source` / `exclude_request_id` are **self-coverage** (#342): when the warehouse
+    approves request R's pull, R's own reservations are exactly what backs the deduction, so they
+    must not be counted against R. Without the exclusion a fully-reserved request could never be
+    approved - its own claim would read as competing demand. Every other caller leaves it unset and
+    therefore sees the whole book of claims.
+    """
+    stmt = (
+        select(
+            InventoryReservationModel.hardware_category,
+            InventoryReservationModel.product_code,
+            func.sum(InventoryReservationModel.quantity),
+        )
+        .where(InventoryReservationModel.project_id == project_id)
+        .group_by(
+            InventoryReservationModel.hardware_category,
+            InventoryReservationModel.product_code,
+        )
+    )
+    combo_clause = _combo_filter(
+        combos,
+        InventoryReservationModel.hardware_category,
+        InventoryReservationModel.product_code,
+    )
+    if combo_clause is not None:
+        stmt = stmt.where(combo_clause)
+    if exclude_source is not None and exclude_request_id is not None:
+        stmt = stmt.where(_SOURCE_COLUMN[exclude_source] != exclude_request_id)
+
+    return {(cat, code): int(total or 0) for cat, code, total in session.execute(stmt).all()}
+
+
+def get_project_availability(session: Session, project_id: uuid.UUID) -> list[dict]:
+    """Per-combo availability for one project, as the Start-a-Task wizard needs it: what is on hand,
+    what of it is condemned, what other requests have claimed, and what is therefore left to claim.
+
+    Two grouped scalar aggregates merged by combo key - one over `inventory_locations`, one over
+    `inventory_reservations`. Reservation-only combos (stock fully claimed, or written off after the
+    claim) are included with `on_hand = 0`, so a creator sees *why* a combo reads zero rather than
+    finding it silently missing.
+
+    `available` is floored at 0: an over-reservation (stock written off under a live claim) is a
+    real state, and reporting it as a negative number would only invite arithmetic on it downstream.
+    """
+    inv_stmt = (
+        select(
+            InventoryLocationModel.hardware_category,
+            InventoryLocationModel.product_code,
+            func.sum(InventoryLocationModel.quantity),
+            func.sum(InventoryLocationModel.deficient_quantity),
+        )
+        .where(InventoryLocationModel.project_id == project_id)
+        .group_by(
+            InventoryLocationModel.hardware_category,
+            InventoryLocationModel.product_code,
+        )
+    )
+    rows: dict[tuple[str, str], dict] = {}
+    for cat, code, on_hand, deficient in session.execute(inv_stmt).all():
+        rows[(cat, code)] = {
+            "hardware_category": cat,
+            "product_code": code,
+            "on_hand_quantity": int(on_hand or 0),
+            "deficient_quantity": int(deficient or 0),
+            "reserved_quantity": 0,
+        }
+
+    for (cat, code), reserved in get_reserved_quantities(session, project_id).items():
+        row = rows.get((cat, code))
+        if row is None:
+            row = {
+                "hardware_category": cat,
+                "product_code": code,
+                "on_hand_quantity": 0,
+                "deficient_quantity": 0,
+                "reserved_quantity": 0,
+            }
+            rows[(cat, code)] = row
+        row["reserved_quantity"] = reserved
+
+    result = []
+    for row in rows.values():
+        row["available_quantity"] = max(
+            0,
+            row["on_hand_quantity"] - row["deficient_quantity"] - row["reserved_quantity"],
+        )
+        result.append(row)
+    result.sort(key=lambda r: (r["hardware_category"], r["product_code"]))
+    return result
+
+
+def create_reservations(
+    session: Session,
+    project_id: uuid.UUID,
+    source: ReservationSource,
+    request_id: uuid.UUID,
+    needs: Iterable[tuple[str, str, int]],
+) -> list[InventoryReservationModel]:
+    """Write one reservation row per (hardware_category, product_code) for a request just created.
+
+    `needs` is aggregated by combo first, so a request that names the same product on five openings
+    holds one row for the total rather than five rows that every availability sum then has to add
+    back up. Zero/negative quantities are dropped (nothing to claim), which is also what keeps the
+    `quantity >= 1` check constraint from being reachable by an empty opening.
+
+    The caller must already have gated on availability in the same transaction - this function
+    writes the claim, it does not decide whether the claim is allowed.
+    """
+    totals: dict[tuple[str, str], int] = {}
+    for cat, code, qty in needs:
+        if qty is None or qty <= 0:
+            continue
+        totals[(cat, code)] = totals.get((cat, code), 0) + qty
+
+    created: list[InventoryReservationModel] = []
+    for (cat, code), qty in sorted(totals.items()):
+        row = InventoryReservationModel(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            hardware_category=cat,
+            product_code=code,
+            quantity=qty,
+            source=source,
+            shop_assembly_request_id=(request_id if source is ReservationSource.SHOP_ASSEMBLY_REQUEST else None),
+            shipping_out_request_id=(request_id if source is ReservationSource.SHIPPING_OUT_REQUEST else None),
+        )
+        session.add(row)
+        created.append(row)
+    if created:
+        session.flush()
+    return created
+
+
+def release_reservations(session: Session, source: ReservationSource, request_id: uuid.UUID) -> int:
+    """Drop every reservation a request holds and return how many rows went. Idempotent.
+
+    This is the single exit from the reservation table, and every path a request can leave the
+    in-flight state on goes through it:
+
+    | Path                                     | Effect                                            |
+    | ---------------------------------------- | ------------------------------------------------- |
+    | Reject (either request type)             | release - the request is dead, the claim dies too |
+    | Reject after a reopen                    | release - same call, same result                  |
+    | Reopen an accepted request (#325)        | **no release** - see below                        |
+    | Pull approval (the reserved path)        | consume - the claim becomes the FIFO deduction    |
+    | Pull approval that comes up short        | **no release** - the pull stays blocked, holding  |
+    | Re-upload drops the request's openings    | release, by rebuilding from what survived         |
+    | Re-upload leaves the request empty       | auto-reject, which releases                       |
+
+    **Reopen deliberately does not release.** A reopen undoes the *accept*, not the *creation*: the
+    request goes back to PENDING and is still a live claim on stock, exactly as it was between
+    creation and the accept it is unwinding. Releasing here would let a second request grab the
+    hardware while the first is still on the board waiting to be re-accepted - which is the
+    accept-time shortfall this whole slice removes, reintroduced through the back door. Rejecting
+    it afterwards is what finally releases, and that path is unchanged.
+
+    Bulk DELETE in one statement (not a load + per-row delete). The ORM's default synchronisation
+    evaluates the criteria against the identity map, so any of these rows the session had already
+    loaded are expunged with it rather than left behind as phantoms.
+    """
+    result = session.execute(
+        delete(InventoryReservationModel).where(
+            InventoryReservationModel.source == source,
+            _SOURCE_COLUMN[source] == request_id,
+        )
+    )
+    session.flush()
+    return int(result.rowcount or 0)

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -527,6 +527,7 @@ def shop_assembly_request_to_type(sar) -> ShopAssemblyRequest:
         created_at=sar.created_at,
         approved_at=sar.approved_at,
         rejected_at=sar.rejected_at,
+        integrity_note=sar.integrity_note,
         openings=[shop_assembly_opening_to_type(o) for o in sar.openings],
     )
 
@@ -558,6 +559,7 @@ def shipping_out_request_to_type(req) -> ShippingOutRequest:
         created_at=req.created_at,
         approved_at=req.approved_at,
         rejected_at=req.rejected_at,
+        integrity_note=req.integrity_note,
         pull_request_id=strawberry.ID(str(req.pull_request_id)) if req.pull_request_id else None,
         items=[shipping_out_request_item_to_type(i) for i in req.items],
     )

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -5,6 +5,7 @@ import uuid
 import strawberry
 
 from app.database import SessionLocal
+from app.errors import InventoryShortfallError
 from app.repositories import (
     import_repository,
     po_repository,
@@ -12,6 +13,7 @@ from app.repositories import (
     shipping_repository,
     shop_assembly_repository,
 )
+from app.services import notification_service
 
 from .converters import (
     po_to_type,
@@ -226,10 +228,29 @@ class ImportMutations:
         }
 
         with SessionLocal() as session:
-            # #293: Start a Task no longer mints PullRequests, so there is no inventory-sufficiency
-            # gate here - a request may be created even if inventory is short. Sufficiency is enforced
-            # when a signed-in user ACCEPTS the shop-assembly request (see accept mutation).
-            result = import_repository.finalize_import_session(session, input_data)
+            # #342: creating a shop-assembly or shipping-out request gates on available inventory
+            # (on-hand - deficient - other requests' reservations) and reserves what it takes. A
+            # short selection raises InventoryShortfallError and nothing is written, so the creator
+            # refines the selection here rather than the acceptor discovering it later.
+            try:
+                result = import_repository.finalize_import_session(session, input_data)
+            except InventoryShortfallError as e:
+                # Notify the PO only for combos that are genuinely *not in the building* - a combo
+                # short only because another request has claimed it is not a purchasing problem, and
+                # a backfill notification for it would send someone to order stock that already
+                # exists. The refusal reaches the creator inline either way.
+                session.rollback()
+                unstocked = [s for s in e.shortfalls if s.short > s.reserved]
+                if unstocked:
+                    with SessionLocal() as notif_session:
+                        notification_service.notify_po_shortfall(
+                            notif_session,
+                            project_id=e.project_id,
+                            request_number=e.request_number,
+                            shortfalls=unstocked,
+                        )
+                        notif_session.commit()
+                raise
             session.commit()
 
             # Re-load everything with the relationships the response types walk

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -6,10 +6,8 @@ import strawberry
 
 from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, require_role, require_user
 from app.database import SessionLocal
-from app.errors import InventoryShortfallError
 from app.repositories import shop_assembly_repository, user_repository
 from app.repositories import warehouse as warehouse_repository
-from app.services import notification_service
 
 from .converters import (
     clerk_user_to_type,
@@ -113,29 +111,17 @@ class ShopAssemblyMutations:
     def accept_shop_assembly_request(
         self, info: strawberry.Info, id: strawberry.ID, accepted_by: str
     ) -> ShopAssemblyRequest:
-        """Accept a PENDING shop-assembly request (#293). Open to any signed-in user. Re-checks
-        inventory sufficiency; if short, notifies the PO for backfill and raises the shortfall inline
-        without minting the PR. If covered, mints the warehouse PullRequest and approves the request."""
+        """Accept a PENDING shop-assembly request (#293). Open to any signed-in user.
+
+        A pure human approval gate since #342: it mints the warehouse PullRequest and approves the
+        request, and re-checks nothing. The hardware was reserved when the request was created, so
+        it already belongs to this request - there is no shortfall left for the acceptor to be shown
+        and nothing they could do about one if there were."""
         require_user(info)
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
-            try:
-                shop_assembly_repository.accept_shop_assembly_request(session, request_id, accepted_by)
-                session.commit()
-            except InventoryShortfallError as e:
-                # Roll the mint back so no PR/partial state survives, then notify the PO for backfill
-                # in a fresh session so it outlives the rollback, and re-raise so the shortfall
-                # reaches the caller inline.
-                session.rollback()
-                with SessionLocal() as notif_session:
-                    notification_service.notify_po_shortfall(
-                        notif_session,
-                        project_id=e.project_id,
-                        request_number=e.request_number,
-                        shortfalls=e.shortfalls,
-                    )
-                    notif_session.commit()
-                raise
+            shop_assembly_repository.accept_shop_assembly_request(session, request_id, accepted_by)
+            session.commit()
             refreshed = shop_assembly_repository.get_request_with_openings(session, request_id)
             return shop_assembly_request_to_type(refreshed)
 

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -597,6 +597,10 @@ class ShopAssemblyRequest:
     created_at: datetime
     approved_at: datetime | None
     rejected_at: datetime | None
+    # Something happened to this request after it was created that the acceptor has to know about
+    # (#342): a schedule re-upload landed under it, or the reservations backfill could not cover it.
+    # Null means nothing has.
+    integrity_note: str | None
     openings: list[ShopAssemblyOpening]
 
 
@@ -627,6 +631,8 @@ class ShippingOutRequest:
     created_at: datetime
     approved_at: datetime | None
     rejected_at: datetime | None
+    # See ShopAssemblyRequest.integrity_note (#342).
+    integrity_note: str | None
     pull_request_id: strawberry.ID | None
     items: list[ShippingOutRequestItem]
 
@@ -783,13 +789,37 @@ class OpeningItemDetail:
 @strawberry.type
 class InventoryShortfall:
     """One shorted (hardware_category, product_code) combo surfaced by an inventory-sufficiency
-    gate (#224): requested vs available (quantity - deficient_quantity), and the gap."""
+    gate (#224): requested vs available, and the gap.
+
+    Since #342 `available` is net of other requests' reservations as well as deficient units, so a
+    zero can mean "the stock is here but claimed". `reserved` carries that separately - it is the
+    difference between "order more" and "release or refine another request"."""
 
     hardware_category: str
     product_code: str
     requested: int
     available: int
     short: int
+    reserved: int = 0
+
+
+@strawberry.type
+class InventoryAvailability:
+    """What one (hardware_category, product_code) in a project can still be claimed for (#342).
+
+    `available = on_hand - deficient - reserved`, floored at 0 - the exact number the Start-a-Task
+    creation gate applies, so the wizard can block an over-selection before submission instead of
+    letting the user find out from a rejected finalize. Note this is deliberately NOT the same as
+    the warehouse inventory view's "available", which is on-hand minus deficient: that view answers
+    "what is physically unspoken-for in the building", this one answers "what may I claim".
+    """
+
+    hardware_category: str
+    product_code: str
+    on_hand_quantity: int
+    deficient_quantity: int
+    reserved_quantity: int
+    available_quantity: int
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -29,6 +29,7 @@ from .types import (
     ApproveResult,
     AuditLogEntry,
     BackOrderedItem,
+    InventoryAvailability,
     InventoryHierarchyNode,
     InventoryItemDetail,
     InventoryLocation,
@@ -107,6 +108,30 @@ class WarehouseQueries:
         with SessionLocal() as session:
             po, receive_records = warehouse_repository.get_po_receiving_details(session, uuid.UUID(str(po_id)))
             return po_to_type(po, receive_records)
+
+    @strawberry.field
+    def project_inventory_availability(self, project_id: strawberry.ID) -> list[InventoryAvailability]:
+        """What each product in a project can still be claimed for (#342):
+        `available = on_hand - deficient - reserved`.
+
+        This is the number the Start-a-Task creation gate applies, exposed so the wizard can block an
+        over-selection with per-combo detail *before* submission rather than bouncing the whole
+        finalize. Deliberately distinct from `inventoryHierarchy`'s availability, which is on-hand
+        minus deficient: that answers "what is physically unspoken-for in the building", this
+        answers "what may I claim". Two grouped scalar aggregates, no per-row work."""
+        with SessionLocal() as session:
+            rows = warehouse_repository.get_project_availability(session, uuid.UUID(str(project_id)))
+            return [
+                InventoryAvailability(
+                    hardware_category=row["hardware_category"],
+                    product_code=row["product_code"],
+                    on_hand_quantity=row["on_hand_quantity"],
+                    deficient_quantity=row["deficient_quantity"],
+                    reserved_quantity=row["reserved_quantity"],
+                    available_quantity=row["available_quantity"],
+                )
+                for row in rows
+            ]
 
     @strawberry.field
     def inventory_hierarchy(
@@ -563,6 +588,7 @@ class WarehouseMutations:
                         requested=s.requested,
                         available=s.available,
                         short=s.short,
+                        reserved=s.reserved,
                     )
                     for s in shortfalls
                 ],

--- a/backend/tests/test_accept_requests.py
+++ b/backend/tests/test_accept_requests.py
@@ -21,6 +21,7 @@ from app.models.enums import (
     ShopAssemblyRequestStatus,
 )
 from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
 from app.models.opening_item import OpeningItem, OpeningItemHardware
 from app.models.project import Opening, Project
 from app.models.pull_request import PullRequest, PullRequestItem
@@ -72,6 +73,13 @@ def _seed_inventory(session, project_id, *, category="HINGE", code="HG-100", qua
     session.add(il)
     session.flush()
     return il
+
+
+def _reservations(session, project_id):
+    """Every live reservation in a project (#342) - the claim requests hold on loose stock."""
+    return list(
+        session.scalars(select(InventoryReservation).where(InventoryReservation.project_id == project_id)).all()
+    )
 
 
 def _finalize_shop_assembly(session, project, *, code="HG-100", qty=2, opening_number="A01"):
@@ -213,18 +221,16 @@ def test_accept_shop_assembly_mints_pr_and_repoints_openings(db_session):
     assert pr_items[0].requested_quantity == 2
 
 
-def test_accept_shop_assembly_blocks_on_shortfall(db_session):
+def test_creating_a_shop_assembly_request_blocks_on_shortfall(db_session):
+    """#342 moved this gate from accept to creation: a selection that does not fit available
+    inventory is refused before anything exists, so there is no request for anyone to accept."""
     project = _make_project(db_session)
     _seed_inventory(db_session, project.id, quantity=1)  # need 2
-    result = _finalize_shop_assembly(db_session, project, qty=2)
-    sar_id = result["shop_assembly_request"].id
-    db_session.flush()
 
     with pytest.raises(InventoryShortfallError):
-        shop_assembly_repository.accept_shop_assembly_request(db_session, sar_id, "acceptor")
+        _finalize_shop_assembly(db_session, project, qty=2)
 
     db_session.rollback()
-    # No PR minted.
     assert (
         db_session.scalars(select(PullRequest).where(PullRequest.source == PullRequestSource.SHOP_ASSEMBLY)).all() == []
     )
@@ -232,9 +238,11 @@ def test_accept_shop_assembly_blocks_on_shortfall(db_session):
 
 def test_reject_shop_assembly_request(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shop_assembly(db_session, project, qty=2)
     sar = result["shop_assembly_request"]
     db_session.flush()
+    assert _reservations(db_session, project.id)  # it was created holding a claim
 
     returned = shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "rejector", "not needed")
     db_session.flush()
@@ -245,6 +253,8 @@ def test_reject_shop_assembly_request(db_session):
     assert returned.rejected_at is not None
     # No PR minted on reject.
     assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is None
+    # The dead request lets go of the hardware it was holding (#342).
+    assert _reservations(db_session, project.id) == []
 
 
 # --- shop-assembly reopen (#325) -------------------------------------------------------------
@@ -306,6 +316,7 @@ def test_reopen_shop_assembly_blocked_when_pr_already_worked(db_session):
 
 def test_reopen_shop_assembly_requires_approved(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shop_assembly(db_session, project, qty=2)
     sar = result["shop_assembly_request"]  # PENDING, never accepted
     db_session.flush()
@@ -346,6 +357,7 @@ def test_reopen_shop_assembly_discards_pr_when_openings_do_not_reference_it(db_s
 
 def test_accept_shipping_out_mints_pr_and_copies_items(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shipping(db_session, project, qty=2)
     req = result["shipping_out_requests"][0]
     req_number = req.request_number
@@ -375,13 +387,16 @@ def test_accept_shipping_out_mints_pr_and_copies_items(db_session):
 
 def test_reject_shipping_out_request(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shipping(db_session, project, qty=2)
     req = result["shipping_out_requests"][0]
     req_number = req.request_number
     db_session.flush()
+    assert _reservations(db_session, project.id)  # the LOOSE line reserved at creation
 
     returned = shipping_repository.reject_shipping_out_request(db_session, req.id, "rejector", "  cancelled  ")
     db_session.flush()
+    assert _reservations(db_session, project.id) == []
 
     assert returned.status == ShippingOutRequestStatus.REJECTED
     assert returned.rejected_by == "rejector"
@@ -564,6 +579,7 @@ def test_complete_never_walks_a_shipped_leaf_back_to_ship_ready(db_session):
 
 def test_reopen_shipping_out_reverts_to_pending_and_deletes_pr(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shipping(db_session, project, qty=2)
     req = result["shipping_out_requests"][0]
     req_number = req.request_number
@@ -614,6 +630,7 @@ def test_reopen_shipping_out_blocked_when_pr_already_worked(db_session):
 
 def test_reopen_shipping_out_requires_approved(db_session):
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
     result = _finalize_shipping(db_session, project, qty=2)
     req = result["shipping_out_requests"][0]  # PENDING, never accepted
     db_session.flush()

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -359,8 +359,9 @@ def test_replace_schedule_preserves_inventory(db_session):
 def test_shop_assembly_request_created_pending(db_session):
     """finalize mints a PENDING ShopAssemblyRequest (#293): NO PullRequest yet, openings hang off the
     SAR via shop_assembly_request_id with pull_request_id NULL, items + snapshot identity captured.
-    No inventory-sufficiency gate at import - it moved to accept."""
+    Creation gates on available inventory and reserves it (#342), so the stock has to be there."""
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
     db_session.commit()
 
     req_number = f"SA-{uuid.uuid4().hex[:6]}"
@@ -724,6 +725,7 @@ def test_leaf_po_ref_attaches_both_leaf_rows_to_one_line(db_session):
 def test_sar_created_per_leaf(db_session):
     """A pair produces one ShopAssemblyOpening per door leaf, each stamped with its leaf."""
     project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
     db_session.commit()
 
     req_number = f"SA-{uuid.uuid4().hex[:6]}"

--- a/backend/tests/test_inventory_reservations.py
+++ b/backend/tests/test_inventory_reservations.py
@@ -1,0 +1,899 @@
+"""Inventory reservations: the claim a request holds between creation and the pull (#342).
+
+Covers the whole lifecycle table in `warehouse/reservations.py` - reserve on create (both request
+types), the availability arithmetic including deficient units and other requests' claims, release on
+reject, hold across a reopen, consumption at pull approval with self-coverage, the PR-REPL pull that
+holds no claim but must still respect everyone else's, and the request-integrity guards
+(duplicate/degenerate/cross-type) and re-upload policy that ship with them.
+
+DB-backed like the rest of the suite: every test runs against a real Postgres in a rolled-back
+transaction.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import InventoryShortfallError, ValidationError
+from app.models.enums import (
+    AssemblyStatus,
+    OpeningItemState,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+    ReservationSource,
+    ShippingOutRequestStatus,
+    ShopAssemblyRequestStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
+from app.models.opening_item import OpeningItem, OpeningItemHardware
+from app.models.project import Opening, Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.shipping_out_request import ShippingOutRequest
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem, ShopAssemblyRequest
+from app.models.stock_item import StockItem
+from app.repositories import (
+    import_repository,
+    shipping_repository,
+    shop_assembly_repository,
+    warehouse_admin_repository,
+)
+from app.repositories import warehouse as warehouse_repository
+
+# --- fixtures / helpers ------------------------------------------------------------------------
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category="HINGE", code="HG-100", quantity, deficient=0, received_at=None):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        received_at=received_at or datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        aisle="A",
+        row="1",
+        bay="1",
+        received_at=received_at or datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _reservations(session, project_id):
+    return list(
+        session.scalars(select(InventoryReservation).where(InventoryReservation.project_id == project_id)).all()
+    )
+
+
+def _reserved_total(session, project_id, category="HINGE", code="HG-100"):
+    return warehouse_repository.get_reserved_quantities(session, project_id).get((category, code), 0)
+
+
+def _finalize_sar(session, project, *, qty=2, code="HG-100", opening_number="A01", leaf=None, openings=None):
+    """Create a shop-assembly request through the real creation path (which is where the gate is)."""
+    sa_openings = openings or [
+        {
+            "opening_number": opening_number,
+            "leaf": leaf,
+            "items": [{"hardware_category": "HINGE", "product_code": code, "quantity": qty}],
+        }
+    ]
+    numbers = sorted({o["opening_number"] for o in sa_openings})
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": n} for n in numbers],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": f"SA-{uuid.uuid4().hex[:6]}",
+            "shop_assembly_openings": sa_openings,
+        },
+    )
+
+
+def _finalize_shipping_loose(session, project, *, qty=2, code="HG-100", opening_number="A01"):
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": opening_number}],
+            "hardware_items": [],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                    "requested_by": "importer",
+                    "items": [
+                        {
+                            "item_type": "LOOSE",
+                            "opening_number": opening_number,
+                            "opening_item_id": None,
+                            "hardware_category": "HINGE",
+                            "product_code": code,
+                            "requested_quantity": qty,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+
+def _make_assembled_leaf(session, project, opening, *, leaf, code="HG-100", category="HINGE"):
+    oi = OpeningItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=opening.id,
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
+        opening_number=opening.opening_number,
+        leaf=leaf,
+        quantity=1,
+        assembly_completed_at=datetime.utcnow(),
+        state=OpeningItemState.IN_INVENTORY,
+    )
+    session.add(oi)
+    session.flush()
+    session.add(
+        OpeningItemHardware(
+            id=uuid.uuid4(),
+            opening_item_id=oi.id,
+            product_code=code,
+            hardware_category=category,
+            quantity=1,
+        )
+    )
+    session.flush()
+    return oi
+
+
+def _finalize_shipping_leaves(session, project, opening_items):
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [],
+            "hardware_items": [],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                    "requested_by": "importer",
+                    "items": [
+                        {
+                            "item_type": "OPENING_ITEM",
+                            "opening_number": oi.opening_number,
+                            "opening_item_id": str(oi.id),
+                            "leaf": oi.leaf,
+                            "requested_quantity": 1,
+                        }
+                        for oi in opening_items
+                    ],
+                }
+            ],
+        },
+    )
+
+
+# --- reserve on create -------------------------------------------------------------------------
+
+
+def test_shop_assembly_creation_reserves_one_row_per_combo(db_session):
+    """Reservations are aggregate: five openings naming the same hinge hold one row for the total,
+    not five rows every availability sum then has to add back up."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+
+    result = _finalize_sar(
+        db_session,
+        project,
+        openings=[
+            {
+                "opening_number": "A01",
+                "leaf": 1,
+                "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 3}],
+            },
+            {
+                "opening_number": "A01",
+                "leaf": 2,
+                "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 4}],
+            },
+        ],
+    )
+    db_session.flush()
+
+    rows = _reservations(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0].quantity == 7
+    assert rows[0].source == ReservationSource.SHOP_ASSEMBLY_REQUEST
+    assert rows[0].shop_assembly_request_id == result["shop_assembly_request"].id
+    assert rows[0].shipping_out_request_id is None
+
+
+def test_shipping_out_loose_lines_reserve_and_opening_item_lines_do_not(db_session):
+    """A LOOSE line claims fungible stock. An assembled leaf claimed its hardware at assembly and
+    ships as itself, so an OPENING_ITEM line reserves nothing at all."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    result = _finalize_shipping_loose(db_session, project, qty=4)
+    db_session.flush()
+
+    rows = _reservations(db_session, project.id)
+    assert len(rows) == 1
+    assert rows[0].quantity == 4
+    assert rows[0].source == ReservationSource.SHIPPING_OUT_REQUEST
+    assert rows[0].shipping_out_request_id == result["shipping_out_requests"][0].id
+
+    # Now an OPENING_ITEM-only request in the same project: no new claim.
+    opening = Opening(id=uuid.uuid4(), project_id=project.id, opening_number="B02")
+    db_session.add(opening)
+    db_session.flush()
+    leaf = _make_assembled_leaf(db_session, project, opening, leaf=1)
+    _finalize_shipping_leaves(db_session, project, [leaf])
+    db_session.flush()
+
+    assert len(_reservations(db_session, project.id)) == 1
+
+
+def test_creation_is_gated_on_what_other_requests_have_already_claimed(db_session):
+    """The second creator sees the first creator's claim, not the raw shelf count."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    _finalize_sar(db_session, project, qty=4, opening_number="A01")
+    db_session.flush()
+
+    with pytest.raises(InventoryShortfallError) as excinfo:
+        _finalize_shipping_loose(db_session, project, qty=2, opening_number="A02")
+
+    s = excinfo.value.shortfalls[0]
+    assert (s.requested, s.available, s.reserved, s.short) == (2, 1, 4, 1)
+
+
+def test_availability_nets_deficient_units_without_double_counting(db_session):
+    """A deficiency reported at the bench bumps the inventory row's quantity AND deficient_quantity
+    together, so it nets to zero in the availability sum - the condemned unit is back in the
+    building, is not available, and is not counted twice against a reservation."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=6)
+    _finalize_sar(db_session, project, qty=2)
+    db_session.flush()
+
+    before = warehouse_repository.get_project_availability(db_session, project.id)[0]
+    assert (before["on_hand_quantity"], before["deficient_quantity"], before["reserved_quantity"]) == (6, 0, 2)
+    assert before["available_quantity"] == 4
+
+    # A unit comes back condemned: quantity 6 -> 7, deficient 0 -> 1.
+    il.quantity += 1
+    il.deficient_quantity += 1
+    db_session.flush()
+
+    after = warehouse_repository.get_project_availability(db_session, project.id)[0]
+    assert (after["on_hand_quantity"], after["deficient_quantity"], after["reserved_quantity"]) == (7, 1, 2)
+    assert after["available_quantity"] == 4  # unchanged - the return was a wash
+
+
+def test_availability_lists_a_fully_claimed_combo_rather_than_hiding_it(db_session):
+    """available floors at 0, and a combo whose stock is entirely spoken for still appears - a
+    creator has to be able to see WHY it reads zero."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=3)
+    _finalize_sar(db_session, project, qty=3)
+    db_session.flush()
+
+    row = warehouse_repository.get_project_availability(db_session, project.id)[0]
+    assert (row["on_hand_quantity"], row["reserved_quantity"], row["available_quantity"]) == (3, 3, 0)
+
+
+# --- release / hold ----------------------------------------------------------------------------
+
+
+def test_reject_releases_a_shop_assembly_claim(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 3
+
+    shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "rejector", "not needed")
+    db_session.flush()
+
+    assert _reserved_total(db_session, project.id) == 0
+    # And the hardware is claimable again.
+    assert warehouse_repository.check_inventory_sufficiency(
+        db_session, project.id, [("HINGE", "HG-100", 5)], reservation_aware=True
+    ).sufficient
+
+
+def test_reopen_keeps_the_claim_and_rejecting_afterwards_releases_it(db_session):
+    """Reopen (#325) undoes the ACCEPT, not the creation. The request goes back to PENDING still
+    holding what it reserved at creation - releasing here would let a second request grab the
+    hardware while the first is still on the board waiting to be re-accepted."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 3  # accept neither spends nor releases
+
+    shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+    db_session.flush()
+    assert db_session.get(ShopAssemblyRequest, sar.id).status == ShopAssemblyRequestStatus.PENDING
+    assert _reserved_total(db_session, project.id) == 3  # still holding
+
+    shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "rejector", "mistake")
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 0  # the reject is what finally lets go
+
+
+def test_reopen_keeps_a_shipping_out_claim_too(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    req = _finalize_shipping_loose(db_session, project, qty=2)["shipping_out_requests"][0]
+    db_session.flush()
+
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+    shipping_repository.reopen_shipping_out_request(db_session, req.id)
+    db_session.flush()
+
+    assert db_session.get(ShippingOutRequest, req.id).status == ShippingOutRequestStatus.PENDING
+    assert _reserved_total(db_session, project.id) == 2
+
+    shipping_repository.reject_shipping_out_request(db_session, req.id, "rejector", None)
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 0
+
+
+# --- consumption at pull approval --------------------------------------------------------------
+
+
+def test_approval_consumes_the_requests_own_claim_and_deducts(db_session):
+    """Self-coverage: the request's own reservation backs the deduction, so the availability check
+    on this path must not count it against the request. A fully-reserved request that took the last
+    of the stock still approves."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=3)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]  # reserves all 3
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    _, outcome, _, shortfalls = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "APPROVED"
+    assert shortfalls == []
+    assert il.quantity == 0  # deducted FIFO, unchanged behaviour
+    assert _reserved_total(db_session, project.id) == 0  # the claim became the deduction
+
+
+def test_approval_consumes_a_shipping_out_claim(db_session):
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=4)
+    req = _finalize_shipping_loose(db_session, project, qty=4)["shipping_out_requests"][0]
+    db_session.flush()
+    shipping_repository.accept_shipping_out_request(db_session, req.id, "acceptor")
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.id == req.pull_request_id))
+    _, outcome, _, _ = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "APPROVED"
+    assert il.quantity == 0
+    assert _reserved_total(db_session, project.id) == 0
+
+
+def test_a_blocked_approval_keeps_the_claim(db_session):
+    """Stock written off under a live claim: the pull is short, stays PENDING, and must NOT hand its
+    hardware to whoever asks next - so the reservation survives the failed attempt."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=3)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    il.quantity = 1  # an admin override under the claim
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    _, outcome, notif, shortfalls = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    assert shortfalls[0].short == 2
+    assert notif is not None
+    assert _reserved_total(db_session, project.id) == 3
+
+
+def test_a_replacement_pull_holds_no_claim_but_respects_everyone_elses(db_session):
+    """A PR-REPL pull is unreserved by nature - nobody can reserve for a deficiency that has not
+    happened yet - so it keeps the reactive check. What it must not do is eat stock another request
+    has already claimed."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    _finalize_sar(db_session, project, qty=4)  # claims 4 of the 5
+    db_session.flush()
+
+    repl = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"PR-REPL-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.PENDING,
+        requested_by="assembler",
+    )
+    db_session.add(repl)
+    db_session.flush()
+    db_session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=repl.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number="A01",
+            hardware_category="HINGE",
+            product_code="HG-100",
+            requested_quantity=2,
+        )
+    )
+    db_session.flush()
+
+    assert warehouse_repository.find_reservation_holder(db_session, repl) is None
+
+    _, outcome, _, shortfalls = warehouse_repository.approve_pull_request(db_session, repl.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    assert (shortfalls[0].available, shortfalls[0].reserved) == (1, 4)
+    # The other request's claim is untouched by the blocked replacement pull.
+    assert _reserved_total(db_session, project.id) == 4
+
+
+def test_a_replacement_pull_approves_out_of_what_is_genuinely_free(db_session):
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=5)
+    _finalize_sar(db_session, project, qty=3)
+    db_session.flush()
+
+    repl = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"PR-REPL-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.PENDING,
+        requested_by="assembler",
+    )
+    db_session.add(repl)
+    db_session.flush()
+    db_session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=repl.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number="A01",
+            hardware_category="HINGE",
+            product_code="HG-100",
+            requested_quantity=2,
+        )
+    )
+    db_session.flush()
+
+    _, outcome, _, _ = warehouse_repository.approve_pull_request(db_session, repl.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "APPROVED"
+    assert il.quantity == 3
+    assert _reserved_total(db_session, project.id) == 3  # the other request still holds its 3
+
+
+# --- request-integrity guards ------------------------------------------------------------------
+
+
+def test_a_leaf_in_a_live_shop_assembly_request_cannot_be_requested_again(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    first = _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)["shop_assembly_request"]
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)
+    assert excinfo.value.field == "shop_assembly_openings"
+    assert first.request_number in excinfo.value.message
+
+
+def test_the_in_flight_guard_is_per_leaf(db_session):
+    """Requesting Leaf 1 must not block Leaf 2 - the same rule the already-assembled guard uses."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _finalize_sar(db_session, project, qty=2, opening_number="PR1", leaf=1)
+    db_session.flush()
+
+    _finalize_sar(db_session, project, qty=2, opening_number="PR1", leaf=2)
+    db_session.flush()
+
+    assert _reserved_total(db_session, project.id) == 4
+
+
+def test_a_rejected_request_stops_blocking_its_leaf(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)["shop_assembly_request"]
+    db_session.flush()
+    shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "rejector", None)
+    db_session.flush()
+
+    _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 2
+
+
+def test_a_completed_work_unit_no_longer_counts_as_in_flight(db_session):
+    """A COMPLETED opening is the already-assembled guard's business, not this one's - otherwise the
+    two guards would give the same leaf two different refusals."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)
+    db_session.flush()
+    sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.opening_number == "A01"))
+    sao.assembly_status = AssemblyStatus.COMPLETED
+    db_session.flush()
+
+    opening = db_session.scalar(select(Opening).where(Opening.project_id == project.id))
+    specs = [("A01", opening.id, 1)]
+    assert shop_assembly_repository.find_in_flight_assembly_leaves(db_session, specs) == []
+
+
+def test_a_leaf_on_a_live_shipping_request_cannot_be_sent_to_shop_assembly(db_session):
+    """Cross-request-type conflict: one physical leaf cannot be both on its way out the door and
+    back on the bench."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    opening = Opening(id=uuid.uuid4(), project_id=project.id, opening_number="A01")
+    db_session.add(opening)
+    db_session.flush()
+    leaf = _make_assembled_leaf(db_session, project, opening, leaf=1)
+    ship_req = _finalize_shipping_leaves(db_session, project, [leaf])["shipping_out_requests"][0]
+    db_session.flush()
+    # Take the assembled unit out of the way so the *already-assembled* guard is not what fires.
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)
+    assert "shipping-out request" in excinfo.value.message
+    assert ship_req.request_number in excinfo.value.message
+
+
+def test_a_leaf_already_on_a_live_shipping_request_cannot_be_requested_again(db_session):
+    project = _make_project(db_session)
+    opening = Opening(id=uuid.uuid4(), project_id=project.id, opening_number="A01")
+    db_session.add(opening)
+    db_session.flush()
+    leaf = _make_assembled_leaf(db_session, project, opening, leaf=1)
+    first = _finalize_shipping_leaves(db_session, project, [leaf])["shipping_out_requests"][0]
+    db_session.flush()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_shipping_leaves(db_session, project, [leaf])
+    assert excinfo.value.field == "opening_item_id"
+    assert first.request_number in excinfo.value.message
+
+
+def test_a_leaf_still_in_shop_assembly_cannot_be_shipped(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(db_session, project, qty=2, opening_number="A01", leaf=1)["shop_assembly_request"]
+    db_session.flush()
+    opening = db_session.scalar(select(Opening).where(Opening.project_id == project.id))
+    leaf = _make_assembled_leaf(db_session, project, opening, leaf=1)
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_shipping_leaves(db_session, project, [leaf])
+    assert "still in shop assembly" in excinfo.value.message
+    assert sar.request_number in excinfo.value.message
+
+
+def test_a_zero_opening_shop_assembly_request_is_refused(db_session):
+    project = _make_project(db_session)
+    with pytest.raises(ValidationError) as excinfo:
+        import_repository.finalize_import_session(
+            db_session,
+            {
+                "project_id": str(project.id),
+                "openings": [{"opening_number": "A01"}],
+                "hardware_items": [],
+                "include_shop_assembly_request": True,
+                "shop_assembly_request_number": f"SA-{uuid.uuid4().hex[:6]}",
+                "shop_assembly_openings": [],
+            },
+        )
+    assert excinfo.value.field == "shop_assembly_openings"
+    assert "at least one opening" in excinfo.value.message
+
+
+def test_a_zero_item_opening_is_refused(db_session):
+    """A leaf with an empty checklist would reach shop assembly as something #339 refuses to
+    complete, so it never gets created."""
+    project = _make_project(db_session)
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize_sar(
+            db_session,
+            project,
+            openings=[{"opening_number": "A01", "leaf": 2, "items": []}],
+        )
+    assert excinfo.value.field == "shop_assembly_openings"
+    assert "Opening A01 Leaf 2" in excinfo.value.message
+
+
+def test_a_zero_line_shipping_request_is_refused(db_session):
+    project = _make_project(db_session)
+    with pytest.raises(ValidationError) as excinfo:
+        import_repository.finalize_import_session(
+            db_session,
+            {
+                "project_id": str(project.id),
+                "openings": [],
+                "hardware_items": [],
+                "shipping_out_pr_drafts": [{"request_number": "SHIP-EMPTY", "requested_by": "importer", "items": []}],
+            },
+        )
+    assert excinfo.value.field == "items"
+    assert "no items" in excinfo.value.message
+
+
+# --- schedule re-upload ------------------------------------------------------------------------
+
+
+def _reupload(session, project, opening_numbers):
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": n} for n in opening_numbers],
+            "hardware_items": [],
+            "replace_schedule": True,
+        },
+    )
+
+
+def test_reupload_drops_vanished_openings_and_releases_their_claim(db_session):
+    """The re-upload is not blocked. A PENDING request is rewritten to what survived, and its
+    reservation is rebuilt from that - releasing exactly what the vanished opening was holding."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(
+        db_session,
+        project,
+        openings=[
+            {
+                "opening_number": "A01",
+                "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 3}],
+            },
+            {
+                "opening_number": "A02",
+                "items": [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 5}],
+            },
+        ],
+    )["shop_assembly_request"]
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 8
+
+    _reupload(db_session, project, ["A01"])  # A02 is gone from the new schedule
+    db_session.flush()
+    db_session.refresh(sar)
+
+    assert _reserved_total(db_session, project.id) == 3
+    remaining = db_session.scalars(
+        select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id)
+    ).all()
+    assert [o.opening_number for o in remaining] == ["A01"]
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+    assert sar.integrity_note is not None
+    assert "no longer exist" in sar.integrity_note
+
+
+def test_reupload_auto_rejects_a_request_that_lost_everything(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(db_session, project, qty=4, opening_number="A01")["shop_assembly_request"]
+    db_session.flush()
+
+    _reupload(db_session, project, ["Z99"])
+    db_session.flush()
+    db_session.refresh(sar)
+
+    assert sar.status == ShopAssemblyRequestStatus.REJECTED
+    assert sar.rejected_by == "Hardware Schedule Import"
+    assert _reserved_total(db_session, project.id) == 0
+
+
+def test_reupload_flags_a_surviving_request_without_touching_its_claim(db_session):
+    """A full-schedule replacement can change the hardware on an opening it kept, so every live
+    request is flagged - not just the ones that lost openings."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(db_session, project, qty=4, opening_number="A01")["shop_assembly_request"]
+    db_session.flush()
+
+    _reupload(db_session, project, ["A01"])
+    db_session.flush()
+    db_session.refresh(sar)
+
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+    assert sar.integrity_note is not None
+    assert "re-uploaded" in sar.integrity_note
+    assert _reserved_total(db_session, project.id) == 4
+
+
+def test_reupload_leaves_an_accepted_requests_pull_alone(db_session):
+    """Once the pull exists it is the authority on what the warehouse will hand over; shrinking it
+    underneath the puller would be worse than a stale bill of hardware. Flag only."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _finalize_sar(db_session, project, qty=4, opening_number="A01")["shop_assembly_request"]
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    _reupload(db_session, project, ["Z99"])  # A01 is gone
+    db_session.flush()
+    db_session.refresh(sar)
+
+    assert sar.status == ShopAssemblyRequestStatus.APPROVED
+    assert sar.integrity_note is not None
+    assert _reserved_total(db_session, project.id) == 4
+    assert (
+        db_session.scalars(
+            select(ShopAssemblyOpeningItem)
+            .join(ShopAssemblyOpening, ShopAssemblyOpeningItem.shop_assembly_opening_id == ShopAssemblyOpening.id)
+            .where(ShopAssemblyOpening.shop_assembly_request_id == sar.id)
+        ).all()
+        != []
+    )
+
+
+def test_reupload_rebuilds_a_shipping_requests_loose_claim(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    req = import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": "A01"}, {"opening_number": "A02"}],
+            "hardware_items": [],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                    "requested_by": "importer",
+                    "items": [
+                        {
+                            "item_type": "LOOSE",
+                            "opening_number": "A01",
+                            "hardware_category": "HINGE",
+                            "product_code": "HG-100",
+                            "requested_quantity": 2,
+                        },
+                        {
+                            "item_type": "LOOSE",
+                            "opening_number": "A02",
+                            "hardware_category": "HINGE",
+                            "product_code": "HG-100",
+                            "requested_quantity": 6,
+                        },
+                    ],
+                }
+            ],
+        },
+    )["shipping_out_requests"][0]
+    db_session.flush()
+    assert _reserved_total(db_session, project.id) == 8
+
+    _reupload(db_session, project, ["A01"])
+    db_session.flush()
+    db_session.refresh(req)
+
+    assert _reserved_total(db_session, project.id) == 2
+    assert [i.opening_number for i in req.items] == ["A01"]
+    assert req.status == ShippingOutRequestStatus.PENDING
+
+
+# --- self-coverage at the repository level ------------------------------------------------------
+
+
+def test_the_exclusion_is_what_makes_a_fully_reserved_request_approvable(db_session):
+    """Directly: without excluding its own claim, a request that reserved exactly what it needs
+    would read as competing with itself and could never be approved."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=3)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+
+    needs = [("HINGE", "HG-100", 3)]
+    without = warehouse_repository.check_inventory_sufficiency(db_session, project.id, needs, reservation_aware=True)
+    assert not without.sufficient
+
+    with_self = warehouse_repository.check_inventory_sufficiency(
+        db_session,
+        project.id,
+        needs,
+        reservation_aware=True,
+        exclude_reservations_of=(ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id),
+    )
+    assert with_self.sufficient
+
+
+def test_release_is_idempotent(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    sar = _finalize_sar(db_session, project, qty=2)["shop_assembly_request"]
+    db_session.flush()
+
+    assert warehouse_repository.release_reservations(db_session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id) == 1
+    assert warehouse_repository.release_reservations(db_session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id) == 0
+    assert _reservations(db_session, project.id) == []
+
+
+def test_reservations_are_scoped_to_their_project(db_session):
+    """A claim in one project cannot make stock look unavailable in another - inventory is
+    project-scoped and so is the claim on it."""
+    project_a = _make_project(db_session)
+    project_b = _make_project(db_session)
+    _seed_inventory(db_session, project_a.id, quantity=5)
+    _seed_inventory(db_session, project_b.id, quantity=5)
+    _finalize_sar(db_session, project_a, qty=5)
+    db_session.flush()
+
+    assert _reserved_total(db_session, project_a.id) == 5
+    assert _reserved_total(db_session, project_b.id) == 0
+    assert warehouse_repository.check_inventory_sufficiency(
+        db_session, project_b.id, [("HINGE", "HG-100", 5)], reservation_aware=True
+    ).sufficient
+
+
+def test_shop_assembly_openings_still_reach_the_bench_after_a_reserved_pull(db_session):
+    """End-to-end sanity: the whole reserve -> accept -> approve -> complete chain still lands the
+    opening in PULLED with nothing left reserved."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=4)
+    sar = _finalize_sar(db_session, project, qty=4)["shop_assembly_request"]
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, pr.id)
+    db_session.flush()
+
+    sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id))
+    assert sao.pull_status == PullStatus.PULLED
+    assert _reserved_total(db_session, project.id) == 0

--- a/backend/tests/test_inventory_sufficiency_gates.py
+++ b/backend/tests/test_inventory_sufficiency_gates.py
@@ -1,8 +1,12 @@
-"""Tests for the two hard inventory-sufficiency gates and the shared helper (#224 / #293).
+"""Tests for the hard inventory-sufficiency gates and the shared helper (#224 / #293 / #342).
 
-Gate 1: accepting a shop-assembly request refuses to mint the PR when short (#293 moved this gate
-        from import "Start a Task" to the accept step).
-Gate 2: warehouse approve_pull_request leaves the PR PENDING (not cancelled) when short.
+Gate 1 moved twice. It started at import "Start a Task", moved to accept in #293, and moved back to
+creation in #342 - this time as a *reservation*: creating a request gates on
+`on-hand - deficient - other requests' reservations` and writes its own claim. Accept is now a pure
+human gate that re-checks nothing, because the hardware is already this request's.
+
+Gate 2: warehouse approve_pull_request leaves the PR PENDING (not cancelled) when short. It still
+exists, and it is still what a PR-REPL replacement pull (which can hold no reservation) runs into.
 Both notify the PO with an INVENTORY_SHORTFALL signal carrying the shortfall detail.
 """
 
@@ -18,9 +22,11 @@ from app.models.enums import (
     PullRequestItemType,
     PullRequestSource,
     PullRequestStatus,
+    ReservationSource,
     ShopAssemblyRequestStatus,
 )
 from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
 from app.models.notification import Notification
 from app.models.project import Project
 from app.models.pull_request import PullRequest, PullRequestItem
@@ -148,7 +154,7 @@ def test_helper_aggregates_duplicate_combos(db_session):
     assert result.shortfalls[0].short == 1
 
 
-# --- gate 1: accepting a shop-assembly request (#293) ----------------------------------------
+# --- gate 1: creating a shop-assembly request (#342) -----------------------------------------
 
 
 def _finalize_shop_assembly(session, project, *, code, qty):
@@ -191,58 +197,79 @@ def _finalize_shop_assembly(session, project, *, code, qty):
     )
 
 
-def test_gate1_import_always_creates_pending_request_even_when_short(db_session):
-    """#293: import no longer gates on inventory - it always mints a PENDING request. Sufficiency is
-    enforced at accept, not here."""
+def test_gate1_creation_refuses_when_short_and_creates_nothing(db_session):
+    """#342: the gate is at creation. A selection that does not fit available inventory is refused
+    whole, naming the shorted combo, and nothing at all is written - the creator refines the
+    selection, which is the only point in the flow where that is still cheap."""
     project = _make_project(db_session)
-    _seed_inventory(db_session, project.id, quantity=1)  # need 3, only 1 available
+    project_id = project.id
+    _seed_inventory(db_session, project_id, quantity=1)  # need 3, only 1 available
     db_session.commit()
 
-    result = _finalize_shop_assembly(db_session, project, code="HG-100", qty=3)
-    db_session.flush()
+    with pytest.raises(InventoryShortfallError) as excinfo:
+        _finalize_shop_assembly(db_session, project, code="HG-100", qty=3)
 
-    sar = result["shop_assembly_request"]
-    assert sar is not None
-    assert sar.status == ShopAssemblyRequestStatus.PENDING
-    # No PR minted at import.
+    err = excinfo.value
+    assert err.project_id == project_id
+    assert len(err.shortfalls) == 1
+    assert (err.shortfalls[0].requested, err.shortfalls[0].available, err.shortfalls[0].short) == (3, 1, 2)
+
+    db_session.rollback()
     assert (
-        db_session.scalars(
-            select(PullRequest).where(
-                PullRequest.project_id == project.id,
-                PullRequest.source == PullRequestSource.SHOP_ASSEMBLY,
-            )
-        ).all()
+        db_session.scalars(select(ShopAssemblyRequest).where(ShopAssemblyRequest.project_id == project_id)).all() == []
+    )
+    assert (
+        db_session.scalars(select(InventoryReservation).where(InventoryReservation.project_id == project_id)).all()
         == []
     )
 
 
-def test_gate1_accept_refuses_when_short_and_creates_no_pr(db_session):
+def test_gate1_creation_reserves_what_it_takes(db_session):
+    """A covered creation writes the claim, and the claim is what later readers see as unavailable."""
     project = _make_project(db_session)
-    project_id = project.id  # stable id for asserts after the refused accept
-    _seed_inventory(db_session, project_id, quantity=1)  # need 3, only 1 available
+    _seed_inventory(db_session, project.id, quantity=5)
+    result = _finalize_shop_assembly(db_session, project, code="HG-100", qty=3)
+    db_session.flush()
+
+    reservations = db_session.scalars(
+        select(InventoryReservation).where(InventoryReservation.project_id == project.id)
+    ).all()
+    assert len(reservations) == 1
+    assert reservations[0].quantity == 3
+    assert reservations[0].source == ReservationSource.SHOP_ASSEMBLY_REQUEST
+    assert reservations[0].shop_assembly_request_id == result["shop_assembly_request"].id
+
+    # 5 on hand, 3 claimed -> 2 left for anyone else.
+    check = warehouse_repository.check_inventory_sufficiency(
+        db_session, project.id, [("HINGE", "HG-100", 3)], reservation_aware=True
+    )
+    assert not check.sufficient
+    assert (check.shortfalls[0].available, check.shortfalls[0].reserved) == (2, 3)
+
+
+def test_gate1_accept_no_longer_rechecks_inventory(db_session):
+    """Accept is a pure human gate (#342). Even if stock is written off after creation, the accept
+    still mints the PR - the request holds a reservation, and the place that decision was made was
+    creation. (The warehouse approve is what would then surface the discrepancy.)"""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=3)
     result = _finalize_shop_assembly(db_session, project, code="HG-100", qty=3)
     sar_id = result["shop_assembly_request"].id
     db_session.flush()
 
-    with pytest.raises(InventoryShortfallError) as excinfo:
-        shop_assembly_repository.accept_shop_assembly_request(db_session, sar_id, "acceptor")
+    il.quantity = 0  # an admin write-off under a live claim
+    db_session.flush()
 
-    # The refusal carries the shortfall detail for the acceptor and the PO notification.
-    err = excinfo.value
-    assert err.project_id == project_id
-    assert len(err.shortfalls) == 1
-    assert err.shortfalls[0].short == 2
+    sar = shop_assembly_repository.accept_shop_assembly_request(db_session, sar_id, "acceptor")
+    db_session.flush()
 
-    # Accept re-checks sufficiency before mutating, so a shortfall raises without touching
-    # anything: no shop-assembly PR is minted and the request stays PENDING.
-    prs = db_session.scalars(
-        select(PullRequest).where(
-            PullRequest.project_id == project_id,
-            PullRequest.source == PullRequestSource.SHOP_ASSEMBLY,
-        )
-    ).all()
-    assert prs == []
-    assert db_session.get(ShopAssemblyRequest, sar_id).status == ShopAssemblyRequestStatus.PENDING
+    assert sar.status == ShopAssemblyRequestStatus.APPROVED
+    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is not None
+    # Accepting neither spends nor releases the claim.
+    assert (
+        len(db_session.scalars(select(InventoryReservation).where(InventoryReservation.project_id == project.id)).all())
+        == 1
+    )
 
 
 def test_gate1_accept_mints_pr_when_covered(db_session):

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -56,6 +56,56 @@ This is why both request types are created from the hardware schedule through **
 schedule is the only thing that knows which leaf of which opening a quantity is owed to. Inventory
 cannot answer that question, because it deliberately forgot.
 
+#### 3a. The reservation: the tag's claim before the pull
+
+The tag is written when the request is created, but the stock is not deducted until the warehouse
+approves the pull - and that gap used to be a hole. Two requests could each be created against the
+same hinges, both pass an accept-time check, and the second pull would then find the shelf empty.
+
+Since #342 **creating a request reserves what it claims.** An `inventory_reservations` row is written
+in the same transaction, and availability everywhere becomes
+
+    available = on-hand - deficient - active reservations
+
+A reservation is the claim half of the tag: it says "these units are spoken for by this request"
+without yet saying *which* units, which is exactly right for fungible stock. Note what the table
+deliberately does not have, for the same reason `InventoryLocation` does not have it:
+
+- **no opening, no leaf** - a hinge is still a hinge; the reservation is aggregate, per
+  `(project, hardware_category, product_code)`;
+- **no `inventory_location_id`** - pinning a claim to specific rows would fight FIFO. The reservation
+  governs *how much* is free, never *which* row. FIFO deduction at approval is unchanged.
+
+The lifecycle of that claim, end to end:
+
+| Path | Effect on the claim |
+| --- | --- |
+| Create a shop-assembly request | **Reserve** every checklist line, aggregated per combo |
+| Create a shipping-out request, LOOSE line | **Reserve** - it claims fungible stock |
+| Create a shipping-out request, OPENING_ITEM line | **Nothing** - the leaf claimed its hardware at assembly and ships as itself |
+| Creation would exceed available | **Refused whole** - typed `InventoryShortfallError` naming every short combo; nothing is written and the creator refines the selection |
+| Accept (either type) | **No change** - accept is a pure human gate and re-checks nothing |
+| Reject (either type) | **Release** - the request is dead, the hardware goes back to the pool |
+| Reopen an accepted request (#325) | **No change** - reopen undoes the *accept*, not the creation; the request returns to PENDING still holding its claim |
+| Reject after a reopen | **Release** - the same reject path, and the only thing that finally lets go |
+| Pull approval, sufficient | **Consume** - the claim becomes the FIFO deduction, atomically, under the same row locks |
+| Pull approval, short | **No change** - the pull stays PENDING and keeps holding, so a blocked request does not hand its hardware to whoever asks next |
+| PR-REPL replacement pull | **Never reserves** - a deficiency cannot be foreseen, so it keeps the reactive check and the PO-backfill loop. It still draws only from on-hand minus deficient minus *others'* reservations |
+| Re-upload drops a PENDING request's openings | **Rebuilt** from what survived, which releases exactly what the vanished openings held |
+| Re-upload empties a PENDING request | **Auto-reject**, which releases |
+
+**Self-coverage** is the one subtlety worth naming. When the warehouse approves request R's pull, R's
+own reservations are precisely what backs the deduction, so the availability check on that path
+excludes them (`exclude_reservations_of`). Without the exclusion a request that reserved exactly what
+it needs would read as competing with itself and could never be approved. Everyone else's claims
+still count - which is also what stops an unreserved PR-REPL pull from eating stock another request
+is holding.
+
+A **deficiency reported at the bench** does not touch reservations, and cannot double-count against
+them: `report_deficiency_at_assembly` raises the inventory row's `quantity` and `deficient_quantity`
+together, so the pair nets to zero in `on-hand - deficient`. The unit is back in the building and is
+not available - which is the truth.
+
 ### 4. The tag materializes
 
 The tag does not become physical all at once. Assembly happens over a shift, unit by unit, and since
@@ -117,10 +167,11 @@ Both pull request sources use `pull_request_items`, but the two `item_type` valu
 different things:
 
 - `LOOSE` - tags fungible inventory onto a leaf for the first time. Approving it deducts stock, so it
-  is gated on inventory sufficiency.
+  is gated on inventory sufficiency - and since #342 it is also what *reserves* stock when the
+  request is created.
 - `OPENING_ITEM` - moves a leaf that was **already tagged** at shop assembly. The hardware left
   fungible inventory when it was installed. Approving it deducts nothing and locks the `OpeningItem`
-  row instead; there is no stock to check.
+  row instead; there is no stock to check, and nothing to reserve either.
 
 Confusing the two is issue #335: the Shipping Out import emitted `LOOSE` lines for hardware that had
 already been assembled onto a leaf, so the warehouse pull asked general inventory for hardware that
@@ -138,6 +189,14 @@ leaf until a pull tags it onto one).
 | --- | --- |
 | Leaf parsed from TITAN | `frontend/src/workers/parserLogic.ts` (`leafFromMaterialId`, ML-level `Leaf` attribute) |
 | Identity dropped | `backend/app/models/inventory.py` (`InventoryLocation`, no opening/leaf column) |
+| Claim written at creation | `backend/app/repositories/import_repository.py` (`finalize_import_session` -> `_gate_on_available_inventory` + `create_reservations`) |
+| Claim modelled | `backend/app/models/inventory_reservation.py` (aggregate; no opening, no leaf, no location) |
+| Availability arithmetic | `backend/app/repositories/warehouse/reservations.py` (`get_reserved_quantities`, `get_project_availability`, grouped aggregates) |
+| Claim respected / self-covered | `backend/app/repositories/warehouse/pull_requests.py` (`check_inventory_sufficiency`, `reservation_aware` + `exclude_reservations_of`) |
+| Claim consumed at the pull | `backend/app/repositories/warehouse/pull_requests.py` (`approve_pull_request` -> `release_reservations` then FIFO deduction) |
+| Claim released | `shop_assembly_repository.reject_shop_assembly_request` / `shipping_repository.reject_shipping_out_request` (reject only - reopen deliberately holds) |
+| Duplicate / cross-type leaf guard | `shop_assembly_repository.find_in_flight_assembly_leaves`, `shipping_repository.find_live_shipping_claims` |
+| Re-upload reconciliation | `backend/app/repositories/import_repository.py` (`_handle_schedule_replacement` -> rebuild, auto-reject, `integrity_note`) |
 | Tag written, shop assembly | `backend/app/repositories/shop_assembly_repository.py` (`accept_shop_assembly_request`) |
 | Tag written, shipping out | `backend/app/repositories/shipping_repository.py` (`accept_shipping_out_request`) |
 | Tag consumes stock | `backend/app/repositories/warehouse/pull_requests.py` (`approve_pull_request`, FIFO deduction) |

--- a/frontend/src/components/RequestsReviewPage.tsx
+++ b/frontend/src/components/RequestsReviewPage.tsx
@@ -19,11 +19,18 @@ import type { DocumentNode } from 'graphql';
 import { useToast } from './Toast';
 import { useIdentity } from '../hooks/useIdentity';
 import ConfirmDialog from './ConfirmDialog';
+import { RESERVATION_STALE_ROOT_FIELDS } from '../graphql/refetch';
 
 interface ReviewableRequest {
   id: string;
   requestNumber: string;
   createdBy: string;
+  /**
+   * Something happened to this request after it was created that the reviewer has to know about
+   * (#342) - a schedule re-upload landed under it, or it holds no inventory reservation. Null on a
+   * healthy request, which is the overwhelming majority, so it renders nothing at all.
+   */
+  integrityNote?: string | null;
 }
 
 interface RequestsReviewPageProps<TRequest extends ReviewableRequest> {
@@ -98,7 +105,16 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
     onError: (e) => settle(e.message, 'error'),
   });
 
+  // Rejecting RELEASES the request's inventory reservation (#342), so the project's availability
+  // changes for everyone. The reader is the Start a Task wizard in another module, never mounted
+  // here, which is exactly what an eviction reaches and refetchQueries does not.
   const [rejectRequest] = useMutation(rejectMutation, {
+    update(cache) {
+      for (const fieldName of RESERVATION_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: () => settle('Request rejected', 'success'),
     onError: (e) => settle(e.message, 'error'),
   });
@@ -163,6 +179,10 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
             </AccordionSummary>
             <AccordionDetails>
               <Stack spacing={2}>
+                {/* Real system state about this specific request (#342), so it earns a status
+                    colour and sits above the detail rather than in a tooltip - it changes what
+                    accepting means. */}
+                {req.integrityNote && <Alert severity="warning">{req.integrityNote}</Alert>}
                 {renderDetails(req)}
 
                 {mode === 'approved' ? (
@@ -226,7 +246,7 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
       <ConfirmDialog
         open={confirmReopenId !== null}
         title="Reopen this request?"
-        message="This undoes the accept: the request goes back to Pending and the warehouse pull request it created is removed. It only works if the warehouse has not started that pull yet."
+        message="This undoes the accept: the request goes back to Pending and the warehouse pull request it created is removed. It only works if the warehouse has not started that pull yet. The request keeps its claim on the hardware it reserved - reject it to release that."
         confirmLabel="Reopen"
         onConfirm={() => {
           const id = confirmReopenId;

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -64,3 +64,14 @@ export const REPLACEMENT_INSTALL_REFETCH_QUERIES = ['GetReplacementWork'];
 // decide whether a leaf is flagged - and the wizard is a different module that is never mounted
 // while an assembler is installing, which is exactly what refetchQueries cannot reach.
 export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems'];
+
+// What creating, accepting, rejecting or reopening a request invalidates (#342). Creating a request
+// RESERVES inventory, so every one of these moments changes `available = on-hand - deficient -
+// reservations` for the whole project.
+//
+// Evicted, not refetched, and there is nothing paired to refetch by name: the reader is the Start a
+// Task wizard, which is a full-screen dialog in another module and is by definition NOT mounted when
+// a request is accepted or rejected - exactly the case refetchQueries cannot reach. Eviction is what
+// stops the next wizard session from opening on the cache-first half of its cache-and-network read
+// and gating a selection against pre-reservation numbers for a beat.
+export const RESERVATION_STALE_ROOT_FIELDS = ['projectInventoryAvailability'];

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -83,6 +83,7 @@ export const GET_SHIPPING_OUT_REQUESTS = gql`
       status
       createdBy
       createdAt
+      integrityNote
       items {
         id
         itemType

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -139,6 +139,7 @@ export const GET_SHOP_ASSEMBLY_REQUESTS = gql`
       status
       createdBy
       createdAt
+      integrityNote
       openings {
         id
         openingNumber

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -1,5 +1,27 @@
 import { gql } from '@apollo/client/core';
 
+/**
+ * What each product in a project can still be CLAIMED for (#342):
+ * `availableQuantity = onHandQuantity - deficientQuantity - reservedQuantity`.
+ *
+ * This is the exact number the Start-a-Task creation gate applies server-side, so the wizard can
+ * block an over-selection with per-combo detail before submission instead of bouncing the whole
+ * finalize. Deliberately NOT the same as `inventoryHierarchy`'s availability (on-hand minus
+ * deficient), which answers "what is physically unspoken-for in the building".
+ */
+export const GET_PROJECT_INVENTORY_AVAILABILITY = gql`
+  query GetProjectInventoryAvailability($projectId: ID!) {
+    projectInventoryAvailability(projectId: $projectId) {
+      hardwareCategory
+      productCode
+      onHandQuantity
+      deficientQuantity
+      reservedQuantity
+      availableQuantity
+    }
+  }
+`;
+
 export const GET_INVENTORY_HIERARCHY = gql`
   query GetInventoryHierarchy($projectId: ID, $warehouseId: ID) {
     inventoryHierarchy(projectId: $projectId, warehouseId: $warehouseId) {

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -34,18 +34,27 @@ import { useHardwareScheduleParser } from '../../hooks/useHardwareScheduleParser
 import { useNavigate } from 'react-router-dom';
 import { GET_PROJECT_EXCLUDED_ITEMS, GET_PROJECT_HARDWARE_SCHEDULE, RECONCILE_SCHEDULE, FINALIZE_IMPORT_SESSION } from '../../graphql/import';
 import { GET_PROJECTS } from '../../graphql/shared';
-import { GET_OPENING_ITEMS, GET_PULL_REQUESTS } from '../../graphql/warehouse';
+import { GET_OPENING_ITEMS, GET_PROJECT_INVENTORY_AVAILABILITY, GET_PULL_REQUESTS } from '../../graphql/warehouse';
 import { GET_SHIPPING_OUT_REQUESTS } from '../../graphql/shipping';
+import { RESERVATION_STALE_ROOT_FIELDS } from '../../graphql/refetch';
 import type { ClassificationRow } from './ClassificationGrid';
 import type {
   AggregatedHardwareItem,
   AssembledLeafCandidate,
   ImportPurpose,
+  InventoryAvailabilityRow,
   ReconciliationRow,
   ShippingPRDraft,
   ShippingPRItem,
 } from './types';
-import { aggregationKey, classificationKey, shippingPRItemKey, toClassificationInputs } from './types';
+import {
+  aggregationKey,
+  classificationKey,
+  computeAvailabilityShortfalls,
+  itemGroupKey,
+  shippingPRItemKey,
+  toClassificationInputs,
+} from './types';
 import type { Project } from '../../types/project';
 import type { ProjectHardwareScheduleResponse } from './hydrateSchedule';
 import { mapScheduleResponseToParseResult } from './hydrateSchedule';
@@ -269,6 +278,16 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       shopAssemblyRequest: { id: string; requestNumber: string; status: string } | null;
     };
   }>(FINALIZE_IMPORT_SESSION, {
+    // The request this creates RESERVES inventory (#342), so the availability the wizard gates on
+    // is stale the moment it succeeds. Evicted rather than refetched: a second Start a Task in the
+    // same session would otherwise open on the cache-first half of its cache-and-network read and
+    // let a selection through against pre-reservation numbers.
+    update(cache) {
+      for (const fieldName of RESERVATION_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     refetchQueries: [{ query: GET_PROJECTS }],
   });
 
@@ -478,6 +497,129 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       return kept.length === draft.items.length ? draft : { ...draft, items: kept };
     });
   }, [purpose, shippingPRDrafts, shippingCandidateKeys]);
+
+  // ---- Reservation-aware availability (#342) ----
+
+  // Creating a request RESERVES the hardware it needs, and the server gates creation on
+  // `on-hand - deficient - other requests' reservations`. Read the same numbers here so the wizard
+  // can refuse an over-selection with per-combo detail instead of letting the whole finalize bounce.
+  const requestPurposeActive = open && (purpose === 'assembly' || purpose === 'shipping');
+  const {
+    data: availabilityData,
+    loading: availabilityLoading,
+    error: availabilityError,
+  } = useQuery<{ projectInventoryAvailability: InventoryAvailabilityRow[] }>(
+    GET_PROJECT_INVENTORY_AVAILABILITY,
+    {
+      variables: { projectId: existingProjectId },
+      skip: !requestPurposeActive,
+      fetchPolicy: 'cache-and-network',
+    },
+  );
+
+  const availabilityByCombo = useMemo(() => {
+    const map = new Map<string, InventoryAvailabilityRow>();
+    for (const row of availabilityData?.projectInventoryAvailability ?? []) {
+      map.set(itemGroupKey({ hardware_category: row.hardwareCategory, product_code: row.productCode }), row);
+    }
+    return map;
+  }, [availabilityData]);
+
+  // The shop-assembly work units this wizard would submit: one per (opening, leaf) with its
+  // SHOP_HARDWARE items aggregated. Derived once and used by BOTH the availability gate and
+  // buildFinalizeInput, so the numbers the user is held to are by construction the numbers that get
+  // sent - a second, parallel calculation here would be a bug waiting to diverge.
+  const shopAssemblyOpeningDrafts = useMemo(() => {
+    if (purpose !== 'assembly' || !parsed) return [];
+    const selectedItems = parsed.hardwareItems.filter((hi) => selectedOpenings.has(hi.opening_number));
+    return parsed.openings
+      .filter((o) => selectedOpenings.has(o.opening_number))
+      .flatMap((opening) => {
+        const shopItems = selectedItems.filter((hi) => {
+          if (hi.opening_number !== opening.opening_number) return false;
+          return classifications.get(classificationKey(hi)) === 'SHOP_HARDWARE';
+        });
+        if (shopItems.length === 0) return [];
+        // One SAR opening per door leaf (#311): group SHOP_HARDWARE by leaf, then aggregate each
+        // leaf's items by (product_code, hardware_category). A pair yields two work units.
+        const byLeaf = new Map<
+          number | null,
+          Map<string, { hardwareCategory: string; productCode: string; quantity: number }>
+        >();
+        for (const hi of shopItems) {
+          let aggMap = byLeaf.get(hi.leaf);
+          if (!aggMap) {
+            aggMap = new Map();
+            byLeaf.set(hi.leaf, aggMap);
+          }
+          const key = `${hi.product_code}|${hi.hardware_category}`;
+          const existing = aggMap.get(key);
+          if (existing) {
+            existing.quantity += hi.item_quantity;
+          } else {
+            aggMap.set(key, {
+              hardwareCategory: hi.hardware_category,
+              productCode: hi.product_code,
+              quantity: hi.item_quantity,
+            });
+          }
+        }
+        // #311: a null-leaf bucket is legitimate for a single door (every item is leaf-null -> one
+        // work unit). On a pair (resolved leaves present) a null-leaf item would otherwise spawn a
+        // spurious third work unit; fold it into the lowest resolved leaf instead.
+        const resolvedLeaves = [...byLeaf.keys()].filter((k): k is number => k !== null);
+        const nullBucket = byLeaf.get(null);
+        if (nullBucket && resolvedLeaves.length > 0) {
+          const targetMap = byLeaf.get(Math.min(...resolvedLeaves))!;
+          for (const [key, agg] of nullBucket) {
+            const existing = targetMap.get(key);
+            if (existing) existing.quantity += agg.quantity;
+            else targetMap.set(key, agg);
+          }
+          byLeaf.delete(null);
+        }
+        return Array.from(byLeaf.entries()).map(([leaf, aggMap]) => ({
+          openingNumber: opening.opening_number,
+          leaf,
+          items: Array.from(aggMap.values()),
+        }));
+      });
+  }, [purpose, parsed, selectedOpenings, classifications]);
+
+  // What this wizard is about to claim, per combo. Shop assembly claims every checklist line;
+  // shipping claims only its LOOSE lines - an assembled leaf left fungible inventory when it was
+  // built and ships as itself (docs/HARDWARE_IDENTITY_LIFECYCLE.md), so it reserves nothing.
+  const requestedByCombo = useMemo(() => {
+    const map = new Map<string, number>();
+    if (purpose === 'assembly') {
+      for (const draft of shopAssemblyOpeningDrafts) {
+        for (const item of draft.items) {
+          const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
+          map.set(key, (map.get(key) ?? 0) + item.quantity);
+        }
+      }
+    } else if (purpose === 'shipping') {
+      for (const draft of effectiveShippingPRDrafts) {
+        for (const item of draft.items) {
+          if (item.itemType !== 'LOOSE' || !item.hardwareCategory || !item.productCode) continue;
+          const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
+          map.set(key, (map.get(key) ?? 0) + item.requestedQuantity);
+        }
+      }
+    }
+    return map;
+  }, [purpose, shopAssemblyOpeningDrafts, effectiveShippingPRDrafts]);
+
+  const availabilityShortfalls = useMemo(
+    // While the lookup is still in flight an empty map would read as "nothing available" and block
+    // everything, so hold off until it has answered. A failed lookup is handled in the steps: they
+    // say so rather than silently letting an over-selection through as if it were fine.
+    () =>
+      availabilityData === undefined
+        ? []
+        : computeAvailabilityShortfalls(requestedByCombo, availabilityByCombo),
+    [availabilityData, requestedByCombo, availabilityByCombo],
+  );
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
@@ -738,9 +880,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   const buildFinalizeInput = useCallback(() => {
     if (!parsed) return null;
-    const filteredHardwareItems = parsed.hardwareItems.filter(
-      (hi) => selectedOpenings.has(hi.opening_number),
-    );
 
     // Build set of BY_OTHERS classificationKeys for PO filtering
     const byOthersKeys = new Set<string>();
@@ -878,63 +1017,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       replaceSchedule: canStartFromLatest && !hydratedFromPersisted,
       // Only ever true after the user confirmed the warning dialog on a flagged leaf (#341).
       acknowledgeIncompleteLeaves: acknowledgedIncompleteLeaves,
-      shopAssemblyOpenings: purpose === 'assembly'
-        ? parsed.openings
-            .filter((o) => selectedOpenings.has(o.opening_number))
-            .flatMap((opening) => {
-              const shopItems = filteredHardwareItems.filter((hi) => {
-                if (hi.opening_number !== opening.opening_number) return false;
-                const ck = classificationKey(hi);
-                return classifications.get(ck) === 'SHOP_HARDWARE';
-              });
-              if (shopItems.length === 0) return [];
-              // One SAR opening per door leaf (#311): group SHOP_HARDWARE by leaf, then aggregate
-              // each leaf's items by (product_code, hardware_category). A pair yields two work units.
-              const byLeaf = new Map<
-                number | null,
-                Map<string, { hardwareCategory: string; productCode: string; quantity: number }>
-              >();
-              for (const hi of shopItems) {
-                let aggMap = byLeaf.get(hi.leaf);
-                if (!aggMap) {
-                  aggMap = new Map();
-                  byLeaf.set(hi.leaf, aggMap);
-                }
-                const key = `${hi.product_code}|${hi.hardware_category}`;
-                const existing = aggMap.get(key);
-                if (existing) {
-                  existing.quantity += hi.item_quantity;
-                } else {
-                  aggMap.set(key, {
-                    hardwareCategory: hi.hardware_category,
-                    productCode: hi.product_code,
-                    quantity: hi.item_quantity,
-                  });
-                }
-              }
-              // #311: a null-leaf bucket is legitimate for a single door (every item is leaf-null ->
-              // one work unit). On a pair (resolved leaves present) a null-leaf item would otherwise
-              // spawn a spurious third work unit; fold it into the lowest resolved leaf instead.
-              const resolvedLeaves = [...byLeaf.keys()].filter((k): k is number => k !== null);
-              const nullBucket = byLeaf.get(null);
-              if (nullBucket && resolvedLeaves.length > 0) {
-                const targetMap = byLeaf.get(Math.min(...resolvedLeaves))!;
-                for (const [key, agg] of nullBucket) {
-                  const existing = targetMap.get(key);
-                  if (existing) existing.quantity += agg.quantity;
-                  else targetMap.set(key, agg);
-                }
-                byLeaf.delete(null);
-              }
-              return Array.from(byLeaf.entries()).map(([leaf, aggMap]) => ({
-                openingNumber: opening.opening_number,
-                leaf,
-                items: Array.from(aggMap.values()),
-              }));
-            })
-        : null,
+      // The exact work units the wizard gated on (#342), not a second derivation of them.
+      shopAssemblyOpenings: purpose === 'assembly' ? shopAssemblyOpeningDrafts : null,
     };
-  }, [parsed, project.id, selectedOpenings, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted, acknowledgedIncompleteLeaves]);
+  }, [parsed, project.id, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, shopAssemblyOpeningDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted, acknowledgedIncompleteLeaves]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1335,10 +1421,12 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
             <ShopAssemblyStep
               sarRequestNumber={sarRequestNumber}
               onSarNumberChange={setSarRequestNumber}
-              openings={openings}
-              selectedOpenings={selectedOpenings}
-              selectedHardwareItems={aggregatedHardwareItems}
-              classifications={classifications}
+              openingDrafts={shopAssemblyOpeningDrafts}
+              requestedByCombo={requestedByCombo}
+              availabilityByCombo={availabilityByCombo}
+              availabilityShortfalls={availabilityShortfalls}
+              availabilityLoading={availabilityLoading && availabilityData === undefined}
+              availabilityError={availabilityError !== undefined}
               onNext={handleNext}
               onBack={handleBack}
             />
@@ -1356,6 +1444,9 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               onRemovePR={removeShippingPR}
               onUpdatePR={updateShippingPR}
               onTogglePRItem={toggleShippingPRItem}
+              availabilityByCombo={availabilityByCombo}
+              availabilityShortfalls={availabilityShortfalls}
+              availabilityError={availabilityError !== undefined}
               onAcknowledgeIncompleteLeaf={() => setAcknowledgedIncompleteLeaves(true)}
               onNext={handleNext}
               onBack={handleBack}

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -14,8 +14,15 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDialog from '../../components/ConfirmDialog';
-import type { AggregatedHardwareItem, AssembledLeafCandidate, ShippingPRDraft, ShippingPRItem } from './types';
-import { aggregationKey, shippingPRItemKey } from './types';
+import type {
+  AggregatedHardwareItem,
+  AssembledLeafCandidate,
+  AvailabilityShortfall,
+  InventoryAvailabilityRow,
+  ShippingPRDraft,
+  ShippingPRItem,
+} from './types';
+import { aggregationKey, itemGroupKey, shippingPRItemKey } from './types';
 import { leafSuffix } from '../../utils/leaf';
 
 interface ShippingPRsStepProps {
@@ -32,6 +39,16 @@ interface ShippingPRsStepProps {
   onRemovePR: (index: number) => void;
   onUpdatePR: (index: number, field: 'requestNumber' | 'requestedBy', value: string) => void;
   onTogglePRItem: (prIndex: number, item: ShippingPRItem) => void;
+  /**
+   * Reservation-aware availability per (category|product) for this project (#342). A LOOSE line
+   * claims fungible stock, so it can only be ticked while the claim fits; an assembled leaf
+   * claimed its hardware at shop assembly and reserves nothing, so leaf selection is unaffected.
+   */
+  availabilityByCombo: Map<string, InventoryAvailabilityRow>;
+  /** Combos the current selection would over-claim. Non-empty blocks the step. */
+  availabilityShortfalls: AvailabilityShortfall[];
+  /** The availability lookup failed; the counts are unknown, not zero. */
+  availabilityError: boolean;
   /**
    * The user confirmed shipping a leaf that is still awaiting replacement hardware (#341). The
    * wizard passes this to the backend as the explicit acknowledgment the creation path requires.
@@ -65,6 +82,9 @@ export default function ShippingPRsStep({
   onRemovePR,
   onUpdatePR,
   onTogglePRItem,
+  availabilityByCombo,
+  availabilityShortfalls,
+  availabilityError,
   onAcknowledgeIncompleteLeaf,
   onNext,
   onBack,
@@ -97,12 +117,15 @@ export default function ShippingPRsStep({
     setPendingIncomplete(null);
   }, [pendingIncomplete, onTogglePRItem, onAcknowledgeIncompleteLeaf]);
 
+  // Creating the request RESERVES what its LOOSE lines ask for (#342), so an over-selection is
+  // blocked here rather than bouncing the whole finalize. A failed availability lookup blocks
+  // too: an unknown count must not read as "fine".
   const canProceed = useMemo(
     () =>
-      shippingPRDrafts.some(
-        (d) => d.requestNumber.trim() !== '' && d.items.length > 0,
-      ),
-    [shippingPRDrafts],
+      shippingPRDrafts.some((d) => d.requestNumber.trim() !== '' && d.items.length > 0) &&
+      availabilityShortfalls.length === 0 &&
+      !availabilityError,
+    [shippingPRDrafts, availabilityShortfalls, availabilityError],
   );
 
   // An assembled leaf is one physical object, so it can sit on exactly one request. Loose hardware
@@ -143,6 +166,31 @@ export default function ShippingPRsStep({
       {shippingPRDrafts.length === 0 && (
         <Alert severity="info" sx={{ mb: 2 }}>
           No shipping pull requests yet. Add one below.
+        </Alert>
+      )}
+
+      {availabilityError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Could not read this project&apos;s available inventory, so the loose-hardware counts below
+          are unknown rather than zero. Go back and retry before creating a request.
+        </Alert>
+      )}
+
+      {availabilityShortfalls.length > 0 && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          The loose hardware selected here asks for more than is available. Available means on hand,
+          minus units flagged deficient, minus what other open requests have already reserved - so a
+          shortfall can mean the stock is here but spoken for. Assembled door leaves are unaffected:
+          their hardware left loose inventory when they were built.
+          <Box component="ul" sx={{ mt: 1, mb: 0, pl: 3 }}>
+            {availabilityShortfalls.map((s) => (
+              <li key={`${s.hardwareCategory}|${s.productCode}`}>
+                {s.hardwareCategory} {s.productCode}: need {s.requested}, {s.available} available
+                {s.reserved > 0 ? ` (${s.reserved} reserved by other requests)` : ''} - short{' '}
+                {s.short}
+              </li>
+            ))}
+          </Box>
         </Alert>
       )}
 
@@ -272,6 +320,10 @@ export default function ShippingPRsStep({
                       productCode: hi.product_code,
                       requestedQuantity: hi.item_quantity,
                     };
+                    const availability = availabilityByCombo.get(itemGroupKey(hi));
+                    const available = availability?.availableQuantity ?? 0;
+                    const reserved = availability?.reservedQuantity ?? 0;
+                    const overClaimed = !availabilityError && hi.item_quantity > available;
                     return (
                       <FormControlLabel
                         key={aggregationKey(hi)}
@@ -283,12 +335,25 @@ export default function ShippingPRsStep({
                           />
                         }
                         label={
-                          <Typography variant="body2">
-                            Opening: {hi.opening_number} | Product: {hi.product_code} | Category:{' '}
-                            {hi.hardware_category} | Qty: {hi.item_quantity}
-                          </Typography>
+                          <Box>
+                            <Typography variant="body2">
+                              Opening: {hi.opening_number} | Product: {hi.product_code} | Category:{' '}
+                              {hi.hardware_category} | Qty: {hi.item_quantity}
+                            </Typography>
+                            {/* Reservation-aware availability (#342), per line, so an over-selection
+                                is visible at the checkbox and not only in the summary alert. */}
+                            <Typography
+                              variant="caption"
+                              color={overClaimed ? 'error.main' : 'text.secondary'}
+                            >
+                              {availabilityError
+                                ? 'Availability unknown'
+                                : `${available} available` +
+                                  (reserved > 0 ? ` (${reserved} reserved by other requests)` : '')}
+                            </Typography>
+                          </Box>
                         }
-                        sx={{ display: 'block' }}
+                        sx={{ display: 'flex', alignItems: 'flex-start', mb: 0.5 }}
                       />
                     );
                   })}

--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -1,26 +1,47 @@
 import { useMemo } from 'react';
 import {
+  Alert,
   Box,
   Button,
+  Chip,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   TextField,
   Typography,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import type { ParsedOpening } from '../../types/hardwareSchedule';
-import type { AggregatedHardwareItem } from './types';
-import { classificationKey } from './types';
+import type { AvailabilityShortfall, InventoryAvailabilityRow } from './types';
+import { leafSuffix } from '../../utils/leaf';
+
+/** One assembly work unit (a door leaf) the wizard would submit, with its checklist aggregated. */
+interface ShopAssemblyOpeningDraft {
+  openingNumber: string;
+  leaf: number | null;
+  items: Array<{ hardwareCategory: string; productCode: string; quantity: number }>;
+}
 
 interface ShopAssemblyStepProps {
   sarRequestNumber: string;
   onSarNumberChange: (value: string) => void;
-  openings: ParsedOpening[];
-  selectedOpenings: Set<string>;
-  selectedHardwareItems: AggregatedHardwareItem[];
-  classifications: Map<string, string>;
+  /** The exact work units finalize will send - the same derivation, not a parallel one. */
+  openingDrafts: ShopAssemblyOpeningDraft[];
+  /** Total demand per (category|product) across every work unit above. */
+  requestedByCombo: Map<string, number>;
+  /** Reservation-aware availability per (category|product) for this project (#342). */
+  availabilityByCombo: Map<string, InventoryAvailabilityRow>;
+  /** Combos this selection would over-claim. Non-empty blocks the step. */
+  availabilityShortfalls: AvailabilityShortfall[];
+  /** The availability lookup has not answered yet, so the counts below are not final. */
+  availabilityLoading: boolean;
+  /** The availability lookup failed; the counts are unknown, not zero. */
+  availabilityError: boolean;
   onNext: () => void;
   onBack: () => void;
 }
@@ -28,31 +49,52 @@ interface ShopAssemblyStepProps {
 export default function ShopAssemblyStep({
   sarRequestNumber,
   onSarNumberChange,
-  openings,
-  selectedOpenings,
-  selectedHardwareItems,
-  classifications,
+  openingDrafts,
+  requestedByCombo,
+  availabilityByCombo,
+  availabilityShortfalls,
+  availabilityLoading,
+  availabilityError,
   onNext,
   onBack,
 }: ShopAssemblyStepProps) {
+  // Creating this request RESERVES the hardware it needs (#342), so the selection has to fit inside
+  // what is actually free right now. Blocking here rather than letting the server refuse the whole
+  // finalize is the point: this is the last screen where refining the selection is cheap.
   const canProceed = useMemo(
-    () => sarRequestNumber.trim() !== '',
-    [sarRequestNumber],
+    () =>
+      sarRequestNumber.trim() !== '' &&
+      openingDrafts.length > 0 &&
+      availabilityShortfalls.length === 0 &&
+      !availabilityLoading &&
+      !availabilityError,
+    [sarRequestNumber, openingDrafts, availabilityShortfalls, availabilityLoading, availabilityError],
   );
 
-  const openingsWithShopItems = useMemo(() => {
-    return openings
-      .filter((o) => selectedOpenings.has(o.opening_number))
-      .map((o) => {
-        const shopItems = selectedHardwareItems.filter((hi) => {
-          if (hi.opening_number !== o.opening_number) return false;
-          const ck = classificationKey(hi);
-          return classifications.get(ck) === 'SHOP_HARDWARE';
-        });
-        return { opening: o, shopItemCount: shopItems.length };
-      })
-      .filter((entry) => entry.shopItemCount > 0);
-  }, [openings, selectedOpenings, selectedHardwareItems, classifications]);
+  // What this request would claim, next to what is available. Sorted so the same combo is always in
+  // the same place between renders.
+  const demandRows = useMemo(
+    () =>
+      Array.from(requestedByCombo.entries())
+        .map(([key, requested]) => {
+          const [hardwareCategory, productCode] = key.split('|');
+          const row = availabilityByCombo.get(key);
+          return {
+            key,
+            hardwareCategory,
+            productCode,
+            requested,
+            available: row?.availableQuantity ?? 0,
+            reserved: row?.reservedQuantity ?? 0,
+          };
+        })
+        .sort(
+          (a, b) =>
+            a.hardwareCategory.localeCompare(b.hardwareCategory) ||
+            a.productCode.localeCompare(b.productCode),
+        ),
+    [requestedByCombo, availabilityByCombo],
+  );
 
   return (
     <Box>
@@ -74,22 +116,102 @@ export default function ShopAssemblyStep({
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         Openings with items classified as Shop Hardware (in the Classification step) will be
-        included.
+        included. Creating the request reserves this hardware, so it has to fit what is available
+        now.
       </Typography>
 
+      {openingDrafts.length === 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          None of the selected openings has hardware classified as Shop Hardware, so there is nothing
+          to send to shop assembly. Go back and classify at least one item as Shop.
+        </Alert>
+      )}
+
       <List dense>
-        {openingsWithShopItems.map(({ opening, shopItemCount }) => (
-          <ListItem key={opening.opening_number}>
+        {openingDrafts.map((draft) => (
+          <ListItem key={`${draft.openingNumber}|${draft.leaf ?? 'none'}`}>
             <ListItemIcon>
               <CheckCircleIcon color="success" fontSize="small" />
             </ListItemIcon>
             <ListItemText
-              primary={opening.opening_number}
-              secondary={`${shopItemCount} shop hardware items`}
+              primary={draft.openingNumber + leafSuffix(draft.leaf)}
+              secondary={`${draft.items.length} shop hardware items`}
             />
           </ListItem>
         ))}
       </List>
+
+      {availabilityError && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          Could not read this project's available inventory, so the counts below are unknown rather
+          than zero. Go back and retry before creating the request.
+        </Alert>
+      )}
+
+      {availabilityLoading && !availabilityError && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          Checking available inventory...
+        </Alert>
+      )}
+
+      {availabilityShortfalls.length > 0 && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          This selection asks for more hardware than is available. Available means on hand, minus
+          units flagged deficient, minus what other open requests have already reserved - so a
+          shortfall can mean the stock is here but spoken for. Reduce the selection, or release
+          another request.
+          <Box component="ul" sx={{ mt: 1, mb: 0, pl: 3 }}>
+            {availabilityShortfalls.map((s) => (
+              <li key={`${s.hardwareCategory}|${s.productCode}`}>
+                {s.hardwareCategory} {s.productCode}: need {s.requested}, {s.available} available
+                {s.reserved > 0 ? ` (${s.reserved} reserved by other requests)` : ''} - short{' '}
+                {s.short}
+              </li>
+            ))}
+          </Box>
+        </Alert>
+      )}
+
+      {demandRows.length > 0 && (
+        <Box sx={{ mt: 3 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+            Hardware this request would reserve
+          </Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Product Code</TableCell>
+                <TableCell>Hardware Category</TableCell>
+                <TableCell align="right">Needed</TableCell>
+                <TableCell align="right">Available</TableCell>
+                <TableCell align="right">Reserved elsewhere</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {demandRows.map((row) => (
+                <TableRow key={row.key}>
+                  <TableCell>{row.productCode}</TableCell>
+                  <TableCell>{row.hardwareCategory}</TableCell>
+                  <TableCell align="right">{row.requested}</TableCell>
+                  <TableCell align="right">{availabilityError ? '?' : row.available}</TableCell>
+                  <TableCell align="right">{availabilityError ? '?' : row.reserved}</TableCell>
+                  <TableCell>
+                    {!availabilityError && row.requested > row.available && (
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        label={`Short ${row.requested - row.available}`}
+                      />
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      )}
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
         <Button onClick={onBack}>Back</Button>

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -9,7 +9,11 @@ import {
   GET_PROJECT_HARDWARE_SCHEDULE,
   RECONCILE_SCHEDULE,
 } from '../../../graphql/import';
-import { GET_OPENING_ITEMS, GET_PULL_REQUESTS } from '../../../graphql/warehouse';
+import {
+  GET_OPENING_ITEMS,
+  GET_PROJECT_INVENTORY_AVAILABILITY,
+  GET_PULL_REQUESTS,
+} from '../../../graphql/warehouse';
 import { GET_SHIPPING_OUT_REQUESTS } from '../../../graphql/shipping';
 import {
   useHardwareScheduleParser,
@@ -163,7 +167,41 @@ const reimportProject: Project = { ...firstImportProject, openingCount: 5 };
 // A re-import project eagerly fetches the persisted schedule (null = nothing
 // persisted, so the upload step stays a plain dropzone) and, once parsed items
 // exist, the project's excluded-items list.
+// Both request purposes read reservation-aware availability (#342) so the wizard can block an
+// over-selection before submission. Generous by default: these tests are about step shape, and a
+// shortfall would disable Next for a reason none of them is asserting.
+const availabilityMock: MockedResponse = {
+  request: {
+    query: GET_PROJECT_INVENTORY_AVAILABILITY,
+    variables: { projectId: 'proj-1' },
+  },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+  result: {
+    data: {
+      projectInventoryAvailability: [
+        {
+          hardwareCategory: 'Hinges',
+          productCode: 'HNG-100',
+          onHandQuantity: 99,
+          deficientQuantity: 0,
+          reservedQuantity: 0,
+          availableQuantity: 99,
+        },
+        {
+          hardwareCategory: 'Locks',
+          productCode: 'LCK-200',
+          onHandQuantity: 99,
+          deficientQuantity: 0,
+          reservedQuantity: 0,
+          availableQuantity: 99,
+        },
+      ],
+    },
+  },
+};
+
 const reimportBaseMocks: MockedResponse[] = [
+  availabilityMock,
   {
     request: {
       query: GET_PROJECT_HARDWARE_SCHEDULE,

--- a/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
+++ b/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
@@ -36,6 +36,9 @@ function renderStep(leaves: AssembledLeafCandidate[], overrides: Record<string, 
       onRemovePR={vi.fn()}
       onUpdatePR={vi.fn()}
       onTogglePRItem={onTogglePRItem}
+      availabilityByCombo={new Map()}
+      availabilityShortfalls={[]}
+      availabilityError={false}
       onAcknowledgeIncompleteLeaf={onAcknowledgeIncompleteLeaf}
       onNext={vi.fn()}
       onBack={vi.fn()}

--- a/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
+++ b/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShopAssemblyStep from '../ShopAssemblyStep';
+import ShippingPRsStep from '../ShippingPRsStep';
+import type {
+  AggregatedHardwareItem,
+  InventoryAvailabilityRow,
+  ShippingPRDraft,
+} from '../types';
+import { computeAvailabilityShortfalls } from '../types';
+
+/**
+ * Reservation-aware availability gating in Start a Task (#342).
+ *
+ * Creating a shop-assembly or shipping-out request RESERVES the hardware it needs, so the server
+ * refuses a selection that does not fit `on-hand - deficient - other requests' reservations`. The
+ * wizard applies the same numbers and blocks before submission - this is the last screen where
+ * refining the selection is cheap, and a bounced finalize tells the user nothing they can act on
+ * without starting over.
+ */
+
+function availability(rows: Partial<InventoryAvailabilityRow>[]): Map<string, InventoryAvailabilityRow> {
+  const map = new Map<string, InventoryAvailabilityRow>();
+  for (const row of rows) {
+    const full: InventoryAvailabilityRow = {
+      hardwareCategory: 'HINGE',
+      productCode: 'HG-100',
+      onHandQuantity: 0,
+      deficientQuantity: 0,
+      reservedQuantity: 0,
+      availableQuantity: 0,
+      ...row,
+    };
+    map.set(`${full.hardwareCategory}|${full.productCode}`, full);
+  }
+  return map;
+}
+
+// ---- the shared arithmetic ----
+
+describe('computeAvailabilityShortfalls', () => {
+  it('reports nothing when every combo fits', () => {
+    const demand = new Map([['HINGE|HG-100', 3]]);
+    expect(computeAvailabilityShortfalls(demand, availability([{ availableQuantity: 3 }]))).toEqual([]);
+  });
+
+  it('treats a combo with no availability row as zero available', () => {
+    // Exactly how the server treats a product this project has never received.
+    const rows = computeAvailabilityShortfalls(new Map([['HINGE|HG-100', 2]]), availability([]));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ requested: 2, available: 0, short: 2 });
+  });
+
+  it('carries the reserved count so "here but spoken for" reads differently from "not here"', () => {
+    const rows = computeAvailabilityShortfalls(
+      new Map([['HINGE|HG-100', 5]]),
+      availability([{ onHandQuantity: 8, reservedQuantity: 6, availableQuantity: 2 }]),
+    );
+    expect(rows[0]).toMatchObject({ requested: 5, available: 2, reserved: 6, short: 3 });
+  });
+
+  it('ignores combos with no demand', () => {
+    expect(computeAvailabilityShortfalls(new Map([['HINGE|HG-100', 0]]), availability([]))).toEqual([]);
+  });
+});
+
+// ---- shop assembly step ----
+
+const SA_DRAFTS = [
+  {
+    openingNumber: 'A01',
+    leaf: 1,
+    items: [{ hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 4 }],
+  },
+];
+
+function renderShopAssembly(overrides: Record<string, unknown> = {}) {
+  const onNext = vi.fn();
+  render(
+    <ShopAssemblyStep
+      sarRequestNumber="SA-1"
+      onSarNumberChange={vi.fn()}
+      openingDrafts={SA_DRAFTS}
+      requestedByCombo={new Map([['HINGE|HG-100', 4]])}
+      availabilityByCombo={availability([{ onHandQuantity: 10, availableQuantity: 10 }])}
+      availabilityShortfalls={[]}
+      availabilityLoading={false}
+      availabilityError={false}
+      onNext={onNext}
+      onBack={vi.fn()}
+      {...overrides}
+    />,
+  );
+  return { onNext };
+}
+
+const nextButton = () => screen.getByRole('button', { name: 'Next' });
+
+describe('ShopAssemblyStep availability gating', () => {
+  it('shows what the request would reserve against what is available', () => {
+    renderShopAssembly({
+      availabilityByCombo: availability([
+        { onHandQuantity: 10, reservedQuantity: 3, availableQuantity: 7 },
+      ]),
+    });
+    expect(screen.getByText('Hardware this request would reserve')).toBeInTheDocument();
+    const row = screen.getByText('HG-100').closest('tr')!;
+    expect(row).toHaveTextContent('4'); // needed
+    expect(row).toHaveTextContent('7'); // available
+    expect(row).toHaveTextContent('3'); // reserved elsewhere
+    expect(nextButton()).toBeEnabled();
+  });
+
+  it('blocks the step and names the short combo when the selection does not fit', () => {
+    renderShopAssembly({
+      availabilityByCombo: availability([
+        { onHandQuantity: 10, reservedQuantity: 8, availableQuantity: 2 },
+      ]),
+      availabilityShortfalls: [
+        {
+          hardwareCategory: 'HINGE',
+          productCode: 'HG-100',
+          requested: 4,
+          available: 2,
+          reserved: 8,
+          short: 2,
+        },
+      ],
+    });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/HINGE HG-100: need 4, 2 available/)).toBeInTheDocument();
+    // The distinction that matters: the stock is here, another request has it.
+    expect(screen.getByText(/8 reserved by other requests/)).toBeInTheDocument();
+  });
+
+  it('blocks while the availability lookup is still in flight', () => {
+    // An empty lookup must not read as "nothing available" and it must not read as "fine" either.
+    renderShopAssembly({ availabilityLoading: true });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/Checking available inventory/)).toBeInTheDocument();
+  });
+
+  it('blocks and says so when the availability lookup failed', () => {
+    renderShopAssembly({ availabilityError: true });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/Could not read this project's available inventory/)).toBeInTheDocument();
+  });
+
+  it('blocks a request with no work units at all', () => {
+    // A zero-opening request is refused server-side too (#342); catching it here saves the round trip.
+    renderShopAssembly({ openingDrafts: [], requestedByCombo: new Map() });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/nothing to send to shop assembly/i)).toBeInTheDocument();
+  });
+});
+
+// ---- shipping step ----
+
+function looseItem(overrides: Partial<AggregatedHardwareItem> = {}): AggregatedHardwareItem {
+  return {
+    opening_number: 'A01',
+    product_code: 'HG-100',
+    hardware_category: 'HINGE',
+    item_quantity: 4,
+    unit_cost: 10,
+    unit_price: null,
+    list_price: null,
+    vendor_discount: null,
+    markup_pct: null,
+    vendor_no: null,
+    manufacturer: null,
+    phase_code: null,
+    item_category_code: null,
+    product_group_code: null,
+    submittal_id: null,
+    ...overrides,
+  } as AggregatedHardwareItem;
+}
+
+const SHIP_DRAFT: ShippingPRDraft = {
+  requestNumber: 'SOR-1',
+  requestedBy: 'ada',
+  items: [
+    {
+      itemType: 'LOOSE',
+      openingNumber: 'A01',
+      hardwareCategory: 'HINGE',
+      productCode: 'HG-100',
+      requestedQuantity: 4,
+    },
+  ],
+};
+
+function renderShipping(overrides: Record<string, unknown> = {}) {
+  render(
+    <ShippingPRsStep
+      shippingPRDrafts={[SHIP_DRAFT]}
+      assembledLeaves={[]}
+      looseItems={[looseItem()]}
+      leavesLoading={false}
+      leavesError={false}
+      onAddPR={vi.fn()}
+      onRemovePR={vi.fn()}
+      onUpdatePR={vi.fn()}
+      onTogglePRItem={vi.fn()}
+      availabilityByCombo={availability([{ onHandQuantity: 10, availableQuantity: 10 }])}
+      availabilityShortfalls={[]}
+      availabilityError={false}
+      onAcknowledgeIncompleteLeaf={vi.fn()}
+      onNext={vi.fn()}
+      onBack={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('ShippingPRsStep availability gating', () => {
+  it('shows reservation-aware availability on each loose line', () => {
+    renderShipping({
+      availabilityByCombo: availability([
+        { onHandQuantity: 10, reservedQuantity: 4, availableQuantity: 6 },
+      ]),
+    });
+    expect(screen.getByText('6 available (4 reserved by other requests)')).toBeInTheDocument();
+    expect(nextButton()).toBeEnabled();
+  });
+
+  it('blocks the step when the loose selection over-claims', () => {
+    renderShipping({
+      availabilityByCombo: availability([
+        { onHandQuantity: 10, reservedQuantity: 9, availableQuantity: 1 },
+      ]),
+      availabilityShortfalls: [
+        {
+          hardwareCategory: 'HINGE',
+          productCode: 'HG-100',
+          requested: 4,
+          available: 1,
+          reserved: 9,
+          short: 3,
+        },
+      ],
+    });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/HINGE HG-100: need 4, 1 available/)).toBeInTheDocument();
+    // Assembled leaves are explicitly exempted - their hardware left loose inventory at assembly.
+    expect(screen.getByText(/Assembled door leaves are unaffected/)).toBeInTheDocument();
+  });
+
+  it('blocks and says the counts are unknown when the lookup failed', () => {
+    renderShipping({ availabilityError: true });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText('Availability unknown')).toBeInTheDocument();
+  });
+
+  it('still lets a loose line be ticked - the gate is on the step, not the checkbox', () => {
+    // Blocking the tick would make it impossible to see the combined effect of a selection, which is
+    // what the per-combo shortfall list is for.
+    const onTogglePRItem = vi.fn();
+    renderShipping({
+      onTogglePRItem,
+      availabilityByCombo: availability([{ onHandQuantity: 1, availableQuantity: 1 }]),
+    });
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(onTogglePRItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -54,6 +54,67 @@ export interface AssembledLeafCandidate {
   awaitingReplacementQuantity: number;
 }
 
+/**
+ * One (hardware_category, product_code) row of `projectInventoryAvailability` (#342):
+ * `availableQuantity = onHandQuantity - deficientQuantity - reservedQuantity`, the number the
+ * server's creation gate applies.
+ */
+export interface InventoryAvailabilityRow {
+  hardwareCategory: string;
+  productCode: string;
+  onHandQuantity: number;
+  deficientQuantity: number;
+  reservedQuantity: number;
+  availableQuantity: number;
+}
+
+/**
+ * One combo the current selection would claim more of than is available (#342). Computed in the
+ * browser from the same numbers the server gates on, so the wizard can refuse to submit a selection
+ * that cannot fit - the creator refines it here rather than having the whole finalize bounce.
+ */
+export interface AvailabilityShortfall {
+  hardwareCategory: string;
+  productCode: string;
+  requested: number;
+  available: number;
+  reserved: number;
+  short: number;
+}
+
+/**
+ * Compare a per-combo demand against a per-combo availability lookup. `demand` is keyed by
+ * `itemGroupKey` (category|product); combos with no availability row at all count as zero
+ * available, which is exactly how the server treats a product the project has never received.
+ */
+export function computeAvailabilityShortfalls(
+  demand: Map<string, number>,
+  availability: Map<string, InventoryAvailabilityRow>,
+): AvailabilityShortfall[] {
+  const rows: AvailabilityShortfall[] = [];
+  for (const [key, requested] of demand) {
+    if (requested <= 0) continue;
+    const row = availability.get(key);
+    const available = row?.availableQuantity ?? 0;
+    if (requested > available) {
+      const [hardwareCategory, productCode] = key.split('|');
+      rows.push({
+        hardwareCategory,
+        productCode,
+        requested,
+        available,
+        reserved: row?.reservedQuantity ?? 0,
+        short: requested - available,
+      });
+    }
+  }
+  rows.sort(
+    (a, b) =>
+      a.hardwareCategory.localeCompare(b.hardwareCategory) || a.productCode.localeCompare(b.productCode),
+  );
+  return rows;
+}
+
 export function hardwareItemKey(hi: ParsedHardwareItem) {
   return `${hi.opening_number}|${hi.product_code}|${hi.material_id}`;
 }

--- a/frontend/src/modules/shipping/ShippingRequestsPage.tsx
+++ b/frontend/src/modules/shipping/ShippingRequestsPage.tsx
@@ -42,6 +42,8 @@ interface ShippingOutRequest {
   status: string;
   createdBy: string;
   createdAt: string;
+  /** Set when a schedule re-upload landed under this request, or it holds no reservation (#342). */
+  integrityNote: string | null;
   items: ShippingRequestItem[];
 }
 
@@ -77,7 +79,7 @@ export default function ShippingRequestsPage({ projectId }: Props) {
         title="Shipping Requests"
         description={
           view === 'PENDING'
-            ? 'Pending requests from Start a Task. Accepting one creates the warehouse pull request.'
+            ? 'Pending requests from Start a Task. Loose hardware was reserved when the request was created, so accepting is purely your approval: it creates the warehouse pull request. Rejecting releases the reservation.'
             : 'Accepted requests whose warehouse pull has not started yet. Reopen one to undo the accept and send it back to Pending.'
         }
         emptyMessage={view === 'PENDING' ? 'No pending shipping requests.' : 'No shipping requests can be reopened.'}

--- a/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
+++ b/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
@@ -45,6 +45,8 @@ interface ShopAssemblyRequest {
   status: string;
   createdBy: string;
   createdAt: string;
+  /** Set when a schedule re-upload landed under this request, or it holds no reservation (#342). */
+  integrityNote: string | null;
   openings: RequestOpening[];
 }
 
@@ -72,7 +74,7 @@ export default function ShopAssemblyRequestsPage() {
         title="Shop Assembly Requests"
         description={
           view === 'PENDING'
-            ? 'Pending requests from Start a Task. Accepting one creates the warehouse pull request.'
+            ? 'Pending requests from Start a Task. The hardware was reserved when the request was created, so accepting is purely your approval: it creates the warehouse pull request. Rejecting releases the reservation.'
             : 'Accepted requests whose warehouse pull has not started yet. Reopen one to undo the accept and send it back to Pending.'
         }
         emptyMessage={

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -157,7 +157,48 @@ DRAFT -> ORDERED -> VENDOR_CONFIRMED -> PARTIALLY_RECEIVED -> CLOSED
 
 **Result**: Creates a project (or updates existing), openings, hardware items, and the selected output (POs, SAR, shipping PRs).
 
+**Creating a request RESERVES inventory (#342).** This is the single biggest behavioural change to
+the wizard, and it changes what "it worked" looks like at every downstream step.
+
+- The Shop Assembly and Shipping PRs steps both read `projectInventoryAvailability`, where
+  `availableQuantity = onHandQuantity - deficientQuantity - reservedQuantity`. **Next is disabled**
+  while the selection asks for more than that, and a red alert lists every short combo as
+  `<CATEGORY> <CODE>: need N, M available (R reserved by other requests) - short S`.
+- The Shop Assembly step now also renders a "Hardware this request would reserve" table (Needed /
+  Available / Reserved elsewhere per product), and refuses to proceed at all when no item was
+  classified as Shop Hardware.
+- The Shipping PRs step shows "<n> available" under each **loose** line only. Assembled door leaves
+  never show one and are never gated - their hardware left fungible inventory at assembly.
+- Next is also disabled while the availability lookup is in flight or has failed. An unknown count is
+  not treated as "fine", so a mocked/blocked GraphQL call reads as a blocked wizard, not a bug.
+- Driving `finalizeImportSession` directly past the UI gate gets an `INSUFFICIENT_INVENTORY` error
+  naming every short combo, and **nothing at all is created** - no request, no reservations, no
+  openings. Useful for exercising the gate without walking the wizard.
+- To make a shortfall on demand: create one request that claims most of a product, then start a
+  second Start a Task for the same product. The second one is short *even though the shelf count is
+  unchanged* - that is the reservation working, and `reserved by other requests` in the message is
+  how to tell it from genuinely absent stock.
+- Other creation-time refusals (all `VALIDATION_ERROR`): a request with zero openings; an opening
+  with zero items; a shipping request with zero lines; a leaf already inside a live shop-assembly
+  request; a leaf already on a live shipping-out request; a leaf claimed by the *other* request type.
+- **Re-upload with `replaceSchedule: true`** is never blocked. Live PENDING requests are rewritten to
+  the openings that survived (their reservations rebuilt from what is left), a request that loses
+  everything is auto-REJECTED by "Hardware Schedule Import", accepted requests are left alone, and
+  every live request gets an `integrityNote` that shows as an amber alert on the accept screen.
+
 ### Warehouse Module
+
+**Two different "available" numbers, and they are supposed to differ (#342).** The Inventory view's
+availability is `on-hand - deficient`: what is physically unspoken-for in the building. The Start a
+Task wizard's is `on-hand - deficient - reservations`: what may still be *claimed*. A product can
+read 10 available in the warehouse and 0 available in the wizard; that is not a bug, it means live
+requests are holding it.
+
+**Approving a pull request consumes its source request's reservation.** A pull whose request reserved
+exactly what it needs still approves - the check excludes the request's own claim (self-coverage). A
+`PR-REPL-*` replacement pull holds no reservation at all, so it keeps the old reactive behaviour: it
+can come up INSUFFICIENT and notify the PO, and it can only draw from what nobody else has claimed.
+
 
 **Entry**: `/app/warehouse` -> Warehouse landing page with stat cards and "Go to" card buttons for: Inventory, Locations, Deliveries, Receiving, Put Away, Pull Requests, Stock Pool, Deficient Items, Shipments. (No longer "three tabs" - this has evolved to a full landing page.)
 
@@ -222,6 +263,19 @@ Both entry points open a "Transfer <productCode>" MUI dialog with: an "X availab
 - Manager creates/approves Shop Assembly Requests (SARs)
 - Approved SARs generate pull requests for warehouse
 - Users get assigned openings, pull hardware, assemble, mark complete
+
+**Accept is a pure human gate since #342.** There is no inventory check on Accept any more and no
+shortfall can surface there - the hardware was reserved when the request was created. Accepting
+neither spends nor releases that claim; approving the warehouse pull spends it; **rejecting** is the
+only thing that releases it.
+
+- **Reopen (#325) deliberately does NOT release.** A reopened request goes back to Pending still
+  holding its hardware, so a second request for the same product stays short until you *reject* the
+  reopened one. The reopen confirm dialog says so. If a colleague reports "I released it but the
+  stock is still claimed", they reopened instead of rejecting.
+- An amber alert at the top of an expanded request is its `integrityNote`: either a schedule
+  re-upload landed under it, or the reservations backfill could not cover it (that second one only
+  appears on data that predates #342).
 
 **Assembly modal is a progress editor, not a one-shot checklist (#340).** Clicking a row in My Work
 (or "Start assembly" / "Continue assembly" on the Assemble List) opens it. Per line it shows Pulled /


### PR DESCRIPTION
Slice 4 of 6. **Stacked on `feat/sa-slice-3-replacement` (PR #347)** — the base is set to that branch so this diff shows only slice 4. Closes #342.

The gap between "a request exists" and "the warehouse pulls for it" was unclaimed. Two requests could each be created against the same hinges, both pass the accept-time sufficiency check, and the second pull would find the shelf empty — leaving a PENDING pull blocked on a PO backfill that nobody asked for. The product owner's decision: **creating a request reserves the hardware it needs.** The creator is held to what is genuinely free while refining the selection is still cheap; accept becomes a pure human gate; the pull spends the claim.

Availability everywhere becomes:

```
available = on-hand − deficient − active reservations
```

## The reservation lifecycle

Every path a request can create, hold, or lose a claim on:

| Path | Effect on the claim |
| --- | --- |
| Create a shop-assembly request | **Reserve** every checklist line, aggregated per combo |
| Create a shipping-out request, `LOOSE` line | **Reserve** — it claims fungible stock |
| Create a shipping-out request, `OPENING_ITEM` line | **Nothing** — the leaf claimed its hardware at assembly and ships as itself |
| Creation would exceed available | **Refused whole** — typed `InventoryShortfallError` naming every short combo; nothing at all is written |
| Accept (either type) | **No change** — accept re-checks nothing now |
| Reject (either type) | **Release** |
| Reopen an accepted request (#325) | **No change** — see below |
| Reject after a reopen | **Release** — the same reject path |
| Pull approval, sufficient | **Consume** — the claim becomes the FIFO deduction, atomically |
| Pull approval, short | **No change** — the pull stays PENDING still holding |
| PR-REPL replacement pull | **Never reserves**, and consumes nothing |
| Re-upload drops a PENDING request's openings | **Rebuilt** from what survived |
| Re-upload empties a PENDING request | **Auto-reject**, which releases |

**Reopen deliberately does not release**, and this is the one that needs saying out loud. A reopen undoes the *accept*, not the *creation*: the request returns to PENDING and is still a live claim, exactly as it was between creation and the accept it is unwinding. Releasing here would let a second request grab the hardware while the first is still on the board waiting to be re-accepted — the accept-time shortfall this slice removes, reintroduced through the back door. Rejecting it afterwards is what finally lets go, and the reopen confirm dialog now says so.

**A deficiency reported at the bench does not touch reservations and cannot double-count against them.** `report_deficiency_at_assembly` raises the inventory row's `quantity` and `deficient_quantity` together, so the pair nets to zero in `on-hand − deficient`: the unit is back in the building and is not available. Asserted directly in `test_availability_nets_deficient_units_without_double_counting`.

## Self-coverage at consumption

When the warehouse approves request R's pull, R's own reservations are precisely what backs the deduction. If the availability check counted them, a request that reserved exactly what it needs would read as competing with itself and could never be approved.

`check_inventory_sufficiency` therefore grows two flags: `reservation_aware=True` subtracts active reservations, and `exclude_reservations_of=(source, request_id)` exempts one request's own claim. `approve_pull_request` resolves the holder first (`find_reservation_holder`: shop-assembly via the shared unique `request_number`, shipping-out via `pull_request_id` — one indexed lookup, no string parsing), then checks under `lock=True`, then consumes and deducts in that order so the two can never be observed apart.

The same call shape covers the three cases where there is no holder, and they all behave identically: a **PR-REPL replacement pull** (nobody can reserve for a deficiency that has not happened yet), a pull whose request was rejected or reopened, and a legacy pull. Their demand is unreserved and reactive, but the pool they draw from is still on-hand − deficient − **everyone else's** reservations, so a replacement can never eat stock another request is holding.

A shortfall on a pull that *did* hold reservations is not normal flow — it means stock vanished under a live claim (an admin write-off or override). It still returns `INSUFFICIENT` and notifies the PO, so the API contract and the approver's screen are unchanged, but it additionally writes a `RESERVED_PULL_SHORT` audit record, because the reserved path is supposed to be un-shortfallable.

## The table

`inventory_reservations`: `project_id`, `hardware_category`, `product_code`, `quantity`, a `reservation_source` discriminator, one of two request FKs (`ON DELETE CASCADE`), `created_at`. A check constraint keeps the discriminator and the FKs from disagreeing, so a claim can never be orphaned from the request that is supposed to release it.

Note what it deliberately does **not** have, for the same reason `InventoryLocation` does not have it:

- **No opening, no leaf.** A hinge is a hinge (`docs/HARDWARE_IDENTITY_LIFECYCLE.md`). The claim is aggregate, per `(project, category, product)`.
- **No `inventory_location_id`.** Pinning a claim to specific rows would fight FIFO. The reservation governs *how much* is free, never *which* row — **FIFO deduction at approval is completely unchanged**.

Every read is a grouped scalar aggregate (`func.sum`); nothing loads reservation rows to count them.

## Migration `062_inventory_reservations` (revises 061)

Creates the table and the `reservation_source` enum, plus `integrity_note` (nullable, 500 chars) on both request tables — one message, two writers, because the acceptor's question is the same either way: *can I still trust this request?*

**Backfill policy.** Existing in-flight requests hold no claim, so the first request created after the migration would reserve stock they are already counting on. They are backfilled **oldest first** — the queue everybody already understands:

- In flight = PENDING, or APPROVED while the minted PullRequest is still PENDING. Past that, inventory has already moved.
- Shipping-out `OPENING_ITEM` lines reserve nothing.
- Where the remaining stock covers a request, its reservation is written and it behaves from then on exactly like one created after this slice.
- Where it does not, **nothing partial is written** and the request is flagged via `integrity_note`. A half-reservation is the worst of both — it reads as covered while the pull is still short. Flagged-and-unreserved is honest: the request keeps the pre-#342 behaviour and the acceptor is told before they act.

Verified on a live cluster with two competing PENDING requests seeded at 061: the older one took its 6 of 10 units, the newer one (needing 6, with 4 left) was flagged and left unreserved. **Downgrade** drops the table, the enum and both columns unconditionally, so availability reverts to on-hand minus deficient — which is what the pre-#342 code computes.

## Re-upload policy: reconcile and flag, never block

`_handle_schedule_replacement` runs just before a `replace_schedule=True` finalize deletes the vanished openings.

**The re-upload is not blocked**, and that was the deliberate choice. Replacing the schedule is how a real revision reaches the system; refusing it whenever any request is open would make the revision wait on the warehouse — the wrong way round. Instead the requests are made to tell the truth about themselves:

- **PENDING requests are rewritten to what survived.** Work units and lines whose opening is gone are deleted, and the reservation is rebuilt from what is left — releasing exactly what the vanished openings held, no more. A request left with nothing is auto-REJECTED by "Hardware Schedule Import", which releases the rest through the ordinary reject path.
- **APPROVED requests are left alone.** Their pull already exists and is the authority on what the warehouse will hand over; silently shrinking it underneath the puller would be worse than a stale bill of hardware.
- **Every live request is flagged**, not just the ones that lost openings — a full-schedule replacement can change the hardware on an opening it kept.

Deliberately *not* done: re-deriving a surviving request's items from the new schedule. The request is a snapshot somebody made a decision about; rewriting its contents under them would make the flag a lie.

## Request-integrity guards

- **Duplicate in-flight leaf.** `find_already_assembled_openings` catches the leaf that has been *built*; `find_in_flight_assembly_leaves` catches the one on its way there — requested, pulled, or half-assembled. Live means `assembly_status != COMPLETED` and the parent request is not REJECTED. Scoped by `opening_id` (a project's own Opening UUID), so it is project-scoped without joining a table a re-upload may have deleted. Still per-leaf: requesting Leaf 1 does not block Leaf 2.
- **Cross-request-type conflict**, surfaced from both directions via `find_live_shipping_claims`. A leaf a live shipping-out request has claimed cannot be sent back to the bench, and a leaf still inside a live shop-assembly work unit cannot be shipped. "Live" is defined by the *pull*, not the request status, because a shipping-out request stays APPROVED forever once accepted.
- **Duplicate shipping claim.** One physical leaf can sit on exactly one live request. The wizard already hid claimed leaves; the backend now enforces it, so a stale tab cannot ship the same leaf twice.
- **Degenerate requests refused at creation**: zero-opening shop-assembly requests, zero-item openings (a leaf with an empty checklist is something #339 already refuses to complete), zero-line shipping requests.

## Frontend

New `projectInventoryAvailability(projectId)` returns on-hand / deficient / reserved / available per combo. **This is deliberately not the same "available" as `inventoryHierarchy`'s** (on-hand minus deficient): that view answers *what is physically unspoken-for in the building*, this one answers *what may I claim*. Both are correct; conflating them is what the field comment and the SDL note exist to prevent.

- **Shop Assembly step**: a "Hardware this request would reserve" table (Needed / Available / Reserved elsewhere, with a `Short N` chip), and Next is disabled while any combo over-claims, while the lookup is in flight, or if it failed — an unknown count must not read as "fine". The shortfall alert distinguishes *not here* from *here but spoken for*, because they call for completely different actions.
- **Shipping PRs step**: per-line "N available (R reserved by other requests)" on **loose** lines only; assembled leaves show nothing and are never gated. Ticking a line is still allowed — the gate is on the step, not the checkbox, because blocking the tick would make the combined effect of a selection impossible to see.
- The work units the wizard gates on are now derived **once** (`shopAssemblyOpeningDrafts`) and used by both the gate and `buildFinalizeInput`, so the numbers the user is held to are by construction the numbers that get sent.
- **Accept UI**: shortfall handling is gone; the copy says the hardware was reserved at creation and that rejecting is what releases it. The reopen confirm adds that a reopened request keeps its claim. An `integrityNote` renders as an amber alert above the request detail.
- `refetch.ts` gains `RESERVATION_STALE_ROOT_FIELDS` — evicted (never paired with a refetch) on finalize and on reject, because the reader is a full-screen wizard in another module that is by definition not mounted when a request is rejected.

## Verification

Ran against a throwaway PostgreSQL 16 cluster (EDB portable binaries, `initdb` into a scratch dir, stopped and cleaned up afterwards):

- **334 backend tests pass** (was 301 pre-slice; 32 new in `tests/test_inventory_reservations.py`), all DB-backed.
- Full CI migration-integrity cycle: `upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean).
- Downgrade separately re-verified **with reservation rows and a flagged request present**, and the backfill separately verified by seeding two competing in-flight requests at 061 and upgrading.
- `uvx ruff check .` / `uvx ruff format --check .` clean (poetry is not installed on this box).
- Frontend: `npm run lint` (0 errors, 17 warnings — the pre-existing set, unchanged), `npm run test:run` **199 pass** (13 new in `availabilityGating.test.tsx`), `npm run build` clean.
- Printed SDL checked: `InventoryAvailability`, `projectInventoryAvailability`, `integrityNote`, `InventoryShortfall.reserved` all present and additive.
- SDL reference docs, `docs/HARDWARE_IDENTITY_LIFECYCLE.md` (new §3a with the full lifecycle table plus eight rows in the enforcement table) and `testing/CLAUDE.md` updated.

### Reworked tests

Three existing tests asserted the accept-time gate that this slice removes. They were reworked to the new model rather than deleted:

- `test_gate1_import_always_creates_pending_request_even_when_short` → `test_gate1_creation_refuses_when_short_and_creates_nothing`. The behaviour it asserted (import mints a request regardless of stock) is precisely what #342 reverses.
- `test_gate1_accept_refuses_when_short_and_creates_no_pr` → `test_gate1_accept_no_longer_rechecks_inventory`, which writes stock off *after* creation and asserts the accept still mints the PR and neither spends nor releases the claim.
- `test_accept_shop_assembly_blocks_on_shortfall` → `test_creating_a_shop_assembly_request_blocks_on_shortfall`, the same refusal one step earlier.

Tests that only needed stock seeding to reach the new creation gate got it, and the reject tests gained assertions that the claim is actually released.

## Deviations from the issue spec

- **One `integrity_note` column per request table rather than a per-opening "schedule changed" flag.** The issue asked to flag surviving in-flight *openings*; the accept UI acts on whole requests, and the backfill needed a flag of its own with the same meaning ("can I still trust this?"). One nullable message, one GraphQL field, one alert, two writers.
- **A shortfall at creation notifies the PO only for combos that are genuinely not in the building** (`short > reserved`). A combo short only because another request has claimed it is not a purchasing problem, and a backfill notification for it would send someone to order stock that already exists. The refusal reaches the creator inline either way.
- **`Shortfall` gained a `reserved` field** (additive, defaults to 0). Without it "0 available" is ambiguous between *order more* and *release or refine a request*, which are opposite actions.
- **The re-upload leaves APPROVED requests' openings and reservations untouched**, flagging only. The issue's minimum was "release reservations for requests whose openings vanished"; doing that to a request whose pull already exists would leave the pull under-reserved relative to what it will consume.
