### PR TITLE
feat(shop-assembly): slice 6 observability + notifications + housekeeping (#344)

### DIFF
--- a/backend/alembic/versions/064_pipeline_notifications.py
+++ b/backend/alembic/versions/064_pipeline_notifications.py
@@ -1,0 +1,89 @@
+"""Pipeline notifications: three new signals and the key that dedupes one of them (#344)
+
+Revision ID: 064
+Revises: 063
+Create Date: 2026-07-26
+
+Slices 1-5 introduced states nobody was told about. A cart staged at 9am (#343) made an opening
+assignable, but the assignment board only found out when somebody refreshed it. A replacement pull
+completing (#341) gave a leaf its expectation back, and the only notification raised was for the
+case where the leaf had *already shipped* - the ordinary case, where the assembler could go and fit
+it, was silent. And a PR-REPL pull holds no reservation by design (#342: a deficiency cannot be
+foreseen), so a replacement blocked on stock had nothing watching for the stock to arrive.
+
+`notification_type` therefore gains:
+
+- `ASSEMBLY_WORK_AVAILABLE` - openings became workable; addressed to the shop-assembly manager
+  audience, because the consequence is that the board has unassigned work on it.
+- `REPLACEMENT_ARRIVED` - a replacement landed for a leaf that has not shipped; addressed to the
+  assembler holding that leaf.
+- `PULL_UNBLOCKED` - a blocked replacement pull became coverable because a receive landed the stock;
+  addressed to the warehouse.
+
+`notifications.pull_request_id` is the other half. `PULL_UNBLOCKED` must not re-fire on every
+subsequent receive, and the dedupe rule chosen is *one unread notification per pull*: raise it only
+when the pull has no open one already. That needs an exact key on the row - matching the request
+number inside `message` would hold only until somebody reworded the message, and this slice exists
+precisely because states were knowable only by reading prose. The column is nullable and set only by
+the pull-centred signals; `ON DELETE SET NULL` keeps the record when #325's reopen hard-deletes a
+still-PENDING pull, since the notification is still a true statement about something that happened.
+
+Additive; no backfill. Existing notifications keep a null `pull_request_id`, which reads as "this
+one is not about a pull" - correct for every row written before this revision.
+
+Downgrade deletes the rows using the three new labels (an enum recast fails on a value that is about
+to stop existing), recreates `notification_type` without them, and drops the column and its index.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "064"
+down_revision = "063"
+branch_labels = None
+depends_on = None
+
+_PULL_INDEX = "ix_notifications_pull_request_unread"
+
+_NEW_NOTIFICATION_TYPES = ("ASSEMBLY_WORK_AVAILABLE", "REPLACEMENT_ARRIVED", "PULL_UNBLOCKED")
+
+_NOTIFICATION_TYPE_WITHOUT = (
+    "'PULL_REQUEST_CANCELLED', 'PULL_REQUEST_COMPLETED', 'SHIPMENT_COMPLETED', "
+    "'INVENTORY_SHORTFALL', 'REPLACEMENT_AFTER_SHIPMENT'"
+)
+
+
+def upgrade() -> None:
+    op.add_column("notifications", sa.Column("pull_request_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "fk_notifications_pull_request_id",
+        "notifications",
+        "pull_requests",
+        ["pull_request_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        _PULL_INDEX,
+        "notifications",
+        ["pull_request_id", "type"],
+        postgresql_where=sa.text("pull_request_id IS NOT NULL AND is_read = false"),
+    )
+
+    for label in _NEW_NOTIFICATION_TYPES:
+        op.execute(f"ALTER TYPE notification_type ADD VALUE IF NOT EXISTS '{label}'")
+
+
+def downgrade() -> None:
+    labels = ", ".join(f"'{label}'" for label in _NEW_NOTIFICATION_TYPES)
+    op.execute(f"DELETE FROM notifications WHERE type IN ({labels})")
+
+    op.execute("ALTER TYPE notification_type RENAME TO notification_type_old")
+    op.execute(f"CREATE TYPE notification_type AS ENUM ({_NOTIFICATION_TYPE_WITHOUT})")
+    op.execute("ALTER TABLE notifications ALTER COLUMN type TYPE notification_type USING type::text::notification_type")
+    op.execute("DROP TYPE notification_type_old")
+
+    op.drop_index(_PULL_INDEX, table_name="notifications")
+    op.drop_constraint("fk_notifications_pull_request_id", "notifications", type_="foreignkey")
+    op.drop_column("notifications", "pull_request_id")

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -27,8 +27,21 @@ enum ShopAssemblyRequestStatus {
 
 type ShopAssemblyOpening {
   id: ID!
-  shop_assembly_request_id: ID!
+  # Legacy SAR parent, nullable since #222 - openings created from Start a Task hang off the
+  # PullRequest below. Still written for new rows (import stamps both), which is what lets a request's
+  # openings be found after a cancellation nulls pull_request_id (#343).
+  shop_assembly_request_id: ID
+  # The shop-assembly PullRequest this opening was created under. Null before the request is accepted,
+  # and again after its pull is cancelled.
+  pull_request_id: ID
   opening_id: ID!
+  # Resolved from the source Opening at request time; populated by myWork, assembleList and
+  # pullRequestOpenings.
+  opening_number: String
+  building: String
+  floor: String
+  # Door leaf this assembly work unit is for (#311): 1 or 2, or null (legacy whole-opening unit).
+  leaf: Int
   # NOT_PULLED until the warehouse confirms this opening's cart is built, then PULLED (#343). Never
   # PARTIAL: one cart cannot be half-built.
   pull_status: PullStatus!
@@ -126,8 +139,107 @@ input AssemblyProgressItemInput {
 
 input RecordAssemblyProgressInput {
   opening_id: ID!
-  items: [AssemblyProgressItemInput!]
+  items: [AssemblyProgressItemInput!]!
   performed_by: String
+}
+
+# --- Pipeline observability (#344) ---
+# Derived, never stored. Every count below comes from a grouped scalar aggregate, so the summary list
+# costs a fixed five statements whether it is scoped to one project or to all of them.
+
+# How far one door leaf has travelled. The stage of a *request* is the stage of its least-advanced
+# opening - what is holding it up, not its best news. REJECTED and CANCELLED are off the ladder
+# rather than at the end of it: they are the two ways a leaf leaves the pipeline unassembled.
+enum PipelineStage {
+  REQUESTED    # the request exists; no pull minted
+  ACCEPTED     # the pull exists but is not approved, so nothing has been picked
+  PULLING      # the pull is approved and stock deducted; this cart is not built
+  STAGED       # this cart is built (#343) and nobody is holding it
+  ASSIGNED     # claimed by an assembler, nothing recorded yet
+  IN_PROGRESS  # hardware recorded onto the leaf, not fully dispositioned (#340)
+  COMPLETED    # an OpeningItem exists for the leaf
+  SHIPPED      # the assembled leaf has left the building
+  REJECTED     # the source request was rejected, releasing its claim (#342)
+  CANCELLED    # the pull was cancelled and restocked (#343); the request is back at PENDING
+}
+
+type PipelineOpening {
+  shop_assembly_opening_id: ID!
+  opening_number: String!
+  leaf: Int
+  building: String
+  floor: String
+  location: String
+  stage: PipelineStage!
+  pull_status: PullStatus!
+  staged_at: DateTime
+  staged_by: String
+  assigned_to_user_id: String
+  assigned_to: String
+  assembly_status: AssemblyStatus!
+  completed_at: DateTime
+  planned_unit_count: Int!
+  installed_unit_count: Int!
+  deficient_unit_count: Int!
+  replacement_pending_unit_count: Int!
+  # Units still owed to this leaf: condemned-and-unreplaced plus arrived-but-not-fitted (#341).
+  awaiting_replacement_unit_count: Int!
+  # Replacement hardware is sitting for a leaf that has already shipped (#341). installReplacement
+  # refuses it; it belongs to reallocation.
+  replacement_arrived_after_ship: Boolean!
+  opening_item_id: ID
+  opening_item_state: OpeningItemState
+  # Where the assembled leaf was put away, "aisle-row-bay", or null if it has not been located.
+  assembled_location: String
+}
+
+type AssemblyPipelineSummary {
+  request_id: ID!
+  request_number: String!
+  project_id: ID!
+  project_code: String
+  project_name: String
+  request_status: ShopAssemblyRequestStatus!
+  created_by: String!
+  created_at: DateTime!
+  accepted_by: String
+  accepted_at: DateTime
+  rejected_by: String
+  rejected_at: DateTime
+  # The same #342 note the accept screen shows as an amber alert.
+  integrity_note: String
+  # The live pull, never a cancelled one (#343 made request_number unique among live pulls only).
+  pull_request_id: ID
+  pull_request_status: PullRequestStatus
+  pull_approved_at: DateTime
+  pull_completed_at: DateTime
+  # Derived staging rollup - the same reading PullRequest.staging_status gives (#343). Null when the
+  # request has no openings, which is "not applicable", never "nothing staged".
+  staging_status: PullStatus
+  # Cancellation history: a cancelled pull keeps its number and hands its openings back to a PENDING
+  # request, so without this the request would read as never having been accepted.
+  cancelled_pull_count: Int!
+  last_cancelled_at: DateTime
+  last_cancelled_by: String
+  last_cancellation_reason: String
+  opening_count: Int!
+  staged_opening_count: Int!
+  assigned_opening_count: Int!
+  in_progress_opening_count: Int!
+  completed_opening_count: Int!
+  shipped_opening_count: Int!
+  planned_unit_count: Int!
+  installed_unit_count: Int!
+  deficient_unit_count: Int!
+  replacement_pending_unit_count: Int!
+  awaiting_replacement_opening_count: Int!
+  replacement_after_ship_opening_count: Int!
+  stage: PipelineStage!
+}
+
+type AssemblyPipeline {
+  summary: AssemblyPipelineSummary!
+  openings: [PipelineOpening!]!
 }
 
 # No item_results since #340: completion reads the persisted per-item progress instead.
@@ -142,15 +254,22 @@ input CompleteOpeningInput {
 # Every field below is gated on an authenticated caller (require_user, #339) except where a
 # stronger role gate is noted. Adding the gate did not change any field's arguments.
 type Query {
-  assembleList(projectId: ID!): [ShopAssemblyOpening!]!
+  # projectId is optional; omit it for the cross-project view.
+  assembleList(projectId: ID): [ShopAssemblyOpening!]!
   myWork(assignedToUserId: String!): [ShopAssemblyOpening!]!
+  # Where every shop-assembly request has got to (#344), newest first. Omit projectId for the
+  # All-Projects view - the repository runs a fixed five statements either way.
+  assemblyPipelineSummaries(projectId: ID, status: ShopAssemblyRequestStatus): [AssemblyPipelineSummary!]!
+  # One request down to the individual door leaf. The header counts come from the same aggregates the
+  # list above uses, so the two screens cannot disagree. NOT_FOUND if the request does not exist.
+  assemblyPipeline(requestId: ID!): AssemblyPipeline!
   # Replacement installs outstanding on already-completed leaves (#341). assignedToUserId scopes it
   # to one assembler's My Work - the opening keeps the assignment it was completed under, so this
   # needs no new assignment concept. Rows whose leaf has shipped are included on purpose.
   replacementWork(assignedToUserId: String, projectId: ID): [ReplacementWorkItem!]!
   # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
   shopAssemblyRequests(projectId: ID, status: ShopAssemblyRequestStatus, reopenableOnly: Boolean! = false): [ShopAssemblyRequest!]!
-  # Manager assignment picker (#330). Manager-gated (Shop Assembly Manager). ClerkUser in user.graphql.
+  # Manager assignment picker (#330). Manager-gated (Shop Assembly Manager). ClerkUser is in user.graphql.
   shopAssemblyMembers: [ClerkUser!]!
 }
 
@@ -179,7 +298,9 @@ type Mutation {
   # bench (record it as progress instead) or has already shipped (that is reallocation's problem).
   installReplacement(input: InstallReplacementInput!): OpeningItem!
   # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
-  # display name. Accept re-checks inventory sufficiency and mints the warehouse PullRequest.
+  # display name. Accept mints the warehouse PullRequest and is a **pure human gate** since #342: the
+  # hardware was reserved when the request was created, so nothing is re-checked here. Reject is what
+  # releases that reservation.
   acceptShopAssemblyRequest(id: ID!, acceptedBy: String!): ShopAssemblyRequest!
   rejectShopAssemblyRequest(id: ID!, rejectedBy: String!, reason: String): ShopAssemblyRequest!
   # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted

--- a/backend/app/graphql/user.graphql
+++ b/backend/app/graphql/user.graphql
@@ -1,0 +1,40 @@
+# User Module SDL Reference
+# Source of truth: Strawberry resolvers in app/schemas/user.py
+#
+# Users do not live in Postgres. They live in Clerk, and `app/repositories/user_repository.py` talks
+# to the Clerk Backend API - which is why roles are not a database enum and why `require_admin` /
+# `require_role` cost a network call while `require_user` does not (app/auth.py).
+#
+# This file existed only as a cross-reference from shop_assembly.graphql ("ClerkUser is in
+# user.graphql") until #344; the reference was dangling. It is written now so the pointer resolves.
+
+# One Clerk account as the app sees it. `roles` comes from Clerk publicMetadata, not from the session
+# token, so it is fetched rather than decoded.
+type ClerkUser {
+  id: String!
+  first_name: String!
+  last_name: String!
+  email: String!
+  # Known values: "Admin/Manager" (app/auth.ADMIN_ROLE) and "Shop Assembly Manager"
+  # (app/auth.SHOP_ASSEMBLY_MANAGER_ROLE). Free-form in Clerk, so this is not an enum.
+  roles: [String!]!
+  # The GP BUYERID this account acts as (#216). Null until an admin links it; createPo and
+  # registerPoInGp enforce that the caller has one.
+  gp_buyer_id: String
+  image_url: String!
+}
+
+type Query {
+  users: [ClerkUser!]!
+  # Shop-assembly team members for the manager assignment picker (#330), defined in
+  # shop_assembly.graphql because that is the module that consumes it. Manager-gated.
+  # shopAssemblyMembers: [ClerkUser!]!
+}
+
+type Mutation {
+  updateUserRoles(userId: String!, roles: [String!]!): ClerkUser!
+  # Admin-driven display-name change (#240).
+  updateUserName(userId: String!, firstName: String!, lastName: String!): ClerkUser!
+  # Link a UC Nexus account to the GP BUYERID it acts as (#216); null clears it.
+  updateUserGpBuyerId(userId: String!, gpBuyerId: String): ClerkUser!
+}

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -23,11 +23,22 @@ type ReceiveLineItem {
 type InventoryLocation {
   id: ID!
   project_id: ID!
-  po_line_item_id: ID!
-  receive_line_item_id: ID!
+  # Null on a row that did not come from a receive: an allocation out of the stock pool, or a row
+  # re-materialized by a deficiency return (#225) or a pull restock (#343).
+  po_line_item_id: ID
+  receive_line_item_id: ID
+  stock_item_id: ID
+  warehouse_id: ID
   hardware_category: String!
   product_code: String!
   quantity: Int!
+  # Units on this row condemned and awaiting deficiency review. Both counts move together when a unit
+  # is condemned, so `available` below is unchanged and the unit cannot be re-pulled.
+  deficient_quantity: Int!
+  # quantity - deficient_quantity. NOT the same "available" as projectInventoryAvailability's, which
+  # also subtracts reservations (#342): this one answers "what is physically unspoken-for in the
+  # building", that one answers "what may I claim".
+  available: Int!
   aisle: String
   row: String
   bay: String
@@ -40,28 +51,42 @@ type InventoryHierarchyNode {
   hardware_category: String!
   product_codes: [ProductCodeNode!]!
   total_quantity: Int!
+  total_available_quantity: Int!
+  total_value: Float!
 }
 
 type ProductCodeNode {
   product_code: String!
   items: [InventoryLocation!]!
   total_quantity: Int!
+  # Computed on both hierarchies since #344 reconciliation; the by-vendor one supplies 0.
+  total_available_quantity: Int!
+  total_value: Float!
 }
 
 type InventoryItemDetail {
   inventory_location: InventoryLocation!
-  po_number: String!
-  classification: Classification!
+  # Both null for a row with no originating PO line (see InventoryLocation.po_line_item_id).
+  po_number: String
+  classification: Classification
+  unit_cost: Float
 }
 
 type OpeningItem {
   id: ID!
   project_id: ID!
   opening_id: ID!
+  warehouse_id: ID
   opening_number: String!
   building: String
   floor: String
   location: String
+  # Door leaf this assembled unit is (#311): 1 or 2, or null for a legacy whole-opening unit. One
+  # OpeningItem per leaf, so a pair ships as two independently-located units.
+  leaf: Int
+  # The opening's total leaf count, the "N of M leaves shipped" denominator. Populated only by the
+  # openingItems list resolver; null elsewhere.
+  leaf_count: Int
   quantity: Int!
   assembly_completed_at: DateTime!
   state: OpeningItemState!
@@ -184,9 +209,13 @@ type ApproveResult {
   shortfalls: [InventoryShortfall!]!
 }
 
+# Two values, because approve_pull_request returns exactly two outcome strings. A third,
+# CANCELLED, was removed as dead state in #344: it dated from the pre-#224 behaviour where an approve
+# that found insufficient stock cancelled the pull, and since #224 such an approve leaves the PR
+# PENDING and returns INSUFFICIENT. GraphQL-only and never persisted, so no migration was needed - a
+# *cancelled pull* is PullRequestStatus.CANCELLED, which is a different enum on a real column.
 enum ApproveOutcome {
   APPROVED
-  CANCELLED
   INSUFFICIENT
 }
 
@@ -241,6 +270,8 @@ type PackingSlipItem {
   item_type: PullRequestItemType!
   opening_item_id: ID
   opening_number: String
+  # Door leaf (#335), snapshotted from the shipped OpeningItem. Null on a LOOSE line.
+  leaf: Int
   product_code: String!
   hardware_category: String!
   quantity: Int!
@@ -292,6 +323,9 @@ type ShipmentReturn {
 type Notification {
   id: ID!
   project_id: ID!
+  # An audience tag, not access control: the bell queries with no recipient filter, so everyone sees
+  # everything and this says who a signal is *for*. Named audiences (PO, SHIPPING,
+  # SHOP_ASSEMBLY_MANAGER, WAREHOUSE) plus, for REPLACEMENT_ARRIVED, one assembler's Clerk user id.
   recipient_role: String!
   type: NotificationType!
   message: String!
@@ -299,10 +333,34 @@ type Notification {
   created_at: DateTime!
 }
 
+# Written by every signal in the system. The three added in #344 close gaps slices 1-5 left:
+enum NotificationType {
+  PULL_REQUEST_CANCELLED
+  PULL_REQUEST_COMPLETED
+  SHIPMENT_COMPLETED
+  # PO backfill signal from the inventory-sufficiency gates (#224).
+  INVENTORY_SHORTFALL
+  # A PR-REPL pull completed for a leaf that had already shipped (#341) -> SHIPPING.
+  REPLACEMENT_AFTER_SHIPMENT
+  # Openings became workable: the warehouse staged carts, or completed a pull that still had
+  # un-staged openings (#344) -> SHOP_ASSEMBLY_MANAGER. One per staging confirmation, never per
+  # opening, and silent when nothing actually became workable.
+  ASSEMBLY_WORK_AVAILABLE
+  # A replacement arrived for a leaf that has NOT shipped (#344) -> the assembler holding it.
+  REPLACEMENT_ARRIVED
+  # A blocked PR-REPL pull became coverable because a receive landed the stock it wanted (#344) ->
+  # WAREHOUSE. Deduped to one *unread* notification per pull; see notification_service.
+  PULL_UNBLOCKED
+}
+
+# received_by is NOT an input (#199): the backend stamps the Clerk-authenticated caller's display
+# name, so a receive records the person and not the relay's Windows account.
 input CreateReceiveInput {
   po_id: ID!
-  received_by: String!
   line_items: [ReceiveLineItemInput!]!
+  warehouse_id: ID
+  # Short-circuits a retried receive against the same GP receipt (services/gp_idempotency.py).
+  idempotency_key: String! = ""
 }
 
 input ReceiveLineItemInput {
@@ -316,6 +374,8 @@ input LocationInput {
   row: String!
   bay: String!
   quantity: Int!
+  # Units of this location's quantity arriving already damaged; 0 <= deficient_quantity <= quantity.
+  deficient_quantity: Int! = 0
 }
 
 input ConfirmShipmentInput {
@@ -371,24 +431,24 @@ type Query {
   openPOs(projectId: ID): [PurchaseOrder!]!
   poReceivingDetails(poId: ID!): PurchaseOrder!
   projectInventoryAvailability(projectId: ID!): [InventoryAvailability!]!
-  inventoryHierarchy(projectId: ID!): [InventoryHierarchyNode!]!
-  inventoryItems(projectId: ID!, category: String!, productCode: String!): [InventoryItemDetail!]!
+  inventoryHierarchy(projectId: ID, warehouseId: ID): [InventoryHierarchyNode!]!
+  inventoryItems(projectId: ID, category: String!, productCode: String!): [InventoryItemDetail!]!
   unlocatedInventory(projectId: ID): [InventoryItemDetail!]!
-  recentReceiveRecords(limit: Int = 10): [RecentReceiveRecord!]!
-  openingItems(projectId: ID!): [OpeningItem!]!
+  recentReceiveRecords(limit: Int! = 10): [RecentReceiveRecord!]!
+  openingItems(projectId: ID): [OpeningItem!]!
   openingItemDetails(id: ID!): OpeningItemDetail!
-  pullRequests(projectId: ID!, source: PullRequestSource, status: PullRequestStatus): [PullRequest!]!
+  pullRequests(projectId: ID, source: PullRequestSource, status: PullRequestStatus): [PullRequest!]!
   pullRequestDetails(id: ID!): PullRequest!
   # The shop-assembly openings a pull covers, with their hardware lines, for the warehouse's
   # per-opening staging checklist (#343). Deliberately a separate query rather than a field on
   # PullRequest: a resolver field would run once per row of the pull-request queue, which never
   # needs it. Empty for a shipping-out / PR-REPL / legacy pull.
   pullRequestOpenings(pullRequestId: ID!): [ShopAssemblyOpening!]!
-  shipReadyItems(projectId: ID!): ShipReadyItems!
+  shipReadyItems(projectId: ID): ShipReadyItems!
   projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
   packingSlips(projectId: ID): [PackingSlip!]!
   returnableLines(packingSlipId: ID!): [ReturnableLine!]!
-  notifications(projectId: ID!, recipientRole: String!, unreadOnly: Boolean, limit: Int = 5): [Notification!]!
+  notifications(projectId: ID, recipientRole: String!, unreadOnly: Boolean, limit: Int! = 5): [Notification!]!
 }
 
 type Mutation {
@@ -412,7 +472,7 @@ type Mutation {
   moveInventoryLocation(inventoryLocationId: ID!, newAisle: String!, newRow: String!, newBay: String!): InventoryLocation!
   markInventoryUnlocated(inventoryLocationId: ID!): InventoryLocation!
   assignInventoryLocation(inventoryLocationId: ID!, aisle: String!, row: String!, bay: String!): InventoryLocation!
-  moveOpeningItemLocation(openingItemId: ID!, aisle: String!, row: String!, bay: String!): OpeningItem!
+  moveOpeningItemLocation(openingItemId: ID!, aisle: String!, row: String!, bay: String!, warehouseId: ID): OpeningItem!
   markOpeningItemUnlocated(openingItemId: ID!): OpeningItem!
   assignOpeningItemLocation(openingItemId: ID!, aisle: String!, row: String!, bay: String!): OpeningItem!
   markNotificationAsRead(id: ID!): Notification!

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -109,6 +109,20 @@ class NotificationType(str, enum.Enum):
     # is real and is owed to an opening that is no longer in the building, so it must not be left to
     # sit silently in the shop - this is the signal that routes it into reallocation/site shipment.
     REPLACEMENT_AFTER_SHIPMENT = "REPLACEMENT_AFTER_SHIPMENT"
+    # Openings became workable on the assembly floor (#344): the warehouse staged one or more carts,
+    # or completed a pull that still had un-staged openings on it. Addressed to the shop-assembly
+    # manager audience, because the actionable consequence is that the assignment board has work in
+    # it that nobody is holding yet. Raised once per staging confirmation, never per opening.
+    ASSEMBLY_WORK_AVAILABLE = "ASSEMBLY_WORK_AVAILABLE"
+    # Replacement hardware arrived for a leaf that has NOT shipped (#344), addressed to the
+    # assembler holding it. The shipped case has its own type above, because it is somebody else's
+    # problem entirely; this one is "go and fit it", and it is the missing half of the #341 loop.
+    REPLACEMENT_ARRIVED = "REPLACEMENT_ARRIVED"
+    # A PENDING replacement (PR-REPL) pull that could not be covered is now coverable, because a
+    # receive landed the stock it was waiting on (#344). Addressed to the warehouse: a replacement
+    # pull holds no reservation (a deficiency cannot be foreseen), so nothing else was going to tell
+    # anybody it had become approvable. Deduped to one *unread* notification per pull.
+    PULL_UNBLOCKED = "PULL_UNBLOCKED"
 
 
 class AuditEntityType(str, enum.Enum):

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, Enum, ForeignKey, Index, String
+from sqlalchemy import Boolean, Enum, ForeignKey, Index, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from . import Base
@@ -17,6 +17,15 @@ class Notification(Base):
             "recipient_role",
             "is_read",
         ),
+        # The dedupe lookup for the "this pull is unblocked again" signal (#344): does this pull
+        # already have an unread notification of this type? Partial, because only the handful of
+        # notifications that are *about* a pull carry the FK at all.
+        Index(
+            "ix_notifications_pull_request_unread",
+            "pull_request_id",
+            "type",
+            postgresql_where=text("pull_request_id IS NOT NULL AND is_read = false"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -27,5 +36,16 @@ class Notification(Base):
         nullable=False,
     )
     message: Mapped[str] = mapped_column(String, nullable=False)
+    # The pull this notification is about, when it is about one (#344). Nullable and set only by the
+    # pull-centred signals, so it is a discriminated extra rather than a required column.
+    #
+    # It exists because the "unblocked" notification needs an exact dedupe key. Matching on the
+    # request number inside `message` would work until somebody rewords the message, and this whole
+    # slice is about states that were only knowable by reading prose. ON DELETE SET NULL, because
+    # #325's reopen hard-deletes a still-PENDING pull and the notification is still a true record of
+    # something that happened.
+    pull_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("pull_requests.id", ondelete="SET NULL"), nullable=True
+    )
     is_read: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -28,6 +28,7 @@ from app.models.enums import (
 )
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.opening_item import OpeningItemHardware as OIHModel
+from app.models.project import Project
 from app.models.pull_request import (
     PullRequest as PullRequestModel,
 )
@@ -1143,3 +1144,669 @@ def reopen_shop_assembly_request(
 
     warehouse_repository.discard_pending_pull_request(session, pr.id if pr is not None else None)
     return sar
+
+
+# ---------------------------------------------------------------------------
+# Pipeline observability (#344)
+# ---------------------------------------------------------------------------
+#
+# Slices 1-5 each added a state, and each one is legible only from the screen that writes it. A
+# request holds a reservation (#342), its pull is part-staged (#343), one leaf is half-built (#340),
+# another is finished but owed a replacement (#341) - and answering "where is opening A01 leaf 2?"
+# meant opening four views and joining them up by eye.
+#
+# Nothing below stores anything. Every value is derived from state slices 1-5 already persist, which
+# is deliberate: a denormalised `pipeline_stage` column would be a fifth thing that can disagree with
+# the other four, and this slice exists because the four already disagree on screen.
+#
+# **Everything is a scalar aggregate.** The rollups are `count`/`sum` with `FILTER`, grouped by
+# request, one statement each for the entire result set - never a `len()` over loaded openings
+# (CLAUDE.md perf rules). `get_assembly_pipeline_summaries` runs a fixed FIVE statements whether it
+# is scoped to one project or to all of them, and `get_assembly_pipeline` runs a fixed EIGHT however
+# many openings a request has. That flatness is what the tests assert, because it is the property
+# that makes the All-Projects view survivable.
+
+# Order of the ladder. The stage of a *request* is the stage of its least-advanced opening: what a
+# pipeline is asked is "what is holding this up", not "what is the best news in it". REJECTED sits
+# below everything because it is not a point on the journey but leaving it, and CANCELLED shares the
+# floor with REQUESTED because that is literally where a cancelled pull puts its openings back
+# (#343: the request returns to PENDING for re-acceptance).
+PIPELINE_STAGE_RANK = {
+    "REJECTED": -1,
+    "CANCELLED": 0,
+    "REQUESTED": 0,
+    "ACCEPTED": 1,
+    "PULLING": 2,
+    "STAGED": 3,
+    "ASSIGNED": 4,
+    "IN_PROGRESS": 5,
+    "COMPLETED": 6,
+    "SHIPPED": 7,
+}
+
+
+@dataclass(frozen=True)
+class PipelineOpening:
+    """Where one door leaf is, and what it is carrying (#344).
+
+    `stage` is the derived ladder position; every raw fact it was derived from is on the row too, so
+    a caller that reads the situation differently can show its own reading rather than be stuck with
+    this one.
+    """
+
+    shop_assembly_opening_id: uuid.UUID
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    location: str | None
+    stage: str
+    pull_status: PullStatus
+    staged_at: datetime | None
+    staged_by: str | None
+    assigned_to_user_id: str | None
+    assigned_to: str | None
+    assembly_status: AssemblyStatus
+    completed_at: datetime | None
+    planned_unit_count: int
+    installed_unit_count: int
+    deficient_unit_count: int
+    replacement_pending_unit_count: int
+    opening_item_id: uuid.UUID | None
+    opening_item_state: OpeningItemState | None
+    # Where the assembled leaf physically is, once there is one - the "completed (location)" rung.
+    assembled_location: str | None
+
+    @property
+    def awaiting_replacement_unit_count(self) -> int:
+        """Units this leaf is still owed: condemned-and-unreplaced plus arrived-but-not-fitted. The
+        same reading `get_awaiting_replacement_quantities` gives the shipping guard (#341), taken
+        here from counts the row already carries."""
+        return self.deficient_unit_count + self.replacement_pending_unit_count
+
+    @property
+    def replacement_arrived_after_ship(self) -> bool:
+        """Replacement hardware is sitting for a leaf that has already left the building (#341).
+        `installReplacement` refuses it and it needs reallocation, so it is the one flag on this row
+        that is somebody else's job entirely."""
+        return self.replacement_pending_unit_count > 0 and self.opening_item_state == OpeningItemState.SHIPPED_OUT
+
+
+@dataclass(frozen=True)
+class AssemblyPipelineSummary:
+    """One shop-assembly request's whole journey, in counts (#344).
+
+    Safe to list at All-Projects scale: every field comes from a grouped aggregate over the whole
+    result set, so adding requests adds rows to five queries rather than adding queries.
+    """
+
+    request_id: uuid.UUID
+    request_number: str
+    project_id: uuid.UUID
+    # The project this request belongs to, so the All-Projects list can say which one without a
+    # second lookup: `project_code` is the human job number, `project_name` its description.
+    project_code: str | None
+    project_name: str | None
+    request_status: ShopAssemblyRequestStatus
+    created_by: str
+    created_at: datetime
+    accepted_by: str | None
+    accepted_at: datetime | None
+    rejected_by: str | None
+    rejected_at: datetime | None
+    # The #342 flag the accept screen already shows as an amber alert - carried here too, so the
+    # pipeline does not quietly become a second, more trusting view of the same request.
+    integrity_note: str | None
+
+    # The live pull (the one a re-accept minted, never a cancelled one - #343 made request_number
+    # unique only among live pulls).
+    pull_request_id: uuid.UUID | None
+    pull_request_status: PullRequestStatus | None
+    pull_approved_at: datetime | None
+    pull_completed_at: datetime | None
+    # Derived staging rollup, the same reading PullRequest.stagingStatus gives (#343).
+    staging_status: PullStatus | None
+
+    # Cancellation history. A cancelled pull keeps its number and its openings go back to a PENDING
+    # request, so without this a cancelled-and-returned request would read as never having been
+    # accepted at all.
+    cancelled_pull_count: int
+    last_cancelled_at: datetime | None
+    last_cancelled_by: str | None
+    last_cancellation_reason: str | None
+
+    opening_count: int
+    staged_opening_count: int
+    assigned_opening_count: int
+    in_progress_opening_count: int
+    completed_opening_count: int
+    shipped_opening_count: int
+
+    planned_unit_count: int
+    installed_unit_count: int
+    deficient_unit_count: int
+    replacement_pending_unit_count: int
+
+    # Openings with something still owed to them, and the subset whose leaf has already shipped.
+    awaiting_replacement_opening_count: int
+    replacement_after_ship_opening_count: int
+
+    stage: str
+
+
+@dataclass(frozen=True)
+class AssemblyPipeline:
+    """A request's summary plus a row per door leaf - the detail view (#344)."""
+
+    summary: AssemblyPipelineSummary
+    openings: list[PipelineOpening]
+
+
+def _opening_stage(
+    *,
+    request_status: ShopAssemblyRequestStatus,
+    pull_request_id: uuid.UUID | None,
+    pull_status: PullStatus,
+    assembly_status: AssemblyStatus,
+    assigned_to_user_id: str | None,
+    opening_item_state: OpeningItemState | None,
+    live_pull_status: PullRequestStatus | None,
+    had_cancelled_pull: bool,
+) -> str:
+    """The furthest rung one opening has provably reached (#344).
+
+    Read top-down; the first true statement wins, so a completed leaf that has shipped reports
+    SHIPPED rather than COMPLETED. The two facts that are *not* about this opening - the request
+    being rejected, and the pull being cancelled - are checked at the ends rather than the middle: a
+    rejection kills the whole request however far any leaf got, and a cancellation is only reachable
+    once the opening has been detached from its pull.
+    """
+    if request_status == ShopAssemblyRequestStatus.REJECTED:
+        return "REJECTED"
+    if opening_item_state == OpeningItemState.SHIPPED_OUT:
+        return "SHIPPED"
+    if assembly_status == AssemblyStatus.COMPLETED:
+        return "COMPLETED"
+    if assembly_status == AssemblyStatus.IN_PROGRESS:
+        return "IN_PROGRESS"
+    if pull_status == PullStatus.PULLED:
+        return "ASSIGNED" if assigned_to_user_id else "STAGED"
+    if pull_request_id is None:
+        # Detached: either the accept has not happened yet, or a cancellation released it (#343),
+        # which also put the request back to PENDING. The cancelled pull is the only way to tell
+        # those two apart, and telling them apart is the whole point of showing a cancellation.
+        return "CANCELLED" if had_cancelled_pull else "REQUESTED"
+    if live_pull_status == PullRequestStatus.PENDING:
+        return "ACCEPTED"
+    if live_pull_status == PullRequestStatus.CANCELLED:
+        return "CANCELLED"
+    # The pull is approved and stock has left inventory, but this opening's own cart is not built.
+    return "PULLING"
+
+
+def _request_stage(counts: dict, unstaged_stage: str, request_status: ShopAssemblyRequestStatus) -> str:
+    """The stage of a request's least-advanced opening - what the request is waiting on - derived
+    from the **counts alone**, never from loaded opening rows.
+
+    This is the one place the ladder is collapsed for a whole request, and it is written against
+    aggregates on purpose: the All-Projects list needs it on every row, and the detail view uses the
+    very same summary rather than a second implementation, so the number under the header and the
+    rows beneath it cannot disagree. A test pins the two together by asserting that this equals the
+    minimum of the per-opening stages `_opening_stage` produces.
+
+    `unstaged_stage` is what an opening of this request that is *not yet staged* reads as - REQUESTED,
+    ACCEPTED, PULLING or CANCELLED. It is a property of the request's pull, not of any one opening,
+    which is why it can be passed in: every opening of a request shares one `pull_request_id` (accept
+    links them all, reopen and cancel detach them all).
+    """
+    if request_status == ShopAssemblyRequestStatus.REJECTED:
+        return "REJECTED"
+    total = counts["opening_count"]
+    if total == 0:
+        # #342 refuses to create a request with no openings, but legacy rows exist and must not take
+        # the list down.
+        return unstaged_stage
+    if total - counts["staged_opening_count"] > 0:
+        return unstaged_stage
+    if counts["staged_unassigned_pending_count"] > 0:
+        return "STAGED"
+    if counts["staged_assigned_pending_count"] > 0:
+        return "ASSIGNED"
+    if counts["in_progress_opening_count"] > 0:
+        return "IN_PROGRESS"
+    if counts["completed_opening_count"] > counts["shipped_opening_count"]:
+        return "COMPLETED"
+    return "SHIPPED"
+
+
+def _pull_rows_by_request_number(session: Session, request_numbers: list[str]) -> dict[str, list[PullRequestModel]]:
+    """Every pull ever minted for these request numbers, live and cancelled, oldest first.
+
+    One statement for the whole page. A cancelled pull keeps its number (#343 replaced the global
+    unique constraint with one that excludes CANCELLED), so a request that has been through a
+    cancel/re-accept cycle legitimately has several - and the cancelled ones are exactly the history
+    the pipeline exists to surface.
+    """
+    if not request_numbers:
+        return {}
+    rows = session.scalars(
+        select(PullRequestModel)
+        .where(
+            PullRequestModel.request_number.in_(request_numbers),
+            PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
+            PullRequestModel.deleted_at.is_(None),
+        )
+        .order_by(PullRequestModel.created_at.asc())
+    ).all()
+    grouped: dict[str, list[PullRequestModel]] = {}
+    for pr in rows:
+        grouped.setdefault(pr.request_number, []).append(pr)
+    return grouped
+
+
+def _opening_stage_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid.UUID, dict]:
+    """Per-request opening counts, in ONE grouped aggregate over every request given.
+
+    `count(*) FILTER (...)` rather than four queries, and rather than a Python pass over loaded rows:
+    these are the fields the All-Projects list renders on every row.
+    """
+    if not request_ids:
+        return {}
+    in_progress = ShopAssemblyOpening.assembly_status == AssemblyStatus.IN_PROGRESS
+    completed = ShopAssemblyOpening.assembly_status == AssemblyStatus.COMPLETED
+    staged = ShopAssemblyOpening.pull_status == PullStatus.PULLED
+    held = ShopAssemblyOpening.assigned_to_user_id.is_not(None)
+    # Staged-and-untouched, split by whether anybody is holding it: the STAGED and ASSIGNED rungs.
+    # They cannot be reconstructed from the other four counts, because `remove_opening_from_user`
+    # (#340) allows unassigning an IN_PROGRESS leaf, so "assigned" and "started" are independent.
+    untouched = and_(staged, ShopAssemblyOpening.assembly_status == AssemblyStatus.PENDING)
+    rows = session.execute(
+        select(
+            ShopAssemblyOpening.shop_assembly_request_id.label("request_id"),
+            func.count(1).label("total"),
+            func.count(1).filter(staged).label("staged"),
+            func.count(1).filter(held).label("assigned"),
+            func.count(1).filter(in_progress).label("in_progress"),
+            func.count(1).filter(completed).label("completed"),
+            func.count(1).filter(and_(untouched, held)).label("staged_assigned_pending"),
+            func.count(1)
+            .filter(and_(untouched, ShopAssemblyOpening.assigned_to_user_id.is_(None)))
+            .label("staged_unassigned_pending"),
+        )
+        .where(ShopAssemblyOpening.shop_assembly_request_id.in_(request_ids))
+        .group_by(ShopAssemblyOpening.shop_assembly_request_id)
+    ).all()
+    return {
+        row.request_id: {
+            "opening_count": int(row.total),
+            "staged_opening_count": int(row.staged),
+            "assigned_opening_count": int(row.assigned),
+            "in_progress_opening_count": int(row.in_progress),
+            "completed_opening_count": int(row.completed),
+            "staged_assigned_pending_count": int(row.staged_assigned_pending),
+            "staged_unassigned_pending_count": int(row.staged_unassigned_pending),
+        }
+        for row in rows
+    }
+
+
+def _unit_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid.UUID, dict]:
+    """Per-request unit rollups, in ONE statement: the progress counters summed, plus how many
+    openings have something outstanding.
+
+    The "how many openings" part is why this is a two-level aggregate rather than a flat one -
+    "openings with anything owed" counts groups that satisfy a predicate on their own sum, so the
+    per-opening sums are computed in a subquery and rolled up in the outer select. Still one
+    round-trip, still no rows loaded.
+    """
+    if not request_ids:
+        return {}
+    per_opening = (
+        select(
+            ShopAssemblyOpening.shop_assembly_request_id.label("request_id"),
+            ShopAssemblyOpening.id.label("opening_id"),
+            func.coalesce(func.sum(ShopAssemblyOpeningItem.quantity), 0).label("planned"),
+            func.coalesce(func.sum(ShopAssemblyOpeningItem.installed_quantity), 0).label("installed"),
+            func.coalesce(func.sum(ShopAssemblyOpeningItem.deficient_quantity), 0).label("deficient"),
+            func.coalesce(func.sum(ShopAssemblyOpeningItem.replacement_pending_quantity), 0).label("pending"),
+        )
+        .join(
+            ShopAssemblyOpeningItem,
+            ShopAssemblyOpeningItem.shop_assembly_opening_id == ShopAssemblyOpening.id,
+        )
+        .where(ShopAssemblyOpening.shop_assembly_request_id.in_(request_ids))
+        .group_by(ShopAssemblyOpening.shop_assembly_request_id, ShopAssemblyOpening.id)
+        .subquery()
+    )
+    outstanding = per_opening.c.deficient + per_opening.c.pending
+    rows = session.execute(
+        select(
+            per_opening.c.request_id,
+            func.coalesce(func.sum(per_opening.c.planned), 0).label("planned"),
+            func.coalesce(func.sum(per_opening.c.installed), 0).label("installed"),
+            func.coalesce(func.sum(per_opening.c.deficient), 0).label("deficient"),
+            func.coalesce(func.sum(per_opening.c.pending), 0).label("pending"),
+            func.count(1).filter(outstanding > 0).label("awaiting_openings"),
+        ).group_by(per_opening.c.request_id)
+    ).all()
+    return {
+        row.request_id: {
+            "planned_unit_count": int(row.planned),
+            "installed_unit_count": int(row.installed),
+            "deficient_unit_count": int(row.deficient),
+            "replacement_pending_unit_count": int(row.pending),
+            "awaiting_replacement_opening_count": int(row.awaiting_openings),
+        }
+        for row in rows
+    }
+
+
+def _shipped_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid.UUID, dict]:
+    """Per-request shipped-leaf counts, in ONE statement.
+
+    There is no FK from a ShopAssemblyOpening to the leaf it produced, so this joins the way
+    `find_assembled_leaf` keys it - (project, opening_id, leaf), a legacy null leaf matching only a
+    null leaf - and scopes the join to the request's own project, because `opening_id` is a
+    historical stamp that a re-upload can reissue.
+
+    `count(DISTINCT opening)` because the item join fans the rows out, and because a leaf that
+    shipped and was then re-assembled by a correction has more than one OpeningItem. Counting an
+    opening as shipped when *any* of its rows shipped is the conservative reading for a rollup; the
+    per-leaf detail view resolves that ambiguity properly, live row winning, exactly as
+    `find_assembled_leaf` does.
+    """
+    if not request_ids:
+        return {}
+    shipped = OpeningItemModel.state == OpeningItemState.SHIPPED_OUT
+    rows = session.execute(
+        select(
+            ShopAssemblyOpening.shop_assembly_request_id.label("request_id"),
+            func.count(func.distinct(ShopAssemblyOpening.id)).filter(shipped).label("shipped"),
+            func.count(func.distinct(ShopAssemblyOpening.id))
+            .filter(and_(shipped, ShopAssemblyOpeningItem.replacement_pending_quantity > 0))
+            .label("after_ship"),
+        )
+        .select_from(ShopAssemblyOpening)
+        .join(ShopAssemblyRequest, ShopAssemblyRequest.id == ShopAssemblyOpening.shop_assembly_request_id)
+        .join(
+            OpeningItemModel,
+            and_(
+                OpeningItemModel.opening_id == ShopAssemblyOpening.opening_id,
+                OpeningItemModel.leaf.is_not_distinct_from(ShopAssemblyOpening.leaf),
+                OpeningItemModel.project_id == ShopAssemblyRequest.project_id,
+            ),
+        )
+        .outerjoin(
+            ShopAssemblyOpeningItem,
+            ShopAssemblyOpeningItem.shop_assembly_opening_id == ShopAssemblyOpening.id,
+        )
+        .where(ShopAssemblyOpening.shop_assembly_request_id.in_(request_ids))
+        .group_by(ShopAssemblyOpening.shop_assembly_request_id)
+    ).all()
+    return {
+        row.request_id: {
+            "shipped_opening_count": int(row.shipped),
+            "replacement_after_ship_opening_count": int(row.after_ship),
+        }
+        for row in rows
+    }
+
+
+_EMPTY_OPENING_COUNTS = {
+    "opening_count": 0,
+    "staged_opening_count": 0,
+    "assigned_opening_count": 0,
+    "in_progress_opening_count": 0,
+    "completed_opening_count": 0,
+    "staged_assigned_pending_count": 0,
+    "staged_unassigned_pending_count": 0,
+}
+_EMPTY_UNIT_COUNTS = {
+    "planned_unit_count": 0,
+    "installed_unit_count": 0,
+    "deficient_unit_count": 0,
+    "replacement_pending_unit_count": 0,
+    "awaiting_replacement_opening_count": 0,
+}
+_EMPTY_SHIPPED_COUNTS = {"shipped_opening_count": 0, "replacement_after_ship_opening_count": 0}
+
+
+def get_assembly_pipeline_summaries(
+    session: Session,
+    project_id: uuid.UUID | None = None,
+    status: ShopAssemblyRequestStatus | None = None,
+    request_ids: list[uuid.UUID] | None = None,
+) -> list[AssemblyPipelineSummary]:
+    """Every shop-assembly request's journey, in counts (#344). FIVE statements, always.
+
+    The statement count does not depend on how many requests come back or how many openings they
+    have, which is the requirement: with `project_id` omitted this is the All-Projects view, and a
+    per-request follow-up query here would be the pattern CLAUDE.md's perf rules exist to prevent.
+    The five are: the requests (with their project name), every pull ever minted for them, and the
+    three grouped aggregates - opening stages, unit progress, shipped leaves.
+
+    Legacy #222 openings that hang straight off a PullRequest with no ShopAssemblyRequest are not
+    covered, because there is no request for them to be a pipeline *of*. They remain visible in the
+    Assemble List and the pull queue, which is where they always were.
+    """
+    # Local, matching the rest of this module: `warehouse.pull_requests` imports back into here at
+    # call time for the replacement-arrival path, so the two packages stay uncoupled at import time.
+    from app.repositories.warehouse import StagingSummary as warehouse_staging_summary
+
+    stmt = (
+        select(ShopAssemblyRequest, Project.project_id, Project.description)
+        .outerjoin(Project, Project.id == ShopAssemblyRequest.project_id)
+        .order_by(ShopAssemblyRequest.created_at.desc())
+    )
+    if project_id is not None:
+        stmt = stmt.where(ShopAssemblyRequest.project_id == project_id)
+    if status is not None:
+        stmt = stmt.where(ShopAssemblyRequest.status == status)
+    if request_ids is not None:
+        if not request_ids:
+            return []
+        stmt = stmt.where(ShopAssemblyRequest.id.in_(request_ids))
+    rows = session.execute(stmt).all()
+    if not rows:
+        return []
+
+    ids = [sar.id for sar, _code, _name in rows]
+    pulls_by_number = _pull_rows_by_request_number(session, [sar.request_number for sar, _c, _n in rows])
+    opening_counts = _opening_stage_counts(session, ids)
+    unit_counts = _unit_counts(session, ids)
+    shipped_counts = _shipped_counts(session, ids)
+
+    summaries: list[AssemblyPipelineSummary] = []
+    for sar, project_code, project_name in rows:
+        pulls = pulls_by_number.get(sar.request_number, [])
+        cancelled = [p for p in pulls if p.status == PullRequestStatus.CANCELLED]
+        live = next((p for p in reversed(pulls) if p.status != PullRequestStatus.CANCELLED), None)
+        counts = {
+            **_EMPTY_OPENING_COUNTS,
+            **opening_counts.get(sar.id, {}),
+            **_EMPTY_UNIT_COUNTS,
+            **unit_counts.get(sar.id, {}),
+            **_EMPTY_SHIPPED_COUNTS,
+            **shipped_counts.get(sar.id, {}),
+        }
+        # What an un-staged opening of this request reads as. A property of the pull, not of any one
+        # opening, so it is computed once here with a placeholder opening.
+        unstaged_stage = _opening_stage(
+            request_status=sar.status,
+            pull_request_id=live.id if live is not None else None,
+            pull_status=PullStatus.NOT_PULLED,
+            assembly_status=AssemblyStatus.PENDING,
+            assigned_to_user_id=None,
+            opening_item_state=None,
+            live_pull_status=live.status if live is not None else None,
+            had_cancelled_pull=bool(cancelled),
+        )
+        staging_status = None
+        if counts["opening_count"] > 0:
+            # Reuse #343's derivation rather than restate it: PARTIAL is the aggregate reading over a
+            # set of openings, and there must be exactly one place that decides what it means.
+            staging_status = warehouse_staging_summary(
+                staged_opening_count=counts["staged_opening_count"],
+                total_opening_count=counts["opening_count"],
+            ).status
+        summaries.append(
+            AssemblyPipelineSummary(
+                request_id=sar.id,
+                request_number=sar.request_number,
+                project_id=sar.project_id,
+                project_code=project_code,
+                project_name=project_name,
+                request_status=sar.status,
+                created_by=sar.created_by,
+                created_at=sar.created_at,
+                accepted_by=sar.approved_by,
+                accepted_at=sar.approved_at,
+                rejected_by=sar.rejected_by,
+                rejected_at=sar.rejected_at,
+                integrity_note=sar.integrity_note,
+                pull_request_id=live.id if live is not None else None,
+                pull_request_status=live.status if live is not None else None,
+                pull_approved_at=live.approved_at if live is not None else None,
+                pull_completed_at=live.completed_at if live is not None else None,
+                staging_status=staging_status,
+                cancelled_pull_count=len(cancelled),
+                last_cancelled_at=cancelled[-1].cancelled_at if cancelled else None,
+                last_cancelled_by=cancelled[-1].cancelled_by if cancelled else None,
+                last_cancellation_reason=cancelled[-1].cancellation_reason if cancelled else None,
+                opening_count=counts["opening_count"],
+                staged_opening_count=counts["staged_opening_count"],
+                assigned_opening_count=counts["assigned_opening_count"],
+                in_progress_opening_count=counts["in_progress_opening_count"],
+                completed_opening_count=counts["completed_opening_count"],
+                shipped_opening_count=counts["shipped_opening_count"],
+                planned_unit_count=counts["planned_unit_count"],
+                installed_unit_count=counts["installed_unit_count"],
+                deficient_unit_count=counts["deficient_unit_count"],
+                replacement_pending_unit_count=counts["replacement_pending_unit_count"],
+                awaiting_replacement_opening_count=counts["awaiting_replacement_opening_count"],
+                replacement_after_ship_opening_count=counts["replacement_after_ship_opening_count"],
+                stage=_request_stage(counts, unstaged_stage, sar.status),
+            )
+        )
+    return summaries
+
+
+def get_assembly_pipeline(session: Session, request_id: uuid.UUID) -> AssemblyPipeline:
+    """One request's pipeline: the summary, plus a row per door leaf (#344). EIGHT statements,
+    however many openings the request has.
+
+    The summary comes from `get_assembly_pipeline_summaries` rather than from the opening rows loaded
+    below, and that is worth three extra aggregate queries on a single request: it means the header
+    numbers on this screen are *by construction* the same numbers as the row for this request in the
+    list, and it keeps the aggregate rule honest rather than "honest except on the detail page".
+
+    The three statements this adds are the opening rows themselves, one grouped aggregate of their
+    hardware lines, and one fetch of the assembled leaves. That is flat in the number of openings,
+    which is what `test_pipeline_detail_query_count_is_flat_as_openings_grow` pins down.
+    """
+    summaries = get_assembly_pipeline_summaries(session, request_ids=[request_id])
+    if not summaries:
+        raise NotFoundError(f"Shop-assembly request {request_id} not found")
+    summary = summaries[0]
+
+    openings = list(
+        session.scalars(
+            select(ShopAssemblyOpening)
+            .where(ShopAssemblyOpening.shop_assembly_request_id == request_id)
+            .order_by(ShopAssemblyOpening.opening_number.asc(), ShopAssemblyOpening.leaf.asc())
+        ).all()
+    )
+    if not openings:
+        return AssemblyPipeline(summary=summary, openings=[])
+
+    opening_ids = [o.id for o in openings]
+    # One grouped aggregate for every opening's hardware lines - not a selectinload plus a Python
+    # sum, because the four counters are all this view wants and summing them in the database is
+    # both the rule and the cheaper read.
+    sums_by_opening = {
+        row.opening_id: row
+        for row in session.execute(
+            select(
+                ShopAssemblyOpeningItem.shop_assembly_opening_id.label("opening_id"),
+                func.coalesce(func.sum(ShopAssemblyOpeningItem.quantity), 0).label("planned"),
+                func.coalesce(func.sum(ShopAssemblyOpeningItem.installed_quantity), 0).label("installed"),
+                func.coalesce(func.sum(ShopAssemblyOpeningItem.deficient_quantity), 0).label("deficient"),
+                func.coalesce(func.sum(ShopAssemblyOpeningItem.replacement_pending_quantity), 0).label("pending"),
+            )
+            .where(ShopAssemblyOpeningItem.shop_assembly_opening_id.in_(opening_ids))
+            .group_by(ShopAssemblyOpeningItem.shop_assembly_opening_id)
+        ).all()
+    }
+
+    # The assembled leaves, in one fetch for the whole request rather than a find_assembled_leaf call
+    # per opening. The live-wins-over-shipped and latest-wins tie-breaks are applied here in exactly
+    # the order that function documents, so a leaf that shipped and was re-assembled resolves the
+    # same way in both places.
+    leaves: dict[tuple[uuid.UUID, int | None], OpeningItemModel] = {}
+    for oi in session.scalars(
+        select(OpeningItemModel).where(
+            OpeningItemModel.project_id == summary.project_id,
+            OpeningItemModel.opening_id.in_({o.opening_id for o in openings}),
+        )
+    ).all():
+        key = (oi.opening_id, oi.leaf)
+        incumbent = leaves.get(key)
+        if incumbent is None or _leaf_wins(oi, incumbent):
+            leaves[key] = oi
+
+    rows: list[PipelineOpening] = []
+    for opening in openings:
+        sums = sums_by_opening.get(opening.id)
+        leaf_row = leaves.get((opening.opening_id, opening.leaf))
+        rows.append(
+            PipelineOpening(
+                shop_assembly_opening_id=opening.id,
+                opening_number=opening.opening_number,
+                leaf=opening.leaf,
+                building=opening.building,
+                floor=opening.floor,
+                location=opening.location,
+                stage=_opening_stage(
+                    request_status=summary.request_status,
+                    pull_request_id=opening.pull_request_id,
+                    pull_status=opening.pull_status,
+                    assembly_status=opening.assembly_status,
+                    assigned_to_user_id=opening.assigned_to_user_id,
+                    opening_item_state=leaf_row.state if leaf_row is not None else None,
+                    live_pull_status=summary.pull_request_status,
+                    had_cancelled_pull=summary.cancelled_pull_count > 0,
+                ),
+                pull_status=opening.pull_status,
+                staged_at=opening.staged_at,
+                staged_by=opening.staged_by,
+                assigned_to_user_id=opening.assigned_to_user_id,
+                assigned_to=opening.assigned_to,
+                assembly_status=opening.assembly_status,
+                completed_at=opening.completed_at,
+                planned_unit_count=int(sums.planned) if sums is not None else 0,
+                installed_unit_count=int(sums.installed) if sums is not None else 0,
+                deficient_unit_count=int(sums.deficient) if sums is not None else 0,
+                replacement_pending_unit_count=int(sums.pending) if sums is not None else 0,
+                opening_item_id=leaf_row.id if leaf_row is not None else None,
+                opening_item_state=leaf_row.state if leaf_row is not None else None,
+                assembled_location=_format_location(leaf_row) if leaf_row is not None else None,
+            )
+        )
+    return AssemblyPipeline(summary=summary, openings=rows)
+
+
+def _leaf_wins(candidate: OpeningItemModel, incumbent: OpeningItemModel) -> bool:
+    """`find_assembled_leaf`'s tie-break, applied to a batch: a live row beats a shipped one, and
+    among equals the most recently assembled wins."""
+    candidate_live = candidate.state != OpeningItemState.SHIPPED_OUT
+    incumbent_live = incumbent.state != OpeningItemState.SHIPPED_OUT
+    if candidate_live != incumbent_live:
+        return candidate_live
+    return candidate.assembly_completed_at > incumbent.assembly_completed_at
+
+
+def _format_location(oi: OpeningItemModel) -> str | None:
+    """The assembled leaf's warehouse address, or None when it has not been put away. Joined here
+    rather than on the client so the pipeline and the warehouse views read the same."""
+    parts = [p for p in (oi.aisle, oi.row, oi.bay) if p]
+    return "-".join(parts) if parts else None

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -59,14 +59,17 @@ from .pull_requests import (
     get_pull_request_openings,
     get_pull_requests,
     get_pull_staging_summaries,
+    notify_assembly_work_available,
     stage_pull_openings,
 )
 from .receiving import (
     create_receive,
+    find_pending_replacement_pulls,
     get_back_ordered_items,
     get_expected_deliveries,
     get_po_receiving_details,
     get_recent_receive_records,
+    notify_unblocked_replacement_pulls,
     validate_receive_eligibility,
 )
 from .reservations import (
@@ -97,6 +100,7 @@ __all__ = [
     "create_receive",
     "create_reservations",
     "discard_pending_pull_request",
+    "find_pending_replacement_pulls",
     "find_reservation_holder",
     "get_audit_log",
     "get_back_ordered_items",
@@ -130,6 +134,8 @@ __all__ = [
     "move_inventory_location",
     "move_opening_item_location",
     "normalize_location_value",
+    "notify_assembly_work_available",
+    "notify_unblocked_replacement_pulls",
     "override_inventory_quantity",
     "release_reservations",
     "stage_pull_openings",

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -39,6 +39,11 @@ from .audit import _log_audit_event
 
 MAX_CANCELLATION_REASON_LENGTH = 500
 
+# How many openings a "work is available" notification names before it starts counting instead
+# (#344). A staging confirmation can cover a whole pull, and a bell entry listing forty openings is
+# not a notification, it is a report.
+_MAX_NAMED_OPENINGS_IN_MESSAGE = 5
+
 
 def get_pull_requests(
     session: Session,
@@ -448,15 +453,17 @@ def _apply_replacement_arrivals(session: Session, pr: PullRequestModel) -> None:
         item.deficient_quantity -= restored
         leaf_completed = opening.assembly_status == AssemblyStatus.COMPLETED
         opening_item = None
+        leaf_label = f"Opening {opening.opening_number}"
+        if opening.leaf is not None:
+            leaf_label += f" Leaf {opening.leaf}"
+        shipped = False
         if leaf_completed:
             item.replacement_pending_quantity += restored
             opening_item = shop_assembly_repository.find_assembled_leaf(
                 session, pr.project_id, opening.opening_id, opening.leaf
             )
-            if opening_item is not None and opening_item.state == OpeningItemState.SHIPPED_OUT:
-                leaf_label = f"Opening {opening.opening_number}"
-                if opening.leaf is not None:
-                    leaf_label += f" Leaf {opening.leaf}"
+            shipped = opening_item is not None and opening_item.state == OpeningItemState.SHIPPED_OUT
+            if shipped:
                 notification_service.create_notification(
                     session,
                     project_id=pr.project_id,
@@ -467,7 +474,35 @@ def _apply_replacement_arrivals(session: Session, pr: PullRequestModel) -> None:
                         f"{leaf_label}, which has already shipped. Route it through reallocation or a "
                         f"site shipment."
                     ),
+                    pull_request_id=pr.id,
                 )
+
+        # The ordinary case, which #341 left silent (#344). The shipped branch above told *shipping*
+        # that a leaf that had left the building was owed something; nothing told the person actually
+        # holding the leaf that the hardware they were waiting for had turned up. Addressed to the
+        # assembler's stable Clerk user id - the ShopAssemblyOpening keeps the assignment it was
+        # completed under, so on a finished leaf this is exactly who owns the replacement install.
+        #
+        # Skipped when nobody is holding the opening: an unassigned leaf's replacement is picked up
+        # by whoever claims it, and a notification with no addressee is noise. It is also skipped for
+        # the shipped case, which is not this person's problem any more.
+        if not shipped and opening.assigned_to_user_id:
+            where_it_lands = (
+                "It is waiting as a replacement install on the finished leaf."
+                if leaf_completed
+                else "It is back on the leaf's checklist as remaining work."
+            )
+            notification_service.create_notification(
+                session,
+                project_id=pr.project_id,
+                recipient_role=opening.assigned_to_user_id,
+                notification_type=NotificationType.REPLACEMENT_ARRIVED,
+                message=(
+                    f"{restored} x {item.product_code} replacement arrived on {pr.request_number} for "
+                    f"{leaf_label}. {where_it_lands}"
+                ),
+                pull_request_id=pr.id,
+            )
 
         _log_audit_event(
             session,
@@ -529,6 +564,7 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID, completed_by: str 
         recipient_role=pr.requested_by,
         notification_type=NotificationType.PULL_REQUEST_COMPLETED,
         message=f"Pull Request {pr.request_number} has been fulfilled.",
+        pull_request_id=pr.id,
     )
 
     # Replacement lines (#341) are keyed on the checklist line they are owed to, not on the PR's
@@ -553,6 +589,7 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID, completed_by: str 
         openings = session.scalars(
             select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id)
         ).all()
+        flipped: list[ShopAssemblyOpening] = []
         for opening in openings:
             # Idempotent for an opening already staged individually (#343): its own staged_at/by
             # stamp is the truth about when that cart was built and must not be overwritten by the
@@ -562,8 +599,55 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID, completed_by: str 
             opening.pull_status = PullStatus.PULLED
             opening.staged_at = now
             opening.staged_by = completed_by or pr.assigned_to or pr.requested_by
+            flipped.append(opening)
+        # Only the openings this call actually made workable (#344). That set is empty when staging
+        # completed the pull - `stage_pull_openings` has already flipped every one of them and raised
+        # its own notification - so the manager audience gets exactly one signal per real event, with
+        # no dedupe logic needed anywhere: the fact that governs is "did anything become workable
+        # here", and it is already computed.
+        notify_assembly_work_available(session, pr, flipped, completed_pull=True)
 
     return pr
+
+
+def notify_assembly_work_available(
+    session: Session,
+    pr: PullRequestModel,
+    openings: list[ShopAssemblyOpening],
+    *,
+    completed_pull: bool,
+) -> None:
+    """Tell the shop-assembly manager audience that openings just became workable (#344).
+
+    Before this, a cart staged at 9am (#343) made its opening assignable immediately and nothing said
+    so - the assignment board found out when somebody happened to reload it, which is the same
+    problem per-opening staging was meant to solve one layer down.
+
+    One notification per *confirmation*, not per opening: the warehouse stages a batch of carts in
+    one action, and N rows in the bell for one trip to the shelf is how a bell stops being read. The
+    openings are named up to a limit and then counted, so the message stays a message.
+
+    A no-op when nothing became workable, which is what keeps `complete_pull_request` from
+    double-announcing a pull that `stage_pull_openings` has already finished.
+    """
+    if not openings:
+        return
+    labels = sorted(f"{o.opening_number}" + (f" leaf {o.leaf}" if o.leaf is not None else "") for o in openings)
+    shown = ", ".join(labels[:_MAX_NAMED_OPENINGS_IN_MESSAGE])
+    if len(labels) > _MAX_NAMED_OPENINGS_IN_MESSAGE:
+        shown += f" and {len(labels) - _MAX_NAMED_OPENINGS_IN_MESSAGE} more"
+    tail = " That was the last of the pull." if completed_pull else " The rest of the pull is still being picked."
+    notification_service.create_notification(
+        session,
+        project_id=pr.project_id,
+        recipient_role=notification_service.SHOP_ASSEMBLY_MANAGER_RECIPIENT_ROLE,
+        notification_type=NotificationType.ASSEMBLY_WORK_AVAILABLE,
+        message=(
+            f"{len(labels)} opening(s) on Pull Request {pr.request_number} are staged and ready to "
+            f"assemble: {shown}.{tail}"
+        ),
+        pull_request_id=pr.id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -738,6 +822,16 @@ def stage_pull_openings(
     completed = summary.total_opening_count > 0 and summary.staged_opening_count >= summary.total_opening_count
     if completed:
         complete_pull_request(session, pr.id, completed_by=staged_by)
+
+    # Raised here rather than inside the loop so a batch confirmation is one signal (#344), and after
+    # the completion call so `completed_pull` is a fact and not a prediction. `complete_pull_request`
+    # finds nothing left to flip in this path, so it stays silent and there is no double-announce.
+    notify_assembly_work_available(
+        session,
+        pr,
+        [o for o in openings if o.id in set(newly_staged)],
+        completed_pull=completed,
+    )
 
     return StageResult(
         pull_request=pr,
@@ -1075,6 +1169,7 @@ def cancel_pull_request(
             + (f": {reason}" if reason else ".")
             + (" The hardware has been returned to inventory." if restocked else "")
         ),
+        pull_request_id=pr.id,
     )
 
     return CancelResult(

--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -3,17 +3,28 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import and_, exists, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import InvalidStateTransitionError, NotFoundError, ValidationError
-from app.models.enums import AuditAction, AuditEntityType, POStatus
+from app.models.enums import (
+    AuditAction,
+    AuditEntityType,
+    NotificationType,
+    POStatus,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+)
 from app.models.inventory import InventoryLocation as InventoryLocationModel
+from app.models.pull_request import PullRequest as PullRequestModel
+from app.models.pull_request import PullRequestItem as PullRequestItemModel
 from app.models.purchase_order import POLineItem as POLineItemModel
 from app.models.purchase_order import PurchaseOrder as POModel
 from app.models.receiving import ReceiveLineItem as ReceiveLineItemModel
 from app.models.receiving import ReceiveRecord as ReceiveRecordModel
 from app.models.vendor import Vendor as VendorModel
+from app.services import notification_service
 
 from .audit import _log_audit_event
 from .locations import _normalize_and_validate_location_fields
@@ -312,7 +323,140 @@ def create_receive(
     elif any_received and po.status not in (POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED):
         po.status = POStatus.PARTIALLY_RECEIVED
 
+    # The backfill retry loop for replacement pulls (#344). Stock arriving is the only thing that can
+    # unblock one, and until now nothing was watching. Stock-pool POs are skipped: a replacement pull
+    # draws on *project* inventory, and allocating from the pool is a separate deliberate act.
+    if not is_stock_po:
+        session.flush()
+        notify_unblocked_replacement_pulls(
+            session,
+            po.project_id,
+            {
+                (poli_dict[li["po_line_item_id"]].hardware_category, poli_dict[li["po_line_item_id"]].product_code)
+                for li in line_items_input
+            },
+        )
+
     return receive_record
+
+
+def find_pending_replacement_pulls(
+    session: Session,
+    project_id: uuid.UUID,
+    combos: set[tuple[str, str]] | None = None,
+) -> list[PullRequestModel]:
+    """PENDING replacement (PR-REPL) pulls in a project, optionally narrowed to those that want at
+    least one of `combos` (#344).
+
+    A replacement pull is identified **structurally** - a SHOP_ASSEMBLY pull at least one of whose
+    lines carries `sa_opening_item_id` (#339), i.e. a line minted against a specific deficient
+    checklist item - rather than by its `PR-REPL-` number prefix. The prefix is a display convention;
+    the FK is the thing that makes the pull a replacement, and a structural test cannot be broken by
+    renaming a request.
+
+    Narrowing by combo is the first half of the dedupe: a receive that landed nothing this pull wants
+    cannot have changed whether it is coverable, so there is no reason to look at it, let alone
+    announce it. Items are eager-loaded because the caller sums their needs.
+    """
+    is_replacement = (
+        select(PullRequestItemModel.id)
+        .where(
+            PullRequestItemModel.pull_request_id == PullRequestModel.id,
+            PullRequestItemModel.sa_opening_item_id.is_not(None),
+        )
+        .exists()
+    )
+    stmt = (
+        select(PullRequestModel)
+        .options(selectinload(PullRequestModel.items))
+        .where(
+            PullRequestModel.project_id == project_id,
+            PullRequestModel.deleted_at.is_(None),
+            PullRequestModel.source == PullRequestSource.SHOP_ASSEMBLY,
+            PullRequestModel.status == PullRequestStatus.PENDING,
+            is_replacement,
+        )
+    )
+    if combos is not None:
+        if not combos:
+            return []
+        wants_a_received_combo = exists().where(
+            PullRequestItemModel.pull_request_id == PullRequestModel.id,
+            or_(
+                *[
+                    and_(
+                        PullRequestItemModel.hardware_category == cat,
+                        PullRequestItemModel.product_code == code,
+                    )
+                    for cat, code in combos
+                ]
+            ),
+        )
+        stmt = stmt.where(wants_a_received_combo)
+    return list(session.scalars(stmt).unique().all())
+
+
+def notify_unblocked_replacement_pulls(
+    session: Session,
+    project_id: uuid.UUID | None,
+    received_combos: set[tuple[str, str]],
+) -> list:
+    """Tell the warehouse that a blocked replacement pull can now be approved (#344).
+
+    A PR-REPL pull is the one kind of pull that holds **no reservation** - nobody can claim stock for
+    a deficiency that has not happened yet (#342) - so it is also the only one whose demand nothing
+    was tracking. It sits PENDING, the approver sees INSUFFICIENT, the PO is told to backfill, and
+    when the backfill finally lands there is no signal that the pull is now approvable. Somebody has
+    to remember to go and retry it. This is that signal.
+
+    **Dedupe, in three parts, and each part is doing different work:**
+
+    1. *Relevance.* Only pulls that wanted one of the combos this receive actually landed are
+       considered. A receive of door closers cannot change whether a hinge replacement is coverable.
+    2. *Transition.* The pull must now be **fully** coverable, under the same reservation-aware
+       availability the approver will apply (`on-hand - deficient - everyone's reservations`, with no
+       self-exclusion, because a replacement pull holds nothing of its own to exclude). A receive that
+       narrows the gap without closing it changes nothing the warehouse can act on, so it says
+       nothing. This is the "insufficient -> sufficient" edge.
+    3. *Open signal.* One **unread** notification per pull. If the last one has not been read yet,
+       the warehouse already knows; raising a second is noise. Once it has been read the signal has
+       done its job, so a pull that goes short again and is later covered again gets a fresh one.
+
+    Returns the notifications raised, so callers and tests can assert on them.
+    """
+    if project_id is None or not received_combos:
+        return []
+    from .pull_requests import check_inventory_sufficiency
+
+    raised = []
+    for pr in find_pending_replacement_pulls(session, project_id, received_combos):
+        needs = [
+            (item.hardware_category, item.product_code, item.requested_quantity)
+            for item in pr.items
+            if item.item_type == PullRequestItemType.LOOSE and item.hardware_category and item.product_code
+        ]
+        if not needs:
+            continue
+        if not check_inventory_sufficiency(session, project_id, needs, reservation_aware=True).sufficient:
+            continue
+        if notification_service.has_unread_notification_for_pull(session, pr.id, NotificationType.PULL_UNBLOCKED):
+            continue
+        raised.append(
+            notification_service.create_notification(
+                session,
+                project_id=project_id,
+                recipient_role=notification_service.WAREHOUSE_RECIPIENT_ROLE,
+                notification_type=NotificationType.PULL_UNBLOCKED,
+                message=(
+                    f"Replacement Pull Request {pr.request_number} can now be fulfilled - the hardware "
+                    "it was waiting on has been received. Approve it to release the replacement."
+                ),
+                pull_request_id=pr.id,
+            )
+        )
+    if raised:
+        session.flush()
+    return raised
 
 
 def get_po_receiving_details(session: Session, po_id: uuid.UUID) -> tuple[POModel, list[ReceiveRecordModel]]:

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -8,7 +8,10 @@ import strawberry
 
 from app.models.project import Project as ProjectModel
 
+from .enums import PipelineStage
 from .types import (
+    AssemblyPipeline,
+    AssemblyPipelineSummary,
     BuyerAssignment,
     BuyerAssignmentProject,
     ClerkUser,
@@ -25,6 +28,7 @@ from .types import (
     OpeningItemHardware,
     PackingSlip,
     PackingSlipItem,
+    PipelineOpening,
     PODocumentData,
     PODocumentInfo,
     PODocumentSettings,
@@ -513,6 +517,90 @@ def shop_assembly_opening_to_type(opening) -> ShopAssemblyOpening:
         floor=opening.floor,
         staged_at=opening.staged_at,
         staged_by=opening.staged_by,
+    )
+
+
+def assembly_pipeline_summary_to_type(row) -> AssemblyPipelineSummary:
+    """A repository AssemblyPipelineSummary dataclass -> the GraphQL type (#344).
+
+    The dataclass is flat scalars the repository computed with grouped aggregates, so there is
+    nothing here that could trigger a load - which is the whole point of the resolver handing this
+    converter finished counts rather than an ORM row to walk.
+    """
+    return AssemblyPipelineSummary(
+        request_id=strawberry.ID(str(row.request_id)),
+        request_number=row.request_number,
+        project_id=strawberry.ID(str(row.project_id)),
+        project_code=row.project_code,
+        project_name=row.project_name,
+        request_status=row.request_status,
+        created_by=row.created_by,
+        created_at=row.created_at,
+        accepted_by=row.accepted_by,
+        accepted_at=row.accepted_at,
+        rejected_by=row.rejected_by,
+        rejected_at=row.rejected_at,
+        integrity_note=row.integrity_note,
+        pull_request_id=(strawberry.ID(str(row.pull_request_id)) if row.pull_request_id else None),
+        pull_request_status=row.pull_request_status,
+        pull_approved_at=row.pull_approved_at,
+        pull_completed_at=row.pull_completed_at,
+        staging_status=row.staging_status,
+        cancelled_pull_count=row.cancelled_pull_count,
+        last_cancelled_at=row.last_cancelled_at,
+        last_cancelled_by=row.last_cancelled_by,
+        last_cancellation_reason=row.last_cancellation_reason,
+        opening_count=row.opening_count,
+        staged_opening_count=row.staged_opening_count,
+        assigned_opening_count=row.assigned_opening_count,
+        in_progress_opening_count=row.in_progress_opening_count,
+        completed_opening_count=row.completed_opening_count,
+        shipped_opening_count=row.shipped_opening_count,
+        planned_unit_count=row.planned_unit_count,
+        installed_unit_count=row.installed_unit_count,
+        deficient_unit_count=row.deficient_unit_count,
+        replacement_pending_unit_count=row.replacement_pending_unit_count,
+        awaiting_replacement_opening_count=row.awaiting_replacement_opening_count,
+        replacement_after_ship_opening_count=row.replacement_after_ship_opening_count,
+        stage=PipelineStage(row.stage),
+    )
+
+
+def pipeline_opening_to_type(row) -> PipelineOpening:
+    """A repository PipelineOpening dataclass -> the GraphQL type (#344). Flat scalars throughout;
+    the two derived readings are the dataclass's own properties, so the ladder and the flags are
+    defined once, in the repository."""
+    return PipelineOpening(
+        shop_assembly_opening_id=strawberry.ID(str(row.shop_assembly_opening_id)),
+        opening_number=row.opening_number,
+        leaf=row.leaf,
+        building=row.building,
+        floor=row.floor,
+        location=row.location,
+        stage=PipelineStage(row.stage),
+        pull_status=row.pull_status,
+        staged_at=row.staged_at,
+        staged_by=row.staged_by,
+        assigned_to_user_id=row.assigned_to_user_id,
+        assigned_to=row.assigned_to,
+        assembly_status=row.assembly_status,
+        completed_at=row.completed_at,
+        planned_unit_count=row.planned_unit_count,
+        installed_unit_count=row.installed_unit_count,
+        deficient_unit_count=row.deficient_unit_count,
+        replacement_pending_unit_count=row.replacement_pending_unit_count,
+        awaiting_replacement_unit_count=row.awaiting_replacement_unit_count,
+        replacement_arrived_after_ship=row.replacement_arrived_after_ship,
+        opening_item_id=(strawberry.ID(str(row.opening_item_id)) if row.opening_item_id else None),
+        opening_item_state=row.opening_item_state,
+        assembled_location=row.assembled_location,
+    )
+
+
+def assembly_pipeline_to_type(pipeline) -> AssemblyPipeline:
+    return AssemblyPipeline(
+        summary=assembly_pipeline_summary_to_type(pipeline.summary),
+        openings=[pipeline_opening_to_type(o) for o in pipeline.openings],
     )
 
 

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -98,11 +98,58 @@ class ReconciliationStatus(enum.Enum):
 
 @strawberry.enum
 class ApproveOutcome(enum.Enum):
+    """What `approvePullRequest` did. Two values, because `approve_pull_request` returns exactly two
+    outcome strings.
+
+    A third value, CANCELLED, was removed in #344 as dead state. It dated from the pre-#224
+    behaviour where an approve that found insufficient stock *cancelled* the pull; since #224 such
+    an approve leaves the PR PENDING (blocked, not cancelled) and returns INSUFFICIENT with the
+    shortfall detail, so no code path could produce it and no client branched on it. It is safe to
+    delete without a migration: ApproveOutcome is a GraphQL-only enum and was never persisted -
+    a *cancelled pull* is `PullRequestStatus.CANCELLED`, which is a different enum on a real column
+    and is very much alive since #343."""
+
     APPROVED = "approved"
-    CANCELLED = "cancelled"
     # #224: an approve blocked by insufficient inventory leaves the PR PENDING (not cancelled) and
     # returns the shortfall to the approver; the PO is notified for backfill.
     INSUFFICIENT = "insufficient"
+
+
+@strawberry.enum
+class PipelineStage(enum.Enum):
+    """How far one door leaf has travelled through shop assembly (#344), derived from existing
+    state - no column stores it.
+
+    The ladder is the one the floor actually asks about: *where is opening A01 leaf 2?* Each value
+    is the furthest point the leaf has provably reached, so the stage of a whole request is the
+    stage of its least-advanced opening - what is holding it up.
+
+    REJECTED and CANCELLED are off the ladder rather than on the end of it: they are the two ways a
+    leaf leaves the pipeline without being assembled, and reading them as "further along than
+    IN_PROGRESS" would be nonsense.
+    """
+
+    # The request exists and is waiting for a human to accept it. No pull has been minted.
+    REQUESTED = "REQUESTED"
+    # Accepted: the warehouse pull exists but has not been approved, so nothing has been picked.
+    ACCEPTED = "ACCEPTED"
+    # The pull is approved and stock is deducted, but this opening's own cart is not built yet.
+    PULLING = "PULLING"
+    # This opening's cart is staged (#343) and nobody is holding it - it is on the assignment board.
+    STAGED = "STAGED"
+    # Claimed by an assembler, with nothing recorded against it yet.
+    ASSIGNED = "ASSIGNED"
+    # Hardware has been recorded onto the leaf but it is not fully dispositioned (#340).
+    IN_PROGRESS = "IN_PROGRESS"
+    # Assembled: an OpeningItem exists for the leaf and it is in (or ready to leave) inventory.
+    COMPLETED = "COMPLETED"
+    # The assembled leaf has left the building.
+    SHIPPED = "SHIPPED"
+    # The source request was rejected, which released its claim on inventory.
+    REJECTED = "REJECTED"
+    # The pull this opening was on was cancelled and its hardware restocked (#343). The opening is
+    # back on a PENDING request awaiting re-acceptance, so this is a state the *history* is in.
+    CANCELLED = "CANCELLED"
 
 
 @strawberry.enum

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -10,6 +10,8 @@ from app.repositories import shop_assembly_repository, user_repository
 from app.repositories import warehouse as warehouse_repository
 
 from .converters import (
+    assembly_pipeline_summary_to_type,
+    assembly_pipeline_to_type,
     clerk_user_to_type,
     opening_item_to_type,
     replacement_work_item_to_type,
@@ -24,6 +26,8 @@ from .inputs import (
     RecordAssemblyProgressInput,
 )
 from .types import (
+    AssemblyPipeline,
+    AssemblyPipelineSummary,
     ClerkUser,
     OpeningItem,
     ReplacementWorkItem,
@@ -96,6 +100,48 @@ class ShopAssemblyQueries:
                 session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
             )
             return [shop_assembly_request_to_type(r) for r in reqs]
+
+    @strawberry.field
+    def assembly_pipeline_summaries(
+        self,
+        info: strawberry.Info,
+        project_id: strawberry.ID | None = None,
+        status: ShopAssemblyRequestStatus | None = None,
+    ) -> list[AssemblyPipelineSummary]:
+        """Where every shop-assembly request has got to (#344), newest first.
+
+        One row per request, carrying the whole ladder as counts: requested -> accepted -> staged x/y
+        (or cancelled) -> assigned -> in progress n/m units -> completed -> shipped, plus the three
+        flags earlier slices introduced (the #342 integrity note, units awaiting replacement, and
+        replacements that arrived after their leaf shipped).
+
+        Omit projectId for the All-Projects view. That is safe here by construction: the repository
+        runs a fixed five statements - the requests, their pulls, and three grouped aggregates -
+        however many requests come back, so the cost of this resolver grows with rows returned and
+        not with queries issued. Open to any signed-in user."""
+        require_user(info)
+        with SessionLocal() as session:
+            rows = shop_assembly_repository.get_assembly_pipeline_summaries(
+                session,
+                project_id=uuid.UUID(str(project_id)) if project_id else None,
+                status=status,
+            )
+            return [assembly_pipeline_summary_to_type(r) for r in rows]
+
+    @strawberry.field
+    def assembly_pipeline(self, info: strawberry.Info, request_id: strawberry.ID) -> AssemblyPipeline:
+        """One request's pipeline, down to the individual door leaf (#344).
+
+        This is the view that answers "where is opening A01 leaf 2?" in one place instead of four:
+        each leaf's rung on the ladder, who is holding it, how many of its units are fitted, where
+        the assembled unit was put away, and what it is still owed. The header counts come from the
+        same aggregates the list uses, so this screen and that one cannot disagree.
+
+        Open to any signed-in user."""
+        require_user(info)
+        with SessionLocal() as session:
+            pipeline = shop_assembly_repository.get_assembly_pipeline(session, uuid.UUID(str(request_id)))
+            return assembly_pipeline_to_type(pipeline)
 
     @strawberry.field
     def shop_assembly_members(self, info: strawberry.Info) -> list[ClerkUser]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -14,6 +14,7 @@ from .enums import (
     LeafStatus,
     NotificationType,
     OpeningItemState,
+    PipelineStage,
     PODocumentType,
     POStatus,
     PullRequestItemType,
@@ -600,6 +601,106 @@ class ShopAssemblyOpening:
     # on openings staged before per-opening staging existed (they were staged wholesale).
     staged_at: datetime | None = None
     staged_by: str | None = None
+
+
+@strawberry.type
+class PipelineOpening:
+    """Where one door leaf is in shop assembly, and what it is still owed (#344).
+
+    Every field is derived from state slices 1-5 already persist; nothing here is stored. The raw
+    facts sit next to the derived `stage` on purpose - a screen that wants to phrase the journey
+    differently should not have to reverse-engineer the ladder.
+    """
+
+    shop_assembly_opening_id: strawberry.ID
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    location: str | None
+    stage: PipelineStage
+    pull_status: PullStatus
+    staged_at: datetime | None
+    staged_by: str | None
+    assigned_to_user_id: str | None
+    assigned_to: str | None
+    assembly_status: AssemblyStatus
+    completed_at: datetime | None
+    planned_unit_count: int
+    installed_unit_count: int
+    deficient_unit_count: int
+    replacement_pending_unit_count: int
+    # Units still owed to this leaf: condemned-and-unreplaced plus arrived-but-not-fitted (#341).
+    awaiting_replacement_unit_count: int
+    # Replacement hardware is sitting for a leaf that has already left the building (#341).
+    # installReplacement refuses it; it belongs to reallocation.
+    replacement_arrived_after_ship: bool
+    opening_item_id: strawberry.ID | None
+    opening_item_state: OpeningItemState | None
+    # Where the assembled leaf physically is - the "completed (location)" rung.
+    assembled_location: str | None
+
+
+@strawberry.type
+class AssemblyPipelineSummary:
+    """One shop-assembly request's journey in counts (#344).
+
+    Listable at All-Projects scale: every count comes from a grouped aggregate over the whole result
+    set, so the resolver's statement count is fixed however many requests come back.
+    """
+
+    request_id: strawberry.ID
+    request_number: str
+    project_id: strawberry.ID
+    # Which project, without a second lookup, for the All-Projects view: project_code is the human
+    # job number and project_name its description.
+    project_code: str | None
+    project_name: str | None
+    request_status: ShopAssemblyRequestStatus
+    created_by: str
+    created_at: datetime
+    accepted_by: str | None
+    accepted_at: datetime | None
+    rejected_by: str | None
+    rejected_at: datetime | None
+    # The same #342 note the accept screen shows as an amber alert.
+    integrity_note: str | None
+    # The live pull, never a cancelled one (#343 made request_number unique among live pulls only).
+    pull_request_id: strawberry.ID | None
+    pull_request_status: PullRequestStatus | None
+    pull_approved_at: datetime | None
+    pull_completed_at: datetime | None
+    # Derived staging rollup - the same reading PullRequest.stagingStatus gives (#343). Null when the
+    # request has no openings, which reads as "not applicable", never "nothing staged".
+    staging_status: PullStatus | None
+    # Cancellation history (#343): a cancelled pull keeps its number and hands its openings back to a
+    # PENDING request, so without this the request would read as never having been accepted.
+    cancelled_pull_count: int
+    last_cancelled_at: datetime | None
+    last_cancelled_by: str | None
+    last_cancellation_reason: str | None
+    opening_count: int
+    staged_opening_count: int
+    assigned_opening_count: int
+    in_progress_opening_count: int
+    completed_opening_count: int
+    shipped_opening_count: int
+    planned_unit_count: int
+    installed_unit_count: int
+    deficient_unit_count: int
+    replacement_pending_unit_count: int
+    awaiting_replacement_opening_count: int
+    replacement_after_ship_opening_count: int
+    # The stage of the least-advanced opening: what the request is waiting on, not its best news.
+    stage: PipelineStage
+
+
+@strawberry.type
+class AssemblyPipeline:
+    """A request's summary plus a row per door leaf (#344) - the detail view."""
+
+    summary: AssemblyPipelineSummary
+    openings: list[PipelineOpening]
 
 
 @strawberry.type

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
 from app.models.enums import NotificationType
@@ -13,6 +14,7 @@ def create_notification(
     recipient_role: str,
     notification_type: NotificationType,
     message: str,
+    pull_request_id: uuid.UUID | None = None,
 ) -> Notification:
     notification = Notification(
         id=uuid.uuid4(),
@@ -20,6 +22,7 @@ def create_notification(
         recipient_role=recipient_role,
         type=notification_type,
         message=message,
+        pull_request_id=pull_request_id,
         is_read=False,
         created_at=datetime.utcnow(),
     )
@@ -27,12 +30,58 @@ def create_notification(
     return notification
 
 
+# `recipient_role` is an audience tag, not an access control. The notification bell queries with no
+# recipient filter, so every signed-in user sees every notification; the tag says who it is *for*,
+# which is what makes a targeted bell a later filtering change rather than a data migration. Two
+# shapes of value live in this column: a named audience (the constants below) and, for the one
+# signal that is owed to a specific person, that person's stable Clerk user id.
+
 # Recipient role for the purchasing officer who backfills short inventory (#224).
 PO_RECIPIENT_ROLE = "PO"
 
 # Recipient role for shipping/reallocation signals (#341): hardware that arrived for a leaf which has
 # already left the building is a shipping problem, not a purchasing one.
 SHIPPING_RECIPIENT_ROLE = "SHIPPING"
+
+# Recipient role for "the assignment board has work on it" (#344). Deliberately the manager audience
+# and not the whole floor: a staged, unassigned opening is a decision about who should build it, and
+# broadcasting it to every assembler would make the useful signals harder to see.
+SHOP_ASSEMBLY_MANAGER_RECIPIENT_ROLE = "SHOP_ASSEMBLY_MANAGER"
+
+# Recipient role for warehouse-actionable signals (#344), i.e. a blocked pull that can now be
+# approved. It is the warehouse that approves a pull, so it is the warehouse that needs telling.
+WAREHOUSE_RECIPIENT_ROLE = "WAREHOUSE"
+
+
+def has_unread_notification_for_pull(
+    session: Session,
+    pull_request_id: uuid.UUID,
+    notification_type: NotificationType,
+) -> bool:
+    """Whether this pull already has an *open* (unread) notification of this type (#344).
+
+    This is the dedupe primitive behind `PULL_UNBLOCKED`. A replacement pull can sit PENDING across
+    many receives, and re-announcing it on each one would turn a useful signal into wallpaper -
+    which is the failure mode that makes people stop reading the bell entirely. Keying on
+    `pull_request_id` rather than on text inside `message` is what makes it exact.
+
+    Unread rather than "ever" is the deliberate choice: once somebody has read it, the signal has
+    done its job, and if the pull goes short again (stock written off under it) and is later covered
+    again, that is genuinely new information and deserves to be raised again.
+
+    One EXISTS against the partial index; no rows are loaded.
+    """
+    return bool(
+        session.scalar(
+            select(
+                exists().where(
+                    Notification.pull_request_id == pull_request_id,
+                    Notification.type == notification_type,
+                    Notification.is_read == False,
+                )
+            )
+        )
+    )
 
 
 def format_shortfall_lines(shortfalls) -> str:

--- a/backend/tests/test_pipeline_observability.py
+++ b/backend/tests/test_pipeline_observability.py
@@ -1,0 +1,1029 @@
+"""Pipeline observability and the notifications that go with it (#344).
+
+Three things are pinned here.
+
+**The pipeline is correct.** A multi-opening request is walked the whole way - requested, accepted,
+part-staged, assigned, half-built, finished, shipped - and the derived stage and every count is
+asserted at each step, including the states slices 1-5 introduced (the #342 integrity note, units
+awaiting replacement, a replacement that arrived after its leaf shipped, and a cancelled pull).
+
+**The pipeline is flat.** `get_assembly_pipeline_summaries` issues a fixed number of statements
+whether it covers one request or many, and `get_assembly_pipeline` a fixed number whether the request
+has two openings or thirty. That is the property that makes the All-Projects view survivable, and it
+is the one an innocent-looking refactor would break, so it is asserted rather than described.
+
+**The notifications fire once.** Staging announces one signal per confirmation and not per opening;
+completing a pull that staging already finished says nothing; a replacement arriving reaches the
+assembler holding the leaf, or shipping if the leaf has gone; and the unblocked-replacement signal
+dedupes to one open notification per pull.
+
+DB-backed like the rest of the suite: every test runs against a real Postgres in a rolled-back
+transaction.
+"""
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import event, select
+
+from app.models.enums import (
+    AssemblyStatus,
+    NotificationType,
+    OpeningItemState,
+    POStatus,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    PullStatus,
+    ShopAssemblyRequestStatus,
+)
+from app.models.inventory import InventoryLocation
+from app.models.notification import Notification
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
+from app.models.stock_item import StockItem
+from app.repositories import import_repository, shop_assembly_repository, warehouse_admin_repository
+from app.repositories import warehouse as warehouse_repository
+from app.schemas.enums import ApproveOutcome, PipelineStage
+
+# --- helpers -----------------------------------------------------------------------------------
+
+
+class _StatementCounter:
+    """Counts SQL statements issued on the test session's connection.
+
+    The point of the pipeline resolvers is that their statement count does not move with the size of
+    the result, so the tests below assert an exact number rather than "not too many": an exact number
+    fails loudly the first time somebody adds a per-row lookup, which is precisely the regression
+    CLAUDE.md's perf rules are about.
+    """
+
+    def __init__(self, session):
+        self._bind = session.get_bind()
+        self.statements: list[str] = []
+
+    def __enter__(self):
+        event.listen(self._bind, "before_cursor_execute", self._record)
+        return self
+
+    def __exit__(self, *_exc):
+        event.remove(self._bind, "before_cursor_execute", self._record)
+        return False
+
+    def _record(self, _conn, _cursor, statement, _params, _context, _executemany):
+        self.statements.append(statement)
+
+    @property
+    def count(self) -> int:
+        return len(self.statements)
+
+
+def _make_project(session, description="Test") -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description=description)
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category="HINGE", code="HG-100", quantity, deficient=0):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=deficient,
+        aisle="A",
+        row="1",
+        bay="1",
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _request(session, project, *, leaves=(1, 2), qty=2, code="HG-100", opening_number="A01"):
+    """A shop-assembly request over N leaves of one opening, through the real creation path."""
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": opening_number}],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": f"SA-{uuid.uuid4().hex[:6]}",
+            "shop_assembly_openings": [
+                {
+                    "opening_number": opening_number,
+                    "leaf": leaf,
+                    "items": [{"hardware_category": "HINGE", "product_code": code, "quantity": qty}],
+                }
+                for leaf in leaves
+            ],
+        },
+    )["shop_assembly_request"]
+
+
+def _accept(session, sar) -> PullRequest:
+    shop_assembly_repository.accept_shop_assembly_request(session, sar.id, "acceptor")
+    session.flush()
+    return session.scalar(
+        select(PullRequest).where(
+            PullRequest.request_number == sar.request_number,
+            PullRequest.status != PullRequestStatus.CANCELLED,
+        )
+    )
+
+
+def _openings(session, pr) -> list[ShopAssemblyOpening]:
+    return list(
+        session.scalars(
+            select(ShopAssemblyOpening)
+            .where(ShopAssemblyOpening.pull_request_id == pr.id)
+            .order_by(ShopAssemblyOpening.leaf.asc())
+        ).all()
+    )
+
+
+def _summary(session, sar):
+    rows = shop_assembly_repository.get_assembly_pipeline_summaries(session, request_ids=[sar.id])
+    assert len(rows) == 1
+    return rows[0]
+
+
+def _notifications(session, notification_type):
+    return list(session.scalars(select(Notification).where(Notification.type == notification_type)).all())
+
+
+def _make_po_with_line(session, project_id, *, code="HG-100", category="HINGE", ordered=10):
+    po = PurchaseOrder(
+        id=uuid.uuid4(),
+        request_number=f"REQ-{uuid.uuid4().hex[:8]}",
+        project_id=project_id,
+        status=POStatus.GP_REGISTERED,
+        po_number=f"PO{uuid.uuid4().hex[:6]}",
+        gp_company="TEST",
+    )
+    session.add(po)
+    session.flush()
+    li = POLineItem(
+        id=uuid.uuid4(),
+        po_id=po.id,
+        hardware_category=category,
+        product_code=code,
+        ordered_quantity=ordered,
+        received_quantity=0,
+        unit_cost=Decimal("1.00"),
+        gp_line_ord=1,
+    )
+    session.add(li)
+    session.flush()
+    return po, li
+
+
+def _receive(session, po, li, quantity):
+    return warehouse_repository.create_receive(
+        session,
+        po.id,
+        "receiver",
+        [
+            {
+                "po_line_item_id": li.id,
+                "quantity_received": quantity,
+                "locations": [{"aisle": "A", "row": "1", "bay": "1", "quantity": quantity}],
+            }
+        ],
+    )
+
+
+# --- the ladder --------------------------------------------------------------------------------
+
+
+def test_pipeline_walks_a_request_from_requested_to_shipped(db_session):
+    """The whole journey, one rung at a time, on a two-leaf request.
+
+    Each assertion is the answer to "where is opening A01 leaf 2?" at that moment, and the request's
+    own stage is always the *least* advanced of its openings - what is holding it up, not its best
+    news. That is the reading the detail header and the list row both use.
+    """
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project)
+
+    # 1. Requested: no pull exists yet, nothing is staged.
+    s = _summary(db_session, sar)
+    assert s.stage == "REQUESTED"
+    assert (s.opening_count, s.staged_opening_count, s.planned_unit_count) == (2, 0, 4)
+    assert s.pull_request_id is None
+    assert s.staging_status == PullStatus.NOT_PULLED
+    assert [o.stage for o in shop_assembly_repository.get_assembly_pipeline(db_session, sar.id).openings] == [
+        "REQUESTED",
+        "REQUESTED",
+    ]
+
+    # 2. Accepted: the pull is minted but not approved, so nothing has left inventory.
+    pr = _accept(db_session, sar)
+    s = _summary(db_session, sar)
+    assert s.stage == "ACCEPTED"
+    assert s.pull_request_id == pr.id
+    assert s.pull_request_status == PullRequestStatus.PENDING
+    assert s.accepted_by == "acceptor"
+
+    # 3. Approved but unstaged: stock is deducted, no cart is built.
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+    assert _summary(db_session, sar).stage == "PULLING"
+
+    # 4. One cart staged: that leaf is workable, the other is not - so the request still reads
+    #    PULLING, and the staging rollup derives PARTIAL.
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    s = _summary(db_session, sar)
+    assert (s.stage, s.staging_status, s.staged_opening_count) == ("PULLING", PullStatus.PARTIAL, 1)
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert [o.stage for o in detail.openings] == ["STAGED", "PULLING"]
+    assert detail.openings[0].staged_by == "picker"
+
+    # 5. Both staged: the pull completes, both leaves are on the board unassigned.
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+    s = _summary(db_session, sar)
+    assert (s.stage, s.staging_status, s.staged_opening_count) == ("STAGED", PullStatus.PULLED, 2)
+    assert s.pull_request_status == PullRequestStatus.COMPLETED
+
+    # 6. One claimed: the request is still waiting on the unclaimed one.
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user_1", "Ana")
+    db_session.flush()
+    s = _summary(db_session, sar)
+    assert (s.stage, s.assigned_opening_count) == ("STAGED", 1)
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert [o.stage for o in detail.openings] == ["ASSIGNED", "STAGED"]
+    assert detail.openings[0].assigned_to == "Ana"
+
+    shop_assembly_repository.assign_openings(db_session, [openings[1].id], "user_2", "Bo")
+    db_session.flush()
+    assert _summary(db_session, sar).stage == "ASSIGNED"
+
+    # 7. Work starts on leaf 1: n/m units is the reading, not "some progress".
+    items = list(
+        db_session.scalars(
+            select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == openings[0].id)
+        ).all()
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        openings[0].id,
+        [shop_assembly_repository.AssemblyProgressUpdate(items[0].id, installed_quantity=1)],
+        performed_by="Ana",
+    )
+    db_session.flush()
+    s = _summary(db_session, sar)
+    # The request is held back by leaf 2, which nobody has touched.
+    assert (s.stage, s.in_progress_opening_count, s.installed_unit_count) == ("ASSIGNED", 1, 1)
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert [o.stage for o in detail.openings] == ["IN_PROGRESS", "ASSIGNED"]
+    assert (detail.openings[0].installed_unit_count, detail.openings[0].planned_unit_count) == (1, 2)
+
+    # 8. Leaf 1 finished: an OpeningItem exists and the pipeline reports where it was put away.
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        openings[0].id,
+        [shop_assembly_repository.AssemblyProgressUpdate(items[0].id, installed_quantity=2)],
+        performed_by="Ana",
+    )
+    db_session.flush()
+    leaf_one = shop_assembly_repository.complete_opening(db_session, openings[0].id, "B", "2", "3", completed_by="Ana")
+    db_session.flush()
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert detail.openings[0].stage == "COMPLETED"
+    assert detail.openings[0].assembled_location == "B-2-3"
+    assert detail.openings[0].opening_item_id == leaf_one.id
+    assert _summary(db_session, sar).completed_opening_count == 1
+
+    # 9. Leaf 1 ships: the rung above COMPLETED, and the one the shipping module writes.
+    leaf_one.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+    s = _summary(db_session, sar)
+    assert s.shipped_opening_count == 1
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert detail.openings[0].stage == "SHIPPED"
+    # And the request still reads by its slowest leaf, which is still on the bench.
+    assert s.stage == "ASSIGNED"
+
+
+def test_request_stage_is_always_the_minimum_of_its_opening_stages(db_session):
+    """The list row and the detail header are computed two different ways - the row from grouped
+    aggregates, the leaves from their own columns - so this pins them together.
+
+    They have to be two implementations: deriving the request stage from loaded opening rows would
+    make the All-Projects list load every opening in the system. This test is what stops them
+    drifting apart.
+    """
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+
+    def _check():
+        detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+        expected = min(
+            (o.stage for o in detail.openings),
+            key=lambda s: shop_assembly_repository.PIPELINE_STAGE_RANK[s],
+        )
+        assert detail.summary.stage == expected
+
+    _check()
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    _check()
+    shop_assembly_repository.assign_openings(db_session, [openings[0].id], "user_1", "Ana")
+    db_session.flush()
+    _check()
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+    _check()
+    shop_assembly_repository.assign_openings(db_session, [openings[1].id], "user_2", "Bo")
+    db_session.flush()
+    _check()
+
+
+def test_unassigning_an_in_progress_leaf_still_reads_in_progress(db_session):
+    """`remove_opening_from_user` (#340) allows unassigning a half-built leaf, so "assigned" and
+    "started" are independent facts. The aggregate stage derivation has to hold up under that, which
+    is why it counts staged-and-untouched openings separately rather than subtracting."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project, leaves=(1,))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    opening = _openings(db_session, pr)[0]
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_1", "Ana")
+    db_session.flush()
+    item = db_session.scalar(
+        select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == opening.id)
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [shop_assembly_repository.AssemblyProgressUpdate(item.id, installed_quantity=1)],
+        performed_by="Ana",
+    )
+    shop_assembly_repository.remove_opening_from_user(db_session, opening.id)
+    db_session.flush()
+
+    s = _summary(db_session, sar)
+    assert (s.stage, s.assigned_opening_count, s.in_progress_opening_count) == ("IN_PROGRESS", 0, 1)
+
+
+def test_rejected_request_reads_rejected_whatever_its_openings_say(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project)
+    shop_assembly_repository.reject_shop_assembly_request(db_session, sar.id, "acceptor", "wrong project")
+    db_session.flush()
+
+    s = _summary(db_session, sar)
+    assert s.stage == "REJECTED"
+    assert s.rejected_by == "acceptor"
+    assert all(
+        o.stage == "REJECTED" for o in shop_assembly_repository.get_assembly_pipeline(db_session, sar.id).openings
+    )
+
+
+def test_cancelled_pull_shows_as_cancelled_with_its_history(db_session):
+    """A cancellation (#343) restocks, detaches the openings and returns the request to PENDING - so
+    without the cancelled pull in view, the request would read as though it had never been accepted
+    at all. That is exactly the confusion this view exists to remove."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project)
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    warehouse_repository.cancel_pull_request(db_session, pr.id, "supervisor", "raised on the wrong project")
+    db_session.flush()
+
+    s = _summary(db_session, sar)
+    assert s.stage == "CANCELLED"
+    assert s.request_status == ShopAssemblyRequestStatus.PENDING
+    assert s.cancelled_pull_count == 1
+    assert s.last_cancelled_by == "supervisor"
+    assert s.last_cancellation_reason == "raised on the wrong project"
+    # The live pull is gone, not merely cancelled: the request is claimable again.
+    assert s.pull_request_id is None
+    assert all(
+        o.stage == "CANCELLED" for o in shop_assembly_repository.get_assembly_pipeline(db_session, sar.id).openings
+    )
+
+
+def test_re_accepting_after_a_cancel_shows_the_live_pull_and_keeps_the_history(db_session):
+    """#343 made request_number unique only among live pulls, so a re-accept legitimately mints a
+    second pull with the same number. The pipeline must resolve the live one and still count the
+    cancelled one."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project)
+    first = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, first.id, "picker")
+    db_session.flush()
+    warehouse_repository.cancel_pull_request(db_session, first.id, "supervisor", None)
+    db_session.flush()
+    second = _accept(db_session, sar)
+    db_session.flush()
+
+    s = _summary(db_session, sar)
+    assert s.pull_request_id == second.id
+    assert s.pull_request_status == PullRequestStatus.PENDING
+    assert s.cancelled_pull_count == 1
+    assert s.stage == "ACCEPTED"
+
+
+def test_pipeline_surfaces_the_integrity_note(db_session):
+    """The #342 flag the accept screen already shows. Carried here too, so the pipeline does not
+    quietly become a second, more trusting view of the same request."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project)
+    sar.integrity_note = "A schedule re-upload landed under this request."
+    db_session.flush()
+
+    assert _summary(db_session, sar).integrity_note == "A schedule re-upload landed under this request."
+
+
+def test_awaiting_replacement_and_arrived_after_ship_are_both_visible(db_session):
+    """The two replacement flags (#341), which is where they finally meet the eye.
+
+    A leaf is finished with one unit condemned, its replacement arrives after the leaf has shipped,
+    and the pipeline reports both that the leaf is still owed a unit and that the unit that turned up
+    cannot be fitted to it.
+    """
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project, leaves=(1,), qty=2)
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    opening = _openings(db_session, pr)[0]
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_1", "Ana")
+    db_session.flush()
+    item = db_session.scalar(
+        select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == opening.id)
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                item.id, installed_quantity=1, flag_deficient_quantity=1, deficient_reason="bent"
+            )
+        ],
+        performed_by="Ana",
+    )
+    db_session.flush()
+
+    # Owed one unit while still on the bench.
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    assert detail.openings[0].awaiting_replacement_unit_count == 1
+    assert detail.openings[0].replacement_arrived_after_ship is False
+    assert _summary(db_session, sar).awaiting_replacement_opening_count == 1
+
+    # Finish and ship the leaf, then let the replacement land.
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [shop_assembly_repository.AssemblyProgressUpdate(item.id, installed_quantity=1)],
+        performed_by="Ana",
+    )
+    db_session.flush()
+    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by="Ana")
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    repl = db_session.scalar(select(PullRequest).where(PullRequest.request_number == f"PR-REPL-{pr.request_number}"))
+    repl.status = PullRequestStatus.IN_PROGRESS
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, repl.id, completed_by="picker")
+    db_session.flush()
+
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
+    row = detail.openings[0]
+    assert row.stage == "SHIPPED"
+    assert row.replacement_pending_unit_count == 1
+    assert row.awaiting_replacement_unit_count == 1
+    assert row.replacement_arrived_after_ship is True
+    s = _summary(db_session, sar)
+    assert s.replacement_after_ship_opening_count == 1
+    assert s.replacement_pending_unit_count == 1
+
+
+def test_summaries_scope_by_project_and_status(db_session):
+    project_a = _make_project(db_session, "A")
+    project_b = _make_project(db_session, "B")
+    _seed_inventory(db_session, project_a.id, quantity=20)
+    _seed_inventory(db_session, project_b.id, quantity=20)
+    sar_a = _request(db_session, project_a, leaves=(1,))
+    sar_b = _request(db_session, project_b, leaves=(1,))
+    _accept(db_session, sar_a)
+
+    scoped = shop_assembly_repository.get_assembly_pipeline_summaries(db_session, project_id=project_b.id)
+    assert [r.request_id for r in scoped] == [sar_b.id]
+    assert (scoped[0].project_name, scoped[0].project_code) == ("B", project_b.project_id)
+
+    pending = shop_assembly_repository.get_assembly_pipeline_summaries(
+        db_session, status=ShopAssemblyRequestStatus.APPROVED
+    )
+    assert sar_a.id in {r.request_id for r in pending}
+    assert sar_b.id not in {r.request_id for r in pending}
+
+
+# --- flatness ----------------------------------------------------------------------------------
+
+
+def test_pipeline_detail_query_count_is_flat_as_openings_grow(db_session):
+    """Eight statements for two openings, eight for thirty.
+
+    The detail view loads its opening rows in one statement and aggregates their hardware lines in
+    another, so an N+1 here would be a per-opening `find_assembled_leaf` or a lazy `items` walk -
+    both of which are exactly what a well-meaning edit reaches for. Comparing two request sizes,
+    rather than asserting a bare number, is what makes the failure message say *what* went wrong.
+    """
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=400)
+    small = _request(db_session, project, leaves=(1, 2), opening_number="A01")
+    big_leaves = tuple(range(1, 31))
+    # 30 leaves of one opening: a pair in the schedule is two, but the query shape is what is under
+    # test, and this is the cheapest way to make the row count move by an order of magnitude.
+    big = _request(db_session, project, leaves=big_leaves, opening_number="B01")
+
+    with _StatementCounter(db_session) as small_counter:
+        small_detail = shop_assembly_repository.get_assembly_pipeline(db_session, small.id)
+    with _StatementCounter(db_session) as big_counter:
+        big_detail = shop_assembly_repository.get_assembly_pipeline(db_session, big.id)
+
+    assert len(small_detail.openings) == 2
+    assert len(big_detail.openings) == 30
+    assert big_counter.count == small_counter.count, (
+        f"statement count moved with opening count: {small_counter.count} for 2 openings, "
+        f"{big_counter.count} for 30.\n" + "\n".join(big_counter.statements)
+    )
+    assert big_counter.count == 8
+
+
+def test_pipeline_summaries_query_count_is_flat_as_requests_grow(db_session):
+    """Five statements for one request, five for twelve - the All-Projects guarantee.
+
+    This is the resolver that runs with no project filter, so a per-request follow-up query here
+    would be a query per shop-assembly request that has ever existed.
+    """
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=400)
+    first = _request(db_session, project, leaves=(1,), opening_number="C01")
+
+    with _StatementCounter(db_session) as one_counter:
+        one = shop_assembly_repository.get_assembly_pipeline_summaries(db_session, project_id=project.id)
+    assert [r.request_id for r in one] == [first.id]
+
+    for n in range(2, 13):
+        _request(db_session, project, leaves=(1, 2), opening_number=f"C{n:02d}")
+
+    with _StatementCounter(db_session) as many_counter:
+        many = shop_assembly_repository.get_assembly_pipeline_summaries(db_session, project_id=project.id)
+    assert len(many) == 12
+
+    assert many_counter.count == one_counter.count, (
+        f"statement count moved with request count: {one_counter.count} for 1 request, "
+        f"{many_counter.count} for 12.\n" + "\n".join(many_counter.statements)
+    )
+    assert many_counter.count == 5
+
+
+# --- notifications -----------------------------------------------------------------------------
+
+
+def test_staging_notifies_the_manager_audience_once_per_confirmation(db_session):
+    """One signal per trip to the shelf, not one per cart. A bell that fires per opening on a
+    forty-opening pull is a bell nobody reads."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2, 3))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings[:2]], "picker")
+    db_session.flush()
+
+    notes = _notifications(db_session, NotificationType.ASSEMBLY_WORK_AVAILABLE)
+    assert len(notes) == 1
+    from app.services import notification_service
+
+    assert notes[0].recipient_role == notification_service.SHOP_ASSEMBLY_MANAGER_RECIPIENT_ROLE
+    assert notes[0].pull_request_id == pr.id
+    assert "2 opening(s)" in notes[0].message
+    assert "still being picked" in notes[0].message
+
+
+def test_staging_the_last_opening_announces_once_not_twice(db_session):
+    """Staging the last cart calls `complete_pull_request`, which also flips openings to PULLED. The
+    two must not both announce - and they cannot, because each announces only the openings *it*
+    made workable, and by then there are none left for completion to flip."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[1].id], "picker")
+    db_session.flush()
+
+    notes = _notifications(db_session, NotificationType.ASSEMBLY_WORK_AVAILABLE)
+    assert len(notes) == 2
+    assert "That was the last of the pull." in notes[-1].message
+
+
+def test_re_staging_an_already_staged_opening_announces_nothing(db_session):
+    """A double-click is a no-op in #343, and it has to be a no-op in the bell too."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+
+    assert len(_notifications(db_session, NotificationType.ASSEMBLY_WORK_AVAILABLE)) == 1
+
+
+def test_completing_an_unstaged_pull_directly_still_announces(db_session):
+    """`complete_pull_request` called on its own means "stage whatever is left". Those openings do
+    become workable, so that call is the one that has to speak."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+
+    warehouse_repository.complete_pull_request(db_session, pr.id, completed_by="picker")
+    db_session.flush()
+
+    notes = _notifications(db_session, NotificationType.ASSEMBLY_WORK_AVAILABLE)
+    assert len(notes) == 1
+    assert "2 opening(s)" in notes[0].message
+    assert "That was the last of the pull." in notes[0].message
+
+
+def _leaf_with_deficiency(db_session, project, *, complete=False, assign_to=("user_1", "Ana")):
+    """One leaf with a unit condemned at the bench, so a PR-REPL pull exists for it."""
+    sar = _request(db_session, project, leaves=(1,), qty=2)
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    opening = _openings(db_session, pr)[0]
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+    shop_assembly_repository.assign_openings(db_session, [opening.id], assign_to[0], assign_to[1])
+    db_session.flush()
+    item = db_session.scalar(
+        select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == opening.id)
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [
+            shop_assembly_repository.AssemblyProgressUpdate(
+                item.id, installed_quantity=1, flag_deficient_quantity=1, deficient_reason="bent"
+            )
+        ],
+        performed_by=assign_to[1],
+    )
+    db_session.flush()
+    if complete:
+        shop_assembly_repository.record_assembly_progress(
+            db_session,
+            opening.id,
+            [shop_assembly_repository.AssemblyProgressUpdate(item.id, installed_quantity=1)],
+            performed_by=assign_to[1],
+        )
+        db_session.flush()
+        shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by=assign_to[1])
+        db_session.flush()
+    repl = db_session.scalar(select(PullRequest).where(PullRequest.request_number == f"PR-REPL-{pr.request_number}"))
+    return sar, pr, opening, item, repl
+
+
+def test_replacement_arrival_notifies_the_leafs_assignee(db_session):
+    """The half of the #341 loop that was silent: the arrival that the assembler can actually act
+    on. Addressed to their stable Clerk user id, which is the assignment the opening already holds."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, _pr, _opening, _item, repl = _leaf_with_deficiency(db_session, project)
+
+    repl.status = PullRequestStatus.IN_PROGRESS
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, repl.id, completed_by="picker")
+    db_session.flush()
+
+    notes = _notifications(db_session, NotificationType.REPLACEMENT_ARRIVED)
+    assert len(notes) == 1
+    assert notes[0].recipient_role == "user_1"
+    assert notes[0].pull_request_id == repl.id
+    assert "remaining work" in notes[0].message
+    # The shipped-leaf signal is somebody else's problem and must not also fire.
+    assert _notifications(db_session, NotificationType.REPLACEMENT_AFTER_SHIPMENT) == []
+
+
+def test_replacement_arrival_on_a_shipped_leaf_notifies_shipping_and_not_the_assembler(db_session):
+    """Once the leaf has left the building, fitting it is not the assembler's job - it is
+    reallocation's. Exactly one of the two signals fires, and it is the other one."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar, _pr, opening, _item, repl = _leaf_with_deficiency(db_session, project, complete=True)
+    leaf = shop_assembly_repository.find_assembled_leaf(db_session, project.id, opening.opening_id, opening.leaf)
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    repl.status = PullRequestStatus.IN_PROGRESS
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, repl.id, completed_by="picker")
+    db_session.flush()
+
+    assert len(_notifications(db_session, NotificationType.REPLACEMENT_AFTER_SHIPMENT)) == 1
+    assert _notifications(db_session, NotificationType.REPLACEMENT_ARRIVED) == []
+    assert _summary(db_session, sar).replacement_after_ship_opening_count == 1
+
+
+def test_replacement_arrival_on_an_unassigned_leaf_notifies_nobody(db_session):
+    """A notification with no addressee is noise. An unassigned leaf's replacement is picked up by
+    whoever claims the work."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, _pr, opening, _item, repl = _leaf_with_deficiency(db_session, project)
+    shop_assembly_repository.remove_opening_from_user(db_session, opening.id)
+    db_session.flush()
+
+    repl.status = PullRequestStatus.IN_PROGRESS
+    db_session.flush()
+    warehouse_repository.complete_pull_request(db_session, repl.id, completed_by="picker")
+    db_session.flush()
+
+    assert _notifications(db_session, NotificationType.REPLACEMENT_ARRIVED) == []
+
+
+# --- the unblocked-pull loop and its dedupe -----------------------------------------------------
+
+
+def _blocked_replacement_pull(db_session, project, *, need=3, code="HG-900"):
+    """A PENDING PR-REPL pull for a combo the project has none of."""
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"PR-REPL-SA-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.PENDING,
+        requested_by="Ana",
+    )
+    db_session.add(pr)
+    db_session.flush()
+    # sa_opening_item_id is what makes it structurally a replacement pull, so it needs a real one.
+    sar = _request(db_session, project, leaves=(1,), qty=1, code="HG-100", opening_number=f"Z{uuid.uuid4().hex[:3]}")
+    sa_item = db_session.scalar(
+        select(ShopAssemblyOpeningItem)
+        .join(ShopAssemblyOpening, ShopAssemblyOpening.id == ShopAssemblyOpeningItem.shop_assembly_opening_id)
+        .where(ShopAssemblyOpening.shop_assembly_request_id == sar.id)
+    )
+    db_session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=pr.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number="Z01",
+            leaf=1,
+            sa_opening_item_id=sa_item.id,
+            hardware_category="HINGE",
+            product_code=code,
+            requested_quantity=need,
+        )
+    )
+    db_session.flush()
+    return pr
+
+
+def test_receiving_unblocks_a_replacement_pull_and_notifies_the_warehouse(db_session):
+    """The backfill retry loop. A replacement pull holds no reservation by design (#342), so nothing
+    else was going to notice that the stock it was waiting on had turned up."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    repl = _blocked_replacement_pull(db_session, project, need=3)
+    po, li = _make_po_with_line(db_session, project.id, code="HG-900")
+
+    _receive(db_session, po, li, 3)
+    db_session.flush()
+
+    notes = _notifications(db_session, NotificationType.PULL_UNBLOCKED)
+    assert len(notes) == 1
+    from app.services import notification_service
+
+    assert notes[0].recipient_role == notification_service.WAREHOUSE_RECIPIENT_ROLE
+    assert notes[0].pull_request_id == repl.id
+    assert repl.request_number in notes[0].message
+
+
+def test_a_receive_that_does_not_close_the_gap_says_nothing(db_session):
+    """Transition, not proximity: the signal means "you can approve this now". Narrowing a shortfall
+    is not something the warehouse can act on, so announcing it would be telling somebody to go and
+    fail."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    _blocked_replacement_pull(db_session, project, need=3)
+    po, li = _make_po_with_line(db_session, project.id, code="HG-900")
+
+    _receive(db_session, po, li, 2)
+    db_session.flush()
+
+    assert _notifications(db_session, NotificationType.PULL_UNBLOCKED) == []
+
+    # ... and the receive that finally covers it does speak.
+    _receive(db_session, po, li, 1)
+    db_session.flush()
+    assert len(_notifications(db_session, NotificationType.PULL_UNBLOCKED)) == 1
+
+
+def test_an_unrelated_receive_is_not_even_considered(db_session):
+    """A receive of door closers cannot have changed whether a hinge replacement is coverable, so
+    the pull is filtered out before any availability arithmetic happens."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    _blocked_replacement_pull(db_session, project, need=1)
+    _seed_inventory(db_session, project.id, code="HG-900", quantity=5)
+    po, li = _make_po_with_line(db_session, project.id, code="CLOSER-1")
+
+    _receive(db_session, po, li, 5)
+    db_session.flush()
+
+    # The pull is fully coverable, but this receive is not what made it so, so it stays quiet.
+    assert _notifications(db_session, NotificationType.PULL_UNBLOCKED) == []
+
+
+def test_the_unblocked_signal_dedupes_to_one_open_notification_per_pull(db_session):
+    """One *unread* notification per pull. A replacement can sit PENDING across many receives, and
+    re-announcing it every time is how a bell stops being read. Once it has been read, the signal
+    has done its job and a later re-coverage is genuinely new information."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    repl = _blocked_replacement_pull(db_session, project, need=3)
+    po, li = _make_po_with_line(db_session, project.id, code="HG-900")
+
+    _receive(db_session, po, li, 3)
+    db_session.flush()
+    assert len(_notifications(db_session, NotificationType.PULL_UNBLOCKED)) == 1
+
+    # A second receive of the same combo: still coverable, still the same open signal.
+    _receive(db_session, po, li, 2)
+    db_session.flush()
+    assert len(_notifications(db_session, NotificationType.PULL_UNBLOCKED)) == 1
+
+    # Somebody reads it, and a later receive is allowed to raise a fresh one.
+    for note in _notifications(db_session, NotificationType.PULL_UNBLOCKED):
+        note.is_read = True
+    db_session.flush()
+    _receive(db_session, po, li, 2)
+    db_session.flush()
+    notes = _notifications(db_session, NotificationType.PULL_UNBLOCKED)
+    assert len(notes) == 2
+    assert {n.pull_request_id for n in notes} == {repl.id}
+
+
+def test_an_ordinary_shop_assembly_pull_is_not_treated_as_a_replacement(db_session):
+    """The discriminator is structural - a line stamped with `sa_opening_item_id` (#339) - not the
+    `PR-REPL-` number prefix. An ordinary accepted pull holds a reservation and is somebody's
+    responsibility already; it must not be announced here."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    sar = _request(db_session, project, leaves=(1,), qty=1)
+    _accept(db_session, sar)
+    po, li = _make_po_with_line(db_session, project.id, code="HG-100")
+
+    _receive(db_session, po, li, 5)
+    db_session.flush()
+
+    assert _notifications(db_session, NotificationType.PULL_UNBLOCKED) == []
+
+
+def test_a_stock_pool_receive_never_unblocks_a_project_replacement(db_session):
+    """A project-less PO routes into the stock pool, which is not project inventory. Allocating from
+    the pool to a project is a separate deliberate act, and that is where the signal would belong."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=10)
+    _blocked_replacement_pull(db_session, project, need=3)
+    po, li = _make_po_with_line(db_session, None, code="HG-900")
+
+    _receive(db_session, po, li, 5)
+    db_session.flush()
+
+    assert _notifications(db_session, NotificationType.PULL_UNBLOCKED) == []
+
+
+# --- dead state --------------------------------------------------------------------------------
+
+
+def test_approve_outcome_has_no_cancelled_value(db_session):
+    """#344's one enum deletion. `approve_pull_request` returns "APPROVED" or "INSUFFICIENT" and
+    nothing else since #224, so CANCELLED was unreachable. It is a GraphQL-only enum and was never
+    persisted, so removing it needed no migration - a *cancelled pull* is
+    `PullRequestStatus.CANCELLED`, a different enum on a real column, and very much alive."""
+    assert {v.name for v in ApproveOutcome} == {"APPROVED", "INSUFFICIENT"}
+    assert PullRequestStatus.CANCELLED.value == "CANCELLED"
+
+
+def test_pull_status_partial_is_derived_and_never_persisted(db_session):
+    """The audit's other finding. `PullStatus.PARTIAL` is reachable - it is what
+    `StagingSummary.status` returns and what `PullRequest.stagingStatus` and the pipeline's
+    `stagingStatus` surface - but no column ever holds it, so it stays in the enum and no migration
+    shrinks the Postgres type."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+    sar = _request(db_session, project, leaves=(1, 2))
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    openings = _openings(db_session, pr)
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [openings[0].id], "picker")
+    db_session.flush()
+
+    assert _summary(db_session, sar).staging_status == PullStatus.PARTIAL
+    assert (
+        db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_status == PullStatus.PARTIAL))
+        is None
+    )
+
+
+def test_every_pipeline_stage_the_repository_can_emit_is_a_graphql_enum_value(db_session):
+    """The ladder is defined once in the repository as strings and once in the schema as a GraphQL
+    enum; the converter maps between them. A stage the repository can produce but the schema cannot
+    express would be a 500 on the detail view, so the two are pinned together here."""
+    assert {s.value for s in PipelineStage} == set(shop_assembly_repository.PIPELINE_STAGE_RANK)
+
+
+def test_assembly_status_values_are_all_reachable(db_session):
+    """PENDING / IN_PROGRESS / COMPLETED, all three written by real code paths since #340."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    sar = _request(db_session, project, leaves=(1,), qty=1)
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    opening = _openings(db_session, pr)[0]
+    assert opening.assembly_status == AssemblyStatus.PENDING
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+    shop_assembly_repository.assign_openings(db_session, [opening.id], "user_1", "Ana")
+    db_session.flush()
+    item = db_session.scalar(
+        select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == opening.id)
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [shop_assembly_repository.AssemblyProgressUpdate(item.id, installed_quantity=1)],
+        performed_by="Ana",
+    )
+    db_session.flush()
+    assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
+
+    shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by="Ana")
+    db_session.flush()
+    assert opening.assembly_status == AssemblyStatus.COMPLETED

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -209,6 +209,60 @@ is allowed and sometimes right - reallocation exists for exactly that - but the 
 path refuses a flagged leaf unless the caller passes an explicit acknowledgment. Warn and confirm,
 never silent, never a hard block.
 
+### 5. Reading the lifecycle back
+
+Every stage above is written by a different screen, and until #344 it could only be *read* from the
+screen that wrote it. A request holds a reservation (§3a), its pull is part-staged (§3b), one leaf is
+half-built (§4), another is finished but owed a replacement (§4b) - and answering **"where is opening
+A01 leaf 2?"** meant opening four views and joining them by eye.
+
+The pipeline is that join, done once and **derived from the same state**. There is deliberately no
+`pipeline_stage` column: a denormalised stage would be a fifth thing that can disagree with the four
+above, and this whole slice exists because the four already disagreed on screen.
+
+The ladder is per door leaf, and the stage of a *request* is the stage of its **least-advanced**
+opening - what is holding it up, not its best news:
+
+    REQUESTED -> ACCEPTED -> PULLING -> STAGED -> ASSIGNED -> IN_PROGRESS -> COMPLETED -> SHIPPED
+
+`REJECTED` and `CANCELLED` sit off the ladder rather than at the end of it. They are the two ways a
+leaf leaves the pipeline unassembled, and reading them as "further along than IN_PROGRESS" would be
+nonsense. `CANCELLED` is also how a cancelled pull stays visible at all: cancellation detaches the
+openings and returns the request to PENDING (§3c), so without the cancelled pull in view the request
+would read as though it had never been accepted.
+
+Two constraints shaped the implementation, both from CLAUDE.md's performance rules:
+
+- **Scalar aggregates only.** Every count is `count`/`sum` with `FILTER`, grouped by request, one
+  statement for the whole result set. `get_assembly_pipeline_summaries` runs a fixed **five**
+  statements whether it covers one project or all of them; `get_assembly_pipeline` a fixed **eight**
+  however many openings a request has. Both numbers are asserted by tests, because a per-row lookup
+  here is exactly what an innocent-looking edit reaches for.
+- **One implementation per reading.** The request's stage is derived from the aggregates (the list
+  needs it on every row); each leaf's stage from its own columns. A test pins them together by
+  asserting the first equals the minimum of the second.
+
+The same view is where the flags earlier slices introduced finally meet the eye: the `integrity_note`
+from §3a, `deficient + replacement_pending` from §4b as "awaiting replacement", and the
+arrived-after-shipping case that `install_replacement` refuses.
+
+### 5a. Being told, rather than looking
+
+Three states slices 1-5 created had nobody watching them, and #344 gave each one a signal:
+
+| Event | Audience | Why it could not be inferred |
+| --- | --- | --- |
+| Openings became workable - carts staged (§3b), or a pull completed with openings still un-staged | Shop-assembly manager | Per-opening staging made an opening assignable the moment its cart was built; the assignment board only found out when somebody reloaded it |
+| A replacement arrived for a leaf that has **not** shipped (§4b) | The assembler holding the leaf | #341 notified only the *shipped* case. The ordinary case - the one somebody can act on - was silent |
+| A blocked PR-REPL pull became coverable because a receive landed the stock | Warehouse | A replacement pull holds **no reservation** by design (§3a), so nothing was tracking its demand. The approver saw INSUFFICIENT, the PO backfilled, and nothing said the retry would now succeed |
+
+The staged/completed pair needs no dedupe logic at all, because each call announces only the openings
+*it* made workable: staging the last cart calls `complete_pull_request`, which then finds nothing left
+to flip and stays silent. The unblocked signal does need one, and it is three rules - only pulls
+wanting a combo this receive landed; only when coverage crosses from insufficient to sufficient; and
+only one **unread** notification per pull, keyed on `notifications.pull_request_id` rather than on
+text inside the message.
+
 ## Corollary: LOOSE vs OPENING_ITEM pull lines
 
 Both pull request sources use `pull_request_items`, but the two `item_type` values do fundamentally
@@ -263,3 +317,10 @@ leaf until a pull tags it onto one).
 | Shipping a short leaf takes a decision | `backend/app/repositories/import_repository.py` (`finalize_import_session`, `acknowledge_incomplete_leaves`) |
 | Replacement stranded after shipment | `backend/app/repositories/warehouse/pull_requests.py` (`REPLACEMENT_AFTER_SHIPMENT` notification) |
 | Tag shipped | `backend/app/repositories/shipping_repository.py` (`confirm_shipment` -> `PackingSlipItem.leaf`) |
+| Lifecycle read back, per request | `backend/app/repositories/shop_assembly_repository.py` (`get_assembly_pipeline_summaries`, fixed five statements at any scale) |
+| Lifecycle read back, per door leaf | `backend/app/repositories/shop_assembly_repository.py` (`get_assembly_pipeline` + `_opening_stage`, fixed eight statements however many openings) |
+| Stage derived, never stored | `backend/app/repositories/shop_assembly_repository.py` (`PIPELINE_STAGE_RANK`, `_opening_stage`, `_request_stage`; `app/schemas/enums.PipelineStage`) |
+| Board told there is work | `backend/app/repositories/warehouse/pull_requests.py` (`notify_assembly_work_available`, called with only the openings that call made workable) |
+| Assembler told a replacement landed | `backend/app/repositories/warehouse/pull_requests.py` (`_apply_replacement_arrivals` -> `REPLACEMENT_ARRIVED`, addressed to `assigned_to_user_id`) |
+| Warehouse told a blocked replacement is coverable | `backend/app/repositories/warehouse/receiving.py` (`notify_unblocked_replacement_pulls` -> `find_pending_replacement_pulls`, structural `sa_opening_item_id` test) |
+| Notification dedupe key | `backend/app/models/notification.py` (`pull_request_id` + partial unread index) / `app/services/notification_service.has_unread_notification_for_pull` |

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -39,6 +39,17 @@ export const SHIPPING_REFETCH_QUERIES = ['GetOpeningLeafStatus'];
 // with different variables, so listing it costs two round-trips for a badge that self-corrects).
 export const SHIPPING_STALE_ROOT_FIELDS = ['shipReadyItems', 'openingItems'];
 
+// The pipeline read (#344). It is a route of its own inside the shop-assembly module, so it is by
+// definition NOT mounted while anybody is accepting a request, staging a cart, saving progress,
+// completing a leaf or cancelling a pull - every one of which moves a leaf along the ladder it draws.
+// That makes it eviction-only in every list below: refetchQueries reaches mounted instances, and
+// there are none.
+//
+// Both fields, always together. `assemblyPipelineSummaries` is the list and `assemblyPipeline` the
+// detail; they are computed from the same aggregates, so leaving one behind would be the one way to
+// make the two screens disagree - which is the exact failure this view exists to fix.
+export const PIPELINE_STALE_ROOT_FIELDS = ['assemblyPipelineSummaries', 'assemblyPipeline'];
+
 // What a shop-assembly progress save invalidates (#340). Same disjointness rule as above: a root
 // field that is evicted must not also be refetched by name, or Apollo fires a repair fetch for the
 // incomplete cache diff on top of the explicit refetch.
@@ -52,7 +63,7 @@ export const ASSEMBLY_PROGRESS_REFETCH_QUERIES = ['GetMyWork'];
 
 // Evicted. assembleList is read by the other entry point into the same modal, and the two views are
 // never mounted together (separate routes), so whichever one is live repairs its own diff.
-export const ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS = ['assembleList'];
+export const ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS = ['assembleList', ...PIPELINE_STALE_ROOT_FIELDS];
 
 // What installing a replacement onto a finished leaf invalidates (#341). Same disjointness rule.
 //
@@ -63,7 +74,46 @@ export const REPLACEMENT_INSTALL_REFETCH_QUERIES = ['GetReplacementWork'];
 // Evicted. openingItems carries awaitingReplacementQuantity, which the shipping wizard reads to
 // decide whether a leaf is flagged - and the wizard is a different module that is never mounted
 // while an assembler is installing, which is exactly what refetchQueries cannot reach.
-export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems'];
+export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems', ...PIPELINE_STALE_ROOT_FIELDS];
+
+// What completing a leaf invalidates (#340 made completion the sole writer of the assembled unit,
+// reading the persisted counters instead of taking a claim as input).
+//
+// Eviction-only, and there is deliberately nothing paired to refetch by name: the two views that can
+// launch a completion (My Work and the Assemble List) each refetch their own list in the modal's
+// onCompleted callback, so naming those root fields here would fire a repair fetch on top of that
+// refetch - the double-run this file exists to prevent. What their local refetch cannot reach is the
+// other modules:
+//   - openingItems: the warehouse's assembled-leaf grid, and the carrier of the #341
+//     awaitingReplacementQuantity flag.
+//   - shipReadyItems: a newly assembled leaf is new shipping inventory, and the shipping wizard is a
+//     different module entirely.
+export const ASSEMBLY_COMPLETE_STALE_ROOT_FIELDS = [
+  'openingItems',
+  'shipReadyItems',
+  ...PIPELINE_STALE_ROOT_FIELDS,
+];
+
+// What claiming or releasing an opening invalidates. All three assignment surfaces (the Assemble
+// List, the manager board, the manager panel) share GET_ASSEMBLE_LIST and refetch it themselves, so
+// again this is eviction-only and `assembleList` is deliberately absent. `myWork` is the assembler's
+// own board, which is a different route and never mounted while a manager is assigning.
+export const ASSIGNMENT_STALE_ROOT_FIELDS = ['myWork', ...PIPELINE_STALE_ROOT_FIELDS];
+
+// What approving or completing a pull invalidates, beyond the queue the caller already refetches.
+//
+// #343 re-keyed workability from "the pull is COMPLETED" to "this opening is PULLED", which made both
+// of these moments change what the assembly floor can see: approving lets the Assemble List show the
+// pull's openings as waiting, and completing stages whatever is left. Neither list is mounted while a
+// warehouse user is working a pull, so both are evicted rather than refetched. shipReadyItems is here
+// for the shipping-out side, where completing the pull is what flips leaves to SHIP_READY.
+export const PULL_LIFECYCLE_STALE_ROOT_FIELDS = [
+  'assembleList',
+  'myWork',
+  'shipReadyItems',
+  'projectInventoryAvailability',
+  ...PIPELINE_STALE_ROOT_FIELDS,
+];
 
 // What creating, accepting, rejecting or reopening a request invalidates (#342). Creating a request
 // RESERVES inventory, so every one of these moments changes `available = on-hand - deficient -
@@ -74,7 +124,12 @@ export const REPLACEMENT_INSTALL_STALE_ROOT_FIELDS = ['openingItems'];
 // a request is accepted or rejected - exactly the case refetchQueries cannot reach. Eviction is what
 // stops the next wizard session from opening on the cache-first half of its cache-and-network read
 // and gating a selection against pre-reservation numbers for a beat.
-export const RESERVATION_STALE_ROOT_FIELDS = ['projectInventoryAvailability'];
+export const RESERVATION_STALE_ROOT_FIELDS = [
+  'projectInventoryAvailability',
+  // Creating, accepting, rejecting and reopening are the first four rungs of the pipeline ladder
+  // (#344), so all four move a request along it.
+  ...PIPELINE_STALE_ROOT_FIELDS,
+];
 
 // What confirming a batch of openings as staged invalidates (#343). Same disjointness rule as above.
 //
@@ -87,7 +142,7 @@ export const PULL_STAGING_REFETCH_QUERIES = ['GetPullRequests'];
 // Evicted. Newly staged openings become assignable and workable at once, and both readers live in
 // the shop-assembly module - a different route that is by definition not mounted while a warehouse
 // user is picking, which is exactly what refetchQueries cannot reach.
-export const PULL_STAGING_STALE_ROOT_FIELDS = ['assembleList', 'myWork'];
+export const PULL_STAGING_STALE_ROOT_FIELDS = ['assembleList', 'myWork', ...PIPELINE_STALE_ROOT_FIELDS];
 
 // What cancelling a pull invalidates (#343). It is the widest blast radius in the warehouse: stock
 // goes back on the shelf, the source request returns to the accept queue, its claim is re-created,
@@ -106,4 +161,7 @@ export const PULL_CANCEL_STALE_ROOT_FIELDS = [
   'myWork',
   'projectInventoryAvailability',
   'shopAssemblyRequests',
+  // A cancellation puts the request back at the start of the ladder and leaves a cancelled pull in
+  // its history (#344), which is the reading that stops it looking like it was never accepted.
+  ...PIPELINE_STALE_ROOT_FIELDS,
 ];

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -122,6 +122,93 @@ export const INSTALL_REPLACEMENT = gql`
   }
 `;
 
+// The pipeline rollup, one row per shop-assembly request (#344). Answers "how far has this request
+// got" for a project, or for every project when projectId is omitted - the backend runs a fixed five
+// statements either way, so the All-Projects view is a normal read rather than a special case.
+const PIPELINE_SUMMARY_FIELDS = `
+  requestId
+  requestNumber
+  projectId
+  projectCode
+  projectName
+  requestStatus
+  createdBy
+  createdAt
+  acceptedBy
+  acceptedAt
+  rejectedBy
+  rejectedAt
+  integrityNote
+  pullRequestId
+  pullRequestStatus
+  pullApprovedAt
+  pullCompletedAt
+  stagingStatus
+  cancelledPullCount
+  lastCancelledAt
+  lastCancelledBy
+  lastCancellationReason
+  openingCount
+  stagedOpeningCount
+  assignedOpeningCount
+  inProgressOpeningCount
+  completedOpeningCount
+  shippedOpeningCount
+  plannedUnitCount
+  installedUnitCount
+  deficientUnitCount
+  replacementPendingUnitCount
+  awaitingReplacementOpeningCount
+  replacementAfterShipOpeningCount
+  stage
+`;
+
+export const GET_ASSEMBLY_PIPELINE_SUMMARIES = gql`
+  query GetAssemblyPipelineSummaries($projectId: ID, $status: ShopAssemblyRequestStatus) {
+    assemblyPipelineSummaries(projectId: $projectId, status: $status) {
+      ${PIPELINE_SUMMARY_FIELDS}
+    }
+  }
+`;
+
+// One request down to the individual door leaf: the query that answers "where is opening A01 leaf 2?"
+// in one place instead of four. The header counts are the same aggregates the list above uses, so the
+// two screens cannot disagree.
+export const GET_ASSEMBLY_PIPELINE = gql`
+  query GetAssemblyPipeline($requestId: ID!) {
+    assemblyPipeline(requestId: $requestId) {
+      summary {
+        ${PIPELINE_SUMMARY_FIELDS}
+      }
+      openings {
+        shopAssemblyOpeningId
+        openingNumber
+        leaf
+        building
+        floor
+        location
+        stage
+        pullStatus
+        stagedAt
+        stagedBy
+        assignedToUserId
+        assignedTo
+        assemblyStatus
+        completedAt
+        plannedUnitCount
+        installedUnitCount
+        deficientUnitCount
+        replacementPendingUnitCount
+        awaitingReplacementUnitCount
+        replacementArrivedAfterShip
+        openingItemId
+        openingItemState
+        assembledLocation
+      }
+    }
+  }
+`;
+
 export const GET_SHOP_ASSEMBLY_STATS = gql`
   query GetShopAssemblyStats {
     shopAssemblyStats {

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -18,6 +18,7 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_ASSEMBLE_LIST, ASSIGN_OPENINGS, REMOVE_OPENING_FROM_USER } from '../../graphql/shop-assembly';
+import { ASSIGNMENT_STALE_ROOT_FIELDS } from '../../graphql/refetch';
 import { leafSuffix } from '../../utils/leaf';
 import OpeningLeafStatusPanel from '../../components/OpeningLeafStatusPanel';
 import { useIdentity } from '../../hooks/useIdentity';
@@ -90,6 +91,15 @@ export default function AssembleListPage() {
   );
 
   const [assignOpenings] = useMutation(ASSIGN_OPENINGS, {
+    // Eviction only; `assembleList` is absent because this page refetches it itself in the
+    // callbacks below (see refetch.ts). What that cannot reach is the assembler's own board and the
+    // pipeline, both on other routes.
+    update(cache) {
+      for (const fieldName of ASSIGNMENT_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: () => {
       showToast('Assigned to you', 'success');
       refetch();
@@ -98,6 +108,15 @@ export default function AssembleListPage() {
   });
 
   const [removeOpening] = useMutation(REMOVE_OPENING_FROM_USER, {
+    // Eviction only; `assembleList` is absent because this page refetches it itself in the
+    // callbacks below (see refetch.ts). What that cannot reach is the assembler's own board and the
+    // pipeline, both on other routes.
+    update(cache) {
+      for (const fieldName of ASSIGNMENT_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: () => {
       showToast('Opening returned to available pool', 'success');
       refetch();

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -20,6 +20,7 @@ import {
 import { useMutation } from '@apollo/client/react';
 import { COMPLETE_OPENING, RECORD_ASSEMBLY_PROGRESS } from '../../graphql/shop-assembly';
 import {
+  ASSEMBLY_COMPLETE_STALE_ROOT_FIELDS,
   ASSEMBLY_PROGRESS_REFETCH_QUERIES,
   ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS,
 } from '../../graphql/refetch';
@@ -103,6 +104,16 @@ export default function AssemblyDetailModal({
   });
 
   const [completeOpening, { loading: completing }] = useMutation(COMPLETE_OPENING, {
+    // Eviction only, and `assembleList`/`myWork` are deliberately not in the list: onCompleted below
+    // calls back into whichever page opened this modal, and that page refetches its own query. What
+    // it cannot reach is the warehouse's assembled-leaf grid, the shipping wizard's ship-ready list
+    // and the pipeline - all in modules that are not mounted at the bench. See refetch.ts.
+    update(cache) {
+      for (const fieldName of ASSEMBLY_COMPLETE_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: () => {
       showToast(`Opening ${opening.openingNumber || 'item'} marked complete`, 'success');
       onCompleted();

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -22,6 +22,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_ASSEMBLE_LIST, ASSIGN_OPENINGS, REMOVE_OPENING_FROM_USER } from '../../graphql/shop-assembly';
+import { ASSIGNMENT_STALE_ROOT_FIELDS } from '../../graphql/refetch';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { leafSuffix } from '../../utils/leaf';
@@ -177,6 +178,15 @@ export default function AssignmentBoard() {
   const { data, refetch } = useQuery<{ assembleList: AssembleOpening[] }>(GET_ASSEMBLE_LIST);
 
   const [assignOpenings] = useMutation(ASSIGN_OPENINGS, {
+    // Eviction only; `assembleList` is absent because this page refetches it itself in the
+    // callbacks below (see refetch.ts). What that cannot reach is the assembler's own board and the
+    // pipeline, both on other routes.
+    update(cache) {
+      for (const fieldName of ASSIGNMENT_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: (data) => {
       const count = (data as { assignOpenings: unknown[] }).assignOpenings.length;
       showToast(`${count} opening(s) assigned`, 'success');
@@ -189,6 +199,15 @@ export default function AssignmentBoard() {
   });
 
   const [removeOpening] = useMutation(REMOVE_OPENING_FROM_USER, {
+    // Eviction only; `assembleList` is absent because this page refetches it itself in the
+    // callbacks below (see refetch.ts). What that cannot reach is the assembler's own board and the
+    // pipeline, both on other routes.
+    update(cache) {
+      for (const fieldName of ASSIGNMENT_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: () => {
       showToast('Opening returned to available pool', 'success');
       refetch();

--- a/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
@@ -24,6 +24,7 @@ import {
   GET_SHOP_ASSEMBLY_MEMBERS,
   ASSIGN_OPENINGS,
 } from '../../graphql/shop-assembly';
+import { ASSIGNMENT_STALE_ROOT_FIELDS } from '../../graphql/refetch';
 import { leafSuffix } from '../../utils/leaf';
 import { useToast } from '../../components/Toast';
 import { isAvailableForAssignment } from './openingFilters';
@@ -93,6 +94,15 @@ export default function ManagerAssignPanel() {
   }, [openings]);
 
   const [assignOpenings, { loading: assigning }] = useMutation(ASSIGN_OPENINGS, {
+    // Eviction only; `assembleList` is absent because this page refetches it itself in the
+    // callbacks below (see refetch.ts). What that cannot reach is the assembler's own board and the
+    // pipeline, both on other routes.
+    update(cache) {
+      for (const fieldName of ASSIGNMENT_STALE_ROOT_FIELDS) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
     onCompleted: (data) => {
       const count = (data as { assignOpenings: unknown[] }).assignOpenings.length;
       const member = members.find((m) => m.id === memberId);

--- a/frontend/src/modules/shop-assembly/PipelinePage.tsx
+++ b/frontend/src/modules/shop-assembly/PipelinePage.tsx
@@ -1,0 +1,379 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  LinearProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import { useQuery } from '@apollo/client/react';
+import type { GridColDef } from '@mui/x-data-grid';
+import { GET_ASSEMBLY_PIPELINE, GET_ASSEMBLY_PIPELINE_SUMMARIES } from '../../graphql/shop-assembly';
+import DataTable from '../../components/DataTable';
+import Modal from '../../components/Modal';
+import { leafSuffix } from '../../utils/leaf';
+import { pipelineFlags, stageColor, stageLabel, stageProgress, unitProgressLabel } from './pipelineStages';
+
+export interface PipelineSummary {
+  requestId: string;
+  requestNumber: string;
+  projectId: string;
+  projectCode: string | null;
+  projectName: string | null;
+  requestStatus: string;
+  createdBy: string;
+  createdAt: string;
+  acceptedBy: string | null;
+  acceptedAt: string | null;
+  rejectedBy: string | null;
+  rejectedAt: string | null;
+  integrityNote: string | null;
+  pullRequestId: string | null;
+  pullRequestStatus: string | null;
+  pullApprovedAt: string | null;
+  pullCompletedAt: string | null;
+  stagingStatus: string | null;
+  cancelledPullCount: number;
+  lastCancelledAt: string | null;
+  lastCancelledBy: string | null;
+  lastCancellationReason: string | null;
+  openingCount: number;
+  stagedOpeningCount: number;
+  assignedOpeningCount: number;
+  inProgressOpeningCount: number;
+  completedOpeningCount: number;
+  shippedOpeningCount: number;
+  plannedUnitCount: number;
+  installedUnitCount: number;
+  deficientUnitCount: number;
+  replacementPendingUnitCount: number;
+  awaitingReplacementOpeningCount: number;
+  replacementAfterShipOpeningCount: number;
+  stage: string;
+}
+
+export interface PipelineOpeningRow {
+  shopAssemblyOpeningId: string;
+  openingNumber: string;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  stage: string;
+  pullStatus: string;
+  stagedAt: string | null;
+  stagedBy: string | null;
+  assignedToUserId: string | null;
+  assignedTo: string | null;
+  assemblyStatus: string;
+  completedAt: string | null;
+  plannedUnitCount: number;
+  installedUnitCount: number;
+  deficientUnitCount: number;
+  replacementPendingUnitCount: number;
+  awaitingReplacementUnitCount: number;
+  replacementArrivedAfterShip: boolean;
+  openingItemId: string | null;
+  openingItemState: string | null;
+  assembledLocation: string | null;
+}
+
+const VIEWS = [
+  { value: '', label: 'All' },
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'REJECTED', label: 'Rejected' },
+];
+
+function StageChip({ stage }: { stage: string }) {
+  return <Chip size='small' variant='outlined' color={stageColor(stage)} label={stageLabel(stage)} />;
+}
+
+const columns: GridColDef[] = [
+  { field: 'requestNumber', headerName: 'Request', flex: 1 },
+  {
+    field: 'project',
+    headerName: 'Project',
+    flex: 1.1,
+    valueGetter: (_v: unknown, row: PipelineSummary) =>
+      [row.projectCode, row.projectName].filter(Boolean).join(' - ') || '-',
+  },
+  {
+    field: 'stage',
+    headerName: 'Stage',
+    flex: 0.9,
+    // The stage of the least-advanced opening: what the request is waiting on, not its best news.
+    renderCell: (params) => <StageChip stage={params.row.stage} />,
+  },
+  {
+    field: 'staging',
+    headerName: 'Staged',
+    flex: 0.8,
+    // Blank rather than "0 of 0" when the request has no openings - the same rule the pull queue's
+    // staging column follows, so "nothing to say" never reads as "nothing done".
+    valueGetter: (_v: unknown, row: PipelineSummary) =>
+      row.openingCount > 0 ? `${row.stagedOpeningCount} of ${row.openingCount}` : '',
+  },
+  {
+    field: 'progress',
+    headerName: 'Progress',
+    flex: 0.9,
+    valueGetter: (_v: unknown, row: PipelineSummary) => unitProgressLabel(row),
+  },
+  {
+    field: 'assembled',
+    headerName: 'Assembled',
+    flex: 0.8,
+    valueGetter: (_v: unknown, row: PipelineSummary) =>
+      row.openingCount > 0 ? `${row.completedOpeningCount} of ${row.openingCount}` : '',
+  },
+  {
+    field: 'shipped',
+    headerName: 'Shipped',
+    flex: 0.7,
+    valueGetter: (_v: unknown, row: PipelineSummary) =>
+      row.openingCount > 0 ? `${row.shippedOpeningCount} of ${row.openingCount}` : '',
+  },
+  {
+    field: 'flags',
+    headerName: 'Flags',
+    flex: 1.2,
+    sortable: false,
+    // Nothing at all when nothing is wrong. A row of reassuring chips would make the one row that
+    // does need attention harder to find, which is the opposite of what this column is for.
+    renderCell: (params) => (
+      <Stack direction='row' spacing={0.5} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
+        {pipelineFlags(params.row as PipelineSummary).map((flag) => (
+          <Chip key={flag.label} size='small' variant='outlined' color={flag.severity} label={flag.label} />
+        ))}
+      </Stack>
+    ),
+  },
+];
+
+function formatWhen(value: string | null): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
+}
+
+/**
+ * Where every shop-assembly request has got to, and where each of its door leaves is (#344).
+ *
+ * Slices 1-5 each added a state that was legible only from the screen that wrote it: a request holds
+ * a reservation, its pull is part-staged, one leaf is half-built, another is finished but owed a
+ * replacement. Answering "where is opening A01 leaf 2?" meant opening four views and joining them by
+ * eye. This is that join, done once.
+ *
+ * Nothing here is editable. It is deliberately a reading, not a console: every one of these states
+ * already has a screen that owns changing it, and a second place to act on them is a second place
+ * for the rules to be enforced.
+ */
+export default function PipelinePage() {
+  const [status, setStatus] = useState('');
+  // Hold the id, not the row: the detail query is the authority on this request, and pinning the
+  // modal to a list snapshot is the trap #340 fixed in the assembly views.
+  const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
+
+  const { data, loading } = useQuery<{ assemblyPipelineSummaries: PipelineSummary[] }>(
+    GET_ASSEMBLY_PIPELINE_SUMMARIES,
+    { variables: { status: status || null }, fetchPolicy: 'cache-and-network' },
+  );
+
+  const rows = useMemo(() => data?.assemblyPipelineSummaries ?? [], [data]);
+  const handleRowClick = useCallback((params: { row: PipelineSummary }) => {
+    setSelectedRequestId(params.row.requestId);
+  }, []);
+
+  return (
+    <Box>
+      <Typography variant='h5' gutterBottom>
+        Pipeline
+      </Typography>
+      <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+        Every shop-assembly request and how far it has got: requested, accepted, staged, assigned,
+        built, shipped. A request reads by its least-advanced opening, so the stage shown is what it
+        is waiting on. Open one to see each door leaf.
+      </Typography>
+
+      <ToggleButtonGroup
+        size='small'
+        exclusive
+        value={status}
+        onChange={(_e, next) => setStatus(next ?? '')}
+        sx={{ mb: 2 }}
+      >
+        {VIEWS.map((view) => (
+          <ToggleButton key={view.value || 'all'} value={view.value}>
+            {view.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+
+      <DataTable
+        rows={rows}
+        columns={columns}
+        loading={loading}
+        onRowClick={handleRowClick}
+        getRowId={(row: PipelineSummary) => row.requestId}
+        height={520}
+      />
+
+      {selectedRequestId && (
+        <PipelineDetailModal requestId={selectedRequestId} onClose={() => setSelectedRequestId(null)} />
+      )}
+    </Box>
+  );
+}
+
+function PipelineDetailModal({ requestId, onClose }: { requestId: string; onClose: () => void }) {
+  const { data, loading } = useQuery<{
+    assemblyPipeline: { summary: PipelineSummary; openings: PipelineOpeningRow[] };
+  }>(GET_ASSEMBLY_PIPELINE, { variables: { requestId }, fetchPolicy: 'cache-and-network' });
+
+  const summary = data?.assemblyPipeline.summary;
+  const openings = data?.assemblyPipeline.openings ?? [];
+  const progress = summary ? stageProgress(summary.stage) : null;
+
+  return (
+    <Modal open title={summary ? `Pipeline - ${summary.requestNumber}` : 'Pipeline'} onClose={onClose}>
+      {loading && !summary && <LinearProgress />}
+      {summary && (
+        <Box>
+          {/* The request-level doubt (#342) comes first, above everything it casts doubt on. */}
+          {summary.integrityNote && (
+            <Alert severity='warning' sx={{ mb: 2 }}>
+              {summary.integrityNote}
+            </Alert>
+          )}
+          {summary.cancelledPullCount > 0 && (
+            <Alert severity='warning' sx={{ mb: 2 }}>
+              {summary.cancelledPullCount === 1 ? 'A pull for this request was' : 'Pulls for this request were'}{' '}
+              cancelled and the hardware returned to inventory
+              {summary.lastCancelledBy ? ` by ${summary.lastCancelledBy}` : ''}
+              {summary.lastCancellationReason ? `: ${summary.lastCancellationReason}` : '.'}
+            </Alert>
+          )}
+          {summary.replacementAfterShipOpeningCount > 0 && (
+            <Alert severity='error' sx={{ mb: 2 }}>
+              Replacement hardware arrived for {summary.replacementAfterShipOpeningCount} leaf/leaves that
+              had already shipped. It cannot be fitted here and needs a reallocation or a site shipment.
+            </Alert>
+          )}
+
+          <Stack direction='row' spacing={1} sx={{ mb: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+            <StageChip stage={summary.stage} />
+            <Chip
+              size='small'
+              variant='outlined'
+              label={
+                summary.openingCount > 0
+                  ? `${summary.stagedOpeningCount} of ${summary.openingCount} staged`
+                  : 'No openings'
+              }
+            />
+            <Chip size='small' variant='outlined' label={unitProgressLabel(summary)} />
+            {summary.awaitingReplacementOpeningCount > 0 && (
+              <Chip
+                size='small'
+                variant='outlined'
+                color='warning'
+                label={`${summary.awaitingReplacementOpeningCount} awaiting replacement`}
+              />
+            )}
+          </Stack>
+          {progress !== null && (
+            <LinearProgress variant='determinate' value={progress * 100} sx={{ mb: 2 }} />
+          )}
+
+          <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+            Requested by {summary.createdBy} on {formatWhen(summary.createdAt)}
+            {summary.acceptedBy ? `, accepted by ${summary.acceptedBy} on ${formatWhen(summary.acceptedAt)}` : ''}
+            {summary.rejectedBy ? `, rejected by ${summary.rejectedBy} on ${formatWhen(summary.rejectedAt)}` : ''}.
+          </Typography>
+
+          {openings.length === 0 ? (
+            <Typography variant='body2' color='text.secondary'>
+              This request has no openings on it.
+            </Typography>
+          ) : (
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table size='small'>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Opening</TableCell>
+                    <TableCell>Stage</TableCell>
+                    <TableCell>Staged</TableCell>
+                    <TableCell>Assigned to</TableCell>
+                    <TableCell>Units</TableCell>
+                    <TableCell>Location</TableCell>
+                    <TableCell>Owed</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {openings.map((row) => (
+                    <TableRow key={row.shopAssemblyOpeningId}>
+                      <TableCell>
+                        {row.openingNumber}
+                        {leafSuffix(row.leaf)}
+                        {(row.building || row.floor) && (
+                          <Typography variant='caption' color='text.secondary' display='block'>
+                            {[row.building, row.floor].filter(Boolean).join(' / ')}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <StageChip stage={row.stage} />
+                      </TableCell>
+                      <TableCell>
+                        {row.stagedAt ? (
+                          <>
+                            {formatWhen(row.stagedAt)}
+                            {row.stagedBy && (
+                              <Typography variant='caption' color='text.secondary' display='block'>
+                                by {row.stagedBy}
+                              </Typography>
+                            )}
+                          </>
+                        ) : (
+                          '-'
+                        )}
+                      </TableCell>
+                      <TableCell>{row.assignedTo ?? '-'}</TableCell>
+                      <TableCell>{unitProgressLabel(row)}</TableCell>
+                      <TableCell>{row.assembledLocation ?? '-'}</TableCell>
+                      <TableCell>
+                        {row.awaitingReplacementUnitCount > 0 ? (
+                          <Chip
+                            size='small'
+                            variant='outlined'
+                            color={row.replacementArrivedAfterShip ? 'error' : 'warning'}
+                            label={
+                              row.replacementArrivedAfterShip
+                                ? `${row.awaitingReplacementUnitCount} arrived after shipping`
+                                : `${row.awaitingReplacementUnitCount} awaiting replacement`
+                            }
+                          />
+                        ) : (
+                          '-'
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/modules/shop-assembly/ShopAssemblyLanding.tsx
+++ b/frontend/src/modules/shop-assembly/ShopAssemblyLanding.tsx
@@ -5,6 +5,7 @@ import HowToRegIcon from '@mui/icons-material/HowToReg';
 import PersonIcon from '@mui/icons-material/Person';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import TimelineIcon from '@mui/icons-material/Timeline';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@apollo/client/react';
 import { StatCard, StatCardSkeleton } from '../../components/StatCard';
@@ -40,6 +41,8 @@ const SUB_ROUTES = [
   { label: 'Assemble List', path: '/app/shop-assembly/assemble', icon: <BuildIcon fontSize="large" /> },
   { label: 'Assignments', path: '/app/shop-assembly/assign', icon: <HowToRegIcon fontSize="large" /> },
   { label: 'My Work', path: '/app/shop-assembly/my-work', icon: <PersonIcon fontSize="large" /> },
+  // Where every request has got to (#344) - the read-only join across the states slices 1-5 added.
+  { label: 'Pipeline', path: '/app/shop-assembly/pipeline', icon: <TimelineIcon fontSize="large" /> },
 ];
 
 export default function ShopAssemblyLanding() {

--- a/frontend/src/modules/shop-assembly/__tests__/PipelinePage.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/PipelinePage.test.tsx
@@ -1,0 +1,308 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import PipelinePage from '../PipelinePage';
+import { GET_ASSEMBLY_PIPELINE, GET_ASSEMBLY_PIPELINE_SUMMARIES } from '../../../graphql/shop-assembly';
+import { pipelineFlags, stageColor, stageLabel, stageProgress, unitProgressLabel } from '../pipelineStages';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// The pipeline is a reading, not a console: it draws the ladder slices 1-5 built and surfaces the
+// flags they introduced, and it changes nothing. These tests pin the readings and the two things a
+// reader would be misled by if they broke - the stage shown for a request, and the flags.
+
+function summary(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'AssemblyPipelineSummary',
+    requestId: 'r1',
+    requestNumber: 'SA-0001',
+    projectId: 'p1',
+    projectCode: 'JOB-1',
+    projectName: 'Riverside',
+    requestStatus: 'APPROVED',
+    createdBy: 'Hardware Schedule Import',
+    createdAt: '2026-07-01T09:00:00',
+    acceptedBy: 'Ana',
+    acceptedAt: '2026-07-02T09:00:00',
+    rejectedBy: null,
+    rejectedAt: null,
+    integrityNote: null,
+    pullRequestId: 'pr1',
+    pullRequestStatus: 'IN_PROGRESS',
+    pullApprovedAt: '2026-07-02T10:00:00',
+    pullCompletedAt: null,
+    stagingStatus: 'PARTIAL',
+    cancelledPullCount: 0,
+    lastCancelledAt: null,
+    lastCancelledBy: null,
+    lastCancellationReason: null,
+    openingCount: 4,
+    stagedOpeningCount: 2,
+    assignedOpeningCount: 1,
+    inProgressOpeningCount: 1,
+    completedOpeningCount: 0,
+    shippedOpeningCount: 0,
+    plannedUnitCount: 16,
+    installedUnitCount: 5,
+    deficientUnitCount: 1,
+    replacementPendingUnitCount: 0,
+    awaitingReplacementOpeningCount: 1,
+    replacementAfterShipOpeningCount: 0,
+    stage: 'PULLING',
+    ...overrides,
+  };
+}
+
+function openingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'PipelineOpening',
+    shopAssemblyOpeningId: 'o1',
+    openingNumber: 'A01',
+    leaf: 2,
+    building: 'A',
+    floor: '2',
+    location: null,
+    stage: 'IN_PROGRESS',
+    pullStatus: 'PULLED',
+    stagedAt: '2026-07-02T11:00:00',
+    stagedBy: 'Picker',
+    assignedToUserId: 'user_1',
+    assignedTo: 'Bo',
+    assemblyStatus: 'IN_PROGRESS',
+    completedAt: null,
+    plannedUnitCount: 4,
+    installedUnitCount: 2,
+    deficientUnitCount: 1,
+    replacementPendingUnitCount: 0,
+    awaitingReplacementUnitCount: 1,
+    replacementArrivedAfterShip: false,
+    openingItemId: null,
+    openingItemState: null,
+    assembledLocation: null,
+    ...overrides,
+  };
+}
+
+function listMock(rows: ReturnType<typeof summary>[]): MockedResponse {
+  return {
+    request: { query: GET_ASSEMBLY_PIPELINE_SUMMARIES, variables: { status: null } },
+    result: { data: { assemblyPipelineSummaries: rows } },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+  };
+}
+
+function detailMock(
+  s: ReturnType<typeof summary>,
+  openings: ReturnType<typeof openingRow>[],
+): MockedResponse {
+  return {
+    request: { query: GET_ASSEMBLY_PIPELINE, variables: { requestId: s.requestId } },
+    result: {
+      data: { assemblyPipeline: { __typename: 'AssemblyPipeline', summary: s, openings } },
+    },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+  };
+}
+
+function renderPage(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <PipelinePage />
+    </MockedProvider>,
+  );
+}
+
+describe('pipelineStages readings', () => {
+  it('labels every rung of the ladder and both ways off it', () => {
+    expect(stageLabel('PULLING')).toBe('Awaiting pull');
+    expect(stageLabel('IN_PROGRESS')).toBe('In progress');
+    expect(stageLabel('COMPLETED')).toBe('Assembled');
+    expect(stageLabel('CANCELLED')).toBe('Pull cancelled');
+  });
+
+  it('keeps status colour for real system state only', () => {
+    // DESIGN.md: colour is reserved. Most of the ladder is just "where the work is", so it stays
+    // neutral; only the readings somebody acts on differently earn a colour.
+    expect(stageColor('STAGED')).toBe('default');
+    expect(stageColor('ASSIGNED')).toBe('default');
+    expect(stageColor('IN_PROGRESS')).toBe('info');
+    expect(stageColor('SHIPPED')).toBe('success');
+    expect(stageColor('REJECTED')).toBe('error');
+    expect(stageColor('CANCELLED')).toBe('warning');
+  });
+
+  it('gives no rail position to a stage that is off the ladder', () => {
+    // Rendering REJECTED at 0 would say a request that got half way through never started.
+    expect(stageProgress('REQUESTED')).toBe(0);
+    expect(stageProgress('SHIPPED')).toBe(1);
+    expect(stageProgress('REJECTED')).toBeNull();
+    expect(stageProgress('CANCELLED')).toBeNull();
+  });
+
+  it('counts dispositioned units, not installed ones', () => {
+    // Completion is gated on installed + deficient + pending === planned (#340/#341), so that is the
+    // number the progress reading has to show or it disagrees with the gate.
+    expect(
+      unitProgressLabel({
+        plannedUnitCount: 8,
+        installedUnitCount: 5,
+        deficientUnitCount: 2,
+        replacementPendingUnitCount: 1,
+      }),
+    ).toBe('8/8 units');
+  });
+
+  it('returns no flags when nothing is wrong', () => {
+    expect(pipelineFlags({ integrityNote: null, awaitingReplacementOpeningCount: 0 })).toEqual([]);
+  });
+
+  it('orders the flags doubt-first and escalates the after-shipping one', () => {
+    const flags = pipelineFlags({
+      integrityNote: 'a re-upload landed',
+      awaitingReplacementOpeningCount: 2,
+      replacementAfterShipOpeningCount: 1,
+    });
+    expect(flags.map((f) => f.label)).toEqual([
+      'Needs review',
+      '2 awaiting replacement',
+      '1 arrived after shipping',
+    ]);
+    expect(flags[2].severity).toBe('error');
+  });
+});
+
+describe('PipelinePage', () => {
+  it('lists a request with its stage, staging and unit progress', async () => {
+    renderPage([listMock([summary()])]);
+
+    expect(await screen.findByText('SA-0001')).toBeInTheDocument();
+    expect(screen.getByText('JOB-1 - Riverside')).toBeInTheDocument();
+    // The stage of the least-advanced opening: what the request is waiting on.
+    expect(screen.getByText('Awaiting pull')).toBeInTheDocument();
+    expect(screen.getByText('2 of 4')).toBeInTheDocument();
+    expect(screen.getByText('6/16 units')).toBeInTheDocument();
+    expect(screen.getByText('1 awaiting replacement')).toBeInTheDocument();
+  });
+
+  it('renders nothing in the staging column for a request with no openings', async () => {
+    // A zeroed "0 of 0" would read as "nothing done" rather than "not applicable" - the same rule the
+    // pull queue's staging chip follows.
+    renderPage([listMock([summary({ openingCount: 0, stagedOpeningCount: 0 })])]);
+
+    expect(await screen.findByText('SA-0001')).toBeInTheDocument();
+    expect(screen.queryByText('0 of 0')).not.toBeInTheDocument();
+  });
+
+  it('opens a request and shows where each door leaf is', async () => {
+    const s = summary();
+    renderPage([
+      listMock([s]),
+      detailMock(s, [
+        // Two leaves of one opening at different rungs - the case the whole view exists for.
+        openingRow(),
+        openingRow({
+          shopAssemblyOpeningId: 'o2',
+          leaf: 1,
+          stage: 'STAGED',
+          assemblyStatus: 'PENDING',
+          assignedToUserId: null,
+          assignedTo: null,
+          installedUnitCount: 0,
+          deficientUnitCount: 0,
+          awaitingReplacementUnitCount: 0,
+        }),
+      ]),
+    ]);
+
+    fireEvent.click(await screen.findByText('SA-0001'));
+
+    // Scoped to the dialog: the list underneath has columns with the same headings, and this test is
+    // about the per-leaf rows.
+    expect(await screen.findByText(/A01 - Leaf 2/)).toBeInTheDocument();
+    const detail = within(screen.getByRole('dialog'));
+    // The question the view exists to answer, one row per leaf, at different rungs.
+    expect(detail.getByText(/A01 - Leaf 1/)).toBeInTheDocument();
+    expect(detail.getByText('Bo')).toBeInTheDocument();
+    expect(detail.getByText('In progress')).toBeInTheDocument();
+    // Leaf 2 has three of four units dispositioned; leaf 1 has not been started.
+    expect(detail.getByText('3/4 units')).toBeInTheDocument();
+    expect(detail.getByText('0/4 units')).toBeInTheDocument();
+    expect(detail.getAllByText('by Picker')).toHaveLength(2);
+    // The header chip and the leaf-2 row both say a unit is owed.
+    expect(detail.getAllByText('1 awaiting replacement')).toHaveLength(2);
+  });
+
+  it('shows the assembled leaf location once there is one', async () => {
+    const s = summary({ stage: 'COMPLETED', completedOpeningCount: 1, openingCount: 1, stagedOpeningCount: 1 });
+    renderPage([
+      listMock([s]),
+      detailMock(s, [
+        openingRow({
+          stage: 'COMPLETED',
+          assemblyStatus: 'COMPLETED',
+          assembledLocation: 'B-2-3',
+          openingItemId: 'oi1',
+          openingItemState: 'IN_INVENTORY',
+          installedUnitCount: 4,
+          deficientUnitCount: 0,
+          awaitingReplacementUnitCount: 0,
+        }),
+      ]),
+    ]);
+
+    fireEvent.click(await screen.findByText('SA-0001'));
+    expect(await screen.findByText('B-2-3')).toBeInTheDocument();
+  });
+
+  it('surfaces the integrity note as an alert above the detail', async () => {
+    const s = summary({ integrityNote: 'A schedule re-upload landed under this request.' });
+    renderPage([listMock([s]), detailMock(s, [openingRow()])]);
+
+    fireEvent.click(await screen.findByText('SA-0001'));
+    expect(
+      await screen.findByText('A schedule re-upload landed under this request.'),
+    ).toBeInTheDocument();
+  });
+
+  it('explains a cancelled pull rather than leaving the request looking untouched', async () => {
+    // A cancellation returns the request to PENDING and detaches its openings, so without this the
+    // request would read as though it had never been accepted.
+    const s = summary({
+      requestStatus: 'PENDING',
+      stage: 'CANCELLED',
+      pullRequestId: null,
+      pullRequestStatus: null,
+      cancelledPullCount: 1,
+      lastCancelledBy: 'Sam',
+      lastCancellationReason: 'raised on the wrong project',
+    });
+    renderPage([listMock([s]), detailMock(s, [openingRow({ stage: 'CANCELLED' })])]);
+
+    fireEvent.click(await screen.findByText('SA-0001'));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/cancelled and the hardware returned to inventory by Sam/),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/raised on the wrong project/)).toBeInTheDocument();
+  });
+
+  it('escalates a replacement that arrived after its leaf shipped', async () => {
+    const s = summary({ replacementAfterShipOpeningCount: 1, replacementPendingUnitCount: 1 });
+    renderPage([
+      listMock([s]),
+      detailMock(s, [
+        openingRow({
+          stage: 'SHIPPED',
+          openingItemState: 'SHIPPED_OUT',
+          replacementPendingUnitCount: 1,
+          awaitingReplacementUnitCount: 1,
+          replacementArrivedAfterShip: true,
+        }),
+      ]),
+    ]);
+
+    fireEvent.click(await screen.findByText('SA-0001'));
+    expect(await screen.findByText(/needs a reallocation or a site shipment/)).toBeInTheDocument();
+    expect(screen.getAllByText('1 arrived after shipping').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/modules/shop-assembly/index.tsx
+++ b/frontend/src/modules/shop-assembly/index.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import AssembleListPage from './AssembleListPage';
 import AssignmentBoard from './AssignmentBoard';
 import MyWorkPage from './MyWorkPage';
+import PipelinePage from './PipelinePage';
 import ShopAssemblyLanding from './ShopAssemblyLanding';
 import ShopAssemblyRequestsPage from './ShopAssemblyRequestsPage';
 import BackToModule from '../../components/BackToModule';
@@ -25,6 +26,7 @@ export default function ShopAssemblyModule() {
       <Route path="assemble" element={<ShopAssemblySubLayout><AssembleListPage /></ShopAssemblySubLayout>} />
       <Route path="assign" element={<ShopAssemblySubLayout><AssignmentBoard /></ShopAssemblySubLayout>} />
       <Route path="my-work" element={<ShopAssemblySubLayout><MyWorkPage /></ShopAssemblySubLayout>} />
+      <Route path="pipeline" element={<ShopAssemblySubLayout><PipelinePage /></ShopAssemblySubLayout>} />
       <Route path="*" element={<Navigate to="" replace />} />
     </Routes>
   );

--- a/frontend/src/modules/shop-assembly/pipelineStages.ts
+++ b/frontend/src/modules/shop-assembly/pipelineStages.ts
@@ -1,0 +1,114 @@
+// Shared readings of the derived shop-assembly pipeline stage (#344), so the request list, the
+// detail ladder and the tests cannot drift apart. Change the wording here, not in each view.
+//
+// The backend derives the stage; nothing here re-derives it. These functions only decide how a stage
+// is *shown*, which is a presentation decision and belongs on this side.
+
+/** The ladder, in order. Mirrors `PIPELINE_STAGE_RANK` in the backend repository - the two are pinned
+ * together by a backend test that asserts the enum and the rank table hold the same values. */
+export const PIPELINE_STAGES = [
+  'REQUESTED',
+  'ACCEPTED',
+  'PULLING',
+  'STAGED',
+  'ASSIGNED',
+  'IN_PROGRESS',
+  'COMPLETED',
+  'SHIPPED',
+] as const;
+
+/** Off-ladder stages: the two ways a leaf leaves the pipeline without being assembled. Rendering
+ * them as a step on the ladder would say they are further along than IN_PROGRESS, which is nonsense. */
+export const TERMINAL_STAGES = ['REJECTED', 'CANCELLED'] as const;
+
+const LABELS: Record<string, string> = {
+  REQUESTED: 'Requested',
+  ACCEPTED: 'Accepted',
+  PULLING: 'Awaiting pull',
+  STAGED: 'Staged',
+  ASSIGNED: 'Assigned',
+  IN_PROGRESS: 'In progress',
+  COMPLETED: 'Assembled',
+  SHIPPED: 'Shipped',
+  REJECTED: 'Rejected',
+  CANCELLED: 'Pull cancelled',
+};
+
+export function stageLabel(stage: string): string {
+  return LABELS[stage] ?? stage;
+}
+
+/** Colour for a stage chip.
+ *
+ * DESIGN.md reserves status colour for real system state, so most of the ladder is deliberately
+ * neutral: "assigned" is not a warning and "staged" is not a success, they are just where the work
+ * is. Only the three readings somebody acts on differently earn colour - a leaf that has shipped is
+ * done (success), a leaf being built right now is live (info), and the two ways out of the pipeline
+ * are the ones that need explaining (error / warning).
+ */
+export function stageColor(stage: string): 'default' | 'info' | 'success' | 'warning' | 'error' {
+  if (stage === 'SHIPPED' || stage === 'COMPLETED') return 'success';
+  if (stage === 'IN_PROGRESS') return 'info';
+  if (stage === 'REJECTED') return 'error';
+  if (stage === 'CANCELLED') return 'warning';
+  return 'default';
+}
+
+/** How far along the ladder a stage is, 0..1, or null when it is off the ladder.
+ *
+ * Used for the progress rail on the detail view. Null rather than 0 so a rejected request renders as
+ * "no rail" instead of "at the very start", which would be a lie about a request that got half way
+ * through before somebody killed it.
+ */
+export function stageProgress(stage: string): number | null {
+  const index = PIPELINE_STAGES.indexOf(stage as (typeof PIPELINE_STAGES)[number]);
+  if (index < 0) return null;
+  return index / (PIPELINE_STAGES.length - 1);
+}
+
+export interface PipelineUnitFields {
+  plannedUnitCount: number;
+  installedUnitCount: number;
+  deficientUnitCount: number;
+  replacementPendingUnitCount: number;
+}
+
+/** "5/8 units", the same reading the assembly views use: units, not lines. A line of 8 hinges with 5
+ * fitted is most of the job, and a line count would report it as untouched.
+ *
+ * Dispositioned - installed plus condemned plus awaiting-a-replacement - rather than installed alone,
+ * because that is the number completion is gated on (#340). */
+export function unitProgressLabel(row: PipelineUnitFields): string {
+  const done = row.installedUnitCount + row.deficientUnitCount + row.replacementPendingUnitCount;
+  return `${done}/${row.plannedUnitCount} units`;
+}
+
+export interface PipelineFlagFields {
+  integrityNote?: string | null;
+  awaitingReplacementOpeningCount?: number | null;
+  replacementAfterShipOpeningCount?: number | null;
+}
+
+/** The flags earlier slices introduced, as short chip labels, in the order somebody should read them:
+ * the request-level doubt first (#342), then what is owed (#341), then what cannot be fitted at all.
+ *
+ * Returns an empty array when everything is fine, so a caller renders nothing rather than a row of
+ * reassuring chips - a screen that says "no problems" ten times makes the one that says otherwise
+ * harder to spot. */
+export function pipelineFlags(row: PipelineFlagFields): { label: string; severity: 'warning' | 'error' }[] {
+  const flags: { label: string; severity: 'warning' | 'error' }[] = [];
+  if (row.integrityNote) flags.push({ label: 'Needs review', severity: 'warning' });
+  if (row.awaitingReplacementOpeningCount) {
+    flags.push({
+      label: `${row.awaitingReplacementOpeningCount} awaiting replacement`,
+      severity: 'warning',
+    });
+  }
+  if (row.replacementAfterShipOpeningCount) {
+    flags.push({
+      label: `${row.replacementAfterShipOpeningCount} arrived after shipping`,
+      severity: 'error',
+    });
+  }
+  return flags;
+}

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -26,6 +26,7 @@ import {
 import {
   PULL_CANCEL_REFETCH_QUERIES,
   PULL_CANCEL_STALE_ROOT_FIELDS,
+  PULL_LIFECYCLE_STALE_ROOT_FIELDS,
 } from '../../graphql/refetch';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
@@ -183,7 +184,19 @@ export default function PullRequestDetailModal({
 
   // --- Mutations ---
 
+  // Eviction only, disjoint from the queue refetch the parent does in onRefetch (see refetch.ts).
+  // #343 re-keyed workability from "the pull is COMPLETED" to "this opening is PULLED", so approving
+  // and completing both change what the assembly floor can see - and the assembly floor is a
+  // different module, never mounted while a warehouse user is working the pull.
+  const evictPullLifecycleFields = (cache: { evict: (o: { id: string; fieldName: string }) => void; gc: () => void }) => {
+    for (const fieldName of PULL_LIFECYCLE_STALE_ROOT_FIELDS) {
+      cache.evict({ id: 'ROOT_QUERY', fieldName });
+    }
+    cache.gc();
+  };
+
   const [approvePR, { loading: approveLoading }] = useMutation(APPROVE_PULL_REQUEST, {
+    update: evictPullLifecycleFields,
     onCompleted: (data) => {
       const approveResult = (
         data as { approvePullRequest?: { outcome?: string; shortfalls?: InventoryShortfall[] } }
@@ -209,6 +222,7 @@ export default function PullRequestDetailModal({
   });
 
   const [completePR, { loading: completeLoading }] = useMutation(COMPLETE_PULL_REQUEST, {
+    update: evictPullLifecycleFields,
     onCompleted: () => {
       setConfirmCompleteOpen(false);
       showToast('Pull Request completed successfully', 'success');

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -85,10 +85,45 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
 /app/warehouse/stock-pool  -> Stock Pool (non-project stock items)
 /app/warehouse/deficient-items -> Deficient Items Review
 /app/warehouse/shipments   -> Shipments (global packing slip list + return dialog)
-/app/shop-assembly         -> Shop Assembly (manager vs user views)
+/app/shop-assembly         -> Shop Assembly landing (stat card + Go-to cards)
+/app/shop-assembly/requests  -> Accept / reject / reopen shop-assembly requests
+/app/shop-assembly/assemble  -> Assemble List (all openings on approved pulls)
+/app/shop-assembly/assign    -> Assignment Board (manager)
+/app/shop-assembly/my-work   -> My Work (+ Replacement Installs)
+/app/shop-assembly/pipeline  -> Pipeline (read-only; where every request and leaf has got to)
 /app/shipping              -> Shipping Out (ship-ready items, packing slips)
 /app/admin                 -> Admin (reports, vendors, projects, users, cleanup)
 ```
+
+---
+
+## The shop-assembly lifecycle, end to end
+
+The module guides below are organised by *screen*, which is the wrong shape for a first read: one
+door leaf's journey crosses four of them. This is that journey once, with the screen that owns each
+step. Everything in it is exercisable against Railway.
+
+| # | What happens | Where you do it | What changes underneath |
+| --- | --- | --- | --- |
+| 1 | **Request** a leaf for shop assembly | Import -> Start a Task | A PENDING `ShopAssemblyRequest`, and the hardware is **reserved** on the spot (#342). Creating over-subscribed is refused whole, naming every short combo |
+| 2 | **Accept** it | Shop Assembly -> Requests | A PENDING warehouse pull. A pure human gate - nothing is re-checked, nothing is spent. Rejecting instead is what releases the claim |
+| 3 | **Approve** the pull | Warehouse -> Pull Requests | Stock is deducted FIFO and the claim is consumed, atomically. This is the only moment inventory moves |
+| 4 | **Stage** each opening's cart | Warehouse -> Pull Requests -> Staging panel | One `pull_status` flips to PULLED per opening (#343). That leaf is assignable *immediately*, while the rest of the pull is still being picked. Nothing moves in inventory |
+| 5 | **Claim** the leaf | Shop Assembly -> Assemble List / Assignment Board | An assignment. A manager may take one off somebody; a self-claim may not |
+| 6 | **Build** it, unit by unit | Shop Assembly -> My Work -> the modal | `installed_quantity` per line, saved as you go (#340). A defect flagged here goes back to inventory *now* and mints a `PR-REPL-*` pull immediately |
+| 7 | **Finish** it | Same modal -> Mark Complete | An `OpeningItem` per leaf, carrying what was actually installed. Refused while any unit is unaccounted for, or if nothing at all was installed |
+| 8 | **Replacement arrives** | Warehouse -> Pull Requests -> approve+complete the `PR-REPL-*` pull | The leaf gets its expectation back (#341). Still on the bench: it becomes Remaining again. Already finished: a Replacement Install card on My Work. Already shipped: a warning, and reallocation's problem |
+| 9 | **Ship** it | Shipping Out | `SHIP_READY`, then a packing slip. A leaf still owed hardware is flagged and takes an explicit "Ship it short" |
+| - | **Undo the pull** at any point before assembly starts | Warehouse -> Pull Requests -> Cancel Pull | Stock restocked, openings released, request back to Pending (#343). Refused, naming blockers, once any opening is IN_PROGRESS or COMPLETED |
+| - | **See all of it at once** | Shop Assembly -> Pipeline | Read-only (#344). Answers "where is opening A01 leaf 2?" without opening the other four screens |
+
+Two things a fresh reader gets wrong every time:
+
+- **"Pulled" is per opening, not per pull.** Since #343 a leaf can be workable while its own sibling
+  on the same pull is still on the shelf. A row with no buttons on the Assemble List is not broken;
+  its cart is not built yet.
+- **Reserved is not deducted.** Between steps 1 and 3 the hardware is claimed but still on the shelf,
+  so the Warehouse inventory number and the Start-a-Task availability number legitimately disagree.
 
 ---
 
@@ -361,6 +396,41 @@ replacement pull is *completed* in the warehouse for a leaf the assembler alread
 - A card whose leaf already shipped shows a "Leaf already shipped" chip and a warning alert instead
   of the button - it cannot be installed, only reallocated. A `REPLACEMENT_AFTER_SHIPMENT`
   notification was also raised for the SHIPPING role when the pull completed.
+
+**Pipeline page (#344)**, `/app/shop-assembly/pipeline`, reachable from the landing "Pipeline" card.
+It is **read-only on purpose** - every state it shows already has a screen that owns changing it, and
+a second place to act on them would be a second place for the rules to live.
+
+- The grid is one row per shop-assembly request across **all** projects by default, with a
+  Pending / Approved / Rejected / All toggle. Columns: Request, Project, Stage, Staged (`2 of 4`),
+  Progress (`6/16 units`), Assembled, Shipped, Flags.
+- **Stage is the request's least-advanced opening**, not its best news. A request with one finished
+  leaf and one that has not been staged reads "Awaiting pull". That is the intended reading: the
+  question is what is holding it up. The ladder is Requested -> Accepted -> Awaiting pull -> Staged ->
+  Assigned -> In progress -> Assembled -> Shipped, plus Rejected and "Pull cancelled" off the end.
+- The Staged / Assembled / Shipped columns are **blank** on a request with no openings, the same rule
+  the pull queue's staging chip follows - "0 of 0" would read as "nothing done".
+- Flags appear only when something is wrong: "Needs review" (the `integrityNote`), "N awaiting
+  replacement", "N arrived after shipping". A clean row shows no chips at all.
+- Clicking a row opens the detail modal: the alerts first (integrity note, cancellation history,
+  replacement-after-shipping), then a chip row and a progress rail, then **one table row per door
+  leaf** - stage, when and by whom it was staged, who holds it, units, the assembled leaf's warehouse
+  location, and what it is still owed.
+- Good end-to-end exercise: stage one leaf of a pair, and watch the pair's two rows in the detail sit
+  at "Staged" and "Awaiting pull" while the request itself reads "Awaiting pull".
+- A **cancelled** pull is the case worth checking deliberately. Cancelling detaches the openings and
+  puts the request back to Pending, so without this view the request looks as though it was never
+  accepted; here it reads "Pull cancelled" with an alert naming who cancelled it and why.
+
+**Notifications raised by this module (#344)**, all visible in the bell (which shows every audience,
+so you will see all of them regardless of your role):
+
+| Type | Fires when | Watch out for |
+| --- | --- | --- |
+| `ASSEMBLY_WORK_AVAILABLE` | You confirm a staging batch, or complete a pull that still had un-staged openings | **One per confirmation, not per opening.** Staging three carts in one action gives one notification naming them. Re-staging an already-staged opening gives none |
+| `REPLACEMENT_ARRIVED` | A `PR-REPL-*` pull completes for a leaf that has **not** shipped | Addressed to the assembler's Clerk user id, so `recipientRole` looks like `user_2ab...`. None is raised if nobody is holding the leaf |
+| `REPLACEMENT_AFTER_SHIPMENT` | Same, but the leaf has already shipped | Exactly one of these two fires, never both |
+| `PULL_UNBLOCKED` | A receive lands stock that makes a blocked `PR-REPL-*` pull fully coverable | Deduped three ways: only pulls wanting a combo you actually received; only when the shortfall is *closed*, not narrowed; and only one **unread** one per pull. Mark it read and receive again to get a second |
 
 ### Shipping Module
 


### PR DESCRIPTION
Slice 6 of 6, and the last. **Stacked on `feat/sa-slice-5-staging` (PR #349)** — the base is set to that branch so this diff shows only slice 6. Closes #344.

Slices 1-5 each added a state, and every one of them is legible only from the screen that wrote it. A request holds a reservation (#342), its pull is part-staged (#343), one leaf is half-built (#340), another is finished but owed a replacement (#341). Answering **"where is opening A01 leaf 2?"** meant opening four views and joining them by eye — and three of those states had nobody watching them at all. This slice is the join, the three missing signals, and the tidying the stack earned.

## 1. Pipeline observability

### Where it lives

A new read-only route, `/app/shop-assembly/pipeline`, off the Shop Assembly landing. Deliberately **read-only**: every state it shows already has a screen that owns changing it, and a second place to act on them would be a second place for the rules to live.

- **The list** is one row per shop-assembly request, across all projects by default, with a Pending / Approved / Rejected / All toggle. Stage, `2 of 4` staged, `6/16 units`, assembled, shipped, and flags.
- **The detail** is one row per **door leaf**: its rung, when and by whom its cart was staged, who holds it, its unit counts, where the assembled leaf was put away, and what it is still owed.

### The ladder, and why the request reads by its slowest leaf

```
REQUESTED → ACCEPTED → PULLING → STAGED → ASSIGNED → IN_PROGRESS → COMPLETED → SHIPPED
```

A request's stage is the stage of its **least-advanced** opening. The question a pipeline is asked is *what is holding this up*, not *what is the best news in it* — a request with one shipped leaf and one nobody has staged reads "Awaiting pull".

`REJECTED` and `CANCELLED` sit **off** the ladder rather than at the end of it. They are the two ways a leaf leaves the pipeline unassembled, and ranking them above IN_PROGRESS would be nonsense. `CANCELLED` is also the only reason a cancelled pull is visible at all: cancellation detaches the openings and returns the request to PENDING (#343), so without it the request reads as though it had never been accepted.

**Nothing is stored.** There is no `pipeline_stage` column, deliberately: a denormalised stage would be a fifth thing that can disagree with the four above, and this slice exists because the four already disagreed on screen.

### The query shape, and the flatness it is tested for

`get_assembly_pipeline_summaries` runs a **fixed five statements** — the requests (with their project), every pull ever minted for them, and three grouped aggregates (opening stages, unit progress, shipped leaves) — whether it is scoped to one project or to all of them. `get_assembly_pipeline` runs a **fixed eight** however many openings a request has.

Every count is `count`/`sum` with `FILTER`, grouped by request, one statement for the whole result set; never a `len()` over loaded openings. The two-level aggregate in `_unit_counts` exists because "openings with anything owed" counts *groups* satisfying a predicate on their own sum — still one round-trip.

Two tests assert the exact numbers by comparing two result sizes, so the failure message says *what* moved:

- `test_pipeline_detail_query_count_is_flat_as_openings_grow` — 2 openings vs 30, both 8 statements.
- `test_pipeline_summaries_query_count_is_flat_as_requests_grow` — 1 request vs 12, both 5.

### One implementation per reading

The request's stage comes from the **aggregates** (the All-Projects list needs it on every row, and deriving it from loaded openings would load every opening in the system); each leaf's stage from its own columns. `test_request_stage_is_always_the_minimum_of_its_opening_stages` pins the two together at five points along a request's life, so they cannot drift.

The detail view takes its summary from `get_assembly_pipeline_summaries` rather than from the opening rows it already has. That costs three extra aggregate queries on a single request and buys something worth more: the header numbers are *by construction* the same numbers as this request's row in the list.

### The flags, where users act on them

- **`integrityNote`** (#342) — verified still on the accept screen, and now also an alert at the top of the pipeline detail, so the pipeline does not quietly become a second, more trusting view of the same request.
- **Awaiting replacement** (#341) — `deficient + replacement_pending`, per leaf and rolled up per request.
- **Replacement arrived after shipping** — its own escalated (error-toned) reading, because `installReplacement` refuses it and it belongs to reallocation.

Flags render **only when something is wrong**. A row of reassuring chips makes the one row that needs attention harder to find.

## 2. Notifications

Extended `notification_service`, not reinvented: same `create_notification`, same audience-tag convention in `recipient_role`, two new named audiences (`SHOP_ASSEMBLY_MANAGER`, `WAREHOUSE`) alongside the existing `PO` / `SHIPPING`.

| Signal | Audience | The gap it closes |
| --- | --- | --- |
| `ASSEMBLY_WORK_AVAILABLE` | Shop-assembly manager | #343 made an opening assignable the moment its cart was built; the assignment board only found out when somebody reloaded it |
| `REPLACEMENT_ARRIVED` | The assembler holding the leaf (their Clerk user id) | #341 notified only the *shipped* case. The ordinary case — the one somebody can act on — was silent |
| `PULL_UNBLOCKED` | Warehouse | A PR-REPL pull holds **no reservation** by design (#342), so nothing tracked its demand. The approver saw INSUFFICIENT, the PO backfilled, and nothing said the retry would now succeed |

### Dedupe

**Staged / completed needs no dedupe machinery, and that is the point.** Each call announces only the openings *it* made workable. Staging the last cart calls `complete_pull_request`, which then finds nothing left to flip and stays silent — so the manager audience gets exactly one signal per real event with no flag, no lock and no lookup. One notification per *confirmation*, never per opening: N bell entries for one trip to the shelf is how a bell stops being read. Re-staging an already-staged opening says nothing.

**Replacement arrived** is naturally exclusive: exactly one of `REPLACEMENT_ARRIVED` and `REPLACEMENT_AFTER_SHIPMENT` fires. It is skipped when nobody holds the opening — a notification with no addressee is noise.

**`PULL_UNBLOCKED` dedupes three ways**, each doing different work:

1. **Relevance** — only pulls wanting a combo this receive actually landed. A receive of door closers cannot change whether a hinge replacement is coverable, so those pulls are filtered out before any availability arithmetic.
2. **Transition** — the pull must now be **fully** coverable, under the same reservation-aware availability the approver will apply. Narrowing a shortfall without closing it is not something the warehouse can act on; announcing it would be telling somebody to go and fail. This is the insufficient → sufficient edge.
3. **One open signal** — one **unread** notification per pull. Unread rather than "ever", deliberately: once it has been read the signal has done its job, and a pull that goes short again (stock written off under it) and is later covered again is genuinely new information.

The key is `notifications.pull_request_id`, not text inside `message`. Matching on a request number in prose would hold until somebody reworded the message, and this slice exists because states were knowable only by reading prose.

A replacement pull is identified **structurally** — a SHOP_ASSEMBLY pull with a line carrying `sa_opening_item_id` (#339) — not by its `PR-REPL-` prefix. The prefix is a display convention; the FK is what makes it a replacement, and a structural test cannot be broken by a rename.

## 3. Migration `064_pipeline_notifications` (revises 063)

`notification_type` += the three labels above; `notifications.pull_request_id` nullable FK `ON DELETE SET NULL` (#325's reopen hard-deletes a still-PENDING pull, and the notification is still a true record), plus a partial index on `(pull_request_id, type) WHERE pull_request_id IS NOT NULL AND is_read = false` — the dedupe lookup, and nothing else.

Additive, no backfill: an existing notification keeps a null `pull_request_id`, which reads as "not about a pull" — correct for every row written before this revision. **Downgrade** deletes rows using the three new labels, recreates the enum without them, and drops the column and index.

## 4. Housekeeping

### Dead-state audit

Every value of `PullStatus`, `PullRequestStatus`, `AssemblyStatus`, `ShopAssemblyRequestStatus`, `ShippingOutRequestStatus`, `PullRequestItemType`, `OpeningItemState`, `ReservationSource`, `NotificationType`, `AuditAction`, `AuditEntityType`, `ApproveOutcome`, `LeafStatus` and `ReconciliationStatus` was traced to a write.

**Removed — `ApproveOutcome.CANCELLED`.** Genuinely unreachable: `approve_pull_request` returns `"APPROVED"` or `"INSUFFICIENT"` and nothing else since #224, the resolver's ternary can only produce those two, and no client branches on it (`PullRequestDetailModal` tests only `=== 'INSUFFICIENT'`). It dated from the pre-#224 behaviour where an approve that found insufficient stock *cancelled* the pull. **No migration**: `ApproveOutcome` is a GraphQL-only enum and was never persisted — a *cancelled pull* is `PullRequestStatus.CANCELLED`, a different enum on a real column, and very much alive since #343.

**Kept, with the reason written down:**

- **`PullStatus.PARTIAL`** — the one #343 named. It is no longer written to any column, but it is *not* dead: it is what `StagingSummary.status` returns and what `PullRequest.stagingStatus` and the pipeline's `stagingStatus` surface. So it stays in the Python enum, stays in the GraphQL enum, and the Postgres `pull_status` type keeps the label — shrinking it would be an enum recreate for zero benefit and would break the ORM round-trip. `test_pull_status_partial_is_derived_and_never_persisted` asserts both halves: PARTIAL comes back from the rollup, and no `shop_assembly_openings` row ever holds it.
- **`AuditAction.SPOT_CHECK`** — no code writes it (the Spot Check UI writes an `ADJUSTMENT` with a `"Spot check: ..."` reason), but it predates this stack, production rows may carry it, and the frontend still renders a label for it. Removing it would need an enum recreate that could not read those rows back. Left alone and reported rather than quietly deleted.

### SDL reference docs

Reconciled by building the schema, printing the SDL, and diffing it field-by-field against each doc (snake_case normalised). The **four domains this stack touched are now byte-for-byte clean**:

- **`shop_assembly.graphql`** — `ShopAssemblyOpening.shop_assembly_request_id` was `ID!` and is nullable; `pull_request_id`, `leaf`, `opening_number`, `building`, `floor` were undocumented; `assembleList(projectId: ID!)` is optional; `RecordAssemblyProgressInput.items` is non-null. The `acceptShopAssemblyRequest` comment still claimed it "re-checks inventory sufficiency", which #342 removed a slice ago. Plus the new pipeline types and queries.
- **`warehouse.graphql`** — `InventoryLocation` was missing `stock_item_id`, `warehouse_id`, `deficient_quantity`, `available`, and had two nullable FKs as `ID!`; the hierarchy nodes were missing `total_available_quantity`/`total_value`; `OpeningItem` was missing `leaf`/`leaf_count`/`warehouse_id`; `PackingSlipItem` was missing `leaf`; `CreateReceiveInput` documented a `received_by` that is *not* an input (#199 stamps the authenticated caller) and omitted `warehouse_id`/`idempotency_key`; `LocationInput` omitted `deficient_quantity`; seven query signatures had a required `projectId` that is optional. `ApproveOutcome` updated, and `NotificationType` documented for the first time.
- **`shipping.graphql`** — already clean.
- **`user.graphql`** — did not exist. `shop_assembly.graphql` has pointed at it since #330 ("ClerkUser is in user.graphql"); the pointer was dangling. Written now.

**Reported, not fixed:** `po.graphql` and `import.graphql` carry substantial pre-existing drift (`PurchaseOrder` is missing ~12 fields, `Mutation` documents four resolvers that no longer exist, `FinalizeImportSessionInput` names a `project` input that is now `projectId`). Neither domain is touched by this stack, and folding that in would have made this diff much harder to review. There is no `stock.graphql` and nothing references one.

### `refetch.ts`

Audited every mutation slices 2-5 added. All four pairs (`ASSEMBLY_PROGRESS_*`, `REPLACEMENT_INSTALL_*`, `PULL_STAGING_*`, `PULL_CANCEL_*`) and `RESERVATION_STALE_ROOT_FIELDS` were **correct and disjoint**; each gained the two pipeline root fields.

New `PIPELINE_STALE_ROOT_FIELDS` is eviction-only everywhere, and the reasoning is the same one that file already makes: the Pipeline is a route of its own, so it is by definition not mounted while anybody is accepting, staging, saving progress, completing or cancelling. Both fields always move together — the list and the detail come from the same aggregates, so leaving one behind is the one way to make the two screens disagree.

The audit also turned up two gaps the earlier slices left, both now closed with eviction-only lists (disjoint from the local refetch each call site already does):

- **`ASSEMBLY_COMPLETE_STALE_ROOT_FIELDS`** — #340 made `completeOpening` the sole writer of the assembled leaf, and nothing invalidated `openingItems` (the warehouse grid, and the carrier of the #341 flag) or `shipReadyItems` (a newly assembled leaf is new shipping inventory). `assembleList`/`myWork` are deliberately *absent*: the modal's `onCompleted` already refetches whichever list opened it, and naming them would fire the repair-fetch double-run this file exists to prevent.
- **`PULL_LIFECYCLE_STALE_ROOT_FIELDS`** — #343 re-keyed workability from "the pull is COMPLETED" to "this opening is PULLED", which made approve and complete change what the assembly floor can see. Neither list is mounted while a warehouse user works a pull.

Plus `ASSIGNMENT_STALE_ROOT_FIELDS` for the three assignment surfaces, which share `GET_ASSEMBLE_LIST` and refetch it themselves but could not reach `myWork` or the pipeline.

### Docs

- **`docs/HARDWARE_IDENTITY_LIFECYCLE.md`** — new §5 (reading the lifecycle back: the ladder, why the request reads by its slowest leaf, the two performance constraints) and §5a (the three signals and why each could not be inferred), plus **eight** rows in the enforcement table covering the pipeline, the stage derivation and all three notifications.
- **`testing/CLAUDE.md`** — the per-slice notes had become five separate module sections describing one journey. Added **"The shop-assembly lifecycle, end to end"**: a single numbered table from Start a Task to the packing slip, naming the screen that owns each step and what changes underneath, plus the two things a fresh reader gets wrong every time ("pulled is per opening, not per pull" and "reserved is not deducted"). The nav map gained all six shop-assembly sub-routes, and the Shop Assembly section gained the Pipeline page and a table of the notifications this module raises with their dedupe behaviour.

## Verification

Ran against a throwaway PostgreSQL 16 cluster (EDB portable binaries, `initdb` into a scratch dir, dropped and removed afterwards):

- **394 backend tests pass** (was 366 pre-slice; 28 new in `tests/test_pipeline_observability.py`), all DB-backed — the full requested→shipped walk with counts asserted at each rung, the aggregate/per-leaf stage agreement, unassigning an IN_PROGRESS leaf, rejection, cancellation and cancel→re-accept, the integrity note, both replacement flags, project/status scoping, the two flatness tests, six notification tests (one-per-confirmation, no double-announce, re-stage silence, direct completion, assignee vs shipping, unassigned), six for the unblocked loop and its three dedupe rules, and three for the enum audit.
- Full CI migration-integrity cycle: `upgrade head` → `alembic check` (clean) → `downgrade base` → `upgrade head` → `alembic check` (clean). Downgrade separately re-verified **with rows using all three new labels and the new FK present**: the three were deleted, the pre-existing `INVENTORY_SHORTFALL` row survived, the column and enum labels went, and the re-upgrade was clean.
- `uvx ruff check .` / `uvx ruff format --check .` clean (poetry is not installed on this box).
- Frontend: `npm run lint` (0 errors, 17 warnings — the pre-existing set, unchanged), `npm run test:run` **231 pass** (13 new: 6 for the shared stage readings, 7 for the page and its detail), `npm run build` clean.
- Printed SDL checked and diffed field-by-field against every reference doc; the four touched domains are clean.

## Deviations from the issue spec

- **Two resolvers, not one.** The issue asks for a per-request detail view; that alone would have had no way in. `assemblyPipelineSummaries` is the list you arrive at (and the All-Projects-safe one), `assemblyPipeline` the detail. The detail reuses the list's aggregates for its header rather than computing them from the rows it loaded — three extra queries on one request, in exchange for the two screens being unable to disagree.
- **The issue's "pull staged x/y (or **blocked**)" became "(or **cancelled**)".** A blocked pull is not a state a request sits in — an unapprovable pull is PENDING, which the ladder already shows as ACCEPTED. What genuinely needed surfacing was the cancellation #343 made reachable, because it detaches the openings and returns the request to PENDING, so without it the request reads as never accepted. The blocked-replacement case is handled by the `PULL_UNBLOCKED` notification instead, which is where somebody can act on it.
- **"Schedule-changed-since-request" is surfaced as the existing `integrityNote`**, not as a separate flag. #342 deliberately collapsed both writers (re-upload reconciliation and backfill shortfall) into one message on the request, and inventing a second flag here would have split a signal the accept screen already shows.
- **One notification type for staged *and* completed**, rather than two. Both mean "the board has work on it", and the message distinguishes them. Two types would have needed dedupe logic between them; one type with a "which openings did *this* call make workable" rule needs none.
- **`notifications.pull_request_id` added**, not called for. `PULL_UNBLOCKED` needs an exact dedupe key, and the alternative was matching a request number inside `message` — a rule that lives only in prose, in a slice about states that were only knowable from prose.
- **`AuditAction.SPOT_CHECK` kept** though the audit found it unreachable. It predates this stack and production rows may carry it; the enum recreate needed to drop it could not read those rows back. Documented rather than deleted.
- **`po.graphql` / `import.graphql` drift reported, not fixed** — neither domain is in this stack, and the fix would have roughly doubled a diff that is already mostly documentation.
- **Three refetch gaps closed beyond the letter of the issue** (`completeOpening`, approve/complete pull, assignment). They are gaps slices 2 and 5 created, they are one eviction list each, and leaving them would have meant reporting a bug I had already found and measured.
