### PR TITLE
feat(warehouse): slice 5 per-opening pull staging + cancel/restock (#343)

### DIFF
--- a/backend/alembic/versions/063_pull_staging_cancel.py
+++ b/backend/alembic/versions/063_pull_staging_cancel.py
@@ -1,0 +1,120 @@
+"""Per-opening pull staging + pull cancel/restock (#343)
+
+Revision ID: 063
+Revises: 062
+Create Date: 2026-07-26
+
+The warehouse stages a pull cart by cart, opening by opening, and the system only knew "pulled" or
+"not pulled" for the whole request - so an opening whose hardware was on a cart at 9am was not
+assignable until the last opening of the pull was picked at 4pm. Staging becomes per opening
+(`shop_assembly_openings.pull_status`, which already existed), and this migration adds the two
+columns that record *when* and *by whom*, since the pull's own `completed_at` can no longer answer
+that question for an individual cart.
+
+The other half is the way back. Once a pull was approved there was no way out: inventory was
+deducted, and `PullRequestStatus.CANCELLED` was an enum value nothing ever set. Cancelling returns
+the hardware to the shelf and sends the source request back to PENDING for re-acceptance - which
+runs straight into `request_number` being globally unique on `pull_requests`, because re-accepting
+mints a pull carrying the same number. (#325's reopen path dodged this by hard-deleting the pull; a
+cancellation has to keep it.) The plain unique constraint is therefore replaced with a **partial**
+unique index excluding cancelled rows: the number identifies the *live* pull for a request, which is
+what every lookup on it actually means.
+
+Columns and enum values:
+- `shop_assembly_openings.staged_at` / `staged_by` - nullable, backfilled for nothing; existing
+  PULLED openings simply have no staging stamp, which is honest (they were staged wholesale).
+- `pull_requests.cancelled_by` / `cancellation_reason` - the actor and reason, alongside the
+  `cancelled_at` that already existed, mirroring how a request rejection records itself.
+- `audit_action` gains PULL_STAGED, PULL_RESTOCK, PULL_CANCELLED; `audit_entity_type` gains
+  PULL_REQUEST (a cancellation is an event about the pull, not about any one inventory row).
+
+Downgrade drops the columns and the new audit rows, recreates both enums without the new labels
+(Postgres cannot drop a label in place), and restores the plain unique constraint - de-duplicating
+first, by suffixing any cancelled row whose number a live row also carries, since that is precisely
+the state this migration made reachable.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "063"
+down_revision = "062"
+branch_labels = None
+depends_on = None
+
+_LIVE_NUMBER_INDEX = "uq_pull_requests_request_number_live"
+_LEGACY_NUMBER_CONSTRAINT = "pull_requests_request_number_key"
+
+_AUDIT_ACTION_WITHOUT = (
+    "'ADJUSTMENT', 'MOVE', 'UNLOCATE', 'RECEIVE', 'PULL_DEDUCTION', 'SPOT_CHECK', 'PUT_AWAY', "
+    "'DESTOCK', 'ALLOCATE_FROM_STOCK', 'RECLASSIFY', 'REPORT_DEFICIENT', 'RESOLVE_DEFICIENT', "
+    "'TRANSFER', 'RETURN', 'INSTALL_PROGRESS', 'ASSEMBLY_COMPLETE', 'REPLACEMENT_RECEIVED', "
+    "'REPLACEMENT_INSTALL'"
+)
+_AUDIT_ENTITY_TYPE_WITHOUT = "'INVENTORY_LOCATION', 'OPENING_ITEM', 'STOCK_ITEM', 'SHOP_ASSEMBLY_OPENING'"
+
+
+def upgrade() -> None:
+    op.add_column("shop_assembly_openings", sa.Column("staged_at", sa.DateTime(), nullable=True))
+    op.add_column("shop_assembly_openings", sa.Column("staged_by", sa.String(), nullable=True))
+
+    op.add_column("pull_requests", sa.Column("cancelled_by", sa.String(), nullable=True))
+    op.add_column("pull_requests", sa.Column("cancellation_reason", sa.String(500), nullable=True))
+
+    # Swap the global uniqueness of request_number for uniqueness among live pulls only.
+    op.drop_constraint(_LEGACY_NUMBER_CONSTRAINT, "pull_requests", type_="unique")
+    op.create_index(
+        _LIVE_NUMBER_INDEX,
+        "pull_requests",
+        ["request_number"],
+        unique=True,
+        postgresql_where=sa.text("status <> 'CANCELLED'"),
+    )
+
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'PULL_STAGED'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'PULL_RESTOCK'")
+    op.execute("ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'PULL_CANCELLED'")
+    op.execute("ALTER TYPE audit_entity_type ADD VALUE IF NOT EXISTS 'PULL_REQUEST'")
+
+
+def downgrade() -> None:
+    # Rows first: an enum recast fails on any value that is about to stop existing.
+    op.execute("DELETE FROM inventory_audit_log WHERE action IN ('PULL_STAGED', 'PULL_RESTOCK', 'PULL_CANCELLED')")
+    op.execute("DELETE FROM inventory_audit_log WHERE entity_type = 'PULL_REQUEST'")
+
+    op.execute("ALTER TYPE audit_action RENAME TO audit_action_old")
+    op.execute(f"CREATE TYPE audit_action AS ENUM ({_AUDIT_ACTION_WITHOUT})")
+    op.execute("ALTER TABLE inventory_audit_log ALTER COLUMN action TYPE audit_action USING action::text::audit_action")
+    op.execute("DROP TYPE audit_action_old")
+
+    op.execute("ALTER TYPE audit_entity_type RENAME TO audit_entity_type_old")
+    op.execute(f"CREATE TYPE audit_entity_type AS ENUM ({_AUDIT_ENTITY_TYPE_WITHOUT})")
+    op.execute(
+        "ALTER TABLE inventory_audit_log ALTER COLUMN entity_type "
+        "TYPE audit_entity_type USING entity_type::text::audit_entity_type"
+    )
+    op.execute("DROP TYPE audit_entity_type_old")
+
+    op.drop_index(_LIVE_NUMBER_INDEX, table_name="pull_requests")
+    # A cancelled pull may legitimately share its number with the live pull a re-accept minted -
+    # that is the whole point of the partial index. Global uniqueness cannot express it, so retire
+    # the cancelled row's number rather than lose the row. Deterministic and self-describing, so the
+    # history stays readable.
+    op.execute(
+        """
+        UPDATE pull_requests p
+           SET request_number = left(p.request_number, 41) || '-X' || left(replace(p.id::text, '-', ''), 8)
+         WHERE p.status = 'CANCELLED'
+           AND EXISTS (
+                 SELECT 1 FROM pull_requests q
+                  WHERE q.request_number = p.request_number AND q.id <> p.id
+               )
+        """
+    )
+    op.create_unique_constraint(_LEGACY_NUMBER_CONSTRAINT, "pull_requests", ["request_number"])
+
+    op.drop_column("pull_requests", "cancellation_reason")
+    op.drop_column("pull_requests", "cancelled_by")
+    op.drop_column("shop_assembly_openings", "staged_by")
+    op.drop_column("shop_assembly_openings", "staged_at")

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -29,7 +29,13 @@ type ShopAssemblyOpening {
   id: ID!
   shop_assembly_request_id: ID!
   opening_id: ID!
+  # NOT_PULLED until the warehouse confirms this opening's cart is built, then PULLED (#343). Never
+  # PARTIAL: one cart cannot be half-built.
   pull_status: PullStatus!
+  # When this opening's cart was confirmed staged, and by whom (#343). Null while NOT_PULLED, and on
+  # openings staged before per-opening staging existed (they were staged wholesale).
+  staged_at: DateTime
+  staged_by: String
   # Stable Clerk user id the opening is claimed by (#324); assigned_to is the display name.
   assigned_to_user_id: String
   assigned_to: String
@@ -40,6 +46,8 @@ type ShopAssemblyOpening {
 
 enum PullStatus {
   NOT_PULLED
+  # Only ever an aggregate reading over a *set* of openings - "some carts built, some not" (#343).
+  # Derived for a whole PullRequest (PullRequest.staging_status); never written to an opening.
   PARTIAL
   PULLED
 }

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -105,6 +105,19 @@ type PullRequest {
   approved_at: DateTime
   completed_at: DateTime
   cancelled_at: DateTime
+  # Who cancelled the pull and why (#343). Null unless status is CANCELLED.
+  cancelled_by: String
+  cancellation_reason: String
+  # Per-opening staging rollup, DERIVED and never stored (#343): NOT_PULLED / PARTIAL / PULLED read
+  # over this pull's shop-assembly openings. PARTIAL is a statement about the *set* of openings, so
+  # it has no place on any single opening's own pull_status - one cart is built or it is not.
+  #
+  # Null = staging does not apply, or was not evaluated. A shipping-out pull, a PR-REPL replacement
+  # pull and a legacy pull all have no openings; resolvers that do not compute the rollup leave it
+  # null rather than implying "nothing staged".
+  staging_status: PullStatus
+  staged_opening_count: Int
+  total_opening_count: Int
   items: [PullRequestItem!]!
 }
 
@@ -122,6 +135,46 @@ type PullRequestItem {
   hardware_category: String
   product_code: String
   requested_quantity: Int!
+}
+
+input StagePullOpeningsInput {
+  pull_request_id: ID!
+  opening_ids: [ID!]!
+  staged_by: String!
+}
+
+type StagePullOpeningsResult {
+  pull_request: PullRequest!
+  openings: [ShopAssemblyOpening!]!
+  # Ids staged by *this* call - an opening already staged is skipped, not refused, so this is how a
+  # caller tells a real confirmation from a replayed one.
+  newly_staged_opening_ids: [ID!]!
+  completed: Boolean!
+}
+
+input CancelPullRequestInput {
+  id: ID!
+  cancelled_by: String!
+  reason: String
+}
+
+type RestockedLine {
+  hardware_category: String!
+  product_code: String!
+  quantity: Int!
+}
+
+type CancelPullRequestResult {
+  pull_request: PullRequest!
+  # The inverse inventory write, per combo. Empty for a pull with no LOOSE lines.
+  restocked: [RestockedLine!]!
+  released_opening_ids: [ID!]!
+  # False for a PR-REPL replacement pull or a legacy pull, which have no source request at all.
+  source_request_returned_to_pending: Boolean!
+  # False when the request holds no claim - no source request, or the availability re-check came up
+  # short, in which case integrity_note says so and the request carries the same message.
+  reservations_recreated: Boolean!
+  integrity_note: String
 }
 
 type ApproveResult {
@@ -326,6 +379,11 @@ type Query {
   openingItemDetails(id: ID!): OpeningItemDetail!
   pullRequests(projectId: ID!, source: PullRequestSource, status: PullRequestStatus): [PullRequest!]!
   pullRequestDetails(id: ID!): PullRequest!
+  # The shop-assembly openings a pull covers, with their hardware lines, for the warehouse's
+  # per-opening staging checklist (#343). Deliberately a separate query rather than a field on
+  # PullRequest: a resolver field would run once per row of the pull-request queue, which never
+  # needs it. Empty for a shipping-out / PR-REPL / legacy pull.
+  pullRequestOpenings(pullRequestId: ID!): [ShopAssemblyOpening!]!
   shipReadyItems(projectId: ID!): ShipReadyItems!
   projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
   packingSlips(projectId: ID): [PackingSlip!]!
@@ -336,7 +394,18 @@ type Query {
 type Mutation {
   createReceive(input: CreateReceiveInput!): ReceiveRecord!
   approvePullRequest(id: ID!, approvedBy: String!): ApproveResult!
-  completePullRequest(id: ID!): PullRequest!
+  # Close the whole pull. Since #343 this reads as "stage everything still outstanding and finish":
+  # any opening not yet confirmed individually is flipped to PULLED and stamped with completedBy.
+  completePullRequest(id: ID!, completedBy: String): PullRequest!
+  # Confirm that the carts for these openings of an approved shop-assembly pull are built (#343).
+  # Each one becomes assignable and workable immediately; staging the last completes the pull.
+  # Nothing moves in inventory - the FIFO deduction and the source request's reservation were both
+  # spent at approval. Already-staged openings are skipped, not refused.
+  stagePullOpenings(input: StagePullOpeningsInput!): StagePullOpeningsResult!
+  # Cancel an approved pull, return its hardware to inventory, and hand the source request back to
+  # PENDING (#343). All-or-nothing: an opening whose assembly has started or finished refuses the
+  # whole cancellation with CONFLICT, naming every blocker.
+  cancelPullRequest(input: CancelPullRequestInput!): CancelPullRequestResult!
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
   adjustInventoryQuantity(inventoryLocationId: ID!, adjustment: Int!, reason: String!): InventoryLocation!

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -67,6 +67,15 @@ class ReservationSource(str, enum.Enum):
 
 
 class PullStatus(str, enum.Enum):
+    """How much of something has been staged by the warehouse.
+
+    Persisted per `ShopAssemblyOpening`, where only NOT_PULLED and PULLED are ever written: one
+    opening is a cart, and a cart is either built or it is not. PARTIAL is the *aggregate* reading
+    over a set of openings - "some of this pull is staged, some is not" - and since #343 it is
+    derived for a whole PullRequest rather than stored (see
+    `warehouse.get_pull_staging_summaries`). Keeping it out of the opening column is what stops a
+    half-truth being persisted about a single cart."""
+
     NOT_PULLED = "NOT_PULLED"
     PARTIAL = "PARTIAL"
     PULLED = "PULLED"
@@ -109,6 +118,10 @@ class AuditEntityType(str, enum.Enum):
     # The assembly work unit (one door leaf) an INSTALL_PROGRESS event is recorded against (#340).
     # Progress happens before any OpeningItem exists, so it cannot hang off OPENING_ITEM.
     SHOP_ASSEMBLY_OPENING = "SHOP_ASSEMBLY_OPENING"
+    # The pull itself (#343). A cancellation is an event about the *pull*, not about any one
+    # inventory row it happened to touch, so it needs an entity of its own rather than being
+    # smuggled onto an INVENTORY_LOCATION row.
+    PULL_REQUEST = "PULL_REQUEST"
 
 
 class AuditAction(str, enum.Enum):
@@ -138,6 +151,18 @@ class AuditAction(str, enum.Enum):
     # Replacement hardware was fitted to an already-completed leaf (#341) - the one legitimate write
     # to an OpeningItem's installed hardware after assembly finished.
     REPLACEMENT_INSTALL = "REPLACEMENT_INSTALL"
+    # One opening of a shop-assembly pull was confirmed staged - its cart is built (#343). Recorded
+    # against the SHOP_ASSEMBLY_OPENING, because staging is per opening and the pull as a whole may
+    # still be part-way through.
+    PULL_STAGED = "PULL_STAGED"
+    # The inverse of PULL_DEDUCTION (#343): a cancelled pull put its hardware back on the shelf.
+    # Distinct from RETURN (a shipment coming back from site) so a restock is never mistaken for
+    # inventory arriving from outside the building.
+    PULL_RESTOCK = "PULL_RESTOCK"
+    # A pull was cancelled after approval (#343). One row per cancellation against the PULL_REQUEST,
+    # carrying what was restocked, which openings were released, and what happened to the source
+    # request - the PULL_RESTOCK rows above are the per-inventory-row detail of the same event.
+    PULL_CANCELLED = "PULL_CANCELLED"
 
 
 class ReturnDisposition(str, enum.Enum):

--- a/backend/app/models/pull_request.py
+++ b/backend/app/models/pull_request.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -19,10 +19,21 @@ class PullRequest(Base):
         ),
         Index("ix_pull_requests_assigned_to", "assigned_to"),
         Index("ix_pull_requests_created_at", "created_at"),
+        # The pull number identifies the *live* pull for a request, not every pull that request has
+        # ever had (#343). A cancelled pull keeps its number for the record, and re-accepting the
+        # source request mints a fresh pull carrying the same number - so the uniqueness that makes
+        # the number a usable key has to exclude cancelled rows, or the second accept would collide
+        # exactly the way #325's reopen path had to hard-delete the PR to avoid.
+        Index(
+            "uq_pull_requests_request_number_live",
+            "request_number",
+            unique=True,
+            postgresql_where=text("status <> 'CANCELLED'"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    request_number: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    request_number: Mapped[str] = mapped_column(String(50), nullable=False)
     project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), nullable=False)
     source: Mapped[PullRequestSource] = mapped_column(
         Enum(PullRequestSource, name="pull_request_source", create_constraint=True),
@@ -39,6 +50,11 @@ class PullRequest(Base):
     approved_at: Mapped[datetime | None] = mapped_column(nullable=True)
     completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
     cancelled_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    # Who cancelled the pull and why (#343). Cancellation returns real hardware to the shelf and
+    # sends the source request back for re-acceptance, so - like a request rejection - it carries
+    # its actor and its reason on the row, not only in the audit log.
+    cancelled_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    cancellation_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
     deleted_at: Mapped[datetime | None] = mapped_column(nullable=True)
 
     items: Mapped[list["PullRequestItem"]] = relationship(back_populates="pull_request")

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -80,10 +80,18 @@ class ShopAssemblyOpening(Base):
     # Door leaf this assembly work unit is for (#311): 1 or 2. A pair produces two rows sharing
     # opening_number, one per leaf. Null = legacy whole-opening unit.
     leaf: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    # NOT_PULLED until the warehouse confirms this opening's cart is built, then PULLED (#343).
+    # Only ever these two values: PARTIAL is an aggregate reading over a *set* of openings and is
+    # derived for the pull as a whole, never written here - one cart cannot be half-built.
     pull_status: Mapped[PullStatus] = mapped_column(
         Enum(PullStatus, name="pull_status", create_constraint=True),
         nullable=False,
     )
+    # When this opening was confirmed staged, and by whom (#343). Staging is per opening now, so the
+    # pull's own completed_at can no longer say when *this* cart became workable - which is the
+    # question the assembly floor asks when a leaf turns up late.
+    staged_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    staged_by: Mapped[str | None] = mapped_column(String, nullable=True)
     # Stable Clerk user id the opening is claimed by (#324): the identity myWork filters on, so a
     # display-name change or a non-UI caller no longer detaches in-flight work. assigned_to below
     # stays the human-readable name for display; both are set/cleared together.

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -47,6 +47,18 @@ MAX_DEFICIENT_REASON_LENGTH = 500
 # Assembly statuses an opening can still be worked in (#340). COMPLETED is terminal.
 _WORKABLE_ASSEMBLY_STATUSES = (AssemblyStatus.PENDING, AssemblyStatus.IN_PROGRESS)
 
+# Pull-request statuses under which an opening's own pull_status is meaningful (#343).
+#
+# This used to be `== COMPLETED` in three places, on the assumption that a pull is staged as one
+# thing, so "the pull is done" and "this opening's hardware is on a cart" were the same fact. Since
+# staging is per opening they are not: an opening staged first thing in the morning is workable
+# while the rest of the pull is still being picked, and the pull only reaches COMPLETED when the
+# last cart is built. Every one of those checks is now keyed on `ShopAssemblyOpening.pull_status ==
+# PULLED` - the fact that actually governs - with the pull-status filter kept only to exclude a pull
+# that never got off the ground (PENDING, nothing deducted) or was cancelled (hardware restocked;
+# cancellation also detaches its openings, so this is belt-and-braces).
+_APPROVED_PULL_STATUSES = (PullRequestStatus.IN_PROGRESS, PullRequestStatus.COMPLETED)
+
 
 @dataclass
 class AssemblyProgressUpdate:
@@ -72,7 +84,18 @@ def get_assemble_list(
     session: Session,
     project_id: uuid.UUID | None = None,
 ) -> list[ShopAssemblyOpening]:
-    """Query ShopAssemblyOpenings whose shop-assembly PullRequest has been pulled (#222)."""
+    """Query ShopAssemblyOpenings on an approved shop-assembly PullRequest (#222, re-keyed in #343).
+
+    Approved, not completed. The pull is staged opening by opening now, so this list fills
+    incrementally: an opening the warehouse has confirmed comes back PULLED and is workable straight
+    away, while its neighbours on the same pull are still NOT_PULLED. The page groups on exactly that
+    column, so the un-staged openings render as "waiting" rather than being invisible until the whole
+    pull is picked - which is what the assembly floor wants to see coming.
+
+    Workability is *not* decided here: `assign_openings`, `record_assembly_progress` and
+    `complete_opening` each gate on the opening's own `pull_status`, so a NOT_PULLED row in this list
+    can be looked at and not acted on.
+    """
     stmt = (
         select(ShopAssemblyOpening)
         .join(
@@ -82,7 +105,7 @@ def get_assemble_list(
         .options(selectinload(ShopAssemblyOpening.items))
         .where(
             PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
-            PullRequestModel.status == PullRequestStatus.COMPLETED,
+            PullRequestModel.status.in_(_APPROVED_PULL_STATUSES),
         )
     )
     if project_id is not None:
@@ -96,7 +119,13 @@ def get_my_work(
 ) -> list[ShopAssemblyOpening]:
     """Query ShopAssemblyOpenings claimed by a user (by stable Clerk user id, #324) that are still
     unfinished - PENDING or, since progress is persisted (#340), IN_PROGRESS. A leaf the assembler
-    saved partial progress on has to stay in My Work or the work would be unreachable."""
+    saved partial progress on has to stay in My Work or the work would be unreachable.
+
+    Keyed on the *opening's* pull_status since #343: My Work is the list of leaves somebody can
+    actually go and build, and a staged opening is buildable whether or not the rest of its pull has
+    been picked. The old `PullRequest.status == COMPLETED` filter would have held a claimed,
+    fully-staged leaf out of its own assembler's board until the last cart on the pull was finished.
+    """
     stmt = (
         select(ShopAssemblyOpening)
         .join(
@@ -107,8 +136,9 @@ def get_my_work(
         .where(
             ShopAssemblyOpening.assigned_to_user_id == assigned_to_user_id,
             ShopAssemblyOpening.assembly_status.in_(_WORKABLE_ASSEMBLY_STATUSES),
+            ShopAssemblyOpening.pull_status == PullStatus.PULLED,
             PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
-            PullRequestModel.status == PullRequestStatus.COMPLETED,
+            PullRequestModel.status.in_(_APPROVED_PULL_STATUSES),
         )
         .order_by(ShopAssemblyOpening.opening_number.asc())
     )
@@ -407,6 +437,12 @@ def complete_opening(
 
     if sa_opening.assembly_status not in _WORKABLE_ASSEMBLY_STATUSES:
         raise InvalidStateTransitionError("Opening assembly is already completed")
+    # This opening's own hardware has to be on a cart (#343). Until staging was per opening, the
+    # `PullRequest.status == COMPLETED` lookup below carried this check implicitly; now that a pull
+    # can be part-staged, the fact that governs is the opening's own pull_status, and it is checked
+    # explicitly - the same gate record_assembly_progress and assign_openings already use.
+    if sa_opening.pull_status != PullStatus.PULLED:
+        raise InvalidStateTransitionError("Opening hardware has not been pulled - there is nothing to assemble yet")
     if sa_opening.assigned_to is None:
         raise ValidationError(
             "Opening must be assigned before it can be completed",
@@ -423,11 +459,11 @@ def complete_opening(
     pr_stmt = select(PullRequestModel).where(
         PullRequestModel.id == sa_opening.pull_request_id,
         PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
-        PullRequestModel.status == PullRequestStatus.COMPLETED,
+        PullRequestModel.status.in_(_APPROVED_PULL_STATUSES),
     )
     pr = session.scalars(pr_stmt).first()
     if pr is None:
-        raise NotFoundError(f"Completed shop-assembly pull request for opening {opening_id} not found")
+        raise NotFoundError(f"Approved shop-assembly pull request for opening {opening_id} not found")
 
     # 3. Duplicate-completion guard (#339). Two shop-assembly openings can name the same
     #    (opening_id, leaf) - e.g. a request was reopened and re-imported, or the same leaf was sent
@@ -1084,8 +1120,16 @@ def reopen_shop_assembly_request(
     # pull_request_id. accept mints the PR unconditionally (even a zero-opening request gets one), so an
     # openings-derived lookup can miss it and leave a PENDING PR orphaned - and since request_number is
     # unique, the next accept would then collide, re-creating the stuck state #325 removes. accept stamps
-    # the PR with request_number == sar.request_number, which is unique on pull_requests.
-    pr = session.scalar(select(PullRequestModel).where(PullRequestModel.request_number == sar.request_number))
+    # the PR with request_number == sar.request_number, which is unique among *live* pull requests
+    # (#343 made that uniqueness partial: a cancelled pull keeps its number, and re-accepting mints a
+    # new pull carrying the same one). Excluding CANCELLED is therefore what keeps this a single-row
+    # lookup after a cancel-then-re-accept cycle.
+    pr = session.scalar(
+        select(PullRequestModel).where(
+            PullRequestModel.request_number == sar.request_number,
+            PullRequestModel.status != PullRequestStatus.CANCELLED,
+        )
+    )
 
     # Re-point the openings + flip the request, then flush BEFORE discarding the PR, so deleting it does
     # not trip the shop_assembly_openings.pull_request_id foreign key. discard_pending_pull_request still

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -42,15 +42,24 @@ from .progress import (
     get_warehouse_dashboard,
 )
 from .pull_requests import (
+    CancelBlocker,
+    CancelResult,
+    RestockedLine,
     Shortfall,
+    StageResult,
+    StagingSummary,
     SufficiencyResult,
     approve_pull_request,
+    cancel_pull_request,
     check_inventory_sufficiency,
     complete_pull_request,
     discard_pending_pull_request,
     find_reservation_holder,
     get_pull_request_details,
+    get_pull_request_openings,
     get_pull_requests,
+    get_pull_staging_summaries,
+    stage_pull_openings,
 )
 from .receiving import (
     create_receive,
@@ -69,7 +78,12 @@ from .reservations import (
 
 __all__ = [
     "PLACED_PO_STATUSES",
+    "CancelBlocker",
+    "CancelResult",
+    "RestockedLine",
     "Shortfall",
+    "StageResult",
+    "StagingSummary",
     "SufficiencyResult",
     "_log_audit_event",
     "_normalize_and_validate_location_fields",
@@ -77,6 +91,7 @@ __all__ = [
     "approve_pull_request",
     "assign_inventory_location",
     "assign_opening_item_location",
+    "cancel_pull_request",
     "check_inventory_sufficiency",
     "complete_pull_request",
     "create_receive",
@@ -102,7 +117,9 @@ __all__ = [
     "get_project_availability",
     "get_project_progress_by_product",
     "get_pull_request_details",
+    "get_pull_request_openings",
     "get_pull_requests",
+    "get_pull_staging_summaries",
     "get_recent_receive_records",
     "get_reserved_quantities",
     "get_unlocated_inventory",
@@ -115,5 +132,6 @@ __all__ = [
     "normalize_location_value",
     "override_inventory_quantity",
     "release_reservations",
+    "stage_pull_openings",
     "validate_receive_eligibility",
 ]

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -6,10 +6,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from sqlalchemy import and_, delete, or_, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.errors import InvalidStateTransitionError, NotFoundError
+from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
 from app.models.enums import (
     AssemblyStatus,
     AuditAction,
@@ -21,6 +21,8 @@ from app.models.enums import (
     PullRequestStatus,
     PullStatus,
     ReservationSource,
+    ShippingOutRequestStatus,
+    ShopAssemblyRequestStatus,
 )
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
@@ -34,6 +36,8 @@ from app.services.locking import lock_rows
 
 from . import reservations
 from .audit import _log_audit_event
+
+MAX_CANCELLATION_REASON_LENGTH = 500
 
 
 def get_pull_requests(
@@ -490,7 +494,7 @@ def _apply_replacement_arrivals(session: Session, pr: PullRequestModel) -> None:
         )
 
 
-def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestModel:
+def complete_pull_request(session: Session, pr_id: uuid.UUID, completed_by: str | None = None) -> PullRequestModel:
     """
     Complete a pull request:
     1. Validate status == In_Progress
@@ -499,6 +503,12 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestMode
     4. Restore any leaf expectations the pull's replacement lines are owed to (#341)
     5. If Shipping_Out source: set Opening_Item states to Ship_Ready
     6. If Shop_Assembly source: update SAR openings pull_status to Pulled
+
+    Since #343 a shop-assembly pull is normally *completed by its last staging* - `stage_pull_openings`
+    calls straight into here once every opening is staged, so the notification and the replacement
+    arrivals still fire exactly once, from one place. Calling it directly stays supported and means
+    "stage whatever is left and close the pull": step 6 flips any remaining opening to PULLED and
+    stamps its staging, which is a no-op for openings already staged individually.
     """
     stmt = select(PullRequestModel).options(selectinload(PullRequestModel.items)).where(PullRequestModel.id == pr_id)
     pr = session.scalars(stmt).unique().first()
@@ -544,9 +554,585 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID) -> PullRequestMode
             select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id)
         ).all()
         for opening in openings:
+            # Idempotent for an opening already staged individually (#343): its own staged_at/by
+            # stamp is the truth about when that cart was built and must not be overwritten by the
+            # moment the *last* cart happened to be finished.
+            if opening.pull_status == PullStatus.PULLED:
+                continue
             opening.pull_status = PullStatus.PULLED
+            opening.staged_at = now
+            opening.staged_by = completed_by or pr.assigned_to or pr.requested_by
 
     return pr
+
+
+# ---------------------------------------------------------------------------
+# Per-opening staging (#343)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StagingSummary:
+    """How far along a shop-assembly pull's staging is, derived - never stored.
+
+    `status` is a `PullStatus` read over the *set* of openings: NOT_PULLED when none is staged,
+    PARTIAL when some are, PULLED when all are. That is the reading the dead `PullStatus.PARTIAL`
+    value was always for, and deriving it is what keeps the persisted state machine honest: the
+    opening column stays a two-valued fact about one cart, and `PullRequestStatus` stays
+    PENDING -> IN_PROGRESS -> COMPLETED/CANCELLED with no half-state wedged into it. A pull whose
+    every opening is staged *is* COMPLETED, so PULLED here is never observed without it.
+    """
+
+    staged_opening_count: int
+    total_opening_count: int
+
+    @property
+    def status(self) -> PullStatus:
+        if self.staged_opening_count == 0:
+            return PullStatus.NOT_PULLED
+        if self.staged_opening_count >= self.total_opening_count:
+            return PullStatus.PULLED
+        return PullStatus.PARTIAL
+
+
+def get_pull_staging_summaries(session: Session, pr_ids: Iterable[uuid.UUID]) -> dict[uuid.UUID, StagingSummary]:
+    """Staged/total opening counts per pull, for every pull id given, in **one grouped aggregate**.
+
+    The pull-request list resolver renders a staging chip per row, so this must never become a
+    per-row query (CLAUDE.md perf rules) - it is `count(*)` and a filtered `count(*)`, grouped by
+    pull, not a `len()` over loaded openings. Pulls with no openings at all (shipping-out, PR-REPL,
+    legacy) are simply absent from the result: staging does not apply to them, and a caller must
+    render nothing rather than "0 of 0 staged".
+    """
+    ids = [pid for pid in pr_ids if pid is not None]
+    if not ids:
+        return {}
+    staged = func.count(1).filter(ShopAssemblyOpening.pull_status == PullStatus.PULLED)
+    rows = session.execute(
+        select(
+            ShopAssemblyOpening.pull_request_id,
+            func.count(1).label("total"),
+            staged.label("staged"),
+        )
+        .where(ShopAssemblyOpening.pull_request_id.in_(ids))
+        .group_by(ShopAssemblyOpening.pull_request_id)
+    ).all()
+    return {
+        row.pull_request_id: StagingSummary(staged_opening_count=int(row.staged), total_opening_count=int(row.total))
+        for row in rows
+    }
+
+
+def get_pull_request_openings(session: Session, pr_id: uuid.UUID) -> list[ShopAssemblyOpening]:
+    """The shop-assembly openings a pull covers, items eager-loaded, for the staging checklist (#343).
+
+    Ordered by opening number then leaf so the checklist reads the way the carts are laid out.
+    Empty for a shipping-out pull, a PR-REPL replacement pull, or a legacy pull.
+    """
+    stmt = (
+        select(ShopAssemblyOpening)
+        .options(selectinload(ShopAssemblyOpening.items))
+        .where(ShopAssemblyOpening.pull_request_id == pr_id)
+        .order_by(ShopAssemblyOpening.opening_number.asc(), ShopAssemblyOpening.leaf.asc())
+    )
+    return list(session.scalars(stmt).unique().all())
+
+
+@dataclass
+class StageResult:
+    """Outcome of one staging confirmation."""
+
+    pull_request: PullRequestModel
+    openings: list[ShopAssemblyOpening]
+    newly_staged_ids: list[uuid.UUID]
+    summary: StagingSummary
+    completed: bool
+
+
+def stage_pull_openings(
+    session: Session,
+    pr_id: uuid.UUID,
+    opening_ids: Iterable[uuid.UUID],
+    staged_by: str,
+) -> StageResult:
+    """Confirm that the cart(s) for these openings of an approved shop-assembly pull are built (#343).
+
+    The warehouse stages a pull opening by opening; before this, `pull_status` was flipped for every
+    opening at once when the whole pull was marked pulled, so an opening picked first thing in the
+    morning was not assignable until the last one was picked. Each confirmed opening flips to PULLED
+    on its own and becomes assignable and workable immediately - `assign_openings`,
+    `record_assembly_progress` and `complete_opening` all gate on the opening's own `pull_status`,
+    so nothing else has to change for the assembly floor to see it.
+
+    **Nothing moves in inventory here.** The FIFO deduction and the consumption of the source
+    request's reservation both happen at approval and stay there (see `approve_pull_request`).
+    Approval is the moment the pull is committed: the reservation the request has held since creation
+    becomes the deduction, atomically, under one set of row locks. Deducting per opening instead
+    would mean an approved-but-unstaged opening held neither a reservation nor a deduction - its
+    hardware would read as free and could be claimed by the next request, which is the exact hole
+    #342 closed - and it would reintroduce a shortfall at staging time, where the only recovery is a
+    half-deducted pull. Staging is progress tracking; `cancel_pull_request` is what reverses stock.
+
+    Staging the last opening completes the pull, by calling `complete_pull_request` rather than
+    reimplementing it, so the completion notification and the replacement-arrival application fire
+    exactly once and from one place. Already-staged openings are skipped rather than refused, so a
+    double-click or a stale checklist is a no-op instead of an error.
+    """
+    ids = list(dict.fromkeys(opening_ids))
+    if not ids:
+        raise ValidationError("opening_ids must not be empty", field="opening_ids")
+
+    locked_prs = lock_rows(session, PullRequestModel, [pr_id])
+    if not locked_prs:
+        raise NotFoundError(f"Pull request {pr_id} not found")
+    pr = locked_prs[0]
+
+    if pr.source != PullRequestSource.SHOP_ASSEMBLY:
+        raise InvalidStateTransitionError(
+            "Per-opening staging applies to shop-assembly pulls only - a shipping-out pull is completed as a whole."
+        )
+    if pr.status != PullRequestStatus.IN_PROGRESS:
+        raise InvalidStateTransitionError(f"Pull request must be In_Progress to stage openings, got {pr.status.value}")
+
+    openings = lock_rows(session, ShopAssemblyOpening, ids)
+    by_id = {o.id: o for o in openings}
+    missing = [str(oid) for oid in ids if oid not in by_id]
+    if missing:
+        raise NotFoundError(f"ShopAssemblyOpenings not found: {missing}")
+    foreign = [str(o.id) for o in openings if o.pull_request_id != pr.id]
+    if foreign:
+        raise ValidationError(
+            f"Openings do not belong to pull request {pr.request_number}: {foreign}",
+            field="opening_ids",
+        )
+
+    now = datetime.utcnow()
+    newly_staged: list[uuid.UUID] = []
+    for opening in openings:
+        if opening.pull_status == PullStatus.PULLED:
+            continue
+        opening.pull_status = PullStatus.PULLED
+        opening.staged_at = now
+        opening.staged_by = staged_by
+        newly_staged.append(opening.id)
+        _log_audit_event(
+            session,
+            project_id=pr.project_id,
+            entity_type=AuditEntityType.SHOP_ASSEMBLY_OPENING,
+            entity_id=opening.id,
+            action=AuditAction.PULL_STAGED,
+            performed_by=staged_by,
+            detail={
+                "pullRequestId": str(pr.id),
+                "pullRequestNumber": pr.request_number,
+                "openingNumber": opening.opening_number,
+                "leaf": opening.leaf,
+                "stagedAt": now.isoformat(),
+            },
+        )
+    session.flush()
+
+    summary = get_pull_staging_summaries(session, [pr.id]).get(
+        pr.id, StagingSummary(staged_opening_count=0, total_opening_count=0)
+    )
+    completed = summary.total_opening_count > 0 and summary.staged_opening_count >= summary.total_opening_count
+    if completed:
+        complete_pull_request(session, pr.id, completed_by=staged_by)
+
+    return StageResult(
+        pull_request=pr,
+        openings=openings,
+        newly_staged_ids=newly_staged,
+        summary=summary,
+        completed=completed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cancel / restock (#343)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CancelBlocker:
+    """One opening that stops a pull being cancelled: work has already started on its leaf."""
+
+    opening_id: uuid.UUID
+    opening_number: str
+    leaf: int | None
+    assembly_status: str
+    assigned_to: str | None
+
+    @property
+    def label(self) -> str:
+        leaf_suffix = f" leaf {self.leaf}" if self.leaf is not None else ""
+        holder = f", {self.assigned_to}" if self.assigned_to else ""
+        return f"{self.opening_number}{leaf_suffix} ({self.assembly_status.lower().replace('_', ' ')}{holder})"
+
+
+@dataclass(frozen=True)
+class RestockedLine:
+    hardware_category: str
+    product_code: str
+    quantity: int
+
+
+@dataclass
+class CancelResult:
+    pull_request: PullRequestModel
+    restocked: list[RestockedLine]
+    released_opening_ids: list[uuid.UUID]
+    source_request_returned_to_pending: bool
+    reservations_recreated: bool
+    integrity_note: str | None
+
+
+def _return_units_to_project_inventory(
+    session: Session,
+    project_id: uuid.UUID,
+    hardware_category: str,
+    product_code: str,
+    quantity: int,
+) -> InventoryLocationModel:
+    """Put `quantity` units of one combo back into project inventory as available stock.
+
+    This is the inverse of the FIFO deduction, and it deliberately does **not** try to reverse it row
+    by row. The deduction spread across whichever `InventoryLocation` rows were oldest; which row a
+    hinge sits on carries no identity (docs/HARDWARE_IDENTITY_LIFECYCLE.md - inventory is fungible),
+    so reconstructing the original split from the audit log would be fragile bookkeeping in service
+    of a distinction the domain does not make. The units land on the project's most recently received
+    row for the combo, exactly the way `report_deficiency_at_assembly` returns a condemned unit, and
+    a row is re-materialized if a schedule re-upload deleted the last one. Landing on the *newest*
+    row is also the conservative choice for future FIFO: older stock still goes out first.
+    """
+    from app.repositories import warehouse_admin_repository
+    from app.repositories.stock.common import _find_or_create_stock_row
+
+    il = session.scalars(
+        select(InventoryLocationModel)
+        .where(
+            InventoryLocationModel.project_id == project_id,
+            InventoryLocationModel.hardware_category == hardware_category,
+            InventoryLocationModel.product_code == product_code,
+        )
+        .order_by(InventoryLocationModel.received_at.desc())
+    ).first()
+    if il is None:
+        now = datetime.utcnow()
+        warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+        stock_row = _find_or_create_stock_row(
+            session,
+            warehouse_id=warehouse_id,
+            hardware_category=hardware_category,
+            product_code=product_code,
+            aisle=None,
+            row=None,
+            bay=None,
+            received_at=now,
+        )
+        il = InventoryLocationModel(
+            project_id=project_id,
+            stock_item_id=stock_row.id,
+            warehouse_id=warehouse_id,
+            hardware_category=hardware_category,
+            product_code=product_code,
+            quantity=0,
+            deficient_quantity=0,
+            received_at=now,
+        )
+        session.add(il)
+        session.flush()
+    il.quantity += quantity
+    return il
+
+
+def cancel_pull_request(
+    session: Session,
+    pr_id: uuid.UUID,
+    cancelled_by: str,
+    reason: str | None = None,
+) -> CancelResult:
+    """Cancel an approved pull, put its hardware back on the shelf, and hand the source request back
+    for re-acceptance (#343).
+
+    Before this there was no way out of an approved pull: inventory had been deducted and
+    `PullRequestStatus.CANCELLED` was an enum value nothing ever set, so a pull raised against the
+    wrong project or superseded by a schedule revision could only be walked forward.
+
+    **All-or-nothing, per pull.** Partial cancellation - keeping the worked openings and releasing
+    the rest - is deliberately not supported, because there is nowhere honest to put the released
+    ones: `PullStatus` has no cancelled value, and `complete_pull_request` flips *every* opening of a
+    pull to PULLED, so a half-cancelled pull would resurrect its released openings the moment the
+    rest was staged. Expressing it properly needs an opening-level cancelled state, which is a
+    different change; until then the refusal names the blockers so the warehouse knows exactly what
+    to finish first.
+
+    **What blocks it**: any opening whose assembly has started (IN_PROGRESS) or finished (COMPLETED).
+    That is where the hardware stops being retrievable - it is on a leaf, and some of it may already
+    have been condemned and replaced. Everything short of that is cancellable, *including openings
+    already staged*: their hardware is on a cart in the shop, which is exactly as retrievable as
+    hardware still on the shelf, and restocking only the un-staged part would leave the staged part
+    deducted with no leaf to show for it. Assignments on released openings are cleared, because there
+    is no longer any work to hold.
+
+    **Which statuses can be cancelled**: IN_PROGRESS always. A COMPLETED pull additionally, but only
+    when it is a shop-assembly pull with openings - since staging is per opening, "completed" there
+    now means no more than "every cart is built", which is not a point of no return. A completed
+    shipping-out pull has already flipped its leaves to SHIP_READY and a completed PR-REPL pull has
+    already given leaves their expectation back; unwinding those is not this function's job.
+
+    **The source request goes back to PENDING**, with its reservation re-created from the returned
+    quantities and re-checked against availability first. The claim was consumed at approval, so
+    re-creating it is a new claim competing with everyone else's: if stock was written off or
+    condemned under it in the meantime the re-check comes up short, and rather than write a partial
+    claim that reads as covered, the request is left unreserved and flagged via `integrity_note` -
+    the same honest-and-flagged shape the #342 backfill uses.
+
+    **A PR-REPL replacement pull has no source request**, so cancelling one restocks and re-creates
+    nothing: it never held a reservation (a deficiency cannot be foreseen, so nobody could have
+    claimed for it). The leaf's `deficient_quantity` is untouched and the expectation stays on the
+    checklist line - the replacement simply has to be requested again.
+    """
+    if not cancelled_by:
+        raise ValidationError("cancelled_by is required", field="cancelled_by")
+    reason = (reason or "").strip() or None
+    if reason is not None and len(reason) > MAX_CANCELLATION_REASON_LENGTH:
+        raise ValidationError(
+            f"Cancellation reason must be {MAX_CANCELLATION_REASON_LENGTH} characters or fewer",
+            field="reason",
+        )
+
+    locked_prs = lock_rows(session, PullRequestModel, [pr_id])
+    if not locked_prs:
+        raise NotFoundError(f"Pull request {pr_id} not found")
+    pr = locked_prs[0]
+    if pr.deleted_at is not None:
+        raise NotFoundError(f"Pull request {pr_id} not found")
+
+    items = list(
+        session.scalars(select(PullRequestItemModel).where(PullRequestItemModel.pull_request_id == pr.id)).all()
+    )
+    openings = list(
+        session.scalars(
+            select(ShopAssemblyOpening)
+            .where(ShopAssemblyOpening.pull_request_id == pr.id)
+            .order_by(ShopAssemblyOpening.opening_number.asc())
+        ).all()
+    )
+
+    cancellable_from_completed = pr.source == PullRequestSource.SHOP_ASSEMBLY and bool(openings)
+    if pr.status == PullRequestStatus.PENDING:
+        raise InvalidStateTransitionError(
+            "This pull has not been approved yet, so nothing has left inventory. Reopen or reject "
+            "the source request instead."
+        )
+    if pr.status == PullRequestStatus.CANCELLED:
+        raise InvalidStateTransitionError("Pull request is already cancelled")
+    if pr.status == PullRequestStatus.COMPLETED and not cancellable_from_completed:
+        raise InvalidStateTransitionError(
+            "This pull is already complete and its hardware has been handed over - it can no longer be cancelled."
+        )
+
+    blockers = [
+        CancelBlocker(
+            opening_id=o.id,
+            opening_number=o.opening_number,
+            leaf=o.leaf,
+            assembly_status=o.assembly_status.value,
+            assigned_to=o.assigned_to,
+        )
+        for o in openings
+        if o.assembly_status != AssemblyStatus.PENDING
+    ]
+    if blockers:
+        raise ConflictError(
+            "Cannot cancel this pull - assembly has already started on "
+            f"{len(blockers)} of its openings: {', '.join(b.label for b in blockers)}. "
+            "Finish or unwind that work first; cancelling is all-or-nothing.",
+            field="opening_ids",
+        )
+
+    now = datetime.utcnow()
+
+    # 1. Inverse inventory write. Only LOOSE lines ever left inventory; an OPENING_ITEM line moves an
+    #    assembled leaf, which approval only locked.
+    needs_by_combo: dict[tuple[str, str], int] = defaultdict(int)
+    for item in items:
+        if item.item_type != PullRequestItemType.LOOSE:
+            continue
+        if not item.hardware_category or not item.product_code or item.requested_quantity <= 0:
+            continue
+        needs_by_combo[(item.hardware_category, item.product_code)] += item.requested_quantity
+
+    restocked: list[RestockedLine] = []
+    for (cat, code), qty in sorted(needs_by_combo.items()):
+        il = _return_units_to_project_inventory(session, pr.project_id, cat, code, qty)
+        restocked.append(RestockedLine(hardware_category=cat, product_code=code, quantity=qty))
+        _log_audit_event(
+            session,
+            project_id=pr.project_id,
+            entity_type=AuditEntityType.INVENTORY_LOCATION,
+            entity_id=il.id,
+            action=AuditAction.PULL_RESTOCK,
+            performed_by=cancelled_by,
+            detail={
+                "pullRequestId": str(pr.id),
+                "pullRequestNumber": pr.request_number,
+                "restockedQuantity": qty,
+                "newQuantity": il.quantity,
+                "hardwareCategory": cat,
+                "productCode": code,
+                "reasonText": reason,
+            },
+        )
+
+    # 2. Release the openings: back to NOT_PULLED, unstaged, unassigned, and off the cancelled pull so
+    #    a re-accept re-links them the way the accept path already does.
+    released_ids: list[uuid.UUID] = []
+    for opening in openings:
+        opening.pull_status = PullStatus.NOT_PULLED
+        opening.staged_at = None
+        opening.staged_by = None
+        opening.assigned_to = None
+        opening.assigned_to_user_id = None
+        opening.pull_request_id = None
+        released_ids.append(opening.id)
+
+    # 3. The pull itself.
+    pr.status = PullRequestStatus.CANCELLED
+    pr.cancelled_at = now
+    pr.cancelled_by = cancelled_by
+    pr.cancellation_reason = reason
+    session.flush()
+
+    # 4. Hand the source request back, and re-claim the returned hardware for it if it is still free.
+    #    The availability check runs *after* the restock, so the units just returned count towards it.
+    source_request, source_reservation = _find_source_request(session, pr)
+    returned_to_pending = False
+    reservations_recreated = False
+    integrity_note: str | None = None
+    if source_request is not None:
+        returned_to_pending = _return_source_request_to_pending(session, pr, source_request)
+        if needs_by_combo:
+            result = check_inventory_sufficiency(
+                session,
+                pr.project_id,
+                [(cat, code, qty) for (cat, code), qty in needs_by_combo.items()],
+                lock=True,
+                reservation_aware=True,
+            )
+            if result.sufficient:
+                reservations.create_reservations(
+                    session,
+                    pr.project_id,
+                    source_reservation,
+                    source_request.id,
+                    [(cat, code, qty) for (cat, code), qty in needs_by_combo.items()],
+                )
+                reservations_recreated = True
+            else:
+                short = ", ".join(
+                    f"{s.hardware_category} {s.product_code} (short {s.short})" for s in result.shortfalls
+                )
+                integrity_note = (
+                    f"Pull {pr.request_number} was cancelled and this request returned to Pending, but its "
+                    f"hardware could not be re-reserved - {short}. It holds no claim on inventory, so the "
+                    "pull can come up short."
+                )[:500]
+                source_request.integrity_note = integrity_note
+
+    _log_audit_event(
+        session,
+        project_id=pr.project_id,
+        entity_type=AuditEntityType.PULL_REQUEST,
+        entity_id=pr.id,
+        action=AuditAction.PULL_CANCELLED,
+        performed_by=cancelled_by,
+        detail={
+            "pullRequestNumber": pr.request_number,
+            "source": pr.source.value,
+            "reasonText": reason,
+            "restocked": [
+                {"hardwareCategory": r.hardware_category, "productCode": r.product_code, "quantity": r.quantity}
+                for r in restocked
+            ],
+            "releasedOpeningIds": [str(oid) for oid in released_ids],
+            "sourceRequestId": str(source_request.id) if source_request is not None else None,
+            "sourceRequestReturnedToPending": returned_to_pending,
+            "reservationsRecreated": reservations_recreated,
+            "integrityNote": integrity_note,
+            "cancelledAt": now.isoformat(),
+        },
+    )
+
+    notification_service.create_notification(
+        session,
+        project_id=pr.project_id,
+        recipient_role=pr.requested_by,
+        notification_type=NotificationType.PULL_REQUEST_CANCELLED,
+        message=(
+            f"Pull Request {pr.request_number} was cancelled by {cancelled_by}"
+            + (f": {reason}" if reason else ".")
+            + (" The hardware has been returned to inventory." if restocked else "")
+        ),
+    )
+
+    return CancelResult(
+        pull_request=pr,
+        restocked=restocked,
+        released_opening_ids=released_ids,
+        source_request_returned_to_pending=returned_to_pending,
+        reservations_recreated=reservations_recreated,
+        integrity_note=integrity_note,
+    )
+
+
+def _find_source_request(session: Session, pr: PullRequestModel):
+    """The request this pull was minted from, and the reservation discriminator it claims under.
+
+    The same two hops `find_reservation_holder` uses, returning the row rather than its id because
+    cancellation has to write to it. `(None, None)` for a PR-REPL replacement pull (its
+    `PR-REPL-...` number matches no request), a legacy pull, or one whose request was already
+    rejected.
+    """
+    if pr.source == PullRequestSource.SHOP_ASSEMBLY:
+        sar = session.scalar(
+            select(ShopAssemblyRequestModel).where(ShopAssemblyRequestModel.request_number == pr.request_number)
+        )
+        if sar is not None:
+            return (sar, ReservationSource.SHOP_ASSEMBLY_REQUEST)
+    elif pr.source == PullRequestSource.SHIPPING_OUT:
+        sor = session.scalar(select(ShippingOutRequestModel).where(ShippingOutRequestModel.pull_request_id == pr.id))
+        if sor is not None:
+            return (sor, ReservationSource.SHIPPING_OUT_REQUEST)
+    return (None, None)
+
+
+def _return_source_request_to_pending(session: Session, pr: PullRequestModel, source_request) -> bool:
+    """Undo the accept on the cancelled pull's source request so it can be re-accepted or rejected.
+
+    Deliberately PENDING and not REJECTED: cancelling a pull says the *pull* was wrong, not that the
+    hardware is no longer wanted, and the request is the record of a decision somebody made. Sending
+    it back to the queue is also what gives the re-created reservation something to hang off. A
+    request that is not APPROVED (already rejected, or reopened by hand while the pull was live) is
+    left exactly as it is.
+    """
+    if isinstance(source_request, ShopAssemblyRequestModel):
+        if source_request.status != ShopAssemblyRequestStatus.APPROVED:
+            return False
+        source_request.status = ShopAssemblyRequestStatus.PENDING
+    else:
+        if source_request.status != ShippingOutRequestStatus.APPROVED:
+            return False
+        source_request.status = ShippingOutRequestStatus.PENDING
+    source_request.approved_by = None
+    source_request.approved_at = None
+    if pr.source == PullRequestSource.SHIPPING_OUT:
+        # A shipping-out request's only link to its pull is this column, and the pull it points at is
+        # dead. Clearing it is what lets a re-accept mint a fresh one (and keeps `reopenable_only`
+        # and the re-upload liveness queries from resolving through a cancelled pull).
+        source_request.pull_request_id = None
+    return True
 
 
 def discard_pending_pull_request(session: Session, pr_id: uuid.UUID | None) -> None:

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -511,6 +511,8 @@ def shop_assembly_opening_to_type(opening) -> ShopAssemblyOpening:
         opening_number=opening.opening_number,
         building=opening.building,
         floor=opening.floor,
+        staged_at=opening.staged_at,
+        staged_by=opening.staged_by,
     )
 
 
@@ -580,7 +582,15 @@ def pull_request_item_to_type(item) -> PullRequestItem:
     )
 
 
-def pull_request_to_type(pr) -> PullRequest:
+def pull_request_to_type(pr, staging=None) -> PullRequest:
+    """Model -> type. `staging` is a `warehouse.StagingSummary` the *caller* computed (#343).
+
+    It is passed in rather than derived here because deriving it needs a query, and a converter that
+    queries is an N+1 waiting to happen on the pull-request list (CLAUDE.md perf rules): the resolver
+    fetches the counts for the whole page in one grouped aggregate and hands each row its own. None
+    leaves the three staging fields null, which reads as "not applicable / not evaluated" - never as
+    "nothing staged".
+    """
     return PullRequest(
         id=strawberry.ID(str(pr.id)),
         request_number=pr.request_number,
@@ -594,7 +604,12 @@ def pull_request_to_type(pr) -> PullRequest:
         approved_at=pr.approved_at,
         completed_at=pr.completed_at,
         cancelled_at=pr.cancelled_at,
+        cancelled_by=pr.cancelled_by,
+        cancellation_reason=pr.cancellation_reason,
         items=[pull_request_item_to_type(i) for i in pr.items],
+        staging_status=staging.status if staging is not None else None,
+        staged_opening_count=staging.staged_opening_count if staging is not None else None,
+        total_opening_count=staging.total_opening_count if staging is not None else None,
     )
 
 

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -480,6 +480,30 @@ class InstallReplacementInput:
 
 
 @strawberry.input
+class StagePullOpeningsInput:
+    """Confirm that the cart(s) for these openings of an approved shop-assembly pull are built (#343).
+
+    Openings already staged are skipped, not refused, so a double-click or a stale checklist is a
+    no-op. Staging the last one completes the pull."""
+
+    pull_request_id: strawberry.ID
+    opening_ids: list[strawberry.ID]
+    staged_by: str
+
+
+@strawberry.input
+class CancelPullRequestInput:
+    """Cancel an approved pull and return its hardware to inventory (#343).
+
+    All-or-nothing: an opening whose assembly has started or finished blocks the whole cancellation,
+    and the refusal names them. `reason` is optional but shown to whoever raised the pull."""
+
+    id: strawberry.ID
+    cancelled_by: str
+    reason: str | None = None
+
+
+@strawberry.input
 class CompleteOpeningInput:
     opening_id: strawberry.ID
     aisle: str | None = None

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -511,6 +511,20 @@ class PullRequest:
     completed_at: datetime | None
     cancelled_at: datetime | None
     items: list[PullRequestItem]
+    # Who cancelled the pull and why (#343). Null unless status is CANCELLED.
+    cancelled_by: str | None = None
+    cancellation_reason: str | None = None
+    # Per-opening staging progress, DERIVED, never stored (#343). NOT_PULLED / PARTIAL / PULLED read
+    # over the pull's shop-assembly openings - PARTIAL being "some carts built, some not", which is
+    # a statement about the set and so has no place on any single opening's own pull_status.
+    #
+    # Null means staging does not apply *or* was not evaluated: a shipping-out pull, a PR-REPL
+    # replacement pull, and a legacy pull all have no openings, and the resolvers that do not compute
+    # the rollup leave it null rather than implying "nothing staged". Populated by pullRequests,
+    # pullRequestDetails, and the staging/approve/complete/cancel mutation results.
+    staging_status: PullStatus | None = None
+    staged_opening_count: int | None = None
+    total_opening_count: int | None = None
 
 
 @strawberry.type
@@ -582,6 +596,10 @@ class ShopAssemblyOpening:
     opening_number: str | None = None
     building: str | None = None
     floor: str | None = None
+    # When this opening's cart was confirmed staged, and by whom (#343). Null while NOT_PULLED, and
+    # on openings staged before per-opening staging existed (they were staged wholesale).
+    staged_at: datetime | None = None
+    staged_by: str | None = None
 
 
 @strawberry.type
@@ -830,6 +848,47 @@ class ApproveResult:
     # Populated when outcome is INSUFFICIENT: the exact per-combo shortfall shown inline to the
     # approver. Empty on APPROVED.
     shortfalls: list[InventoryShortfall] = strawberry.field(default_factory=list)
+
+
+@strawberry.type
+class StagePullOpeningsResult:
+    """What one staging confirmation did (#343).
+
+    `openings` comes back so the checklist can re-render from the server's answer rather than an
+    optimistic guess, and `completed` says whether this confirmation was the one that finished the
+    pull - the client shows a different message for "3 of 8 staged" and "pull complete"."""
+
+    pull_request: PullRequest
+    openings: list[ShopAssemblyOpening]
+    # Ids staged by *this* call. An opening already staged is skipped, not refused, so this is how a
+    # caller tells a real confirmation from a replayed one.
+    newly_staged_opening_ids: list[strawberry.ID]
+    completed: bool
+
+
+@strawberry.type
+class RestockedLine:
+    hardware_category: str
+    product_code: str
+    quantity: int
+
+
+@strawberry.type
+class CancelPullRequestResult:
+    """What a cancellation put back and where the source request ended up (#343)."""
+
+    pull_request: PullRequest
+    # The inverse inventory write, per combo. Empty for a pull with no LOOSE lines.
+    restocked: list[RestockedLine]
+    released_opening_ids: list[strawberry.ID]
+    # The source request went back to PENDING for re-acceptance. False for a PR-REPL replacement
+    # pull or a legacy pull, which have no source request at all.
+    source_request_returned_to_pending: bool
+    # The returned hardware was re-claimed for that request. False when it holds no claim - either
+    # because there is no source request, or because the re-check came up short, in which case
+    # integrityNote says so and the request carries the same message.
+    reservations_recreated: bool
+    integrity_note: str | None = None
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -20,15 +20,24 @@ from .converters import (
     po_to_type,
     pull_request_to_type,
     receive_record_to_type,
+    shop_assembly_opening_to_type,
     stock_item_to_type,
     warehouse_to_type,
 )
 from .enums import ApproveOutcome, AuditEntityType, LeafStatus, PullRequestSource, PullRequestStatus
-from .inputs import CreateReceiveInput, CreateWarehouseInput, OverrideInventoryQuantityInput, UpdateWarehouseInput
+from .inputs import (
+    CancelPullRequestInput,
+    CreateReceiveInput,
+    CreateWarehouseInput,
+    OverrideInventoryQuantityInput,
+    StagePullOpeningsInput,
+    UpdateWarehouseInput,
+)
 from .types import (
     ApproveResult,
     AuditLogEntry,
     BackOrderedItem,
+    CancelPullRequestResult,
     InventoryAvailability,
     InventoryHierarchyNode,
     InventoryItemDetail,
@@ -50,6 +59,9 @@ from .types import (
     PurchaseOrder,
     ReceiveRecord,
     RecentReceiveRecord,
+    RestockedLine,
+    ShopAssemblyOpening,
+    StagePullOpeningsResult,
     VendorInventoryNode,
     Warehouse,
     WarehouseDashboard,
@@ -276,13 +288,31 @@ class WarehouseQueries:
             prs = warehouse_repository.get_pull_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, source, status
             )
-            return [pull_request_to_type(pr) for pr in prs]
+            # One grouped aggregate for the whole page, not one query per row (#343 / CLAUDE.md perf
+            # rules): the queue renders a staging chip on every shop-assembly row.
+            staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id for pr in prs])
+            return [pull_request_to_type(pr, staging.get(pr.id)) for pr in prs]
 
     @strawberry.field
     def pull_request_details(self, id: strawberry.ID) -> PullRequest:
         with SessionLocal() as session:
             pr = warehouse_repository.get_pull_request_details(session, uuid.UUID(str(id)))
-            return pull_request_to_type(pr)
+            staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
+            return pull_request_to_type(pr, staging.get(pr.id))
+
+    @strawberry.field
+    def pull_request_openings(self, info: strawberry.Info, pull_request_id: strawberry.ID) -> list[ShopAssemblyOpening]:
+        """The shop-assembly openings a pull covers, with their hardware lines, for the warehouse's
+        per-opening staging checklist (#343).
+
+        Deliberately a separate query rather than a field on `PullRequest`: a resolver field would
+        run once per row of the pull-request queue, and the queue never needs it - only the detail
+        view does. Returns an empty list for a shipping-out pull, a PR-REPL replacement pull, or a
+        legacy pull, none of which have openings. Open to any signed-in user."""
+        require_user(info)
+        with SessionLocal() as session:
+            openings = warehouse_repository.get_pull_request_openings(session, uuid.UUID(str(pull_request_id)))
+            return [shop_assembly_opening_to_type(o) for o in openings]
 
     @strawberry.field
     def expected_deliveries(self, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
@@ -576,9 +606,10 @@ class WarehouseMutations:
             )
             session.commit()
             pr = warehouse_repository.get_pull_request_details(session, pr.id)
+            staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
 
             return ApproveResult(
-                pull_request=pull_request_to_type(pr),
+                pull_request=pull_request_to_type(pr, staging.get(pr.id)),
                 outcome=ApproveOutcome.APPROVED if outcome == "APPROVED" else ApproveOutcome.INSUFFICIENT,
                 notification=notification_to_type(notification) if notification else None,
                 shortfalls=[
@@ -595,12 +626,88 @@ class WarehouseMutations:
             )
 
     @strawberry.mutation
-    def complete_pull_request(self, id: strawberry.ID) -> PullRequest:
+    def complete_pull_request(self, id: strawberry.ID, completed_by: str | None = None) -> PullRequest:
+        """Close the whole pull in one go. Since #343 this reads as "stage everything still
+        outstanding and finish": any opening not yet confirmed individually is flipped to PULLED and
+        stamped here. `completedBy` is optional and additive - it only names the actor on those
+        stamps, so existing callers are unaffected."""
         with SessionLocal() as session:
-            pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)))
+            pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)), completed_by=completed_by)
             session.commit()
             pr = warehouse_repository.get_pull_request_details(session, pr.id)
-            return pull_request_to_type(pr)
+            staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
+            return pull_request_to_type(pr, staging.get(pr.id))
+
+    @strawberry.mutation
+    def stage_pull_openings(self, info: strawberry.Info, input: StagePullOpeningsInput) -> StagePullOpeningsResult:
+        """Confirm that the carts for these openings of an approved shop-assembly pull are built (#343).
+
+        Each confirmed opening flips to PULLED on its own and becomes assignable and workable
+        immediately, so the assignment board fills as the warehouse picks rather than all at once at
+        the end. Nothing moves in inventory: the FIFO deduction and the source request's reservation
+        were both spent at approval, and staging is progress tracking. Staging the last opening
+        completes the pull through the ordinary completion path, so its notification and any
+        replacement-arrival application still happen exactly once.
+
+        Open to any signed-in user - it makes hardware workable, so it must not be reachable
+        anonymously."""
+        require_user(info)
+        with SessionLocal() as session:
+            result = warehouse_repository.stage_pull_openings(
+                session,
+                uuid.UUID(str(input.pull_request_id)),
+                [uuid.UUID(str(oid)) for oid in input.opening_ids],
+                input.staged_by,
+            )
+            session.commit()
+            pr = warehouse_repository.get_pull_request_details(session, result.pull_request.id)
+            staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
+            openings = warehouse_repository.get_pull_request_openings(session, pr.id)
+            return StagePullOpeningsResult(
+                pull_request=pull_request_to_type(pr, staging.get(pr.id)),
+                openings=[shop_assembly_opening_to_type(o) for o in openings],
+                newly_staged_opening_ids=[strawberry.ID(str(oid)) for oid in result.newly_staged_ids],
+                completed=result.completed,
+            )
+
+    @strawberry.mutation
+    def cancel_pull_request(self, info: strawberry.Info, input: CancelPullRequestInput) -> CancelPullRequestResult:
+        """Cancel an approved pull, return its hardware to inventory, and hand the source request
+        back for re-acceptance (#343).
+
+        All-or-nothing: any opening whose assembly has started or finished refuses the whole
+        cancellation with a CONFLICT naming the blockers, because there is nowhere honest to park a
+        half-cancelled pull. Everything short of that comes back, staged openings included - their
+        hardware is on a cart in the shop, not on a leaf. The source request returns to PENDING and
+        its claim is re-created from the returned quantities if availability still allows; if it does
+        not, the request is left unreserved and flagged rather than half-claimed.
+
+        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously."""
+        require_user(info)
+        with SessionLocal() as session:
+            result = warehouse_repository.cancel_pull_request(
+                session,
+                uuid.UUID(str(input.id)),
+                input.cancelled_by,
+                input.reason,
+            )
+            session.commit()
+            pr = warehouse_repository.get_pull_request_details(session, result.pull_request.id)
+            return CancelPullRequestResult(
+                pull_request=pull_request_to_type(pr),
+                restocked=[
+                    RestockedLine(
+                        hardware_category=r.hardware_category,
+                        product_code=r.product_code,
+                        quantity=r.quantity,
+                    )
+                    for r in result.restocked
+                ],
+                released_opening_ids=[strawberry.ID(str(oid)) for oid in result.released_opening_ids],
+                source_request_returned_to_pending=result.source_request_returned_to_pending,
+                reservations_recreated=result.reservations_recreated,
+                integrity_note=result.integrity_note,
+            )
 
     # Admin Corrections
     @strawberry.mutation

--- a/backend/tests/test_pull_staging_cancel.py
+++ b/backend/tests/test_pull_staging_cancel.py
@@ -1,0 +1,831 @@
+"""Per-opening pull staging and pull cancel/restock (#343).
+
+Two halves of the same change. Staging: the warehouse confirms a pull cart by cart, each opening
+becomes workable the moment it is staged rather than when the whole pull is picked, the pull's
+display status derives as PARTIAL in between, and staging the last opening completes the pull
+exactly once. Cancel: an approved pull can be unwound - inventory returned, openings released, the
+source request handed back to PENDING with its claim re-created if availability still allows - and
+is refused whole when assembly has already started on any of its openings.
+
+DB-backed like the rest of the suite: every test runs against a real Postgres in a rolled-back
+transaction.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import (
+    ConflictError,
+    InvalidStateTransitionError,
+    NotFoundError,
+    ValidationError,
+)
+from app.models.audit_log import InventoryAuditLog
+from app.models.enums import (
+    AssemblyStatus,
+    AuditAction,
+    AuditEntityType,
+    NotificationType,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+    ReservationSource,
+    ShippingOutRequestStatus,
+    ShopAssemblyRequestStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
+from app.models.notification import Notification
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.shipping_out_request import ShippingOutRequest
+from app.models.shop_assembly import ShopAssemblyOpening
+from app.models.stock_item import StockItem
+from app.repositories import import_repository, shop_assembly_repository, warehouse_admin_repository
+from app.repositories import warehouse as warehouse_repository
+
+# --- helpers -----------------------------------------------------------------------------------
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category="HINGE", code="HG-100", quantity, deficient=0):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        aisle="A",
+        row="1",
+        bay="1",
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _on_hand(session, project_id, *, category="HINGE", code="HG-100") -> int:
+    rows = session.scalars(
+        select(InventoryLocation).where(
+            InventoryLocation.project_id == project_id,
+            InventoryLocation.hardware_category == category,
+            InventoryLocation.product_code == code,
+        )
+    ).all()
+    return sum(r.quantity for r in rows)
+
+
+def _two_leaf_request(session, project, *, qty=2, code="HG-100", opening_number="A01"):
+    """A shop-assembly request over two leaves of one opening, through the real creation path."""
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": opening_number}],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": f"SA-{uuid.uuid4().hex[:6]}",
+            "shop_assembly_openings": [
+                {
+                    "opening_number": opening_number,
+                    "leaf": leaf,
+                    "items": [{"hardware_category": "HINGE", "product_code": code, "quantity": qty}],
+                }
+                for leaf in (1, 2)
+            ],
+        },
+    )
+
+
+def _approved_pull(session, project, *, qty=2, code="HG-100", opening_number="A01"):
+    """Create the request, accept it, approve the pull. Returns (sar, pr, [openings by leaf])."""
+    result = _two_leaf_request(session, project, qty=qty, code=code, opening_number=opening_number)
+    sar = result["shop_assembly_request"]
+    shop_assembly_repository.accept_shop_assembly_request(session, sar.id, "acceptor")
+    session.flush()
+    pr = session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    warehouse_repository.approve_pull_request(session, pr.id, "picker")
+    session.flush()
+    openings = list(
+        session.scalars(
+            select(ShopAssemblyOpening)
+            .where(ShopAssemblyOpening.pull_request_id == pr.id)
+            .order_by(ShopAssemblyOpening.leaf.asc())
+        ).all()
+    )
+    return sar, pr, openings
+
+
+def _audit(session, action):
+    return list(session.scalars(select(InventoryAuditLog).where(InventoryAuditLog.action == action)).all())
+
+
+# --- staging -----------------------------------------------------------------------------------
+
+
+def test_staging_one_opening_leaves_the_other_not_pulled(db_session):
+    """Each cart is confirmed on its own: the pull is not an all-or-nothing flip any more."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    assert [o.pull_status for o in openings] == [PullStatus.NOT_PULLED, PullStatus.NOT_PULLED]
+
+    result = warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+
+    assert result.newly_staged_ids == [openings[0].id]
+    assert result.completed is False
+    assert openings[0].pull_status == PullStatus.PULLED
+    assert openings[0].staged_at is not None
+    assert openings[0].staged_by == "picker"
+    assert openings[1].pull_status == PullStatus.NOT_PULLED
+    assert openings[1].staged_at is None
+    # The pull itself stays IN_PROGRESS - the state machine gains no half-state.
+    assert pr.status == PullRequestStatus.IN_PROGRESS
+
+
+def test_partial_derivation(db_session):
+    """PullStatus.PARTIAL is the aggregate reading over the openings, derived and never stored."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+
+    before = warehouse_repository.get_pull_staging_summaries(db_session, [pr.id])[pr.id]
+    assert (before.status, before.staged_opening_count, before.total_opening_count) == (PullStatus.NOT_PULLED, 0, 2)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    mid = warehouse_repository.get_pull_staging_summaries(db_session, [pr.id])[pr.id]
+    assert (mid.status, mid.staged_opening_count, mid.total_opening_count) == (PullStatus.PARTIAL, 1, 2)
+    # PARTIAL never lands on an opening: one cart is built or it is not.
+    assert {o.pull_status for o in openings} == {PullStatus.PULLED, PullStatus.NOT_PULLED}
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+    after = warehouse_repository.get_pull_staging_summaries(db_session, [pr.id])[pr.id]
+    assert (after.status, after.staged_opening_count) == (PullStatus.PULLED, 2)
+
+
+def test_staging_summaries_omit_pulls_with_no_openings(db_session):
+    """A shipping-out or PR-REPL pull has no openings, so it gets no staging reading at all - which
+    is what lets the UI render nothing rather than "0 of 0 staged"."""
+    project = _make_project(db_session)
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"PR-REPL-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.IN_PROGRESS,
+        requested_by="tester",
+    )
+    db_session.add(pr)
+    db_session.flush()
+    assert warehouse_repository.get_pull_staging_summaries(db_session, [pr.id]) == {}
+
+
+def test_staged_opening_is_immediately_assignable_and_workable(db_session):
+    """The whole point: an opening staged first thing is assignable and appears in the work lists
+    while the rest of its pull is still being picked."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+
+    # Assemble list shows both (the un-staged one renders as "waiting"), keyed on the opening's own
+    # pull_status rather than the pull being COMPLETED.
+    assemble = shop_assembly_repository.get_assemble_list(db_session, project.id)
+    assert {o.id for o in assemble} == {openings[0].id, openings[1].id}
+
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user-1", "Assembler One")
+    db_session.flush()
+    assert [o.id for o in shop_assembly_repository.get_my_work(db_session, "user-1")] == [openings[0].id]
+
+    # The un-staged one is refused at the data layer, not merely hidden.
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.assign_openings(db_session, [openings[1].id], "user-1", "Assembler One")
+
+
+def test_my_work_excludes_a_claimed_opening_whose_staging_was_undone(db_session):
+    """My Work is keyed on the opening's own pull_status, so an opening released back to NOT_PULLED
+    drops out of the board even though the pull it hung off is otherwise fine."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user-1", "Assembler One")
+    db_session.flush()
+    assert len(shop_assembly_repository.get_my_work(db_session, "user-1")) == 1
+
+    openings[0].pull_status = PullStatus.NOT_PULLED
+    db_session.flush()
+    assert shop_assembly_repository.get_my_work(db_session, "user-1") == []
+
+
+def test_staging_the_last_opening_completes_the_pull_once(db_session):
+    """Completion runs through complete_pull_request, so the notification fires exactly once."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    assert pr.status == PullRequestStatus.IN_PROGRESS
+
+    result = warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+    assert result.completed is True
+    assert pr.status == PullRequestStatus.COMPLETED
+    assert pr.completed_at is not None
+
+    completions = db_session.scalars(
+        select(Notification).where(
+            Notification.project_id == project.id,
+            Notification.type == NotificationType.PULL_REQUEST_COMPLETED,
+        )
+    ).all()
+    assert len(completions) == 1
+
+
+def test_replacement_arrivals_are_not_applied_twice_by_staging(db_session):
+    """A pull carrying both openings and a replacement line must apply the arrival once, at the
+    single completion staging triggers - not once per staged opening."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    item = openings[0].items[0]
+    item.deficient_quantity = 1
+    item.installed_quantity = 0
+    db_session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=pr.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number=openings[0].opening_number,
+            leaf=openings[0].leaf,
+            sa_opening_item_id=item.id,
+            hardware_category=item.hardware_category,
+            product_code=item.product_code,
+            requested_quantity=1,
+        )
+    )
+    db_session.flush()
+    # The pull's items collection was loaded before this line existed; expire it so the completion
+    # path sees what a fresh resolver session would.
+    db_session.expire(pr, ["items"])
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    assert item.deficient_quantity == 1  # nothing applied yet - the pull is only part-staged
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+    assert item.deficient_quantity == 0
+    assert len(_audit(db_session, AuditAction.REPLACEMENT_RECEIVED)) == 1
+
+
+def test_restaging_an_already_staged_opening_is_a_no_op(db_session):
+    """A double-click or a stale checklist must not be an error, and must not restamp the opening."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    first_stamp = openings[0].staged_at
+
+    result = warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "someone-else")
+    db_session.flush()
+    assert result.newly_staged_ids == []
+    assert result.completed is False
+    assert openings[0].staged_at == first_stamp
+    assert openings[0].staged_by == "picker"
+    assert len(_audit(db_session, AuditAction.PULL_STAGED)) == 1
+
+
+def test_staging_writes_an_audit_row_per_opening(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+
+    rows = _audit(db_session, AuditAction.PULL_STAGED)
+    assert len(rows) == 2
+    assert {r.entity_type for r in rows} == {AuditEntityType.SHOP_ASSEMBLY_OPENING}
+    assert {r.entity_id for r in rows} == {o.id for o in openings}
+
+
+def test_staging_refuses_a_pull_that_is_not_approved(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    result = _two_leaf_request(db_session, project)
+    sar = result["shop_assembly_request"]
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    opening = db_session.scalars(
+        select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id)
+    ).first()
+
+    with pytest.raises(InvalidStateTransitionError):
+        warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+
+
+def test_staging_refuses_an_opening_from_another_pull(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    _sar_a, pr_a, _openings_a = _approved_pull(db_session, project, opening_number="A01")
+    _sar_b, _pr_b, openings_b = _approved_pull(db_session, project, opening_number="B01")
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.stage_pull_openings(db_session, pr_a.id, [openings_b[0].id], "picker")
+
+
+def test_staging_refuses_an_empty_selection_and_an_unknown_opening(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.stage_pull_openings(db_session, pr.id, [], "picker")
+    with pytest.raises(NotFoundError):
+        warehouse_repository.stage_pull_openings(db_session, pr.id, [uuid.uuid4()], "picker")
+
+
+def test_completing_the_pull_wholesale_still_stages_whatever_is_left(db_session):
+    """The old "Mark as Pulled" path is now "stage everything remaining", and it must not overwrite
+    the stamp on a cart that was already confirmed individually."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    first_stamp = openings[0].staged_at
+
+    warehouse_repository.complete_pull_request(db_session, pr.id, completed_by="supervisor")
+    db_session.flush()
+    assert openings[1].pull_status == PullStatus.PULLED
+    assert openings[1].staged_by == "supervisor"
+    assert openings[0].staged_at == first_stamp
+    assert openings[0].staged_by == "picker"
+
+
+def test_staging_deducts_no_inventory(db_session):
+    """Deduction timing is unchanged (#343): approval commits the pull, staging only tracks it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    after_approve = _on_hand(db_session, project.id)
+    assert after_approve == 16  # 20 - (2 leaves x 2 units)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    assert _on_hand(db_session, project.id) == after_approve
+
+
+# --- cancel / restock --------------------------------------------------------------------------
+
+
+def test_cancel_restocks_releases_and_returns_the_request_to_pending(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar, pr, openings = _approved_pull(db_session, project)
+    assert _on_hand(db_session, project.id) == 16
+    assert sar.status == ShopAssemblyRequestStatus.APPROVED
+
+    result = warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", "wrong project")
+    db_session.flush()
+
+    assert _on_hand(db_session, project.id) == 20
+    assert pr.status == PullRequestStatus.CANCELLED
+    assert pr.cancelled_by == "warehouse"
+    assert pr.cancellation_reason == "wrong project"
+    assert pr.cancelled_at is not None
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+    assert sar.approved_by is None
+    assert result.source_request_returned_to_pending is True
+    assert [(r.hardware_category, r.product_code, r.quantity) for r in result.restocked] == [("HINGE", "HG-100", 4)]
+    for opening in openings:
+        assert opening.pull_status == PullStatus.NOT_PULLED
+        assert opening.pull_request_id is None
+        assert opening.assigned_to_user_id is None
+
+
+def test_cancel_returns_staged_openings_too(db_session):
+    """Staged-but-unassembled hardware is on a cart in the shop, which is exactly as retrievable as
+    hardware still on the shelf - so it comes back, stamp and all."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+
+    assert _on_hand(db_session, project.id) == 20
+    assert openings[0].pull_status == PullStatus.NOT_PULLED
+    assert openings[0].staged_at is None
+    assert openings[0].staged_by is None
+
+
+def test_cancel_recreates_the_reservation_for_the_returned_quantities(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar, pr, _openings = _approved_pull(db_session, project)
+    # Approval consumed the claim.
+    assert warehouse_repository.get_reserved_quantities(db_session, project.id) == {}
+
+    result = warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+
+    assert result.reservations_recreated is True
+    assert result.integrity_note is None
+    assert sar.integrity_note is None
+    assert warehouse_repository.get_reserved_quantities(db_session, project.id) == {("HINGE", "HG-100"): 4}
+
+
+def test_cancel_flags_rather_than_oversubscribes_when_stock_vanished(db_session):
+    """The claim was consumed at approval, so re-creating it competes with everyone else. If another
+    request claimed the freed stock and some of it was then written off, the returned units cannot
+    all be re-claimed - and the request is left unreserved and flagged, never half-claimed."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=20)
+    sar, pr, _openings = _approved_pull(db_session, project, opening_number="A01")
+    assert _on_hand(db_session, project.id) == 16
+    # A second request claims everything the first one left behind...
+    _two_leaf_request(db_session, project, qty=8, opening_number="B01")
+    db_session.flush()
+    assert warehouse_repository.get_reserved_quantities(db_session, project.id) == {("HINGE", "HG-100"): 16}
+    # ...and then an admin writes 14 units off from under it.
+    il.quantity -= 14
+    db_session.flush()
+    assert _on_hand(db_session, project.id) == 2
+
+    result = warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+
+    assert _on_hand(db_session, project.id) == 6
+    assert result.reservations_recreated is False
+    assert result.integrity_note is not None
+    assert "could not be re-reserved" in result.integrity_note
+    assert sar.integrity_note == result.integrity_note
+    # Nothing partial was written: the only claim left is the second request's, untouched.
+    assert warehouse_repository.get_reserved_quantities(db_session, project.id) == {("HINGE", "HG-100"): 16}
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+
+
+def test_cancel_is_blocked_by_an_opening_in_progress(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user-1", "Assembler One")
+    db_session.flush()
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        openings[0].id,
+        [shop_assembly_repository.AssemblyProgressUpdate(openings[0].items[0].id, installed_quantity=1)],
+        performed_by="Assembler One",
+    )
+    db_session.flush()
+    on_hand_before = _on_hand(db_session, project.id)
+
+    with pytest.raises(ConflictError) as exc:
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+
+    assert "A01" in str(exc.value)
+    assert "in progress" in str(exc.value).lower()
+    # All-or-nothing: nothing was restocked, and the pull is untouched.
+    assert _on_hand(db_session, project.id) == on_hand_before
+    assert pr.status == PullRequestStatus.COMPLETED
+
+
+def test_cancel_is_blocked_by_a_completed_opening(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    openings[1].assembly_status = AssemblyStatus.COMPLETED
+    db_session.flush()
+
+    with pytest.raises(ConflictError) as exc:
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    assert "completed" in str(exc.value).lower()
+
+
+def test_a_fully_staged_shop_assembly_pull_is_still_cancellable(db_session):
+    """Staging is per opening now, so a COMPLETED shop-assembly pull means no more than "every cart
+    is built" - which is not a point of no return."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    assert pr.status == PullRequestStatus.COMPLETED
+
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+    assert pr.status == PullRequestStatus.CANCELLED
+    assert _on_hand(db_session, project.id) == 20
+
+
+def test_cancel_refuses_a_pending_or_already_cancelled_pull(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    result = _two_leaf_request(db_session, project)
+    sar = result["shop_assembly_request"]
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+
+    with pytest.raises(InvalidStateTransitionError) as exc:
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    assert "not been approved" in str(exc.value)
+
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+    with pytest.raises(InvalidStateTransitionError):
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+
+
+def test_cancel_audits_the_pull_and_every_restocked_row(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", "duplicate")
+    db_session.flush()
+
+    cancels = _audit(db_session, AuditAction.PULL_CANCELLED)
+    assert len(cancels) == 1
+    assert cancels[0].entity_type == AuditEntityType.PULL_REQUEST
+    assert cancels[0].entity_id == pr.id
+    assert cancels[0].detail["reasonText"] == "duplicate"
+    assert cancels[0].detail["restocked"] == [{"hardwareCategory": "HINGE", "productCode": "HG-100", "quantity": 4}]
+
+    restocks = _audit(db_session, AuditAction.PULL_RESTOCK)
+    assert len(restocks) == 1
+    assert restocks[0].entity_type == AuditEntityType.INVENTORY_LOCATION
+
+    notifications = db_session.scalars(
+        select(Notification).where(
+            Notification.project_id == project.id,
+            Notification.type == NotificationType.PULL_REQUEST_CANCELLED,
+        )
+    ).all()
+    assert len(notifications) == 1
+
+
+def test_cancel_rejects_a_missing_actor_and_an_over_long_reason(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "", None)
+    with pytest.raises(ValidationError):
+        warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", "x" * 501)
+
+
+def test_a_cancelled_request_can_be_re_accepted_and_re_pulled(db_session):
+    """The whole point of returning the request to PENDING: re-accepting mints a fresh pull carrying
+    the same request number, which is why uniqueness on that number had to become partial."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar, first_pr, _openings = _approved_pull(db_session, project)
+    warehouse_repository.cancel_pull_request(db_session, first_pr.id, "warehouse", None)
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    live = db_session.scalars(
+        select(PullRequest).where(
+            PullRequest.request_number == sar.request_number,
+            PullRequest.status != PullRequestStatus.CANCELLED,
+        )
+    ).all()
+    assert len(live) == 1
+    assert live[0].id != first_pr.id
+
+    warehouse_repository.approve_pull_request(db_session, live[0].id, "picker")
+    db_session.flush()
+    assert live[0].status == PullRequestStatus.IN_PROGRESS
+    assert _on_hand(db_session, project.id) == 16
+    # The cancelled pull's openings were re-pointed at the new one by the accept.
+    reattached = db_session.scalars(
+        select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == live[0].id)
+    ).all()
+    assert len(reattached) == 2
+
+
+def test_reopen_still_finds_the_live_pull_after_a_cancel(db_session):
+    """The reopen lookup is by request_number, which a cancelled pull now shares with a live one."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar, first_pr, _openings = _approved_pull(db_session, project)
+    warehouse_repository.cancel_pull_request(db_session, first_pr.id, "warehouse", None)
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    shop_assembly_repository.reopen_shop_assembly_request(db_session, sar.id)
+    db_session.flush()
+
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+    remaining = db_session.scalars(select(PullRequest).where(PullRequest.request_number == sar.request_number)).all()
+    assert [p.id for p in remaining] == [first_pr.id]  # only the cancelled record survives
+
+
+def test_cancelling_a_replacement_pull_restocks_without_reservations(db_session):
+    """A PR-REPL pull never held a claim (nobody can reserve for a deficiency that has not happened
+    yet), so cancelling it restocks and re-creates nothing. The leaf's deficient expectation stands -
+    the replacement simply has to be requested again."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user-1", "Assembler One")
+    db_session.flush()
+    item = openings[0].items[0]
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        openings[0].id,
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                item.id, installed_quantity=1, flag_deficient_quantity=1, deficient_reason="bent"
+            )
+        ],
+        performed_by="Assembler One",
+    )
+    db_session.flush()
+
+    repl = db_session.scalar(
+        select(PullRequest).where(PullRequest.request_number.like("PR-REPL-%"), PullRequest.project_id == project.id)
+    )
+    assert repl is not None
+    warehouse_repository.approve_pull_request(db_session, repl.id, "picker")
+    db_session.flush()
+    on_hand_after_repl_pull = _on_hand(db_session, project.id)
+
+    result = warehouse_repository.cancel_pull_request(db_session, repl.id, "warehouse", "supplier cannot supply")
+    db_session.flush()
+
+    assert repl.status == PullRequestStatus.CANCELLED
+    assert _on_hand(db_session, project.id) == on_hand_after_repl_pull + 1
+    assert result.source_request_returned_to_pending is False
+    assert result.reservations_recreated is False
+    assert warehouse_repository.get_reserved_quantities(db_session, project.id) == {}
+    # The expectation stays on the leaf.
+    assert item.deficient_quantity == 1
+
+
+def test_cancelling_a_shipping_out_pull_returns_its_request_and_reserves_loose_lines_only(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": "A01"}],
+            "hardware_items": [],
+            "shipping_out_pr_drafts": [
+                {
+                    "request_number": f"SHIP-{uuid.uuid4().hex[:6]}",
+                    "requested_by": "importer",
+                    "items": [
+                        {
+                            "item_type": "LOOSE",
+                            "opening_number": "A01",
+                            "opening_item_id": None,
+                            "hardware_category": "HINGE",
+                            "product_code": "HG-100",
+                            "requested_quantity": 3,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    db_session.flush()
+    sor = db_session.scalars(select(ShippingOutRequest).where(ShippingOutRequest.project_id == project.id)).first()
+    from app.repositories import shipping_repository
+
+    shipping_repository.accept_shipping_out_request(db_session, sor.id, "acceptor")
+    db_session.flush()
+    warehouse_repository.approve_pull_request(db_session, sor.pull_request_id, "picker")
+    db_session.flush()
+    pr_id = sor.pull_request_id
+    assert _on_hand(db_session, project.id) == 17
+
+    result = warehouse_repository.cancel_pull_request(db_session, pr_id, "warehouse", None)
+    db_session.flush()
+
+    assert _on_hand(db_session, project.id) == 20
+    assert sor.status == ShippingOutRequestStatus.PENDING
+    assert sor.pull_request_id is None
+    assert result.reservations_recreated is True
+    reserved = db_session.scalars(
+        select(InventoryReservation).where(InventoryReservation.project_id == project.id)
+    ).all()
+    assert [(r.source, r.quantity) for r in reserved] == [(ReservationSource.SHIPPING_OUT_REQUEST, 3)]
+
+
+def test_restock_lands_on_the_projects_newest_row_and_re_materializes_a_deleted_one(db_session):
+    """Which row a hinge sits on carries no identity, so the return is not a row-by-row reversal of
+    the FIFO deduction - and it must still land somewhere if a re-upload deleted every row."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+    db_session.delete(il)
+    db_session.flush()
+    assert _on_hand(db_session, project.id) == 0
+
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+    assert _on_hand(db_session, project.id) == 4
+
+
+def test_complete_opening_works_while_the_pull_is_only_part_staged(db_session):
+    """The COMPLETED-filter rework, end to end: a leaf can be built and finished while its pull is
+    still IN_PROGRESS, and an un-staged sibling still cannot."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project, qty=1)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user-1", "Assembler One")
+    db_session.flush()
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        openings[0].id,
+        [shop_assembly_repository.AssemblyProgressUpdate(openings[0].items[0].id, installed_quantity=1)],
+        performed_by="Assembler One",
+    )
+    db_session.flush()
+
+    opening_item = shop_assembly_repository.complete_opening(db_session, openings[0].id, "A", "1", "1")
+    db_session.flush()
+    assert opening_item.opening_number == "A01"
+    assert openings[0].assembly_status == AssemblyStatus.COMPLETED
+    assert pr.status == PullRequestStatus.IN_PROGRESS
+
+    openings[1].assigned_to = "Assembler One"
+    openings[1].assigned_to_user_id = "user-1"
+    db_session.flush()
+    with pytest.raises(InvalidStateTransitionError):
+        shop_assembly_repository.complete_opening(db_session, openings[1].id, "A", "1", "1")
+
+
+def test_get_pull_request_openings_orders_by_opening_and_leaf(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+
+    rows = warehouse_repository.get_pull_request_openings(db_session, pr.id)
+    assert [(r.opening_number, r.leaf) for r in rows] == [("A01", 1), ("A01", 2)]
+    assert all(r.items for r in rows)
+    assert warehouse_repository.get_pull_request_openings(db_session, uuid.uuid4()) == []
+
+
+def test_assemble_list_excludes_a_cancelled_pulls_openings(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, _openings = _approved_pull(db_session, project)
+    assert len(shop_assembly_repository.get_assemble_list(db_session, project.id)) == 2
+
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
+    db_session.flush()
+    assert shop_assembly_repository.get_assemble_list(db_session, project.id) == []

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -106,6 +106,54 @@ them: `report_deficiency_at_assembly` raises the inventory row's `quantity` and 
 together, so the pair nets to zero in `on-hand - deficient`. The unit is back in the building and is
 not available - which is the truth.
 
+#### 3b. Staging: the tag moves onto a cart, opening by opening
+
+Approving the pull is one decision; *executing* it is a shift's work. The warehouse picks a pull cart
+by cart, and before #343 the system only knew "pulled" or "not pulled" for the whole request, so an
+opening whose hardware was on a cart at 9am was not assignable until the last opening was picked at
+4pm.
+
+**Staging is per opening.** `stage_pull_openings` flips one `ShopAssemblyOpening.pull_status` to
+`PULLED` at a time, stamping `staged_at` / `staged_by`, and that opening becomes assignable and
+workable immediately. Staging the last one calls `complete_pull_request`, so the completion
+notification and the replacement-arrival application still fire exactly once, from one place.
+
+Two state facts, deliberately kept apart:
+
+- `ShopAssemblyOpening.pull_status` is only ever `NOT_PULLED` or `PULLED`. One cart is built or it is
+  not; persisting a half-truth about a single cart would be a lie.
+- `PullStatus.PARTIAL` is the **aggregate** reading over a set of openings, and it is **derived, not
+  stored** (`warehouse.get_pull_staging_summaries`, one grouped aggregate for a whole page).
+  `PullRequestStatus` therefore stays `PENDING -> IN_PROGRESS -> COMPLETED/CANCELLED` with no
+  half-state wedged into it.
+
+**Deduction timing does not move.** FIFO deduction and consumption of the source request's
+reservation both stay at approval. Approval is where the pull is committed, and per-opening deduction
+would break two things at once: an approved-but-unstaged opening would hold neither a reservation nor
+a deduction, so its hardware would read as free to the next request (the hole §3a closed); and a
+shortfall could then surface at staging time, where the only recovery is a half-deducted pull.
+Staging is progress tracking. Cancellation is what reverses stock.
+
+#### 3c. Cancelling a pull: the tag comes off
+
+Once a pull was approved there was no way back - stock was deducted and `PullRequestStatus.CANCELLED`
+was an enum value nothing ever set. `cancel_pull_request` is the way back, and it is
+**all-or-nothing per pull**:
+
+| Rule | Why |
+| --- | --- |
+| Blocked by any opening whose assembly is IN_PROGRESS or COMPLETED, naming every blocker | That is where the hardware stops being retrievable - it is on a leaf, and some of it may already have been condemned and replaced |
+| Staged-but-unassembled openings **do** come back | Their hardware is on a cart in the shop, exactly as retrievable as hardware on the shelf. Restocking only the un-staged part would leave the staged part deducted with no leaf to show for it |
+| No partial cancel | `PullStatus` has no cancelled value, and `complete_pull_request` flips *every* opening of a pull to PULLED - so a half-cancelled pull would resurrect its released openings the moment the rest was staged. Expressing it properly needs an opening-level cancelled state |
+| Cancellable from IN_PROGRESS, and from COMPLETED for a shop-assembly pull with openings | Since staging is per opening, COMPLETED there means no more than "every cart is built". A completed shipping-out pull has already flipped leaves to SHIP_READY, and a completed PR-REPL pull has already restored expectations |
+| Restock lands on the project's newest `InventoryLocation` row for the combo, not a row-by-row reversal | Which row a hinge sits on carries no identity (the rule at the top of this document). Landing on the newest row is also conservative for future FIFO: older stock still goes out first |
+| Source request returns to **PENDING**, and its reservation is re-created after the restock, availability re-checked | The claim was consumed at approval, so re-creating it is a new claim competing with everyone else's. If it cannot be covered, the request is left **unreserved and flagged** via `integrity_note` rather than half-claimed - the same honest-and-flagged shape the #342 backfill uses |
+| A PR-REPL replacement pull restocks and re-creates nothing | It never held a reservation. The leaf's `deficient_quantity` is untouched: the expectation stays on the checklist line and the replacement has to be requested again |
+
+Cancelling keeps the pull row, which is why `pull_requests.request_number` is unique only among
+**live** pulls (a partial unique index excluding `CANCELLED`): re-accepting the returned request
+mints a fresh pull carrying the same number.
+
 ### 4. The tag materializes
 
 The tag does not become physical all at once. Assembly happens over a shift, unit by unit, and since
@@ -200,6 +248,12 @@ leaf until a pull tags it onto one).
 | Tag written, shop assembly | `backend/app/repositories/shop_assembly_repository.py` (`accept_shop_assembly_request`) |
 | Tag written, shipping out | `backend/app/repositories/shipping_repository.py` (`accept_shipping_out_request`) |
 | Tag consumes stock | `backend/app/repositories/warehouse/pull_requests.py` (`approve_pull_request`, FIFO deduction) |
+| Tag staged, opening by opening | `backend/app/repositories/warehouse/pull_requests.py` (`stage_pull_openings` -> one `ShopAssemblyOpening.pull_status`, `staged_at` / `staged_by`; last one calls `complete_pull_request`) |
+| PARTIAL derived, never stored | `backend/app/repositories/warehouse/pull_requests.py` (`get_pull_staging_summaries` / `StagingSummary.status`, one grouped aggregate per page) |
+| Workability keyed on the opening, not the pull | `backend/app/repositories/shop_assembly_repository.py` (`_APPROVED_PULL_STATUSES` + `pull_status == PULLED` in `get_assemble_list`, `get_my_work`, `assign_openings`, `record_assembly_progress`, `complete_opening`) |
+| Tag comes off, stock returned | `backend/app/repositories/warehouse/pull_requests.py` (`cancel_pull_request` -> `_return_units_to_project_inventory`, all-or-nothing, blockers named) |
+| Claim re-created after a cancel | `backend/app/repositories/warehouse/pull_requests.py` (`cancel_pull_request` -> availability re-check then `create_reservations`, else `integrity_note`) |
+| Pull number unique among live pulls only | `backend/app/models/pull_request.py` (`uq_pull_requests_request_number_live`, partial index excluding CANCELLED) |
 | Tag worked, incrementally | `backend/app/repositories/shop_assembly_repository.py` (`record_assembly_progress` -> `installed_quantity` / `deficient_quantity`) |
 | Deficient unit returned + replaced | `backend/app/repositories/stock/deficiency.py` (`report_deficiency_at_assembly` -> PR-REPL line) |
 | Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`, quantities = installed) |

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -75,3 +75,35 @@ export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems'];
 // stops the next wizard session from opening on the cache-first half of its cache-and-network read
 // and gating a selection against pre-reservation numbers for a beat.
 export const RESERVATION_STALE_ROOT_FIELDS = ['projectInventoryAvailability'];
+
+// What confirming a batch of openings as staged invalidates (#343). Same disjointness rule as above.
+//
+// Refetched. GetPullRequests is the queue the staging modal was opened from and is mounted by
+// definition, so refetchQueries reaches it; its staging chip goes from "3 of 8" to "4 of 8", and the
+// pull's own status flips when the last opening lands. The panel refetches its own
+// GetPullRequestOpenings in onCompleted, so that one is deliberately not listed here.
+export const PULL_STAGING_REFETCH_QUERIES = ['GetPullRequests'];
+
+// Evicted. Newly staged openings become assignable and workable at once, and both readers live in
+// the shop-assembly module - a different route that is by definition not mounted while a warehouse
+// user is picking, which is exactly what refetchQueries cannot reach.
+export const PULL_STAGING_STALE_ROOT_FIELDS = ['assembleList', 'myWork'];
+
+// What cancelling a pull invalidates (#343). It is the widest blast radius in the warehouse: stock
+// goes back on the shelf, the source request returns to the accept queue, its claim is re-created,
+// and the openings leave the assembly floor.
+//
+// Refetched. GetPullRequests is the queue the cancel was launched from (the row must show
+// Cancelled), and the warehouse inventory summaries are the ones a mounted warehouse view is
+// showing while the restock happens.
+export const PULL_CANCEL_REFETCH_QUERIES = ['GetPullRequests', ...WAREHOUSE_REFETCH_QUERIES];
+
+// Evicted. All three are read by modules that are not mounted at cancel time: the assembly floor's
+// two work lists, the Start-a-Task wizard's availability (the re-created reservation changes what
+// may be claimed), and the accept queue that the source request has just rejoined.
+export const PULL_CANCEL_STALE_ROOT_FIELDS = [
+  'assembleList',
+  'myWork',
+  'projectInventoryAvailability',
+  'shopAssemblyRequests',
+];

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -230,6 +230,12 @@ export const GET_PULL_REQUESTS = gql`
       approvedAt
       completedAt
       cancelledAt
+      cancelledBy
+      cancellationReason
+      # Derived per-opening staging rollup (#343). Null on pulls that have no openings.
+      stagingStatus
+      stagedOpeningCount
+      totalOpeningCount
       items {
         id
         pullRequestId
@@ -526,14 +532,25 @@ export const CREATE_RECEIVE = gql`
   }
 `;
 
+// Shared shape so a pull read from a mutation result is cache-identical to one read from the queue.
+const PULL_REQUEST_FIELDS = `
+  id requestNumber projectId source status requestedBy assignedTo
+  createdAt updatedAt approvedAt completedAt cancelledAt cancelledBy cancellationReason
+  stagingStatus stagedOpeningCount totalOpeningCount
+  items { id pullRequestId itemType openingNumber openingItemId leaf hardwareCategory productCode requestedQuantity }
+`;
+
+// One opening of a shop-assembly pull, with the hardware lines that make up its cart (#343).
+const PULL_STAGING_OPENING_FIELDS = `
+  id pullRequestId openingId openingNumber leaf building floor
+  pullStatus assemblyStatus assignedToUserId assignedTo stagedAt stagedBy
+  items { id shopAssemblyOpeningId hardwareCategory productCode quantity }
+`;
+
 export const APPROVE_PULL_REQUEST = gql`
   mutation ApprovePullRequest($id: ID!, $approvedBy: String!) {
     approvePullRequest(id: $id, approvedBy: $approvedBy) {
-      pullRequest {
-        id requestNumber projectId source status requestedBy assignedTo
-        createdAt updatedAt approvedAt completedAt cancelledAt
-        items { id pullRequestId itemType openingNumber openingItemId leaf hardwareCategory productCode requestedQuantity }
-      }
+      pullRequest { ${PULL_REQUEST_FIELDS} }
       outcome
       notification {
         id projectId recipientRole type message isRead createdAt
@@ -546,11 +563,37 @@ export const APPROVE_PULL_REQUEST = gql`
 `;
 
 export const COMPLETE_PULL_REQUEST = gql`
-  mutation CompletePullRequest($id: ID!) {
-    completePullRequest(id: $id) {
-      id requestNumber projectId source status requestedBy assignedTo
-      createdAt updatedAt approvedAt completedAt cancelledAt
-      items { id pullRequestId itemType openingNumber openingItemId leaf hardwareCategory productCode requestedQuantity }
+  mutation CompletePullRequest($id: ID!, $completedBy: String) {
+    completePullRequest(id: $id, completedBy: $completedBy) { ${PULL_REQUEST_FIELDS} }
+  }
+`;
+
+export const GET_PULL_REQUEST_OPENINGS = gql`
+  query GetPullRequestOpenings($pullRequestId: ID!) {
+    pullRequestOpenings(pullRequestId: $pullRequestId) { ${PULL_STAGING_OPENING_FIELDS} }
+  }
+`;
+
+export const STAGE_PULL_OPENINGS = gql`
+  mutation StagePullOpenings($input: StagePullOpeningsInput!) {
+    stagePullOpenings(input: $input) {
+      pullRequest { ${PULL_REQUEST_FIELDS} }
+      openings { ${PULL_STAGING_OPENING_FIELDS} }
+      newlyStagedOpeningIds
+      completed
+    }
+  }
+`;
+
+export const CANCEL_PULL_REQUEST = gql`
+  mutation CancelPullRequest($input: CancelPullRequestInput!) {
+    cancelPullRequest(input: $input) {
+      pullRequest { ${PULL_REQUEST_FIELDS} }
+      restocked { hardwareCategory productCode quantity }
+      releasedOpeningIds
+      sourceRequestReturnedToPending
+      reservationsRecreated
+      integrityNote
     }
   }
 `;

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -11,16 +11,28 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  TextField,
   Divider,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import { useMutation, useQuery } from '@apollo/client/react';
-import { APPROVE_PULL_REQUEST, COMPLETE_PULL_REQUEST, GET_INVENTORY_HIERARCHY } from '../../graphql/warehouse';
+import {
+  APPROVE_PULL_REQUEST,
+  CANCEL_PULL_REQUEST,
+  COMPLETE_PULL_REQUEST,
+  GET_INVENTORY_HIERARCHY,
+} from '../../graphql/warehouse';
+import {
+  PULL_CANCEL_REFETCH_QUERIES,
+  PULL_CANCEL_STALE_ROOT_FIELDS,
+} from '../../graphql/refetch';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import PullStagingPanel from './PullStagingPanel';
+import { isCancellable, stagingChipColor, stagingChipLabel } from './pullStaging';
 import type { PullRequest, PullRequestItem } from './PullRequestQueue';
 import { leafLabel } from '../../utils/leaf';
 
@@ -116,6 +128,12 @@ export default function PullRequestDetailModal({
   // Confirm dialog state
   const [confirmApproveOpen, setConfirmApproveOpen] = useState(false);
   const [confirmCompleteOpen, setConfirmCompleteOpen] = useState(false);
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const [cancelReason, setCancelReason] = useState('');
+  // #343: a cancel refused because assembly has already started. The server names every blocker in
+  // one message, so it is shown verbatim and the dialog stays open - the user is being told what to
+  // go and finish, not just that it failed.
+  const [cancelBlockedMessage, setCancelBlockedMessage] = useState<string | null>(null);
 
   // #224 gate 2: the shortfall the server returned when an approve was blocked for insufficient
   // inventory. The PR is left PENDING; we show this inline instead of cancelling.
@@ -202,6 +220,46 @@ export default function PullRequestDetailModal({
     },
   });
 
+  const [cancelPR, { loading: cancelLoading }] = useMutation(CANCEL_PULL_REQUEST, {
+    refetchQueries: PULL_CANCEL_REFETCH_QUERIES,
+    update(cache) {
+      // Disjoint from the refetch list (see refetch.ts).
+      for (const field of PULL_CANCEL_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName: field });
+      }
+      cache.gc();
+    },
+    onCompleted: (data) => {
+      const result = (
+        data as {
+          cancelPullRequest?: {
+            restocked?: { quantity: number }[];
+            reservationsRecreated?: boolean;
+            integrityNote?: string | null;
+          };
+        }
+      )?.cancelPullRequest;
+      const units = (result?.restocked ?? []).reduce((sum, r) => sum + r.quantity, 0);
+      setCancelOpen(false);
+      setCancelBlockedMessage(null);
+      if (result?.integrityNote) {
+        // The hardware came back but could not be re-claimed for the request. That is a real state
+        // the acceptor has to know about, so it is a warning, not a success.
+        showToast(result.integrityNote, 'warning');
+      } else {
+        showToast(
+          `Pull cancelled. ${units} unit(s) returned to inventory` +
+            (result?.reservationsRecreated ? ' and reserved for the request again.' : '.'),
+          'success',
+        );
+      }
+      onRefetch();
+    },
+    onError: (error) => {
+      setCancelBlockedMessage(error.message);
+    },
+  });
+
   // --- Handlers ---
 
   const handleApprove = () => {
@@ -210,7 +268,16 @@ export default function PullRequestDetailModal({
   };
 
   const handleComplete = () => {
-    completePR({ variables: { id: pr.id } });
+    completePR({ variables: { id: pr.id, completedBy: displayName } });
+  };
+
+  const handleCancel = () => {
+    setCancelBlockedMessage(null);
+    cancelPR({
+      variables: {
+        input: { id: pr.id, cancelledBy: displayName, reason: cancelReason.trim() || null },
+      },
+    });
   };
 
   // --- Visibility rules ---
@@ -223,7 +290,20 @@ export default function PullRequestDetailModal({
   const isAssignedToCurrentUser = isInProgress && pr.assignedTo === displayName;
   const isLockedToOtherUser = isInProgress && pr.assignedTo !== displayName;
 
+  // #343: the staging checklist is the shop-assembly pull's execution view. It is shown from
+  // approval onwards - including after completion, read-only, so the record of who staged what
+  // survives the pull being finished.
+  const showStaging = pr.source === 'SHOP_ASSEMBLY' && (isInProgress || isCompleted);
+  const canCancel = isCancellable(pr);
+  const stagingLabel = stagingChipLabel(pr);
+
   // --- Action buttons ---
+
+  const cancelButton = canCancel ? (
+    <Button variant="outlined" color="error" onClick={() => setCancelOpen(true)} disabled={cancelLoading}>
+      Cancel Pull
+    </Button>
+  ) : null;
 
   let actionButtons: React.ReactNode | undefined;
 
@@ -243,6 +323,7 @@ export default function PullRequestDetailModal({
   } else if (isAssignedToCurrentUser) {
     actionButtons = (
       <Stack direction="row" spacing={1}>
+        {cancelButton}
         <Button
           variant="contained"
           color="primary"
@@ -253,6 +334,8 @@ export default function PullRequestDetailModal({
         </Button>
       </Stack>
     );
+  } else if (canCancel) {
+    actionButtons = <Stack direction="row" spacing={1}>{cancelButton}</Stack>;
   }
 
   // --- Render ---
@@ -279,6 +362,9 @@ export default function PullRequestDetailModal({
               color={STATUS_CHIP_COLOR[pr.status] ?? 'default'}
               size="medium"
             />
+            {stagingLabel && (
+              <Chip label={stagingLabel} color={stagingChipColor(pr)} size="medium" variant="outlined" />
+            )}
           </Stack>
           <InfoRow label="Request #" value={pr.requestNumber} />
           <InfoRow label="Created Date" value={formatDate(pr.createdAt)} />
@@ -299,7 +385,10 @@ export default function PullRequestDetailModal({
         {isCancelled && (
           <Box sx={{ mb: 2 }}>
             <Alert severity="error">
-              This Pull Request was cancelled at {formatDateTime(pr.cancelledAt)}.
+              This Pull Request was cancelled at {formatDateTime(pr.cancelledAt)}
+              {pr.cancelledBy ? ` by ${pr.cancelledBy}` : ''}
+              {pr.cancellationReason ? `: ${pr.cancellationReason}` : '.'}
+              {' '}Its hardware was returned to inventory and the source request went back to Pending.
             </Alert>
           </Box>
         )}
@@ -345,6 +434,21 @@ export default function PullRequestDetailModal({
         )}
 
         <Divider sx={{ mb: 2 }} />
+
+        {/* Per-opening staging checklist (#343). Read-only once the pull is complete. */}
+        {showStaging && (
+          <>
+            <PullStagingPanel
+              pullRequestId={pr.id}
+              pullRequestNumber={pr.requestNumber}
+              editable={isInProgress}
+              onStaged={(completed) => {
+                if (completed) onRefetch();
+              }}
+            />
+            <Divider sx={{ mb: 2 }} />
+          </>
+        )}
 
         {/* Items table */}
         <Typography variant="h6" gutterBottom>
@@ -454,12 +558,53 @@ export default function PullRequestDetailModal({
       <ConfirmDialog
         open={confirmCompleteOpen}
         title="Complete Pull Request"
-        message={`Mark Pull Request ${pr.requestNumber} as pulled? This action cannot be undone.`}
+        message={
+          showStaging
+            ? `Mark Pull Request ${pr.requestNumber} as pulled? Any opening not yet confirmed will be staged as well.`
+            : `Mark Pull Request ${pr.requestNumber} as pulled? This action cannot be undone.`
+        }
         confirmLabel="Mark as Pulled"
         cancelLabel="Cancel"
         onConfirm={handleComplete}
         onCancel={() => setConfirmCompleteOpen(false)}
       />
+
+      {/* Cancel: its own dialog rather than ConfirmDialog, because it takes a reason and has to be
+          able to show the server's blocker list without closing. */}
+      <Modal
+        open={cancelOpen}
+        title={`Cancel ${pr.requestNumber}`}
+        onClose={() => setCancelOpen(false)}
+        maxWidth="sm"
+        actions={
+          <Stack direction="row" spacing={1}>
+            <Button onClick={() => setCancelOpen(false)}>Keep pull</Button>
+            <Button variant="contained" color="error" onClick={handleCancel} disabled={cancelLoading}>
+              {cancelLoading ? 'Cancelling...' : 'Cancel pull and restock'}
+            </Button>
+          </Stack>
+        }
+      >
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Every unit this pull took will go back into project inventory, its openings return to the
+          not-pulled state, and the request that raised it goes back to Pending for re-acceptance.
+          Openings whose assembly has already started will block the cancellation.
+        </Alert>
+        {cancelBlockedMessage && (
+          <Alert severity="error" sx={{ mb: 2 }} data-testid="cancel-blocked">
+            {cancelBlockedMessage}
+          </Alert>
+        )}
+        <TextField
+          label="Reason (optional)"
+          value={cancelReason}
+          onChange={(e) => setCancelReason(e.target.value)}
+          fullWidth
+          multiline
+          minRows={2}
+          slotProps={{ htmlInput: { maxLength: 500 } }}
+        />
+      </Modal>
     </>
   );
 }

--- a/frontend/src/modules/warehouse/PullRequestQueue.tsx
+++ b/frontend/src/modules/warehouse/PullRequestQueue.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, Typography, Chip } from '@mui/material';
 import { useQuery } from '@apollo/client/react';
 import type { GridColDef, GridRowParams } from '@mui/x-data-grid';
@@ -6,6 +6,7 @@ import { GET_PULL_REQUESTS } from '../../graphql/warehouse';
 import DataTable from '../../components/DataTable';
 import Tabs from '../../components/Tabs';
 import PullRequestDetailModal from './PullRequestDetailModal';
+import { stagingChipColor, stagingChipLabel } from './pullStaging';
 
 // --- Types ---
 
@@ -35,6 +36,13 @@ export interface PullRequest {
   approvedAt: string | null;
   completedAt: string | null;
   cancelledAt: string | null;
+  cancelledBy: string | null;
+  cancellationReason: string | null;
+  /** Derived per-opening staging rollup (#343): NOT_PULLED / PARTIAL / PULLED over this pull's
+   *  shop-assembly openings. Null when the pull has none (shipping-out, PR-REPL, legacy). */
+  stagingStatus: string | null;
+  stagedOpeningCount: number | null;
+  totalOpeningCount: number | null;
   items: PullRequestItem[];
 }
 
@@ -102,78 +110,74 @@ const columns: GridColDef[] = [
       />
     ),
   },
+  {
+    // #343: how far the warehouse has got picking this pull, opening by opening. Blank rather than
+    // a zeroed chip on a pull with no openings - staging does not apply there.
+    field: 'staging',
+    headerName: 'Staging',
+    flex: 1,
+    minWidth: 140,
+    sortable: false,
+    valueGetter: (_value: unknown, row: PullRequest) => stagingChipLabel(row) ?? '',
+    renderCell: (params) => {
+      const label = stagingChipLabel(params.row as PullRequest);
+      if (!label) return null;
+      return <Chip label={label} color={stagingChipColor(params.row as PullRequest)} size="small" />;
+    },
+  },
 ];
 
 // --- Tab content component ---
 
 interface PullRequestTabProps {
   source: string;
-  onRowClick: (pr: PullRequest) => void;
 }
 
-function PullRequestTab({ source, onRowClick }: PullRequestTabProps) {
+function PullRequestTab({ source }: PullRequestTabProps) {
+  // The id, not the row (#343). The modal stages openings and cancels the pull, both of which
+  // refetch this list; holding the object would pin the modal's staging chip to the pre-staging
+  // snapshot - the same trap #340 fixed in the assembly views.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
   const { data, loading } = useQuery<{ pullRequests: PullRequest[] }>(GET_PULL_REQUESTS, {
     variables: { source },
   });
 
-  const requests = data?.pullRequests ?? [];
+  const requests = useMemo(() => data?.pullRequests ?? [], [data]);
+  const selected = useMemo(() => requests.find((pr) => pr.id === selectedId) ?? null, [requests, selectedId]);
 
   const handleRowClick = (params: GridRowParams<PullRequest>) => {
-    onRowClick(params.row);
+    setSelectedId(params.row.id);
   };
 
   return (
-    <DataTable
-      columns={columns}
-      rows={requests}
-      loading={loading}
-      onRowClick={handleRowClick}
-      sx={{ cursor: 'pointer' }}
-      getRowId={(row) => row.id}
-    />
+    <>
+      <DataTable
+        columns={columns}
+        rows={requests}
+        loading={loading}
+        onRowClick={handleRowClick}
+        sx={{ cursor: 'pointer' }}
+        getRowId={(row) => row.id}
+      />
+      {selected && (
+        <PullRequestDetailModal
+          open
+          pr={selected}
+          onClose={() => setSelectedId(null)}
+          onRefetch={() => setSelectedId(null)}
+        />
+      )}
+    </>
   );
 }
 
 // --- Main component ---
 
 export default function PullRequestQueue() {
-  const [selectedPR, setSelectedPR] = useState<PullRequest | null>(null);
-  const [modalOpen, setModalOpen] = useState(false);
-
-  const handleRowClick = (pr: PullRequest) => {
-    setSelectedPR(pr);
-    setModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-    setSelectedPR(null);
-  };
-
-  const handleRefetch = () => {
-    setModalOpen(false);
-    setSelectedPR(null);
-  };
-
   const tabs = [
-    {
-      label: 'Shop Assembly',
-      content: (
-        <PullRequestTab
-          source="SHOP_ASSEMBLY"
-          onRowClick={handleRowClick}
-        />
-      ),
-    },
-    {
-      label: 'Shipping Out',
-      content: (
-        <PullRequestTab
-          source="SHIPPING_OUT"
-          onRowClick={handleRowClick}
-        />
-      ),
-    },
+    { label: 'Shop Assembly', content: <PullRequestTab source="SHOP_ASSEMBLY" /> },
+    { label: 'Shipping Out', content: <PullRequestTab source="SHIPPING_OUT" /> },
   ];
 
   return (
@@ -183,15 +187,6 @@ export default function PullRequestQueue() {
       </Typography>
 
       <Tabs tabs={tabs} defaultTab={0} />
-
-      {selectedPR && (
-        <PullRequestDetailModal
-          open={modalOpen}
-          pr={selectedPR}
-          onClose={handleCloseModal}
-          onRefetch={handleRefetch}
-        />
-      )}
     </Box>
   );
 }

--- a/frontend/src/modules/warehouse/PullStagingPanel.tsx
+++ b/frontend/src/modules/warehouse/PullStagingPanel.tsx
@@ -1,0 +1,271 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useMutation, useQuery } from '@apollo/client/react';
+import { GET_PULL_REQUEST_OPENINGS, STAGE_PULL_OPENINGS } from '../../graphql/warehouse';
+import {
+  PULL_STAGING_REFETCH_QUERIES,
+  PULL_STAGING_STALE_ROOT_FIELDS,
+} from '../../graphql/refetch';
+import { useToast } from '../../components/Toast';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useIdentity } from '../../hooks/useIdentity';
+import { isStageable, type PullStagingOpening } from './pullStaging';
+import { leafLabel } from '../../utils/leaf';
+
+function openingLabel(opening: PullStagingOpening): string {
+  const leaf = leafLabel(opening.leaf);
+  return `${opening.openingNumber ?? 'Opening'}${leaf ? ` - ${leaf}` : ''}`;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return '';
+  return new Date(value).toLocaleString();
+}
+
+// --- Component ---------------------------------------------------------------------------------
+
+interface PullStagingPanelProps {
+  pullRequestId: string;
+  pullRequestNumber: string;
+  /** Staging only applies to an approved pull. The panel renders read-only otherwise. */
+  editable: boolean;
+  onStaged?: (completed: boolean) => void;
+}
+
+/**
+ * The warehouse's per-opening staging checklist (#343).
+ *
+ * A pull is picked cart by cart, so the unit of confirmation here is one opening and its hardware
+ * lines - not the whole pull. Each opening confirmed flips to Staged on its own and becomes
+ * assignable on the assembly floor immediately; the pull completes when the last one is ticked, and
+ * the panel says so rather than leaving the user to infer it from a disappearing button.
+ *
+ * Confirming is deliberately a two-step (tick, then Confirm) rather than a checkbox that fires on
+ * click: staging is a statement that hardware is physically on a cart, and a mis-click on a
+ * virtualized list should not make that claim.
+ */
+export default function PullStagingPanel({
+  pullRequestId,
+  pullRequestNumber,
+  editable,
+  onStaged,
+}: PullStagingPanelProps) {
+  const { showToast } = useToast();
+  const { displayName } = useIdentity();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { data, loading, refetch } = useQuery<{ pullRequestOpenings: PullStagingOpening[] }>(
+    GET_PULL_REQUEST_OPENINGS,
+    { variables: { pullRequestId } },
+  );
+
+  const openings = useMemo(() => data?.pullRequestOpenings ?? [], [data]);
+  const stageable = useMemo(() => openings.filter(isStageable), [openings]);
+  const stagedCount = openings.length - stageable.length;
+
+  const [stageOpenings, { loading: staging }] = useMutation(STAGE_PULL_OPENINGS, {
+    refetchQueries: PULL_STAGING_REFETCH_QUERIES,
+    update(cache) {
+      // Disjoint from the refetch list above (see refetch.ts): evicting a field a mounted query
+      // also refetches makes Apollo run the heavy resolver twice concurrently.
+      for (const field of PULL_STAGING_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName: field });
+      }
+      cache.gc();
+    },
+    onCompleted: (result) => {
+      const payload = (result as { stagePullOpenings?: { completed?: boolean } })?.stagePullOpenings;
+      setSelected(new Set());
+      setConfirmOpen(false);
+      showToast(
+        payload?.completed
+          ? `All openings staged - ${pullRequestNumber} is complete.`
+          : 'Openings staged. They are now available for assembly.',
+        'success',
+      );
+      refetch();
+      onStaged?.(Boolean(payload?.completed));
+    },
+    onError: (error) => {
+      setConfirmOpen(false);
+      showToast(error.message, 'error');
+    },
+  });
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    setSelected((prev) => (prev.size === stageable.length ? new Set() : new Set(stageable.map((o) => o.id))));
+  }, [stageable]);
+
+  const handleConfirm = () => {
+    stageOpenings({
+      variables: {
+        input: {
+          pullRequestId,
+          openingIds: Array.from(selected),
+          stagedBy: displayName,
+        },
+      },
+    });
+  };
+
+  if (loading && !data) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Loading openings...
+      </Typography>
+    );
+  }
+
+  if (openings.length === 0) {
+    return null;
+  }
+
+  const stagingAll = selected.size > 0 && selected.size === stageable.length;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Staging ({stagedCount} of {openings.length} openings)
+        </Typography>
+        {editable && stageable.length > 0 && (
+          <Button size="small" variant="text" onClick={toggleAll}>
+            {selected.size === stageable.length ? 'Clear selection' : 'Select all remaining'}
+          </Button>
+        )}
+      </Stack>
+
+      {editable && stageable.length > 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Confirm an opening once its cart is built. Each one becomes available for assembly
+          straight away - you do not have to finish the whole pull first.
+        </Alert>
+      )}
+
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {editable && <TableCell padding="checkbox" />}
+            <TableCell>Opening</TableCell>
+            <TableCell>Location</TableCell>
+            <TableCell>Hardware</TableCell>
+            <TableCell>Staging</TableCell>
+            <TableCell>Assembly</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {openings.map((opening) => {
+            const stageableRow = isStageable(opening);
+            return (
+              <TableRow key={opening.id} data-testid={`staging-row-${opening.id}`}>
+                {editable && (
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selected.has(opening.id)}
+                      disabled={!stageableRow}
+                      onChange={() => toggle(opening.id)}
+                      inputProps={{ 'aria-label': `Stage ${openingLabel(opening)}` }}
+                    />
+                  </TableCell>
+                )}
+                <TableCell>{openingLabel(opening)}</TableCell>
+                <TableCell>
+                  {[opening.building, opening.floor].filter(Boolean).join(' / ') || '-'}
+                </TableCell>
+                <TableCell>
+                  {opening.items.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      No lines
+                    </Typography>
+                  ) : (
+                    <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                      {opening.items.map((item) => (
+                        <li key={item.id}>
+                          {item.quantity} x {item.productCode} ({item.hardwareCategory})
+                        </li>
+                      ))}
+                    </Box>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {stageableRow ? (
+                    <Chip label="Not staged" size="small" />
+                  ) : (
+                    <Stack spacing={0.5}>
+                      <Chip label="Staged" color="success" size="small" />
+                      {opening.stagedBy && (
+                        <Typography variant="caption" color="text.secondary">
+                          {opening.stagedBy} {formatDateTime(opening.stagedAt)}
+                        </Typography>
+                      )}
+                    </Stack>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {opening.assemblyStatus === 'COMPLETED' ? (
+                    <Chip label="Assembled" color="success" size="small" />
+                  ) : opening.assemblyStatus === 'IN_PROGRESS' ? (
+                    <Chip label="In Progress" color="info" size="small" />
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      {opening.assignedTo ?? 'Unassigned'}
+                    </Typography>
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {editable && (
+        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+          <Button
+            variant="contained"
+            disabled={selected.size === 0 || staging}
+            onClick={() => setConfirmOpen(true)}
+          >
+            {staging ? 'Confirming...' : `Confirm ${selected.size} staged`}
+          </Button>
+        </Stack>
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Confirm staged openings"
+        message={
+          stagingAll
+            ? `Confirm the last ${selected.size} opening(s) of ${pullRequestNumber} as staged? This completes the pull.`
+            : `Confirm ${selected.size} opening(s) of ${pullRequestNumber} as staged? They become available for assembly immediately.`
+        }
+        confirmLabel="Confirm staged"
+        cancelLabel="Cancel"
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/modules/warehouse/__tests__/PullRequestCancel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullRequestCancel.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { GraphQLError } from 'graphql';
+import { ToastProvider } from '../../../components/Toast';
+import PullRequestDetailModal from '../PullRequestDetailModal';
+import type { PullRequest } from '../PullRequestQueue';
+import {
+  CANCEL_PULL_REQUEST,
+  GET_INVENTORY_HIERARCHY,
+  GET_PULL_REQUEST_OPENINGS,
+} from '../../../graphql/warehouse';
+
+/**
+ * Cancelling an approved pull (#343). It returns real hardware to the shelf and sends the source
+ * request back for re-acceptance, so it is behind a confirm that states exactly that. It is
+ * all-or-nothing: the server refuses whole when assembly has started, naming every blocker, and the
+ * dialog stays open showing that list rather than closing on a toast.
+ */
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Picker',
+    userId: 'picker',
+    roles: [],
+    hasRole: () => false,
+    isAdmin: false,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+function pullRequest(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    id: 'pr-1',
+    requestNumber: 'PR-SA-0001',
+    projectId: 'p1',
+    source: 'SHOP_ASSEMBLY',
+    status: 'IN_PROGRESS',
+    requestedBy: 'importer',
+    assignedTo: 'Picker',
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    approvedAt: '2026-07-01T00:00:00Z',
+    completedAt: null,
+    cancelledAt: null,
+    cancelledBy: null,
+    cancellationReason: null,
+    stagingStatus: 'PARTIAL',
+    stagedOpeningCount: 1,
+    totalOpeningCount: 2,
+    items: [],
+    ...overrides,
+  };
+}
+
+const openingsMock: MockedResponse = {
+  request: { query: GET_PULL_REQUEST_OPENINGS, variables: { pullRequestId: 'pr-1' } },
+  result: { data: { pullRequestOpenings: [] } },
+  maxUsageCount: 5,
+};
+
+const inventoryMock: MockedResponse = {
+  request: { query: GET_INVENTORY_HIERARCHY, variables: { projectId: 'p1' } },
+  result: { data: { inventoryHierarchy: [] } },
+  maxUsageCount: 5,
+};
+
+function cancelVariables(reason: string | null) {
+  return { input: { id: 'pr-1', cancelledBy: 'Picker', reason } };
+}
+
+function cancelSuccessMock(integrityNote: string | null = null): MockedResponse {
+  return {
+    request: { query: CANCEL_PULL_REQUEST, variables: cancelVariables(null) },
+    result: {
+      data: {
+        cancelPullRequest: {
+          pullRequest: { ...pullRequest({ status: 'CANCELLED' }), __typename: undefined } as never,
+          restocked: [{ hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 4 }],
+          releasedOpeningIds: ['sao-1', 'sao-2'],
+          sourceRequestReturnedToPending: true,
+          reservationsRecreated: integrityNote === null,
+          integrityNote,
+        },
+      },
+    },
+  };
+}
+
+function cancelBlockedMock(): MockedResponse {
+  return {
+    request: { query: CANCEL_PULL_REQUEST, variables: cancelVariables(null) },
+    result: {
+      errors: [
+        new GraphQLError(
+          'Cannot cancel this pull - assembly has already started on 1 of its openings: ' +
+            '0019-EX leaf 1 (in progress, Ada). Finish or unwind that work first; cancelling is ' +
+            'all-or-nothing.',
+        ),
+      ],
+    },
+  };
+}
+
+function renderModal(mocks: MockedResponse[], pr: PullRequest = pullRequest()) {
+  const onRefetch = vi.fn();
+  const view = render(
+    <MockedProvider mocks={[openingsMock, inventoryMock, ...mocks]}>
+      <ToastProvider>
+        <PullRequestDetailModal open pr={pr} onClose={() => {}} onRefetch={onRefetch} />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+  return { ...view, onRefetch };
+}
+
+it('shows the derived staging progress on an approved pull', async () => {
+  renderModal([]);
+  expect(await screen.findByText('1 of 2 staged')).toBeInTheDocument();
+});
+
+it('offers Cancel Pull on an approved pull but not on a pending one', async () => {
+  const { unmount } = renderModal([]);
+  expect(await screen.findByRole('button', { name: 'Cancel Pull' })).toBeInTheDocument();
+  unmount();
+
+  renderModal([], pullRequest({ status: 'PENDING', stagingStatus: 'NOT_PULLED', stagedOpeningCount: 0 }));
+  expect(await screen.findByRole('button', { name: /Approve and Start/ })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Cancel Pull' })).not.toBeInTheDocument();
+});
+
+it('states what cancelling will do before it happens', async () => {
+  renderModal([]);
+  fireEvent.click(await screen.findByRole('button', { name: 'Cancel Pull' }));
+
+  expect(await screen.findByText(/Cancel PR-SA-0001/)).toBeInTheDocument();
+  expect(
+    screen.getByText(/go back into project inventory.*back to Pending for re-acceptance/s),
+  ).toBeInTheDocument();
+  expect(screen.getByText(/assembly has already started will block the cancellation/)).toBeInTheDocument();
+});
+
+it('reports what came back and that the claim was re-created', async () => {
+  const { onRefetch } = renderModal([cancelSuccessMock()]);
+  fireEvent.click(await screen.findByRole('button', { name: 'Cancel Pull' }));
+  fireEvent.click(await screen.findByRole('button', { name: /Cancel pull and restock/ }));
+
+  expect(
+    await screen.findByText(/4 unit\(s\) returned to inventory and reserved for the request again/),
+  ).toBeInTheDocument();
+  expect(onRefetch).toHaveBeenCalled();
+});
+
+it('warns rather than celebrates when the hardware came back but could not be re-claimed', async () => {
+  renderModal([cancelSuccessMock('Pull PR-SA-0001 was cancelled ... could not be re-reserved.')]);
+  fireEvent.click(await screen.findByRole('button', { name: 'Cancel Pull' }));
+  fireEvent.click(await screen.findByRole('button', { name: /Cancel pull and restock/ }));
+
+  expect(await screen.findByText(/could not be re-reserved/)).toBeInTheDocument();
+});
+
+it('keeps the dialog open and names the blockers when the cancel is refused', async () => {
+  const { onRefetch } = renderModal([cancelBlockedMock()]);
+  fireEvent.click(await screen.findByRole('button', { name: 'Cancel Pull' }));
+  fireEvent.click(await screen.findByRole('button', { name: /Cancel pull and restock/ }));
+
+  const blocked = await screen.findByTestId('cancel-blocked');
+  expect(blocked).toHaveTextContent('0019-EX leaf 1 (in progress, Ada)');
+  expect(blocked).toHaveTextContent('all-or-nothing');
+  // Still open, so the user can read the list and act on it.
+  expect(screen.getByRole('button', { name: /Cancel pull and restock/ })).toBeInTheDocument();
+  expect(onRefetch).not.toHaveBeenCalled();
+});
+
+it('explains a cancelled pull after the fact', async () => {
+  renderModal(
+    [],
+    pullRequest({
+      status: 'CANCELLED',
+      cancelledAt: '2026-07-03T10:00:00Z',
+      cancelledBy: 'Picker',
+      cancellationReason: 'raised against the wrong project',
+      stagingStatus: null,
+      stagedOpeningCount: null,
+      totalOpeningCount: null,
+    }),
+  );
+
+  const alert = await screen.findByText(/This Pull Request was cancelled/);
+  expect(alert).toHaveTextContent('by Picker');
+  expect(alert).toHaveTextContent('raised against the wrong project');
+  expect(alert).toHaveTextContent('source request went back to Pending');
+  expect(screen.queryByRole('button', { name: 'Cancel Pull' })).not.toBeInTheDocument();
+});

--- a/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import PullStagingPanel from '../PullStagingPanel';
+import { isStageable, stagingChipColor, stagingChipLabel, isCancellable } from '../pullStaging';
+import { GET_PULL_REQUEST_OPENINGS, STAGE_PULL_OPENINGS } from '../../../graphql/warehouse';
+
+/**
+ * Per-opening pull staging (#343). The warehouse picks a pull cart by cart, so the checklist's unit
+ * of confirmation is one opening and its hardware lines. Confirming is a two-step (tick, then
+ * Confirm) because staging is a claim that hardware is physically on a cart.
+ */
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Picker',
+    userId: 'picker',
+    roles: [],
+    hasRole: () => false,
+    isAdmin: false,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+function opening(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sao-1',
+    pullRequestId: 'pr-1',
+    openingId: 'op-1',
+    openingNumber: '0019-EX',
+    leaf: 1,
+    building: 'A',
+    floor: '2',
+    pullStatus: 'NOT_PULLED',
+    assemblyStatus: 'PENDING',
+    assignedToUserId: null,
+    assignedTo: null,
+    stagedAt: null,
+    stagedBy: null,
+    items: [
+      {
+        id: 'sai-1',
+        shopAssemblyOpeningId: 'sao-1',
+        hardwareCategory: 'HINGE',
+        productCode: 'HG-100',
+        quantity: 3,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function openingsMock(rows: unknown[]): MockedResponse {
+  return {
+    request: { query: GET_PULL_REQUEST_OPENINGS, variables: { pullRequestId: 'pr-1' } },
+    result: { data: { pullRequestOpenings: rows } },
+    maxUsageCount: 5,
+  };
+}
+
+function stageMock(openingIds: string[], completed: boolean, resulting: unknown[]): MockedResponse {
+  return {
+    request: {
+      query: STAGE_PULL_OPENINGS,
+      variables: { input: { pullRequestId: 'pr-1', openingIds, stagedBy: 'Picker' } },
+    },
+    result: {
+      data: {
+        stagePullOpenings: {
+          pullRequest: {
+            id: 'pr-1',
+            requestNumber: 'PR-SA-0001',
+            projectId: 'p1',
+            source: 'SHOP_ASSEMBLY',
+            status: completed ? 'COMPLETED' : 'IN_PROGRESS',
+            requestedBy: 'importer',
+            assignedTo: 'Picker',
+            createdAt: '2026-07-01T00:00:00Z',
+            updatedAt: '2026-07-01T00:00:00Z',
+            approvedAt: '2026-07-01T00:00:00Z',
+            completedAt: completed ? '2026-07-02T00:00:00Z' : null,
+            cancelledAt: null,
+            cancelledBy: null,
+            cancellationReason: null,
+            stagingStatus: completed ? 'PULLED' : 'PARTIAL',
+            stagedOpeningCount: completed ? 2 : 1,
+            totalOpeningCount: 2,
+            items: [],
+          },
+          openings: resulting,
+          newlyStagedOpeningIds: openingIds,
+          completed,
+        },
+      },
+    },
+  };
+}
+
+function renderPanel(mocks: MockedResponse[], editable = true) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <PullStagingPanel
+          pullRequestId="pr-1"
+          pullRequestNumber="PR-SA-0001"
+          editable={editable}
+        />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+// --- the checklist -----------------------------------------------------------------------------
+
+it('groups the pull by opening and lists that opening s hardware lines', async () => {
+  renderPanel([openingsMock([opening(), opening({ id: 'sao-2', leaf: 2 })])]);
+
+  expect(await screen.findByText(/Staging \(0 of 2 openings\)/)).toBeInTheDocument();
+  expect(screen.getAllByText(/0019-EX/)).toHaveLength(2);
+  expect(screen.getAllByText(/3 x HG-100 \(HINGE\)/)).toHaveLength(2);
+});
+
+it('shows a staged opening as staged, with who staged it, and does not offer it again', async () => {
+  renderPanel([
+    openingsMock([
+      opening({ pullStatus: 'PULLED', stagedBy: 'Ada', stagedAt: '2026-07-02T09:00:00Z' }),
+      opening({ id: 'sao-2', leaf: 2 }),
+    ]),
+  ]);
+
+  expect(await screen.findByText(/Staging \(1 of 2 openings\)/)).toBeInTheDocument();
+  expect(screen.getByText('Staged')).toBeInTheDocument();
+  expect(screen.getByText(/Ada/)).toBeInTheDocument();
+  // The already-staged row's checkbox is disabled; only the outstanding one can be ticked.
+  const boxes = screen.getAllByRole('checkbox');
+  expect(boxes[0]).toBeDisabled();
+  expect(boxes[1]).toBeEnabled();
+});
+
+it('will not confirm anything until an opening is ticked', async () => {
+  renderPanel([openingsMock([opening()])]);
+  const confirm = await screen.findByRole('button', { name: /Confirm 0 staged/ });
+  expect(confirm).toBeDisabled();
+});
+
+it('confirms behind a dialog rather than staging on the tick', async () => {
+  renderPanel([openingsMock([opening(), opening({ id: 'sao-2', leaf: 2 })])]);
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Stage 0019-EX - Leaf 1/ }));
+
+  fireEvent.click(screen.getByRole('button', { name: /Confirm 1 staged/ }));
+  expect(await screen.findByText('Confirm staged openings')).toBeInTheDocument();
+  expect(
+    screen.getByText(/They become available for assembly immediately/),
+  ).toBeInTheDocument();
+});
+
+it('stages the ticked opening and says the rest of the pull is still outstanding', async () => {
+  renderPanel([
+    openingsMock([opening(), opening({ id: 'sao-2', leaf: 2 })]),
+    stageMock(['sao-1'], false, [
+      opening({ pullStatus: 'PULLED', stagedBy: 'Picker', stagedAt: '2026-07-02T09:00:00Z' }),
+      opening({ id: 'sao-2', leaf: 2 }),
+    ]),
+  ]);
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Stage 0019-EX - Leaf 1/ }));
+  fireEvent.click(screen.getByRole('button', { name: /Confirm 1 staged/ }));
+  fireEvent.click(await screen.findByRole('button', { name: 'Confirm staged' }));
+
+  expect(
+    await screen.findByText(/Openings staged. They are now available for assembly./),
+  ).toBeInTheDocument();
+});
+
+it('says the pull is complete when the last opening is staged', async () => {
+  renderPanel([
+    openingsMock([opening({ pullStatus: 'PULLED', stagedBy: 'Ada' }), opening({ id: 'sao-2', leaf: 2 })]),
+    stageMock(['sao-2'], true, []),
+  ]);
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Stage 0019-EX - Leaf 2/ }));
+  fireEvent.click(screen.getByRole('button', { name: /Confirm 1 staged/ }));
+  // The dialog says so before it happens, too.
+  expect(await screen.findByText(/This completes the pull/)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Confirm staged' }));
+
+  expect(
+    await screen.findByText(/All openings staged - PR-SA-0001 is complete./),
+  ).toBeInTheDocument();
+});
+
+it('is read-only once the pull is no longer in progress', async () => {
+  renderPanel([openingsMock([opening({ pullStatus: 'PULLED', stagedBy: 'Ada' })])], false);
+  expect(await screen.findByText(/Staging \(1 of 1 openings\)/)).toBeInTheDocument();
+  expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Confirm/ })).not.toBeInTheDocument();
+});
+
+it('renders nothing for a pull with no openings', async () => {
+  const { container } = renderPanel([openingsMock([])]);
+  await waitFor(() => expect(screen.queryByText(/Loading openings/)).not.toBeInTheDocument());
+  expect(container.querySelector('table')).toBeNull();
+});
+
+// --- derived readings --------------------------------------------------------------------------
+
+it('derives the staging chip only when staging applies', () => {
+  expect(stagingChipLabel({ stagingStatus: 'PARTIAL', stagedOpeningCount: 4, totalOpeningCount: 8 })).toBe(
+    '4 of 8 staged',
+  );
+  // A shipping-out / PR-REPL / legacy pull has no openings: null, never "0 of 0 staged".
+  expect(stagingChipLabel({ stagingStatus: null, stagedOpeningCount: null, totalOpeningCount: null })).toBeNull();
+  expect(stagingChipLabel({ stagingStatus: 'NOT_PULLED', stagedOpeningCount: 0, totalOpeningCount: 0 })).toBeNull();
+});
+
+it('colours the staging chip by real state only', () => {
+  expect(stagingChipColor({ stagingStatus: 'NOT_PULLED' })).toBe('default');
+  expect(stagingChipColor({ stagingStatus: 'PARTIAL' })).toBe('warning');
+  expect(stagingChipColor({ stagingStatus: 'PULLED' })).toBe('success');
+});
+
+it('treats only an un-staged opening as stageable', () => {
+  expect(isStageable(opening() as never)).toBe(true);
+  expect(isStageable(opening({ pullStatus: 'PULLED' }) as never)).toBe(false);
+});
+
+it('offers cancel on an approved pull, and on a fully staged shop-assembly one', () => {
+  expect(isCancellable({ status: 'PENDING', source: 'SHOP_ASSEMBLY' })).toBe(false);
+  expect(isCancellable({ status: 'IN_PROGRESS', source: 'SHOP_ASSEMBLY' })).toBe(true);
+  expect(isCancellable({ status: 'IN_PROGRESS', source: 'SHIPPING_OUT' })).toBe(true);
+  // "Completed" for a shop-assembly pull now means only "every cart is built".
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY' })).toBe(true);
+  // A completed shipping-out pull has already flipped its leaves to ship-ready.
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHIPPING_OUT' })).toBe(false);
+  expect(isCancellable({ status: 'CANCELLED', source: 'SHOP_ASSEMBLY' })).toBe(false);
+});

--- a/frontend/src/modules/warehouse/pullStaging.ts
+++ b/frontend/src/modules/warehouse/pullStaging.ts
@@ -1,0 +1,71 @@
+// Shared readings of a pull's derived per-opening staging rollup (#343), so the queue column, the
+// detail header and the tests cannot drift apart. Change the wording here, not in each view.
+
+/** Fields the backend derives for a pull (`stagingStatus` is null on pulls that have no openings -
+ * shipping-out, PR-REPL, legacy - which is "not applicable", never "nothing staged"). */
+export interface PullStagingFields {
+  stagingStatus?: string | null;
+  stagedOpeningCount?: number | null;
+  totalOpeningCount?: number | null;
+}
+
+/** "4 of 8 staged", or null when staging does not apply to this pull.
+ *
+ * Deliberately returns null rather than an empty string so a caller has to decide what to render in
+ * the not-applicable case instead of drawing an empty chip. */
+export function stagingChipLabel(pr: PullStagingFields): string | null {
+  if (!pr.stagingStatus || pr.totalOpeningCount == null || pr.totalOpeningCount === 0) return null;
+  return `${pr.stagedOpeningCount ?? 0} of ${pr.totalOpeningCount} staged`;
+}
+
+/** Chip colour for the staging rollup. Only real system state gets colour (DESIGN.md): nothing
+ * staged is neutral, part-staged is the amber "in flight" reading, fully staged is success. */
+export function stagingChipColor(pr: PullStagingFields): 'default' | 'warning' | 'success' {
+  if (pr.stagingStatus === 'PULLED') return 'success';
+  if (pr.stagingStatus === 'PARTIAL') return 'warning';
+  return 'default';
+}
+
+export interface PullStagingOpeningItem {
+  id: string;
+  shopAssemblyOpeningId: string;
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+}
+
+export interface PullStagingOpening {
+  id: string;
+  pullRequestId: string | null;
+  openingId: string;
+  openingNumber: string | null;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  pullStatus: string;
+  assemblyStatus: string;
+  assignedToUserId: string | null;
+  assignedTo: string | null;
+  stagedAt: string | null;
+  stagedBy: string | null;
+  items: PullStagingOpeningItem[];
+}
+
+/** An opening the warehouse can still confirm: its cart is not built yet.
+ *
+ * One definition shared by the panel's gate and its tests. Deliberately keyed on `pullStatus`
+ * alone - the backend enforces the same rule, so a stale client cannot widen it. */
+export function isStageable(opening: PullStagingOpening): boolean {
+  return opening.pullStatus !== 'PULLED';
+}
+
+/** Whether a pull can still be cancelled from the UI's point of view.
+ *
+ * A pull that has not been approved has moved no inventory (reopen or reject the source request
+ * instead), and a cancelled one is terminal. A COMPLETED shop-assembly pull *is* cancellable, since
+ * per-opening staging means "completed" there is no more than "every cart is built" - the backend
+ * still refuses if assembly has started on any opening, and names which ones. */
+export function isCancellable(pr: { status: string; source: string }): boolean {
+  if (pr.status === 'IN_PROGRESS') return true;
+  return pr.status === 'COMPLETED' && pr.source === 'SHOP_ASSEMBLY';
+}

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -212,7 +212,46 @@ can come up INSUFFICIENT and notify the PO, and it can only draw from what nobod
 
 **Inventory**: Browse by hardware category and product code, see storage locations.
 
-**Pull Requests**: Queue of pull requests from shop assembly or shipping modules.
+**Pull Requests**: Queue of pull requests from shop assembly or shipping modules. Two tabs (Shop
+Assembly / Shipping Out); clicking a row opens the detail modal. The grid has a **Staging** column
+since #343 - a chip reading "4 of 8 staged" (grey at 0, amber part-staged, green all-staged). It is
+**blank** on shipping-out and `PR-REPL-*` pulls: those have no openings, so staging does not apply
+and the UI deliberately shows nothing rather than "0 of 0".
+
+**Per-opening staging (#343)** is the shop-assembly pull's execution view, inside the detail modal
+between the header and the Items table, headed `Staging (N of M openings)`.
+
+- One row per opening, showing its leaf, location and its own hardware lines (`3 x HG-100 (HINGE)`).
+- Confirming is **two-step**: tick the checkboxes (`Stage <opening> - Leaf N`), press
+  `Confirm N staged`, then confirm the dialog. A tick alone writes nothing - staging is a claim that
+  hardware is physically on a cart. `Select all remaining` ticks every un-staged row.
+- Each confirmed opening is **immediately** assignable/workable in Shop Assembly, while the rest of
+  the pull is still un-staged. This is the thing to exercise: stage one leaf of a pair, then go to
+  `/app/shop-assembly/assemble` and claim it while its sibling still shows as waiting.
+- An already-staged row has a disabled checkbox and a green "Staged" chip with who staged it and when.
+- Staging the **last** opening completes the pull (toast: "All openings staged - <PR> is complete.").
+  The panel then renders read-only, so the record of who staged what survives.
+- `Mark as Pulled` still exists and now means "stage everything remaining and finish"; its confirm
+  dialog says so.
+- Nothing moves in inventory at staging. Stock was deducted when the pull was **approved**.
+
+**Cancel Pull (#343)**: an outlined red button in the modal's action bar on any IN_PROGRESS pull, and
+on a COMPLETED *shop-assembly* pull (there "completed" only means every cart is built). Absent on a
+PENDING pull - reopen or reject the source request instead - and on a completed shipping-out pull.
+
+- It opens its own modal (not the standard ConfirmDialog) with a warning alert, an optional Reason
+  textarea, `Keep pull` and `Cancel pull and restock`.
+- Success toast names the units returned and whether the claim was re-created. If the returned
+  hardware could **not** be re-reserved you get a *warning* toast carrying the request's new
+  `integrityNote` instead - that is a real state, not a failure.
+- **Refusal keeps the dialog open** and renders the server's message in a red alert
+  (`data-testid="cancel-blocked"`) listing every opening whose assembly has started. Cancelling is
+  all-or-nothing; finish or unwind those leaves first.
+- After a cancel: stock is back in project inventory, the pull's openings are NOT_PULLED and
+  unassigned (they vanish from the Assemble List), and the source request is back in the
+  Shop Assembly / Shipping accept queue as Pending. Re-accepting it mints a **new** pull with the
+  **same request number** - so a search by number can legitimately return a cancelled row and a live
+  one.
 
 **Stock Pool** (`/app/warehouse/stock-pool`): Shows stock items not tied to a project. Has a "Warehouse" filter dropdown in the filter row with options "All warehouses", "Warden (WRD)", "VP (VP)". Grid has a "Warehouse" column (visible when data rows exist). Empty state shows "Nothing in the stock pool yet" message.
 
@@ -263,6 +302,13 @@ Both entry points open a "Transfer <productCode>" MUI dialog with: an "X availab
 - Manager creates/approves Shop Assembly Requests (SARs)
 - Approved SARs generate pull requests for warehouse
 - Users get assigned openings, pull hardware, assemble, mark complete
+
+**The Assemble List fills incrementally since #343.** It now lists the openings of any *approved*
+pull, not only completed ones, and groups them by the opening's own pull status: Pulled ("Ready"),
+Partial ("Waiting"), Not Pulled ("Pending"). Only a **Pulled** row offers "Assign to me" / "Start
+assembly" - an un-staged row is visible but inert, which is deliberate (the floor can see what is
+coming). If a leaf you expect is missing entirely, its pull is still PENDING in the warehouse or was
+cancelled; if it is present but has no buttons, the warehouse has not staged that opening yet.
 
 **Accept is a pure human gate since #342.** There is no inventory check on Accept any more and no
 shortfall can surface there - the hardware was reserved when the request was created. Accepting


### PR DESCRIPTION
Slice 5 of 6. **Stacked on `feat/sa-slice-4-reservations` (PR #348)** — the base is set to that branch so this diff shows only slice 5. Closes #343.

Two things the warehouse could not do. It could not tell the system it had picked *part* of a pull, so an opening whose hardware was on a cart at 9am was not assignable until the last opening was picked at 4pm — the pull was one all-or-nothing flip. And once a pull was approved there was no way back: stock was deducted and `PullRequestStatus.CANCELLED` was an enum value nothing ever set.

## Per-opening staging

`stagePullOpenings` flips one `ShopAssemblyOpening.pull_status` to `PULLED` at a time, stamping `staged_at` / `staged_by`. That opening becomes assignable and workable immediately. Staging the last one calls `complete_pull_request` rather than reimplementing it, so the completion notification and the replacement-arrival application still fire **exactly once, from one place**. An already-staged opening is skipped, not refused, so a double-click or a stale checklist is a no-op and does not restamp who staged it.

### Where PARTIAL lives, and why not on the row

Two facts, deliberately kept apart:

- **`ShopAssemblyOpening.pull_status` is only ever NOT_PULLED or PULLED.** One opening is one cart, and a cart is either built or it is not. Persisting PARTIAL there would be a half-truth about a single physical thing.
- **`PullStatus.PARTIAL` is the aggregate reading over a *set* of openings, and it is derived, not stored.** `get_pull_staging_summaries` returns staged/total per pull in **one grouped aggregate for the whole page** (`count(*)` + a filtered `count(*)`, never a `len()` over loaded openings) and the resolver hands each row its own — the converter takes the summary as a parameter precisely so it cannot become an N+1 on the pull-request queue. `PullRequest.stagingStatus` / `stagedOpeningCount` / `totalOpeningCount` are null on a pull with no openings, which reads as "not applicable", never "nothing staged".

That keeps the persisted state machine honest: `PullRequestStatus` stays `PENDING → IN_PROGRESS → COMPLETED/CANCELLED` with no half-state wedged into it, and the dead enum value finally earns its keep as what it always was — a rollup.

### Deduction timing: unchanged, at approval

FIFO deduction and consumption of the source request's reservation both stay at `approve_pull_request`. Staging moves nothing in inventory. Three reasons, and I don't think per-opening deduction is close:

1. **It would reopen the hole #342 closed.** An approved-but-unstaged opening would hold neither a reservation (consumed at approve) nor a deduction, so its hardware would read as free and could be claimed by the next request.
2. **The reservation table cannot express it.** Reservations are aggregate per `(project, category, product)` with no opening and no leaf column — deliberately, per `docs/HARDWARE_IDENTITY_LIFECYCLE.md`. Consuming "this opening's share" would mean re-introducing opening identity into the claim.
3. **It would put a shortfall where there is no recovery.** Approval either commits the whole pull or leaves it PENDING and blocked. N staging transactions each racing for FIFO rows can leave half a pull deducted, and there is no sensible thing to do about that at 3pm on the shop floor.

Staging is progress tracking. Cancellation is what reverses stock.

### Shipping-out: scoped out, deliberately

It does not fall out of the same mechanism. Staging keys on `ShopAssemblyOpening.pull_status`, a per-opening column that already exists; `pull_request_items` has no equivalent, so per-line staging needs a new column *and* a different downstream contract — the consumer of a staged OPENING_ITEM line is `OpeningItem.state`, so per-line staging would have to flip leaves to `SHIP_READY` one at a time, which changes what `get_ship_ready_items` lists and what `confirm_shipment` will accept mid-pull. That is a shipping change, not a staging change. `stage_pull_openings` refuses a non-shop-assembly pull with a typed error, and shipping-out pulls keep the whole-pull "Mark as Pulled". Follow-up if the warehouse asks for it.

## Cancel / restock

`cancelPullRequest` returns the hardware, releases the openings, and hands the source request back.

| Decision | Rationale |
| --- | --- |
| **All-or-nothing per pull.** Any opening whose assembly is IN_PROGRESS or COMPLETED refuses the whole cancellation with a `CONFLICT` naming every blocker | There is nowhere honest to park a half-cancelled pull: `PullStatus` has no cancelled value, and `complete_pull_request` flips *every* opening of a pull to PULLED — so a half-cancelled pull would **resurrect its released openings** the moment the rest was staged. Expressing it properly needs an opening-level cancelled state, which is a different change; the refusal names what to finish first |
| **Staged-but-unassembled openings come back too** | Physical reality: that hardware is on a cart in the shop, exactly as retrievable as hardware still on the shelf. Restocking only the un-staged part would leave the staged part deducted with no leaf to show for it. Assembly starting is the line where hardware stops being retrievable, and that is exactly where the blocker check sits |
| **Cancellable from IN_PROGRESS, and from COMPLETED for a shop-assembly pull with openings** | Since staging is per opening, COMPLETED there means no more than "every cart is built" — not a point of no return. A completed shipping-out pull has already flipped leaves to SHIP_READY and a completed PR-REPL pull has already restored expectations; unwinding those is not this function's job |
| **Restock lands on the project's newest `InventoryLocation` row for the combo**, not a row-by-row reversal of the FIFO deduction | Which row a hinge sits on carries no identity. Reconstructing the original split from the audit log would be fragile bookkeeping in service of a distinction the domain does not make. Same landing rule `report_deficiency_at_assembly` already uses, including re-materializing a row a re-upload deleted. Landing on the *newest* row is also conservative for future FIFO: older stock still goes out first |
| **Source request returns to PENDING**, claim re-created after the restock with availability re-checked | Cancelling says the *pull* was wrong, not that the hardware is unwanted. The claim was consumed at approval, so re-creating it is a new claim competing with everyone else's — if stock was written off or condemned under it, the request is left **unreserved and flagged** via `integrity_note` rather than half-claimed. Same honest-and-flagged shape the #342 backfill uses |
| **A PR-REPL pull restocks and re-creates nothing** | It never held a reservation — nobody can reserve for a deficiency that has not happened yet. The leaf's `deficient_quantity` is untouched: the expectation stays on the checklist line and the replacement has to be requested again |

Audited as `PULL_CANCELLED` against a new `AuditEntityType.PULL_REQUEST` (a cancellation is an event about the *pull*, not about any one inventory row it happened to touch), plus a `PULL_RESTOCK` row per inventory row — distinct from `RETURN`, which is a shipment coming back from site.

### The uniqueness problem cancellation creates

Returning the request to PENDING means a re-accept mints a pull carrying the **same** `request_number`, which was globally unique on `pull_requests`. (#325's reopen dodged this by hard-deleting the pull; a cancellation has to keep it.) The constraint is replaced with a **partial unique index excluding `CANCELLED`** — the number identifies the *live* pull for a request, which is what every lookup on it already meant. `reopen_shop_assembly_request`'s by-number lookup gained the matching `status != CANCELLED` filter; the other by-number joins (`_live_shop_assembly_requests`, `reopenable_only`, the PR-REPL find-or-create) already filter on a live status.

## The COMPLETED-filter rework

`PullRequestModel.status == COMPLETED` appeared in three places on the assumption that "the pull is done" and "this opening's hardware is on a cart" are the same fact. With per-opening staging they are not. Every one is now keyed on the fact that actually governs, with a `_APPROVED_PULL_STATUSES = (IN_PROGRESS, COMPLETED)` filter kept only to exclude a pull that never got off the ground or was cancelled:

| Site | Before | After |
| --- | --- | --- |
| `get_assemble_list` | PR COMPLETED | PR approved — **the list now fills incrementally**, and the page's long-dead PARTIAL / NOT_PULLED sections become live: an un-staged opening renders as "waiting" instead of being invisible until the whole pull is picked. Workability is not decided here |
| `get_my_work` | PR COMPLETED | `ShopAssemblyOpening.pull_status == PULLED` + PR approved. The old filter would have held a claimed, fully-staged leaf out of its own assembler's board until the last cart on the pull was finished |
| `complete_opening`'s PR lookup | PR COMPLETED (carrying the staging check implicitly) | PR approved, **plus an explicit `pull_status == PULLED` guard** — the same gate `assign_openings` and `record_assembly_progress` already used. The implicit check had to become explicit or completion would have been the one path a part-staged opening could slip through |

Swept and found already correct: `assign_openings` / `record_assembly_progress` / `remove_opening_from_user` gate on the opening (unchanged); `import_repository`'s PR-status branches are progress-rollup buckets, not workability; `shipping_repository`'s COMPLETED filter is about fulfilled shipping-out lines. `get_assemble_list` excludes cancelled pulls both by the status filter and because cancellation detaches the openings.

## Migration `063_pull_staging_cancel` (revises 062)

`shop_assembly_openings.staged_at` / `staged_by`; `pull_requests.cancelled_by` / `cancellation_reason` (alongside the `cancelled_at` that already existed, mirroring how a request rejection records itself); the unique-constraint → partial-index swap; `audit_action` += PULL_STAGED / PULL_RESTOCK / PULL_CANCELLED; `audit_entity_type` += PULL_REQUEST. Additive, no backfill — an existing PULLED opening simply has no staging stamp, which is honest (it was staged wholesale).

**Downgrade** drops the columns and the new audit rows, recreates both enums without the new labels, and restores the plain unique constraint — **de-duplicating first**, by suffixing any cancelled row whose number a live row also carries, since that is precisely the state this migration made reachable. Verified on a live cluster seeded with exactly that shape: a cancelled `PR-SA-0007` next to a live `PR-SA-0007`, a part-staged pull (one opening PULLED with a stamp, one NOT_PULLED), and audit rows using every new label. The cancelled row was retired to `PR-SA-0007-X22222222`, the live one kept its number, and the re-upgrade was clean.

## Frontend

- **Pull Request Queue** gains a Staging column: "4 of 8 staged", grey/amber/green by real state, and **blank** on a pull with no openings rather than a zeroed chip. The tab now holds the selected pull **by id**, not as a row snapshot — staging refetches the list, and holding the object would have pinned the open modal's chip to the pre-staging numbers (the trap #340 fixed in the assembly views).
- **`PullStagingPanel`** is the execution view: one row per opening with its leaf, location and its own hardware lines, a disabled checkbox + green "Staged / by whom / when" on rows already done, `Select all remaining`, and a confirm dialog whose wording changes when the selection is the last of the pull. Confirming is deliberately two-step rather than a checkbox that fires on click — staging is a statement that hardware is physically on a cart, and a mis-click should not make that claim. Read-only once the pull is complete, so the record survives.
- **Cancel Pull** is an outlined error button, present exactly where `isCancellable` says. It opens its own modal (not `ConfirmDialog`) because it takes a reason **and has to be able to show the server's blocker list without closing** — a refusal renders the message verbatim in a red alert and the dialog stays open, since the user is being told what to go and finish. A cancel that restocked but could not re-reserve raises a **warning** toast carrying the `integrityNote`, not a success one.
- `refetch.ts` gains two disjoint refetch/evict pairs. Staging refetches `GetPullRequests` and evicts `assembleList` / `myWork` (the shop-assembly module is a different route, never mounted while a warehouse user is picking). Cancel refetches the queue plus the warehouse inventory summaries and evicts those two plus `projectInventoryAvailability` and `shopAssemblyRequests`.
- `pullStaging.ts` holds the shared readings (`stagingChipLabel`, `stagingChipColor`, `isStageable`, `isCancellable`) so the queue column, the modal header and the tests cannot drift.

## Verification

Ran against a throwaway PostgreSQL 16 cluster (EDB portable binaries, `initdb` into a scratch dir, dropped afterwards):

- **366 backend tests pass** (was 334 pre-slice; 32 new in `tests/test_pull_staging_cancel.py`), all DB-backed — incremental staging and immediate assignability/workability while the PR is partial, PARTIAL derivation and its absence on an opening-less pull, single completion + replacement arrivals not double-applied, re-staging as a no-op, cancel full/blocked-by-IN_PROGRESS/blocked-by-COMPLETED, restock math including the re-materialized row, reservation re-creation and the oversubscribed `integrity_note` path, PR-REPL cancel restocking without reservations, the shipping-out cancel, and cancel→re-accept→re-pull with reopen still resolving the live pull.
- Full CI migration-integrity cycle: `upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean), plus the data-present downgrade above.
- `uvx ruff check .` / `uvx ruff format --check .` clean (poetry is not installed on this box).
- Frontend: `npm run lint` (0 errors, 17 warnings — the pre-existing set, unchanged), `npm run test:run` **218 pass** (19 new: 12 for the staging panel and its derived readings, 7 for the cancel flow), `npm run build` clean, `tsc -b` clean.
- Printed SDL checked: `stagePullOpenings`, `cancelPullRequest`, `pullRequestOpenings`, `stagingStatus`, `stagedAt` all present and additive (`completePullRequest` gained an optional `completedBy`, so existing callers are unaffected).
- SDL reference docs, `docs/HARDWARE_IDENTITY_LIFECYCLE.md` (new §3b and §3c plus seven rows in the enforcement table) and `testing/CLAUDE.md` updated.

### Existing tests

None needed reworking. The five fixtures that drive `pr.status = COMPLETED` directly to make an opening workable (`test_assembly_progress`, `test_completion_deficiency_checklist`, `test_replacement_loop`, `test_shop_assembly_completion_guards`, `test_import_repository_full_schedule`) all *also* set `sao.pull_status = PULLED`, so they were already asserting against the fact this slice made load-bearing rather than the one it relaxed. They pass unchanged, which is the reassuring outcome — and the new `test_complete_opening_works_while_the_pull_is_only_part_staged` covers the case they could not reach.

## Deviations from the issue spec

- **Shipping-out per-line staging is scoped out**, with the reasoning above; the issue allowed either.
- **Cancel is all-or-nothing rather than partial.** The issue's wording ("block cancellation of their portion") leaves room for a per-opening cancel; the `complete_pull_request` interaction makes that unsound without an opening-level cancelled state, so it is documented as the follow-up rather than half-built.
- **A COMPLETED shop-assembly pull is cancellable**, which the issue's "cancel an approved (IN_PROGRESS) pull" does not mention. Without it, staging the last cart would become an accidental point of no return — the exact rigidity this slice exists to remove.
- Added `cancelled_by` / `cancellation_reason` columns, not called for explicitly. Cancellation returns real hardware and bounces the source request; like a request rejection it needs its actor and reason on the row, not only in the audit log, because the accept queue is where somebody next reads it.
