### PR TITLE
fix(shop-assembly): review findings across the slice stack

### DIFF
--- a/backend/alembic/versions/063_pull_staging_cancel.py
+++ b/backend/alembic/versions/063_pull_staging_cancel.py
@@ -100,11 +100,12 @@ def downgrade() -> None:
     # A cancelled pull may legitimately share its number with the live pull a re-accept minted -
     # that is the whole point of the partial index. Global uniqueness cannot express it, so retire
     # the cancelled row's number rather than lose the row. Deterministic and self-describing, so the
-    # history stays readable.
+    # history stays readable. The 40 + 2 + 8 split is deliberate: `request_number` is varchar(50) and
+    # a longer suffix would fail the downgrade on any number already near the limit.
     op.execute(
         """
         UPDATE pull_requests p
-           SET request_number = left(p.request_number, 41) || '-X' || left(replace(p.id::text, '-', ''), 8)
+           SET request_number = left(p.request_number, 40) || '-X' || left(replace(p.id::text, '-', ''), 8)
          WHERE p.status = 'CANCELLED'
            AND EXISTS (
                  SELECT 1 FROM pull_requests q

--- a/backend/alembic/versions/065_leaf_uniqueness_and_pull_status_check.py
+++ b/backend/alembic/versions/065_leaf_uniqueness_and_pull_status_check.py
@@ -1,0 +1,99 @@
+"""One live assembled leaf, structurally; and pull_status really is binary (#345, #350)
+
+Revision ID: 065
+Revises: 064
+Create Date: 2026-07-26
+
+Two invariants that the code already believed and the database did not enforce.
+
+**One live `OpeningItem` per (project, opening, leaf).** `complete_opening` refuses to assemble a
+leaf that already has a live assembled unit (#339's duplicate-completion guard), because minting a
+second one for a single physical door leaf double-counts inventory and lets the same leaf ship
+twice. That guard is a read followed by a write, so two assemblers finishing the two
+ShopAssemblyOpenings that name the same leaf - a reopened-and-re-imported request, or a leaf sent to
+the shop twice - can both pass it. A partial unique index makes it an invariant instead of a race:
+`(project_id, opening_id, coalesce(leaf, 0)) WHERE state <> 'SHIPPED_OUT'`.
+
+`coalesce(leaf, 0)` rather than a plain `leaf` column because NULLs do not collide in a unique index
+and a legacy whole-opening unit (leaf IS NULL) is exactly as singular as leaf 1 or leaf 2. The
+`WHERE` clause is the same shape as the guard it hardens: a **shipped** leaf has left the building
+and a correction is allowed to assemble another one, which is precisely what
+`find_already_assembled_openings` and `find_assembled_leaf` already encode.
+
+Upgrade refuses to run on a database that already violates it, naming the offenders, rather than
+picking a row to keep. A dev database should be clean; if one is not, silently deduplicating real
+assembled leaves is a worse outcome than a loud stop.
+
+**`shop_assembly_openings.pull_status` is NOT_PULLED or PULLED, never PARTIAL.** One opening is one
+cart, and a cart is either built or it is not; `PullStatus.PARTIAL` is the *aggregate* reading over a
+set of openings and is derived per pull, never stored (#343, `get_pull_staging_summaries`). The enum
+type has to keep the label - the derived reading uses it - so the column carries a CHECK constraint
+saying which of its values are writable here. That turns a comment into something a bad write cannot
+get past.
+
+Downgrade drops both; neither has a data component, so it is exact.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "065"
+down_revision = "064"
+branch_labels = None
+depends_on = None
+
+_LIVE_LEAF_INDEX = "uq_opening_items_live_leaf"
+_LIVE_LEAF_WHERE = "state <> 'SHIPPED_OUT'"
+_PULL_STATUS_CHECK = "ck_shop_assembly_openings_pull_status_binary"
+_PULL_STATUS_CONDITION = "pull_status IN ('NOT_PULLED', 'PULLED')"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    duplicates = conn.execute(
+        sa.text(
+            f"""
+            SELECT project_id, opening_id, coalesce(leaf, 0) AS leaf_key, count(*) AS n
+              FROM opening_items
+             WHERE {_LIVE_LEAF_WHERE}
+             GROUP BY project_id, opening_id, coalesce(leaf, 0)
+            HAVING count(*) > 1
+             ORDER BY n DESC
+             LIMIT 20
+            """
+        )
+    ).all()
+    if duplicates:
+        offenders = "; ".join(
+            f"project {r.project_id} opening {r.opening_id} leaf {r.leaf_key}: {r.n} rows" for r in duplicates
+        )
+        raise RuntimeError(
+            "Cannot add uq_opening_items_live_leaf: more than one live assembled unit already exists "
+            f"for the same door leaf. Resolve these by hand first (up to 20 shown): {offenders}"
+        )
+
+    partials = conn.execute(
+        sa.text(f"SELECT count(*) FROM shop_assembly_openings WHERE NOT ({_PULL_STATUS_CONDITION})")
+    ).scalar_one()
+    if partials:
+        raise RuntimeError(
+            f"Cannot add {_PULL_STATUS_CHECK}: {partials} shop_assembly_openings row(s) hold a "
+            "pull_status other than NOT_PULLED / PULLED. PARTIAL is an aggregate reading and was "
+            "never meant to be stored - set those rows to NOT_PULLED or PULLED first."
+        )
+
+    op.create_index(
+        _LIVE_LEAF_INDEX,
+        "opening_items",
+        ["project_id", "opening_id", sa.text("coalesce(leaf, 0)")],
+        unique=True,
+        postgresql_where=sa.text(_LIVE_LEAF_WHERE),
+    )
+    op.create_check_constraint(_PULL_STATUS_CHECK, "shop_assembly_openings", _PULL_STATUS_CONDITION)
+
+
+def downgrade() -> None:
+    op.drop_constraint(_PULL_STATUS_CHECK, "shop_assembly_openings", type_="check")
+    op.drop_index(_LIVE_LEAF_INDEX, table_name="opening_items")

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -357,8 +357,10 @@ enum NotificationType {
 # name, so a receive records the person and not the relay's Windows account.
 input CreateReceiveInput {
   po_id: ID!
-  line_items: [ReceiveLineItemInput!]!
-  warehouse_id: ID
+  warehouse_id: ID = null
+  # Defaulted, not required: an empty receive is a legal (if pointless) call, and the resolver -
+  # not the schema - is what refuses one with a typed error naming the reason.
+  line_items: [ReceiveLineItemInput!]! = []
   # Short-circuits a retried receive against the same GP receipt (services/gp_idempotency.py).
   idempotency_key: String! = ""
 }
@@ -448,7 +450,9 @@ type Query {
   projectProgressByProduct(projectId: ID!): [ProjectProgressByProduct!]!
   packingSlips(projectId: ID): [PackingSlip!]!
   returnableLines(packingSlipId: ID!): [ReturnableLine!]!
-  notifications(projectId: ID, recipientRole: String!, unreadOnly: Boolean, limit: Int! = 5): [Notification!]!
+  # recipientRole defaults to "" and that default is load-bearing: empty means "every audience",
+  # which is what the bell asks for. Passing a role narrows to that audience.
+  notifications(projectId: ID = null, recipientRole: String! = "", unreadOnly: Boolean = null, limit: Int! = 5): [Notification!]!
 }
 
 type Mutation {

--- a/backend/app/models/opening_item.py
+++ b/backend/app/models/opening_item.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -24,6 +24,21 @@ class OpeningItem(Base):
         Index("ix_opening_items_opening_id", "opening_id"),
         Index("ix_opening_items_warehouse", "warehouse_id", "aisle", "row", "bay"),
         CheckConstraint("quantity >= 1", name="ck_opening_items_quantity_positive"),
+        # One live assembled unit per door leaf (#345). `complete_opening`'s duplicate-completion
+        # guard is a read-then-write and two assemblers finishing two ShopAssemblyOpenings that name
+        # the same leaf can both pass it; this is the same rule as an invariant. `coalesce(leaf, 0)`
+        # because NULLs do not collide in a unique index and a legacy whole-opening unit is exactly
+        # as singular as leaf 1. Shipped units are excluded: the leaf has left the building, and a
+        # correction is allowed to assemble another one - the same carve-out
+        # `find_already_assembled_openings` and `find_assembled_leaf` already make.
+        Index(
+            "uq_opening_items_live_leaf",
+            "project_id",
+            "opening_id",
+            text("coalesce(leaf, 0)"),
+            unique=True,
+            postgresql_where=text("state <> 'SHIPPED_OUT'"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -59,12 +59,29 @@ class ShopAssemblyOpening(Base):
             "opening_id",
             "pull_status",
         ),
+        # One opening is one cart, and a cart is either built or it is not (#343). `PullStatus`
+        # keeps a PARTIAL label because the *aggregate* reading over a set of openings needs it, and
+        # that reading is derived per pull (`get_pull_staging_summaries`), never stored. The check is
+        # what makes "PARTIAL is never persisted here" structural rather than a comment.
+        CheckConstraint(
+            "pull_status IN ('NOT_PULLED', 'PULLED')",
+            name="ck_shop_assembly_openings_pull_status_binary",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    # Legacy parent, nullable since #222 and now unused for new rows: openings created from
-    # Start a Task hang off a PullRequest (pull_request_id below), not a SAR. The SAR approval
-    # flow that used to set this was retired in #223; the column is kept for existing rows.
+    # The request this opening was imported under. Nullable since #222, when the *operational*
+    # parent became the shop-assembly PullRequest below - `pull_request_id` is what the assembly
+    # floor, staging and cancellation all key on, and the SAR approval flow that used to drive
+    # `pull_status` from here was retired in #223.
+    #
+    # It is **not** dead weight and it is **not** unset on new rows: `finalize_import_session` stamps
+    # it at creation, and the whole pipeline (#344) groups on it - `_opening_stage_counts`,
+    # `_unit_counts`, `_shipped_counts` and `get_assembly_pipeline` all read a request's openings
+    # through this column, because it is the only link that survives a pull being cancelled
+    # (cancellation nulls `pull_request_id`). Null means a legacy #222-era opening that hangs off a
+    # PullRequest alone; those are invisible to the pipeline, which is why it has no request to be a
+    # pipeline of.
     shop_assembly_request_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("shop_assembly_requests.id"), nullable=True
     )

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -5,7 +5,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, true, tuple_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import (
@@ -537,7 +538,22 @@ def complete_opening(
         bay=bay,
     )
     session.add(opening_item)
-    session.flush()  # Get opening_item.id for OpeningItemHardware FK
+    try:
+        session.flush()  # Get opening_item.id for OpeningItemHardware FK
+    except IntegrityError as exc:
+        # `uq_opening_items_live_leaf` (#345) is step 3's guard as a database invariant, and it is
+        # what actually holds when two assemblers finish two ShopAssemblyOpenings naming the same
+        # leaf at once: step 3 is a read-then-write, and both readers can see nothing. Translate it
+        # into the same typed conflict the guard raises so the loser gets the identical message
+        # rather than a 500.
+        if "uq_opening_items_live_leaf" not in str(getattr(exc, "orig", exc)):
+            raise
+        leaf_suffix = f" leaf {sa_opening.leaf}" if sa_opening.leaf is not None else ""
+        raise ConflictError(
+            f"Opening {sa_opening.opening_number}{leaf_suffix} has already been assembled - "
+            "an assembled unit for it is still in the system",
+            field="opening_id",
+        ) from exc
 
     # 6. Snapshot what was actually installed (#340): the recorded installed_quantity, not the
     #    planned quantity. A line whose units were all flagged deficient contributes no row at all -
@@ -638,35 +654,55 @@ def get_awaiting_replacement_quantities(
     (CLAUDE.md perf rules): the shipping selection lists every assembled leaf in a project, and a
     per-leaf query here would be an N+1 on the heaviest list in the module. Only non-zero entries are
     returned, so callers can treat a missing key as "nothing outstanding".
+
+    **Exactly one assembly per leaf is counted: the one that produced that leaf.** A leaf can be sent
+    to the shop more than once - it shipped and a correction re-assembled it, or a request was
+    reopened and re-imported - and (opening_id, leaf) alone matches every one of those work units. A
+    plain join therefore made the newly assembled leaf inherit the *previous* assembly's outstanding
+    units and read as "awaiting replacement" the moment it was built. The lateral resolves it the way
+    `find_assembled_leaf` resolves the other direction: latest completion wins, bounded by the leaf's
+    own `assembly_completed_at` so each assembled unit reads its own work unit and not a later one.
     """
     ids = list(opening_item_ids)
     if not ids:
         return {}
+    # Scope the correlation to the leaf's own project: opening_id is a historical stamp, not an FK,
+    # and a re-upload can reissue it.
+    latest_assembly = (
+        select(ShopAssemblyOpening.id.label("sa_opening_id"))
+        .join(PullRequestModel, PullRequestModel.id == ShopAssemblyOpening.pull_request_id)
+        .where(
+            ShopAssemblyOpening.opening_id == OpeningItemModel.opening_id,
+            ShopAssemblyOpening.leaf.is_not_distinct_from(OpeningItemModel.leaf),
+            ShopAssemblyOpening.assembly_status == AssemblyStatus.COMPLETED,
+            PullRequestModel.project_id == OpeningItemModel.project_id,
+            # The work unit that produced *this* leaf finished no later than the leaf did -
+            # `complete_opening` stamps both from the same `now`. A legacy row with no completion
+            # stamp is allowed through and ordered last, so it is picked only when nothing else fits.
+            or_(
+                ShopAssemblyOpening.completed_at.is_(None),
+                ShopAssemblyOpening.completed_at <= OpeningItemModel.assembly_completed_at,
+            ),
+        )
+        .order_by(
+            ShopAssemblyOpening.completed_at.desc().nulls_last(),
+            ShopAssemblyOpening.id.desc(),
+        )
+        .limit(1)
+        .lateral("latest_assembly")
+    )
     outstanding = func.sum(
         ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity
     )
     stmt = (
         select(OpeningItemModel.id, outstanding.label("outstanding"))
         .select_from(OpeningItemModel)
-        .join(
-            ShopAssemblyOpening,
-            and_(
-                ShopAssemblyOpening.opening_id == OpeningItemModel.opening_id,
-                ShopAssemblyOpening.leaf.is_not_distinct_from(OpeningItemModel.leaf),
-                ShopAssemblyOpening.assembly_status == AssemblyStatus.COMPLETED,
-            ),
-        )
-        .join(PullRequestModel, PullRequestModel.id == ShopAssemblyOpening.pull_request_id)
+        .join(latest_assembly, true())
         .join(
             ShopAssemblyOpeningItem,
-            ShopAssemblyOpeningItem.shop_assembly_opening_id == ShopAssemblyOpening.id,
+            ShopAssemblyOpeningItem.shop_assembly_opening_id == latest_assembly.c.sa_opening_id,
         )
-        .where(
-            OpeningItemModel.id.in_(ids),
-            # Scope the join to the leaf's own project: opening_id is a historical stamp, not an FK,
-            # and a re-upload can reissue it.
-            PullRequestModel.project_id == OpeningItemModel.project_id,
-        )
+        .where(OpeningItemModel.id.in_(ids))
         .group_by(OpeningItemModel.id)
         .having(outstanding > 0)
     )
@@ -734,14 +770,20 @@ def get_replacement_work(
         return []
 
     # One batched lookup of the assembled leaves rather than one per row: the pending set is small,
-    # but "small today" is how N+1s get written.
+    # but "small today" is how N+1s get written. Keyed on (project, opening) rather than on the leaf
+    # as well, because a legacy null leaf has to match only a null leaf and SQL's `IN` over tuples
+    # cannot express that - the leaf match and `find_assembled_leaf`'s tie-break (a live row beats a
+    # shipped one, latest assembly wins among equals, via `_leaf_wins`) are applied in Python below,
+    # so both call sites resolve a re-assembled leaf identically.
+    keys = {(proj_id, opening.opening_id) for _item, opening, proj_id in rows}
     leaf_by_key: dict[tuple[uuid.UUID, uuid.UUID, int | None], OpeningItemModel] = {}
-    for _item, opening, proj_id in rows:
-        key = (proj_id, opening.opening_id, opening.leaf)
-        if key not in leaf_by_key:
-            found = find_assembled_leaf(session, proj_id, opening.opening_id, opening.leaf)
-            if found is not None:
-                leaf_by_key[key] = found
+    for oi in session.scalars(
+        select(OpeningItemModel).where(tuple_(OpeningItemModel.project_id, OpeningItemModel.opening_id).in_(keys))
+    ).all():
+        key = (oi.project_id, oi.opening_id, oi.leaf)
+        incumbent = leaf_by_key.get(key)
+        if incumbent is None or _leaf_wins(oi, incumbent):
+            leaf_by_key[key] = oi
 
     result: list[ReplacementWorkItem] = []
     for item, opening, proj_id in rows:
@@ -826,6 +868,17 @@ def install_replacement(
         raise InvalidStateTransitionError(
             f"Opening {opening.opening_number} has already shipped - this replacement has to be "
             "routed through reallocation or a site shipment, not installed here"
+        )
+    # SHIP_READY is the same problem one step earlier. The leaf is staged at the dock against a
+    # confirmed pull, and `confirm_shipment` snapshots its hardware onto the PackingSlipItem from
+    # whatever the leaf carries at that moment - so hardware added here lands on a packing slip for a
+    # unit that was picked and checked without it. The unit stays in replacement_pending and stays
+    # queryable; unwinding the shipment (or reallocation) is the route, not a quiet late write.
+    if opening_item.state == OpeningItemState.SHIP_READY:
+        raise InvalidStateTransitionError(
+            f"Opening {opening.opening_number} is staged for shipment - the packing slip is already "
+            "built against what is on the leaf. Unwind the shipping-out request first, or route this "
+            "replacement through reallocation"
         )
 
     oih = session.scalars(
@@ -1514,6 +1567,13 @@ def _shipped_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid
     opening as shipped when *any* of its rows shipped is the conservative reading for a rollup; the
     per-leaf detail view resolves that ambiguity properly, live row winning, exactly as
     `find_assembled_leaf` does.
+
+    **Only COMPLETED openings can be shipped.** (opening_id, leaf) is not scoped to a request, so a
+    leaf that shipped under an earlier request and was then re-requested matches the *new* request's
+    opening too - and without this filter the new request read as already SHIPPED before anybody had
+    picked its cart, taking its pipeline stage, its shipped count and its after-ship count with it.
+    An opening that has not been assembled cannot have produced the leaf that shipped, so requiring
+    COMPLETED is both the fix and the honest statement of the join.
     """
     if not request_ids:
         return {}
@@ -1534,6 +1594,7 @@ def _shipped_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid
                 OpeningItemModel.opening_id == ShopAssemblyOpening.opening_id,
                 OpeningItemModel.leaf.is_not_distinct_from(ShopAssemblyOpening.leaf),
                 OpeningItemModel.project_id == ShopAssemblyRequest.project_id,
+                ShopAssemblyOpening.assembly_status == AssemblyStatus.COMPLETED,
             ),
         )
         .outerjoin(
@@ -1741,7 +1802,9 @@ def get_assembly_pipeline(session: Session, request_id: uuid.UUID) -> AssemblyPi
     # The assembled leaves, in one fetch for the whole request rather than a find_assembled_leaf call
     # per opening. The live-wins-over-shipped and latest-wins tie-breaks are applied here in exactly
     # the order that function documents, so a leaf that shipped and was re-assembled resolves the
-    # same way in both places.
+    # same way in both places. The match is only *used* for an opening this request actually finished
+    # (see below): (opening_id, leaf) carries no request lineage, so a re-requested leaf would
+    # otherwise read the previous request's shipped unit as its own.
     leaves: dict[tuple[uuid.UUID, int | None], OpeningItemModel] = {}
     for oi in session.scalars(
         select(OpeningItemModel).where(
@@ -1757,7 +1820,13 @@ def get_assembly_pipeline(session: Session, request_id: uuid.UUID) -> AssemblyPi
     rows: list[PipelineOpening] = []
     for opening in openings:
         sums = sums_by_opening.get(opening.id)
-        leaf_row = leaves.get((opening.opening_id, opening.leaf))
+        # An opening that has not been completed has not produced a leaf, whatever else in the
+        # project happens to carry the same (opening_id, leaf).
+        leaf_row = (
+            leaves.get((opening.opening_id, opening.leaf))
+            if opening.assembly_status == AssemblyStatus.COMPLETED
+            else None
+        )
         rows.append(
             PipelineOpening(
                 shop_assembly_opening_id=opening.id,

--- a/backend/app/repositories/stock/deficiency.py
+++ b/backend/app/repositories/stock/deficiency.py
@@ -20,6 +20,45 @@ from app.models.stock_item import StockItem
 from .common import _find_or_create_stock_row, _log_audit_event
 from .items import get_stock_item
 
+# `pull_requests.request_number` is varchar(50), and it is unique among live (non-cancelled) pulls.
+# Every replacement number this module mints has to fit inside that, suffix included.
+_MAX_REQUEST_NUMBER_LENGTH = 50
+_REPLACEMENT_NUMBER_PREFIX = "PR-REPL-"
+# The widest disambiguating suffix we will mint ("-999"). Reserved when searching for the family so
+# one prefix query finds every member, whatever its stem was truncated to.
+_MAX_REPLACEMENT_SUFFIX_LENGTH = 4
+_MAX_REPLACEMENT_ATTEMPTS = 999
+
+
+def _replacement_number(basis: str, n: int) -> str:
+    """The nth replacement-pull number for a source pull number.
+
+    n == 1 is the plain `PR-REPL-{basis}` the module has always minted, kept for continuity so the
+    ordinary one-replacement-pull-per-pull case reads exactly as before. n >= 2 appends `-{n}`,
+    truncating the *basis* portion rather than the suffix so the result always fits varchar(50) and
+    the suffix - the part that makes it unique - is never the thing that gets cut.
+    """
+    full = f"{_REPLACEMENT_NUMBER_PREFIX}{basis}"
+    if n <= 1:
+        return full[:_MAX_REQUEST_NUMBER_LENGTH]
+    suffix = f"-{n}"
+    return full[: _MAX_REQUEST_NUMBER_LENGTH - len(suffix)] + suffix
+
+
+def _is_replacement_number(number: str, basis: str) -> bool:
+    """Is `number` one of the numbers `_replacement_number(basis, n)` can produce?
+
+    Used to narrow a prefix query down to the exact family, so a basis that happens to be a prefix of
+    another basis ("PR-SA-1" vs "PR-SA-12") never has its pulls confused with its neighbour's.
+    """
+    full = f"{_REPLACEMENT_NUMBER_PREFIX}{basis}"
+    if number == full[:_MAX_REQUEST_NUMBER_LENGTH]:
+        return True
+    stem, sep, tail = number.rpartition("-")
+    if not sep or not tail.isdigit() or tail.startswith("0"):
+        return False
+    return stem == full[: _MAX_REQUEST_NUMBER_LENGTH - (len(tail) + 1)]
+
 
 def report_inventory_deficiency(
     session: Session,
@@ -119,7 +158,9 @@ def report_deficiency_at_assembly(
     available (= quantity - deficient) is unchanged, so the returned unit can't be re-pulled.
 
     The replacement pull request is derived from the opening's shop-assembly PullRequest
-    (#222 re-parenting); the retired SAR link is only a fallback for legacy rows.
+    (#222 re-parenting); the retired SAR link is only a fallback for legacy rows. It is reused only
+    while it is still PENDING - see the comment at the mint site - and a repeated flag against the
+    same checklist line and product increments that pull's existing line rather than adding another.
 
     Returns (inventory_location, replacement_pull_request_item).
     """
@@ -220,14 +261,46 @@ def report_deficiency_at_assembly(
     )
 
     # Find or create an open replacement pull request for this opening's shop-assembly PR.
-    replacement_request_number = f"PR-REPL-{replacement_basis}"
-    existing_pr_stmt = select(PullRequestModel).where(
-        PullRequestModel.request_number == replacement_request_number,
-        PullRequestModel.deleted_at.is_(None),
-        PullRequestModel.status.in_([PullRequestStatus.PENDING, PullRequestStatus.IN_PROGRESS]),
+    #
+    # **Only a PENDING replacement pull is reusable.** A pull that has been approved (IN_PROGRESS)
+    # has already had its stock deducted and its sufficiency checked line by line; a line appended
+    # after that point is never deducted and never checked, yet `_apply_replacement_arrivals` counts
+    # it as delivered at completion and `cancel_pull_request` restocks it as if it had been. And once
+    # a replacement pull has COMPLETED, reusing its number is not even possible - the partial unique
+    # index on live pulls would reject the insert. So the second deficiency on the same source pull
+    # gets a pull of its own, numbered `PR-REPL-{basis}-2`, `-3`, and so on.
+    family_prefix = f"{_REPLACEMENT_NUMBER_PREFIX}{replacement_basis}"[
+        : _MAX_REQUEST_NUMBER_LENGTH - _MAX_REPLACEMENT_SUFFIX_LENGTH
+    ]
+    # Soft-deleted rows are included deliberately: `uq_pull_requests_request_number_live` excludes
+    # only CANCELLED, so a soft-deleted pull still owns its number and minting it again would be an
+    # IntegrityError. They are excluded from *reuse* below.
+    family = [
+        p
+        for p in session.scalars(
+            select(PullRequestModel)
+            .where(PullRequestModel.request_number.startswith(family_prefix, autoescape=True))
+            .order_by(PullRequestModel.created_at.asc())
+        ).all()
+        if _is_replacement_number(p.request_number, replacement_basis)
+    ]
+    replacement_pr = next(
+        (p for p in family if p.status == PullRequestStatus.PENDING and p.deleted_at is None),
+        None,
     )
-    existing_pr = session.scalars(existing_pr_stmt).first()
-    if existing_pr is None:
+    if replacement_pr is None:
+        taken = {p.request_number for p in family}
+        replacement_request_number = None
+        for n in range(1, _MAX_REPLACEMENT_ATTEMPTS + 1):
+            candidate = _replacement_number(replacement_basis, n)
+            if candidate not in taken:
+                replacement_request_number = candidate
+                break
+        if replacement_request_number is None:
+            raise ValidationError(
+                f"Too many replacement pull requests already exist for {replacement_basis}",
+                field="shop_assembly_opening_item_id",
+            )
         replacement_pr = PullRequestModel(
             request_number=replacement_request_number,
             project_id=il.project_id,
@@ -237,27 +310,42 @@ def report_deficiency_at_assembly(
         )
         session.add(replacement_pr)
         session.flush()
-    else:
-        replacement_pr = existing_pr
 
     opening_number = sa_opening.opening_number or "REPLACEMENT"
 
-    pri = PullRequestItemModel(
-        pull_request_id=replacement_pr.id,
-        item_type=PullRequestItemType.LOOSE,
-        opening_number=opening_number,
-        # Restore the identity the replacement is owed to (#339). Without these the replacement was
-        # a bare (opening, product) line: the warehouse could not tell a pair's leaf-1 replacement
-        # from its leaf-2 one, and nothing tied the pulled unit back to the checklist item that
-        # failed. leaf comes from the ShopAssemblyOpening (the assembly work unit is one leaf);
-        # sa_opening_item_id is the direct link the replacement-loop closure reads.
-        leaf=sa_opening.leaf,
-        sa_opening_item_id=sa_oi.id,
-        hardware_category=il.hardware_category,
-        product_code=il.product_code,
-        requested_quantity=quantity,
-    )
-    session.add(pri)
+    # Repeated flags against the same checklist line and product belong on **one** line, not on a
+    # growing stack of one-unit rows: the pull sheet reads as a quantity to pick, and every consumer
+    # of these lines (`_apply_replacement_arrivals`, the cancel restock, the sufficiency gate) has to
+    # re-aggregate them anyway. Only reachable on a reused PENDING pull - a freshly minted one has no
+    # lines - which is exactly the window in which merging is still safe.
+    pri = session.scalars(
+        select(PullRequestItemModel).where(
+            PullRequestItemModel.pull_request_id == replacement_pr.id,
+            PullRequestItemModel.sa_opening_item_id == sa_oi.id,
+            PullRequestItemModel.item_type == PullRequestItemType.LOOSE,
+            PullRequestItemModel.hardware_category == il.hardware_category,
+            PullRequestItemModel.product_code == il.product_code,
+        )
+    ).first()
+    if pri is not None:
+        pri.requested_quantity += quantity
+    else:
+        pri = PullRequestItemModel(
+            pull_request_id=replacement_pr.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number=opening_number,
+            # Restore the identity the replacement is owed to (#339). Without these the replacement
+            # was a bare (opening, product) line: the warehouse could not tell a pair's leaf-1
+            # replacement from its leaf-2 one, and nothing tied the pulled unit back to the checklist
+            # item that failed. leaf comes from the ShopAssemblyOpening (the assembly work unit is
+            # one leaf); sa_opening_item_id is the direct link the replacement-loop closure reads.
+            leaf=sa_opening.leaf,
+            sa_opening_item_id=sa_oi.id,
+            hardware_category=il.hardware_category,
+            product_code=il.product_code,
+            requested_quantity=quantity,
+        )
+        session.add(pri)
     session.flush()
 
     return (il, pri)

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -76,6 +76,7 @@ from .reservations import (
     create_reservations,
     get_project_availability,
     get_reserved_quantities,
+    get_reserved_total,
     release_reservations,
 )
 
@@ -126,6 +127,7 @@ __all__ = [
     "get_pull_staging_summaries",
     "get_recent_receive_records",
     "get_reserved_quantities",
+    "get_reserved_total",
     "get_unlocated_inventory",
     "get_warehouse_dashboard",
     "mark_inventory_unlocated",

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -305,7 +305,13 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
             request_number=pr.request_number,
             shortfalls=result.shortfalls,
         )
-        if holder is not None:
+        # The audit below is an *integrity* signal, so it has to fire only for a pull that genuinely
+        # held a claim. Having a source request is not the same as holding reservations: the #342
+        # backfill deliberately left the whole pre-existing in-flight population unreserved and
+        # flagged rather than inventing claims for it, and a cancel that could not re-reserve leaves a
+        # live request in the same state. Those are the *expected* shortfall population - flagging
+        # every one of them as an integrity error is exactly how a real one gets missed.
+        if holder is not None and reservations.get_reserved_total(session, holder[0], holder[1]) > 0:
             # The reserved path is not supposed to be able to come up short. Record it against the
             # pull so the discrepancy is investigable rather than indistinguishable from the normal
             # PR-REPL / legacy shortfall the approver sees.
@@ -428,17 +434,30 @@ def _apply_replacement_arrivals(session: Session, pr: PullRequestModel) -> None:
     if not by_item:
         return
 
-    items = list(session.scalars(select(SAOpeningItemModel).where(SAOpeningItemModel.id.in_(by_item.keys()))).all())
+    # Lock the owning work units before touching their checklist lines. `deficient_quantity` /
+    # `replacement_pending_quantity` are guarded by the ShopAssemblyOpening lock everywhere else -
+    # `record_assembly_progress`, `complete_opening` and `install_replacement` all take it - and
+    # writing them from here without it is a lost update against a concurrent install, or a breach of
+    # the `installed + deficient + replacement_pending <= quantity` constraint. The opening ids come
+    # from an id-only pass so the lock is taken *before* the rows it protects are read.
+    opening_ids = set(
+        session.scalars(
+            select(SAOpeningItemModel.shop_assembly_opening_id).where(SAOpeningItemModel.id.in_(by_item.keys()))
+        ).all()
+    )
+    if not opening_ids:
+        return
+    openings = {o.id: o for o in lock_rows(session, ShopAssemblyOpening, sorted(opening_ids))}
+
+    items = list(
+        session.scalars(
+            select(SAOpeningItemModel)
+            .where(SAOpeningItemModel.id.in_(by_item.keys()))
+            .execution_options(populate_existing=True)
+        ).all()
+    )
     if not items:
         return
-    openings = {
-        o.id: o
-        for o in session.scalars(
-            select(ShopAssemblyOpening).where(
-                ShopAssemblyOpening.id.in_({item.shop_assembly_opening_id for item in items})
-            )
-        ).all()
-    }
 
     for item in items:
         arrived = by_item[item.id]
@@ -545,6 +564,14 @@ def complete_pull_request(session: Session, pr_id: uuid.UUID, completed_by: str 
     "stage whatever is left and close the pull": step 6 flips any remaining opening to PULLED and
     stamps its staging, which is a no-op for openings already staged individually.
     """
+    # Take the pull's row lock before reading its status. Completion has two entry points since
+    # #343 - the explicit "mark pulled" action and the last staging confirmation - so two callers can
+    # arrive at an IN_PROGRESS pull at once, both pass the status check, and both run the completion
+    # side effects: two PULL_REQUEST_COMPLETED notifications, and `_apply_replacement_arrivals`
+    # applied twice. Re-locking inside `stage_pull_openings`' transaction (which already holds this
+    # row) is a no-op.
+    if not lock_rows(session, PullRequestModel, [pr_id]):
+        raise NotFoundError(f"Pull request {pr_id} not found")
     stmt = select(PullRequestModel).options(selectinload(PullRequestModel.items)).where(PullRequestModel.id == pr_id)
     pr = session.scalars(stmt).unique().first()
     if pr is None:
@@ -1006,12 +1033,19 @@ def cancel_pull_request(
     items = list(
         session.scalars(select(PullRequestItemModel).where(PullRequestItemModel.pull_request_id == pr.id)).all()
     )
-    openings = list(
-        session.scalars(
-            select(ShopAssemblyOpening)
-            .where(ShopAssemblyOpening.pull_request_id == pr.id)
-            .order_by(ShopAssemblyOpening.opening_number.asc())
-        ).all()
+    # Lock the openings, do not merely read them. The blocker check below is what makes cancellation
+    # all-or-nothing, and every other mutator of these rows (`stage_pull_openings`, `assign_openings`,
+    # `record_assembly_progress`, `complete_opening`) takes this lock first. Reading them unlocked let
+    # a concurrent `complete_opening` slip between the check and the release: its hardware would end
+    # up both on a finished leaf and back on the shelf, and the opening would be left COMPLETED with
+    # `pull_request_id` NULL. Lock order is pull-then-openings, the same order `stage_pull_openings`
+    # takes them in, so this introduces no new cycle.
+    opening_ids = list(
+        session.scalars(select(ShopAssemblyOpening.id).where(ShopAssemblyOpening.pull_request_id == pr.id)).all()
+    )
+    openings = sorted(
+        lock_rows(session, ShopAssemblyOpening, opening_ids),
+        key=lambda o: (o.opening_number or "", o.leaf if o.leaf is not None else -1),
     )
 
     cancellable_from_completed = pr.source == PullRequestSource.SHOP_ASSEMBLY and bool(openings)

--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -25,6 +25,7 @@ from app.models.receiving import ReceiveLineItem as ReceiveLineItemModel
 from app.models.receiving import ReceiveRecord as ReceiveRecordModel
 from app.models.vendor import Vendor as VendorModel
 from app.services import notification_service
+from app.services.locking import lock_rows
 
 from .audit import _log_audit_event
 from .locations import _normalize_and_validate_location_fields
@@ -323,9 +324,11 @@ def create_receive(
     elif any_received and po.status not in (POStatus.PARTIALLY_RECEIVED, POStatus.CLOSED):
         po.status = POStatus.PARTIALLY_RECEIVED
 
-    # The backfill retry loop for replacement pulls (#344). Stock arriving is the only thing that can
-    # unblock one, and until now nothing was watching. Stock-pool POs are skipped: a replacement pull
-    # draws on *project* inventory, and allocating from the pool is a separate deliberate act.
+    # The backfill retry loop for replacement pulls (#344). A receive is the *usual* way one becomes
+    # coverable and the one this module can see; other paths exist (a cancelled pull restocking, an
+    # allocation from the pool, a deficiency resolved back to available) and simply do not raise this
+    # signal today. Stock-pool POs are skipped: a replacement pull draws on *project* inventory, and
+    # allocating from the pool is a separate deliberate act.
     if not is_stock_po:
         session.flush()
         notify_unblocked_replacement_pulls(
@@ -413,14 +416,21 @@ def notify_unblocked_replacement_pulls(
 
     1. *Relevance.* Only pulls that wanted one of the combos this receive actually landed are
        considered. A receive of door closers cannot change whether a hinge replacement is coverable.
-    2. *Transition.* The pull must now be **fully** coverable, under the same reservation-aware
+    2. *Coverability.* The pull must now be **fully** coverable, under the same reservation-aware
        availability the approver will apply (`on-hand - deficient - everyone's reservations`, with no
        self-exclusion, because a replacement pull holds nothing of its own to exclude). A receive that
        narrows the gap without closing it changes nothing the warehouse can act on, so it says
-       nothing. This is the "insufficient -> sufficient" edge.
+       nothing. Note this is the state *after* the receive only - the prior state is not re-derived,
+       so a pull that was already coverable and gets more stock still qualifies here; what actually
+       stops it being announced twice is rule 3.
     3. *Open signal.* One **unread** notification per pull. If the last one has not been read yet,
        the warehouse already knows; raising a second is noise. Once it has been read the signal has
        done its job, so a pull that goes short again and is later covered again gets a fresh one.
+
+    Rule 3 is a check followed by an insert, so it needs the pull's row lock to mean anything: two
+    receives landing the same combo concurrently would both find no unread notification and both
+    write one. The lock is taken per pull, after the pull is known to be relevant and coverable, so a
+    receive that changes nothing takes no locks at all.
 
     Returns the notifications raised, so callers and tests can assert on them.
     """
@@ -438,6 +448,8 @@ def notify_unblocked_replacement_pulls(
         if not needs:
             continue
         if not check_inventory_sufficiency(session, project_id, needs, reservation_aware=True).sufficient:
+            continue
+        if not lock_rows(session, PullRequestModel, [pr.id]):
             continue
         if notification_service.has_unread_notification_for_pull(session, pr.id, NotificationType.PULL_UNBLOCKED):
             continue

--- a/backend/app/repositories/warehouse/reservations.py
+++ b/backend/app/repositories/warehouse/reservations.py
@@ -17,7 +17,7 @@ them in Python (CLAUDE.md perf rules).
 import uuid
 from collections.abc import Iterable
 
-from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy import and_, delete, func, not_, or_, select
 from sqlalchemy.orm import Session
 
 from app.models.enums import ReservationSource
@@ -82,9 +82,39 @@ def get_reserved_quantities(
     if combo_clause is not None:
         stmt = stmt.where(combo_clause)
     if exclude_source is not None and exclude_request_id is not None:
-        stmt = stmt.where(_SOURCE_COLUMN[exclude_source] != exclude_request_id)
+        # Exclude exactly one row set: the given request's own claims. It has to be written as a
+        # negated conjunction, not as `column != id`, because that column is NULL on every row of the
+        # *other* source - a shipping-out reservation has no `shop_assembly_request_id` - and
+        # `NULL != <id>` is NULL, which SQL drops. Written the naive way this silently subtracted
+        # every opposite-source claim in the project from the aggregate, so the cross-type guarantee
+        # the reservation table exists for was void on the one path that matters (pull approval).
+        stmt = stmt.where(
+            not_(
+                and_(
+                    InventoryReservationModel.source == exclude_source,
+                    _SOURCE_COLUMN[exclude_source] == exclude_request_id,
+                )
+            )
+        )
 
     return {(cat, code): int(total or 0) for cat, code, total in session.execute(stmt).all()}
+
+
+def get_reserved_total(session: Session, source: ReservationSource, request_id: uuid.UUID) -> int:
+    """How much stock one request currently holds, summed across every combo. One scalar aggregate.
+
+    The question this answers is "does this request hold a claim at all", which is not the same as
+    "was this request created after #342": the backfill deliberately left the pre-existing in-flight
+    population *unreserved and flagged* rather than inventing claims for it, and a re-upload or a
+    cancelled-and-not-re-reservable pull can strip a claim from a live request too.
+    """
+    total = session.scalar(
+        select(func.coalesce(func.sum(InventoryReservationModel.quantity), 0)).where(
+            InventoryReservationModel.source == source,
+            _SOURCE_COLUMN[source] == request_id,
+        )
+    )
+    return int(total or 0)
 
 
 def get_project_availability(session: Session, project_id: uuid.UUID) -> list[dict]:

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -1,6 +1,7 @@
 """Hardware-schedule import queries + mutations (module name avoids the `import` keyword)."""
 
 import uuid
+from dataclasses import replace
 
 import strawberry
 
@@ -240,7 +241,15 @@ class ImportMutations:
                 # a backfill notification for it would send someone to order stock that already
                 # exists. The refusal reaches the creator inline either way.
                 session.rollback()
-                unstocked = [s for s in e.shortfalls if s.short > s.reserved]
+                # ...and for those combos, tell the PO only about the part that is genuinely absent.
+                # `short` is measured against *available* (= on-hand - deficient - reservations), so
+                # forwarding it verbatim asks purchasing to buy the reserved units a second time.
+                # `short - reserved` is what the shelf is actually missing; floored at 0 because a
+                # combo whose whole shortfall is other people's claims is not a purchasing problem at
+                # all, and it has already been filtered out above.
+                unstocked = [
+                    replace(s, short=max(0, s.short - s.reserved)) for s in e.shortfalls if s.short > s.reserved
+                ]
                 if unstocked:
                     with SessionLocal() as notif_session:
                         notification_service.notify_po_shortfall(

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -4,6 +4,7 @@ import uuid
 
 import strawberry
 
+from app.auth import require_user
 from app.database import SessionLocal
 from app.repositories import stock as stock_repository
 
@@ -250,7 +251,12 @@ class StockMutations:
             )
 
     @strawberry.mutation
-    def report_inventory_deficiency(self, input: ReportInventoryDeficiencyInput) -> InventoryLocation:
+    def report_inventory_deficiency(
+        self, info: strawberry.Info, input: ReportInventoryDeficiencyInput
+    ) -> InventoryLocation:
+        """Condemn units on a project inventory row. Open to any signed-in user - it makes stock
+        unavailable to every other request in the project, so it must not be reachable anonymously."""
+        require_user(info)
         with SessionLocal() as session:
             il = stock_repository.report_inventory_deficiency(
                 session,
@@ -264,7 +270,10 @@ class StockMutations:
             return inventory_location_to_type(il)
 
     @strawberry.mutation
-    def report_stock_deficiency(self, input: ReportStockDeficiencyInput) -> StockItem:
+    def report_stock_deficiency(self, info: strawberry.Info, input: ReportStockDeficiencyInput) -> StockItem:
+        """Condemn units on a stock-pool row. Open to any signed-in user - same reasoning as
+        reportInventoryDeficiency: it takes stock out of circulation."""
+        require_user(info)
         with SessionLocal() as session:
             si = stock_repository.report_stock_deficiency(
                 session,
@@ -278,7 +287,12 @@ class StockMutations:
             return stock_item_to_type(si)
 
     @strawberry.mutation
-    def report_deficiency_at_assembly(self, input: ReportDeficiencyAtAssemblyInput) -> SAReplacementResult:
+    def report_deficiency_at_assembly(
+        self, info: strawberry.Info, input: ReportDeficiencyAtAssemblyInput
+    ) -> SAReplacementResult:
+        """Flag a unit deficient at the bench. Open to any signed-in user - it writes project
+        inventory and mints a replacement pull request, so it must not be reachable anonymously."""
+        require_user(info)
         with SessionLocal() as session:
             il, pri = stock_repository.report_deficiency_at_assembly(
                 session,
@@ -296,7 +310,10 @@ class StockMutations:
             )
 
     @strawberry.mutation
-    def resolve_deficiency(self, input: ResolveDeficiencyInput) -> DeficiencyReview:
+    def resolve_deficiency(self, info: strawberry.Info, input: ResolveDeficiencyInput) -> DeficiencyReview:
+        """Disposition a condemned batch (scrap, repair, RMA, destock). Open to any signed-in user -
+        it moves or writes off real stock, so it must not be reachable anonymously."""
+        require_user(info)
         with SessionLocal() as session:
             review = stock_repository.resolve_deficiency(
                 session,

--- a/backend/tests/test_assembly_progress.py
+++ b/backend/tests/test_assembly_progress.py
@@ -341,7 +341,10 @@ def test_progress_refused_when_hardware_is_not_pulled(db_session):
         project.id,
         request_number="PR-SA-P10",
         items=[(*HINGE, 2)],
-        pull_status=PullStatus.PARTIAL,
+        # NOT_PULLED, not PARTIAL: since #345 the column carries a CHECK saying an opening's
+        # pull_status is binary. PARTIAL is the derived reading over a *set* of openings and is not
+        # storable on one of them, so "this cart is not built" is spelled NOT_PULLED.
+        pull_status=PullStatus.NOT_PULLED,
     )
     with pytest.raises(InvalidStateTransitionError):
         shop_assembly_repository.record_assembly_progress(

--- a/backend/tests/test_inventory_reservations.py
+++ b/backend/tests/test_inventory_reservations.py
@@ -897,3 +897,121 @@ def test_shop_assembly_openings_still_reach_the_bench_after_a_reserved_pull(db_s
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id))
     assert sao.pull_status == PullStatus.PULLED
     assert _reserved_total(db_session, project.id) == 0
+
+
+# --- 8. self-coverage excludes ONE request, not one whole source (#348 review) -------------------
+
+
+def test_self_coverage_excludes_only_that_request_not_the_other_source(db_session):
+    """`exclude_reservations_of` names a single request. Written as `column != id` it silently
+    dropped every row of the *opposite* source too, because that column is NULL on those rows and
+    `NULL != id` is NULL - so the cross-type guarantee the table exists for was void."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=5)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    sor = _finalize_shipping_loose(db_session, project, qty=2)["shipping_out_requests"][0]
+    db_session.flush()
+
+    assert _reserved_total(db_session, project.id) == 5
+
+    # Excluding the shop-assembly request must leave the shipping-out claim standing, and vice versa.
+    assert warehouse_repository.get_reserved_quantities(
+        db_session,
+        project.id,
+        [("HINGE", "HG-100")],
+        exclude_source=ReservationSource.SHOP_ASSEMBLY_REQUEST,
+        exclude_request_id=sar.id,
+    ) == {("HINGE", "HG-100"): 2}
+    assert warehouse_repository.get_reserved_quantities(
+        db_session,
+        project.id,
+        [("HINGE", "HG-100")],
+        exclude_source=ReservationSource.SHIPPING_OUT_REQUEST,
+        exclude_request_id=sor.id,
+    ) == {("HINGE", "HG-100"): 3}
+
+
+def test_a_pull_is_refused_when_the_other_request_type_is_holding_the_stock(db_session):
+    """End to end: a shop-assembly pull approved while a shipping-out request holds part of the
+    shelf. With the exclusion written correctly the pull sees only what is genuinely free."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=5)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    _finalize_shipping_loose(db_session, project, qty=2)
+    db_session.flush()
+
+    # A unit is condemned under the two live claims, so 4 are on hand and 2 are spoken for.
+    il.deficient_quantity = 1
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+
+    _, outcome, _, shortfalls = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    assert [(s.product_code, s.available, s.short, s.reserved) for s in shortfalls] == [("HG-100", 2, 1, 2)]
+    assert il.quantity == 5  # nothing deducted
+
+
+def test_an_unreserved_holder_that_comes_up_short_is_not_an_integrity_error(db_session):
+    """The #342 backfill deliberately left the pre-existing in-flight population unreserved and
+    flagged. Those requests are the *expected* shortfall case; auditing every one of them as
+    RESERVED_PULL_SHORT is how a real one would get missed."""
+    from app.models.audit_log import InventoryAuditLog
+
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=3)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+    # Strip the claim, exactly as a backfill-era request holds none.
+    warehouse_repository.release_reservations(db_session, ReservationSource.SHOP_ASSEMBLY_REQUEST, sar.id)
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    # Now the stock goes away under it.
+    il = db_session.scalar(select(InventoryLocation).where(InventoryLocation.project_id == project.id))
+    il.quantity = 1
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    _, outcome, _, _ = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    integrity_rows = [
+        row
+        for row in db_session.scalars(select(InventoryAuditLog).where(InventoryAuditLog.entity_id == pr.id)).all()
+        if (row.detail or {}).get("integrityError") == "RESERVED_PULL_SHORT"
+    ]
+    assert integrity_rows == []
+
+
+def test_a_holder_that_really_does_hold_a_claim_still_records_the_integrity_error(db_session):
+    """The other half: a request that *is* reserved is not supposed to be able to come up short, so
+    when it does the discrepancy stays investigable."""
+    from app.models.audit_log import InventoryAuditLog
+
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, quantity=3)
+    sar = _finalize_sar(db_session, project, qty=3)["shop_assembly_request"]
+    db_session.flush()
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    il.quantity = 1  # written off under a live claim
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    _, outcome, _, _ = warehouse_repository.approve_pull_request(db_session, pr.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    integrity_rows = [
+        row
+        for row in db_session.scalars(select(InventoryAuditLog).where(InventoryAuditLog.entity_id == pr.id)).all()
+        if (row.detail or {}).get("integrityError") == "RESERVED_PULL_SHORT"
+    ]
+    assert len(integrity_rows) == 1

--- a/backend/tests/test_pipeline_observability.py
+++ b/backend/tests/test_pipeline_observability.py
@@ -1027,3 +1027,100 @@ def test_assembly_status_values_are_all_reachable(db_session):
     shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by="Ana")
     db_session.flush()
     assert opening.assembly_status == AssemblyStatus.COMPLETED
+
+
+# --- lineage: a re-requested leaf is not the leaf that already shipped (#350 review) -------------
+
+
+def _build_and_complete(db_session, sar, *, assign_to=("user_1", "Ana")):
+    """Walk one single-leaf request all the way to an assembled OpeningItem."""
+    pr = _accept(db_session, sar)
+    warehouse_repository.approve_pull_request(db_session, pr.id, "picker")
+    db_session.flush()
+    opening = _openings(db_session, pr)[0]
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [opening.id], "picker")
+    shop_assembly_repository.assign_openings(db_session, [opening.id], *assign_to)
+    db_session.flush()
+    item = db_session.scalar(
+        select(ShopAssemblyOpeningItem).where(ShopAssemblyOpeningItem.shop_assembly_opening_id == opening.id)
+    )
+    shop_assembly_repository.record_assembly_progress(
+        db_session,
+        opening.id,
+        [shop_assembly_repository.AssemblyProgressUpdate(item.id, installed_quantity=item.quantity)],
+        performed_by=assign_to[1],
+    )
+    db_session.flush()
+    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by=assign_to[1])
+    db_session.flush()
+    return pr, opening, leaf
+
+
+def test_a_re_requested_leaf_does_not_inherit_the_shipment_of_the_previous_one(db_session):
+    """(opening_id, leaf) carries no request lineage, so a leaf that shipped under request 1 matched
+    request 2's opening for the same leaf as well. Three things read wrong at once: the new
+    request's shipped count, its after-ship count, and the leaf's stage - which jumped straight to
+    SHIPPED before anybody had picked its cart."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+
+    first = _request(db_session, project, leaves=(1,), qty=2, opening_number="A01")
+    _pr1, first_opening, leaf = _build_and_complete(db_session, first)
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+    assert _summary(db_session, first).shipped_opening_count == 1
+
+    # The same physical leaf is sent back to the shop under a brand new request.
+    second = _request(db_session, project, leaves=(1,), qty=2, opening_number="A01")
+    pr2 = _accept(db_session, second)
+    second_opening = _openings(db_session, pr2)[0]
+    second_opening.opening_id = first_opening.opening_id
+    db_session.flush()
+
+    summary = _summary(db_session, second)
+    assert summary.shipped_opening_count == 0
+    assert summary.replacement_after_ship_opening_count == 0
+
+    detail = shop_assembly_repository.get_assembly_pipeline(db_session, second.id)
+    row = detail.openings[0]
+    assert row.stage != PipelineStage.SHIPPED.value
+    assert row.opening_item_id is None
+    assert row.opening_item_state is None
+
+    # The request that really did ship it still says so.
+    assert _summary(db_session, first).shipped_opening_count == 1
+
+
+def test_the_re_assembled_leaf_reads_as_its_own_unit_in_the_detail(db_session):
+    """The other side of the same filter: scoping to COMPLETED openings must not stop a request from
+    reading its own leaf - only from reading somebody else's.
+
+    Once *both* requests have finished a unit for the same leaf key, the rollup is deliberately
+    conservative (`_shipped_counts` counts an opening as shipped when any of its matched rows
+    shipped, and says so). The per-leaf detail is where that ambiguity is resolved properly, live row
+    winning, exactly as `find_assembled_leaf` resolves it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=40)
+
+    first = _request(db_session, project, leaves=(1,), qty=2, opening_number="A01")
+    _pr1, first_opening, leaf = _build_and_complete(db_session, first)
+    leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    second = _request(db_session, project, leaves=(1,), qty=2, opening_number="A01")
+    _pr2, second_opening, second_leaf = _build_and_complete(db_session, second)
+    second_opening.opening_id = first_opening.opening_id
+    second_leaf.opening_id = first_opening.opening_id
+    db_session.flush()
+
+    row = shop_assembly_repository.get_assembly_pipeline(db_session, second.id).openings[0]
+    assert row.opening_item_id == second_leaf.id
+    assert row.opening_item_state == OpeningItemState.IN_INVENTORY
+    assert row.stage == PipelineStage.COMPLETED.value
+
+    second_leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+    assert _summary(db_session, second).shipped_opening_count == 1
+    assert shop_assembly_repository.get_assembly_pipeline(db_session, second.id).openings[0].stage == (
+        PipelineStage.SHIPPED.value
+    )

--- a/backend/tests/test_pull_staging_cancel.py
+++ b/backend/tests/test_pull_staging_cancel.py
@@ -829,3 +829,71 @@ def test_assemble_list_excludes_a_cancelled_pulls_openings(db_session):
     warehouse_repository.cancel_pull_request(db_session, pr.id, "warehouse", None)
     db_session.flush()
     assert shop_assembly_repository.get_assemble_list(db_session, project.id) == []
+
+
+# --- grouping: one aggregate really does cover several pulls (#343 review) -----------------------
+
+
+def test_staging_summaries_group_correctly_across_several_pulls(db_session):
+    """The resolver asks for a whole page of pulls in one call, so the grouping - not just the
+    arithmetic - has to be right. Three pulls at three different stages, one statement."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=60)
+
+    _sar_a, pr_a, openings_a = _approved_pull(db_session, project, opening_number="A01")
+    _sar_b, pr_b, openings_b = _approved_pull(db_session, project, opening_number="B01")
+    _sar_c, pr_c, _openings_c = _approved_pull(db_session, project, opening_number="C01")
+
+    # A: nothing staged. B: one of two. C: both, which completes it.
+    warehouse_repository.stage_pull_openings(db_session, pr_b.id, [openings_b[0].id], "picker")
+    warehouse_repository.stage_pull_openings(db_session, pr_c.id, [o.id for o in _openings_c], "picker")
+    db_session.flush()
+
+    # A pull with no openings at all rides along and must simply be absent from the result.
+    empty = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"PR-REPL-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHOP_ASSEMBLY,
+        status=PullRequestStatus.IN_PROGRESS,
+        requested_by="tester",
+    )
+    db_session.add(empty)
+    db_session.flush()
+
+    summaries = warehouse_repository.get_pull_staging_summaries(db_session, [pr_a.id, pr_b.id, pr_c.id, empty.id])
+
+    assert set(summaries) == {pr_a.id, pr_b.id, pr_c.id}
+    assert (summaries[pr_a.id].staged_opening_count, summaries[pr_a.id].total_opening_count) == (0, 2)
+    assert (summaries[pr_b.id].staged_opening_count, summaries[pr_b.id].total_opening_count) == (1, 2)
+    assert (summaries[pr_c.id].staged_opening_count, summaries[pr_c.id].total_opening_count) == (2, 2)
+    assert summaries[pr_a.id].status == PullStatus.NOT_PULLED
+    assert summaries[pr_b.id].status == PullStatus.PARTIAL
+    assert summaries[pr_c.id].status == PullStatus.PULLED
+    # Openings of one pull never leak into another's count.
+    assert {o.pull_request_id for o in openings_a} == {pr_a.id}
+
+
+def test_completing_a_pull_twice_is_refused_rather_than_double_announced(db_session):
+    """Staging gave completion a second entry point. The pull's own row lock plus the status check
+    is what keeps the completion notification and the replacement arrivals to exactly one run."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=20)
+    _sar, pr, openings = _approved_pull(db_session, project)
+
+    warehouse_repository.stage_pull_openings(db_session, pr.id, [o.id for o in openings], "picker")
+    db_session.flush()
+    assert pr.status == PullRequestStatus.COMPLETED
+
+    with pytest.raises(InvalidStateTransitionError):
+        warehouse_repository.complete_pull_request(db_session, pr.id, completed_by="picker")
+
+    completions = list(
+        db_session.scalars(
+            select(Notification).where(
+                Notification.pull_request_id == pr.id,
+                Notification.type == NotificationType.PULL_REQUEST_COMPLETED,
+            )
+        ).all()
+    )
+    assert len(completions) == 1

--- a/backend/tests/test_replacement_loop.py
+++ b/backend/tests/test_replacement_loop.py
@@ -668,3 +668,201 @@ def test_shipping_out_creation_is_untouched_for_a_whole_leaf(db_session):
     result = _shipping_finalize(db_session, project, leaf, request_number="SOR-R3")
     db_session.flush()
     assert len(result["shipping_out_requests"]) == 1
+
+
+# --- 6. replacement pull identity: one PENDING pull, then a fresh one (#345-#350 review) ---------
+
+
+def _repl_pulls_for(session, sao_item) -> list[PullRequest]:
+    """Every PR-REPL pull carrying a line for this checklist item, oldest first."""
+    ids = list(
+        session.scalars(
+            select(PullRequestItem.pull_request_id).where(PullRequestItem.sa_opening_item_id == sao_item.id)
+        ).all()
+    )
+    pulls = [session.get(PullRequest, pid) for pid in dict.fromkeys(ids)]
+    return sorted(pulls, key=lambda p: p.created_at)
+
+
+def test_repeated_flags_on_one_line_increment_a_single_replacement_line(db_session):
+    """Two flags against the same checklist line and product are one line to pick, not two rows the
+    replacement loop has to re-aggregate."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RN1", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+
+    _flag_deficient(db_session, opening, item, 1)
+    _flag_deficient(db_session, opening, item, 2)
+
+    lines = list(db_session.scalars(select(PullRequestItem).where(PullRequestItem.sa_opening_item_id == item.id)).all())
+    assert len(lines) == 1
+    assert lines[0].requested_quantity == 3
+    assert len(_repl_pulls_for(db_session, item)) == 1
+
+
+def test_a_second_deficiency_after_the_replacement_completed_mints_a_new_pull(db_session):
+    """The crash regression. `PR-REPL-{basis}` is unique among live pulls, so once the first
+    replacement pull has completed the next deficiency on the same source pull cannot reuse its
+    number - it gets `-2` instead of an IntegrityError."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RN2", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+
+    _flag_deficient(db_session, opening, item, 1)
+    first = _repl_pull_for(db_session, item)
+    assert first.request_number == "PR-REPL-PR-SA-RN2"
+
+    _work_the_pull(db_session, first)
+    warehouse_repository.complete_pull_request(db_session, first.id)
+    db_session.flush()
+    assert first.status == PullRequestStatus.COMPLETED
+
+    # The second flag must not try to write the same number again.
+    _flag_deficient(db_session, opening, item, 1)
+    db_session.flush()
+
+    pulls = _repl_pulls_for(db_session, item)
+    assert [p.request_number for p in pulls] == ["PR-REPL-PR-SA-RN2", "PR-REPL-PR-SA-RN2-2"]
+    assert pulls[1].status == PullRequestStatus.PENDING
+    # And the new pull carries its own line, at the newly flagged quantity only.
+    new_lines = [line for line in pulls[1].items if line.sa_opening_item_id == item.id]
+    assert [line.requested_quantity for line in new_lines] == [1]
+
+
+def test_a_deficiency_during_an_approved_replacement_pull_starts_a_fresh_pull(db_session):
+    """An IN_PROGRESS pull has already been deducted and sufficiency-checked line by line. Appending
+    to it would deliver a unit nothing paid for - and restock one on cancel that never left."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RN3", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+
+    _flag_deficient(db_session, opening, item, 1)
+    first = _repl_pull_for(db_session, item)
+    warehouse_repository.approve_pull_request(db_session, first.id, "warehouse")
+    db_session.flush()
+    assert first.status == PullRequestStatus.IN_PROGRESS
+
+    _flag_deficient(db_session, opening, item, 1)
+    db_session.flush()
+
+    pulls = _repl_pulls_for(db_session, item)
+    assert len(pulls) == 2
+    assert pulls[1].request_number == "PR-REPL-PR-SA-RN3-2"
+    assert [line.requested_quantity for line in first.items] == [1]
+
+
+def test_a_long_source_number_keeps_the_suffix_and_stays_inside_varchar_50(db_session):
+    """`request_number` is varchar(50). When the basis is long enough that the suffix would not fit,
+    the *basis* is what gets truncated - the suffix is the part that makes the number unique."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    long_number = "PR-SA-" + "L" * 40  # 46 chars; "PR-REPL-" + this is 54
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number=long_number, items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+
+    _flag_deficient(db_session, opening, item, 1)
+    first = _repl_pull_for(db_session, item)
+    _work_the_pull(db_session, first)
+    warehouse_repository.complete_pull_request(db_session, first.id)
+    db_session.flush()
+
+    _flag_deficient(db_session, opening, item, 1)
+    db_session.flush()
+
+    numbers = [p.request_number for p in _repl_pulls_for(db_session, item)]
+    assert all(len(n) <= 50 for n in numbers)
+    assert numbers[0] != numbers[1]
+    assert numbers[1].endswith("-2")
+
+
+def test_cancelling_a_replacement_pull_restocks_exactly_what_it_deducted(db_session):
+    """A multi-line PR-REPL pull, approved and then cancelled, returns precisely the units approval
+    took - and nothing belonging to the deficiency flagged after it was approved."""
+    project = _make_project(db_session)
+    hinges = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    locks = _seed_inventory(db_session, project.id, category=LOCK[0], code=LOCK[1], quantity=10)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-RN4", items=[(*HINGE, 4), (*LOCK, 4)]
+    )
+
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    _flag_deficient(db_session, opening, sao[LOCK[1]], 1)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    assert {line.product_code for line in repl.items} == {HINGE[1], LOCK[1]}
+
+    before_hinges, before_locks = hinges.quantity, locks.quantity
+    warehouse_repository.approve_pull_request(db_session, repl.id, "warehouse")
+    db_session.flush()
+    assert hinges.quantity == before_hinges - 2
+    assert locks.quantity == before_locks - 1
+
+    # A third flag lands on a *new* pull, so it must not be restocked by this cancellation.
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    db_session.flush()
+    after_third_flag = hinges.quantity
+
+    result = warehouse_repository.cancel_pull_request(db_session, repl.id, "warehouse", reason="wrong pull")
+    db_session.flush()
+
+    assert {(r.product_code, r.quantity) for r in result.restocked} == {(HINGE[1], 2), (LOCK[1], 1)}
+    assert hinges.quantity == after_third_flag + 2
+    assert locks.quantity == before_locks
+
+
+def test_install_is_refused_while_the_leaf_is_staged_for_shipment(db_session):
+    """SHIP_READY is the shipped problem one step earlier: the packing slip is built from what the
+    leaf carries, so a late write here lands hardware on a slip that was picked without it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RN5", items=[(*HINGE, 4)])
+    item = sao[HINGE[1]]
+    _flag_deficient(db_session, opening, item, 2)
+    leaf = _complete(db_session, opening, sao)
+
+    repl = _work_the_pull(db_session, _repl_pull_for(db_session, item))
+    warehouse_repository.complete_pull_request(db_session, repl.id)
+    db_session.flush()
+    assert item.replacement_pending_quantity == 2
+
+    leaf.state = OpeningItemState.SHIP_READY
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError) as exc:
+        shop_assembly_repository.install_replacement(db_session, item.id, 1)
+    assert "staged for shipment" in str(exc.value)
+    # It stays queryable rather than being silently dropped.
+    work = shop_assembly_repository.get_replacement_work(db_session)
+    assert [w.opening_item_state for w in work] == [OpeningItemState.SHIP_READY]
+
+
+def test_awaiting_replacement_reads_only_the_latest_assembly_of_a_leaf(db_session):
+    """A leaf shipped short and was re-assembled. The new unit is whole; the old work unit's
+    outstanding units belong to the shipped one and must not follow the leaf into the shop again."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=20)
+    first_opening, first_items = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-RN6", items=[(*HINGE, 4)]
+    )
+    _flag_deficient(db_session, first_opening, first_items[HINGE[1]], 1)
+    shipped_leaf = _complete(db_session, first_opening, first_items)
+    shipped_leaf.state = OpeningItemState.SHIPPED_OUT
+    db_session.flush()
+
+    # The same physical leaf comes back through the shop under a second pull, this time whole.
+    second_opening, second_items = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-RN7", items=[(*HINGE, 4)]
+    )
+    second_opening.opening_id = first_opening.opening_id
+    second_opening.opening_number = first_opening.opening_number
+    db_session.flush()
+    fresh_leaf = _complete(db_session, second_opening, second_items)
+    db_session.flush()
+
+    awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(
+        db_session, [shipped_leaf.id, fresh_leaf.id]
+    )
+    assert awaiting.get(fresh_leaf.id, 0) == 0
+    assert awaiting.get(shipped_leaf.id, 0) == 1

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -1,0 +1,190 @@
+"""Every gated resolver in the shop-assembly and stock modules actually calls its gate (#345).
+
+Auth in this codebase is **opt-in per resolver** (CLAUDE.md): there is no middleware to catch a
+resolver that forgets, and `get_context` only stashes the request. That makes a dropped
+`require_user(info)` invisible - the resolver keeps working, it just works for anonymous callers
+too, which is exactly how `reportDeficiencyAtAssembly` came to mint replacement pull requests and
+write project inventory with no session at all.
+
+These are pin tests, not behaviour tests. Each one replaces the gate with something that raises a
+sentinel and asserts the sentinel comes back out: if the gate runs, the call cannot proceed, so no
+database is needed and nothing about the resolver body is asserted. A refactor that drops a gate
+makes the resolver return (or fail differently) and the test goes red on that resolver by name.
+
+`shopAssemblyMembers` and the manager branch of `assignOpenings` are role-gated rather than
+user-gated; both gates are pinned.
+"""
+
+import uuid
+
+import pytest
+
+from app.schemas import shop_assembly as shop_assembly_module
+from app.schemas import stock as stock_module
+from app.schemas.enums import DeficiencyResolution
+from app.schemas.inputs import (
+    AssignOpeningsInput,
+    CompleteOpeningInput,
+    InstallReplacementInput,
+    RecordAssemblyProgressInput,
+    ReportDeficiencyAtAssemblyInput,
+    ReportInventoryDeficiencyInput,
+    ReportStockDeficiencyInput,
+    ResolveDeficiencyInput,
+)
+from app.schemas.shop_assembly import ShopAssemblyMutations, ShopAssemblyQueries
+from app.schemas.stock import StockMutations
+
+
+class _GateReached(Exception):
+    """Raised by the stubbed gate. Seeing it means the resolver asked before it acted."""
+
+
+class FakeInfo:
+    def __init__(self, request=None):
+        self.context = {"request": request}
+
+
+def _id() -> str:
+    return str(uuid.uuid4())
+
+
+# (label, module the resolver resolves its gate from, callable taking no args)
+_USER_GATED = [
+    ("assembleList", shop_assembly_module, lambda: ShopAssemblyQueries().assemble_list(FakeInfo())),
+    ("myWork", shop_assembly_module, lambda: ShopAssemblyQueries().my_work(FakeInfo(), "user_1")),
+    ("replacementWork", shop_assembly_module, lambda: ShopAssemblyQueries().replacement_work(FakeInfo())),
+    (
+        "shopAssemblyRequests",
+        shop_assembly_module,
+        lambda: ShopAssemblyQueries().shop_assembly_requests(FakeInfo()),
+    ),
+    (
+        "assemblyPipelineSummaries",
+        shop_assembly_module,
+        lambda: ShopAssemblyQueries().assembly_pipeline_summaries(FakeInfo()),
+    ),
+    (
+        "assemblyPipeline",
+        shop_assembly_module,
+        lambda: ShopAssemblyQueries().assembly_pipeline(FakeInfo(), _id()),
+    ),
+    (
+        "acceptShopAssemblyRequest",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().accept_shop_assembly_request(FakeInfo(), _id(), "acceptor"),
+    ),
+    (
+        "rejectShopAssemblyRequest",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().reject_shop_assembly_request(FakeInfo(), _id(), "rejector"),
+    ),
+    (
+        "reopenShopAssemblyRequest",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().reopen_shop_assembly_request(FakeInfo(), _id()),
+    ),
+    (
+        "assignOpenings",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().assign_openings(
+            FakeInfo(),
+            AssignOpeningsInput(opening_ids=[_id()], assigned_to_user_id="user_1", assigned_to="Someone"),
+        ),
+    ),
+    (
+        "removeOpeningFromUser",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().remove_opening_from_user(FakeInfo(), _id()),
+    ),
+    (
+        "recordAssemblyProgress",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().record_assembly_progress(
+            FakeInfo(), RecordAssemblyProgressInput(opening_id=_id(), items=[])
+        ),
+    ),
+    (
+        "installReplacement",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().install_replacement(
+            FakeInfo(), InstallReplacementInput(shop_assembly_opening_item_id=_id(), quantity=1)
+        ),
+    ),
+    (
+        "completeOpening",
+        shop_assembly_module,
+        lambda: ShopAssemblyMutations().complete_opening(FakeInfo(), CompleteOpeningInput(opening_id=_id())),
+    ),
+    (
+        "reportInventoryDeficiency",
+        stock_module,
+        lambda: StockMutations().report_inventory_deficiency(
+            FakeInfo(), ReportInventoryDeficiencyInput(inventory_location_id=_id(), quantity=1)
+        ),
+    ),
+    (
+        "reportStockDeficiency",
+        stock_module,
+        lambda: StockMutations().report_stock_deficiency(
+            FakeInfo(), ReportStockDeficiencyInput(stock_item_id=_id(), quantity=1)
+        ),
+    ),
+    (
+        "reportDeficiencyAtAssembly",
+        stock_module,
+        lambda: StockMutations().report_deficiency_at_assembly(
+            FakeInfo(), ReportDeficiencyAtAssemblyInput(shop_assembly_opening_item_id=_id(), quantity=1)
+        ),
+    ),
+    (
+        "resolveDeficiency",
+        stock_module,
+        lambda: StockMutations().resolve_deficiency(
+            FakeInfo(),
+            ResolveDeficiencyInput(
+                inventory_location_id=_id(),
+                resolution=DeficiencyResolution.REPAIR,
+                quantity=1,
+                reviewed_by="reviewer",
+            ),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("label, module, call", _USER_GATED, ids=[row[0] for row in _USER_GATED])
+def test_resolver_requires_a_signed_in_user(label, module, call, monkeypatch):
+    def _gate(info):
+        raise _GateReached(label)
+
+    monkeypatch.setattr(module, "require_user", _gate)
+
+    with pytest.raises(_GateReached):
+        call()
+
+
+def test_shop_assembly_members_requires_the_manager_role(monkeypatch):
+    def _gate(info, role):
+        raise _GateReached(role)
+
+    monkeypatch.setattr(shop_assembly_module, "require_role", _gate)
+
+    with pytest.raises(_GateReached):
+        ShopAssemblyQueries().shop_assembly_members(FakeInfo())
+
+
+def test_assigning_to_another_user_requires_the_manager_role(monkeypatch):
+    """The one gate that is conditional: self-assignment is open, assigning somebody else is not."""
+
+    def _role_gate(info, role):
+        raise _GateReached(role)
+
+    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
+    monkeypatch.setattr(shop_assembly_module, "require_role", _role_gate)
+
+    with pytest.raises(_GateReached):
+        ShopAssemblyMutations().assign_openings(
+            FakeInfo(),
+            AssignOpeningsInput(opening_ids=[_id()], assigned_to_user_id="somebody_else", assigned_to="Other"),
+        )

--- a/docs/HARDWARE_IDENTITY_LIFECYCLE.md
+++ b/docs/HARDWARE_IDENTITY_LIFECYCLE.md
@@ -121,7 +121,8 @@ notification and the replacement-arrival application still fire exactly once, fr
 Two state facts, deliberately kept apart:
 
 - `ShopAssemblyOpening.pull_status` is only ever `NOT_PULLED` or `PULLED`. One cart is built or it is
-  not; persisting a half-truth about a single cart would be a lie.
+  not; persisting a half-truth about a single cart would be a lie. Since #345 that is a CHECK
+  constraint on the column rather than a convention, so a bad write cannot express it either.
 - `PullStatus.PARTIAL` is the **aggregate** reading over a set of openings, and it is **derived, not
   stored** (`warehouse.get_pull_staging_summaries`, one grouped aggregate for a whole page).
   `PullRequestStatus` therefore stays `PENDING -> IN_PROGRESS -> COMPLETED/CANCELLED` with no
@@ -170,6 +171,17 @@ The tag does not become physical all at once. Assembly happens over a shift, uni
   PR-REPL replacement pull line carrying the leaf and the source `ShopAssemblyOpeningItem`. That is
   the identity round-trip in miniature - the unit loses its leaf on the way back into inventory, and
   the replacement line is what re-tags a fresh one.
+
+  **One replacement pull per open round of deficiencies**, numbered `PR-REPL-{source pull number}`,
+  then `-2`, `-3` on collision (truncating the basis, never the suffix, to stay inside
+  `request_number`'s varchar(50)). A flag reuses the existing replacement pull only while it is
+  **PENDING**, and merges into that pull's existing line for the same checklist item and product
+  rather than stacking one-unit rows. Once the pull is approved it is closed to new lines, and the
+  reason is the same rule the rest of this document is about: approval is where the claim on stock
+  is settled. A line appended afterwards was never sufficiency-checked and never deducted, yet
+  `_apply_replacement_arrivals` would count it as delivered and `cancel_pull_request` would restock
+  it - inventory conjured from a row that had no hardware behind it. The next deficiency therefore
+  starts a pull of its own.
 - **Shop assembly complete** - *this* is where the tag becomes physical. An `OpeningItem` row is
   created per leaf (`opening_items.leaf`), with one `OpeningItemHardware` row per line that had units
   installed, at the **installed** quantity, not the planned one. Completion is refused while any unit
@@ -197,10 +209,13 @@ Where the freed unit lands depends on whether the tag is still being worked:
   than merely intended. `install_replacement` then moves it `replacement_pending -> installed` and
   appends or increments the leaf's `OpeningItemHardware` row: **the one legitimate write to an
   assembled leaf's hardware after completion**, bounded by what the pull actually delivered.
-- **Leaf already SHIPPED_OUT** - the hardware cannot be fitted to something that has left the
-  building. The pending state is still recorded, so the unit stays queryable rather than silently
-  stranded, and a `REPLACEMENT_AFTER_SHIPMENT` notification hands it to the reallocation /
-  site-shipment world. `install_replacement` refuses it.
+- **Leaf already SHIPPED_OUT, or staged at the dock as SHIP_READY** - the hardware cannot be fitted.
+  A shipped leaf has left the building; a SHIP_READY one has been picked and checked against a
+  confirmed pull, and `confirm_shipment` snapshots its hardware onto the `PackingSlipItem`, so a late
+  write here would put hardware on a packing slip for a unit that shipped without it. The pending
+  state is still recorded in both cases, so the unit stays queryable rather than silently stranded,
+  and for the shipped case a `REPLACEMENT_AFTER_SHIPMENT` notification hands it to the reallocation /
+  site-shipment world. `install_replacement` refuses both.
 
 **A leaf with anything in `deficient_quantity` or `replacement_pending_quantity` is physically short
 of the hardware list it would ship under.** That sum is `OpeningItem.awaiting_replacement_quantity`,
@@ -311,6 +326,8 @@ leaf until a pull tags it onto one).
 | Tag worked, incrementally | `backend/app/repositories/shop_assembly_repository.py` (`record_assembly_progress` -> `installed_quantity` / `deficient_quantity`) |
 | Deficient unit returned + replaced | `backend/app/repositories/stock/deficiency.py` (`report_deficiency_at_assembly` -> PR-REPL line) |
 | Tag materialized | `backend/app/repositories/shop_assembly_repository.py` (`complete_opening` -> `OpeningItem`, quantities = installed) |
+| One live assembled unit per leaf | `backend/app/models/opening_item.py` (`uq_opening_items_live_leaf`, partial unique index on `(project, opening, coalesce(leaf,0))` excluding shipped units); `complete_opening` translates the violation into the same `ConflictError` its read-then-write guard raises |
+| Replacement pull numbering | `backend/app/repositories/stock/deficiency.py` (`_replacement_number` / `_is_replacement_number`: reuse only a PENDING pull, otherwise mint `PR-REPL-{basis}-{n}`) |
 | Replacement arrives, expectation restored | `backend/app/repositories/warehouse/pull_requests.py` (`_apply_replacement_arrivals` -> `deficient_quantity` down, `replacement_pending_quantity` up on a completed leaf) |
 | Replacement fitted to a finished leaf | `backend/app/repositories/shop_assembly_repository.py` (`install_replacement` -> `OpeningItemHardware`) |
 | Leaf is short of its own list | `backend/app/repositories/shop_assembly_repository.py` (`get_awaiting_replacement_quantities`, one grouped aggregate) |

--- a/frontend/src/graphql/__tests__/refetch.test.ts
+++ b/frontend/src/graphql/__tests__/refetch.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import * as refetch from '../refetch';
+
+// refetch.ts encodes one rule with real consequences (CLAUDE.md perf rules, #337): for any single
+// mutation, the queries refetched by name and the root fields evicted must be DISJOINT. Evicting a
+// root field a mounted query also refetches makes Apollo fire a repair fetch for the incomplete
+// cache diff on top of the explicit refetch, and the two heaviest resolvers then run concurrently
+// against a small connection pool.
+//
+// The rule is stated in prose at the top of that file and was, until now, checked by nobody. These
+// tests are cheap and they fail on exactly the edit that would break it.
+
+/** Operation name -> the root field it writes, for the pairs the lists below actually use. */
+const ROOT_FIELD_OF_QUERY: Record<string, string> = {
+  GetAssembleList: 'assembleList',
+  GetMyWork: 'myWork',
+  GetReplacementWork: 'replacementWork',
+  GetPullRequests: 'pullRequests',
+  GetOpeningLeafStatus: 'openingLeafStatus',
+  GetInventoryHierarchy: 'inventoryHierarchy',
+  GetInventoryByVendor: 'inventoryByVendor',
+  GetUnlocatedInventory: 'unlocatedInventory',
+  GetStockItems: 'stockItems',
+  GetDeficientItems: 'deficientItems',
+  GetDeficiencyReviews: 'deficiencyReviews',
+  GetWarehouseDashboard: 'warehouseDashboard',
+  GetProjectProgressByProduct: 'projectProgressByProduct',
+};
+
+const PAIRS: [string, string[], string[]][] = [
+  ['shipment confirm', refetch.SHIPPING_REFETCH_QUERIES, refetch.SHIPPING_STALE_ROOT_FIELDS],
+  ['assembly progress save', refetch.ASSEMBLY_PROGRESS_REFETCH_QUERIES, refetch.PIPELINE_STALE_ROOT_FIELDS],
+  [
+    'replacement install',
+    refetch.REPLACEMENT_INSTALL_REFETCH_QUERIES,
+    refetch.REPLACEMENT_INSTALL_STALE_ROOT_FIELDS,
+  ],
+  ['pull staging', refetch.PULL_STAGING_REFETCH_QUERIES, refetch.PULL_STAGING_STALE_ROOT_FIELDS],
+  ['pull cancel', refetch.PULL_CANCEL_REFETCH_QUERIES, refetch.PULL_CANCEL_STALE_ROOT_FIELDS],
+];
+
+describe('refetch/evict lists stay disjoint', () => {
+  it.each(PAIRS)('%s', (_label, refetched, evicted) => {
+    const evictedSet = new Set(evicted);
+    const collisions = refetched
+      .map((op) => ROOT_FIELD_OF_QUERY[op])
+      .filter((field) => field !== undefined && evictedSet.has(field));
+    expect(collisions).toEqual([]);
+  });
+});
+
+it('refetches the Assemble List after a progress save rather than evicting it', () => {
+  // The modal is rendered from a row of `assembleList`, and the manager board reads the same query,
+  // so evicting the field empties it for every mounted watcher and unmounts the modal mid-save.
+  expect(refetch.ASSEMBLY_PROGRESS_REFETCH_QUERIES).toContain('GetAssembleList');
+  expect(refetch.PIPELINE_STALE_ROOT_FIELDS).not.toContain('assembleList');
+  // The constant that used to carry that eviction is gone for good.
+  expect('ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS' in refetch).toBe(false);
+});
+
+it('invalidates both request queues when a pull is cancelled', () => {
+  // Cancelling returns the source request to PENDING, and that is true of either source. Both
+  // queues live on routes that are not mounted at cancel time, so both have to be evicted.
+  expect(refetch.PULL_CANCEL_STALE_ROOT_FIELDS).toContain('shopAssemblyRequests');
+  expect(refetch.PULL_CANCEL_STALE_ROOT_FIELDS).toContain('shippingOutRequests');
+});

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -54,16 +54,27 @@ export const PIPELINE_STALE_ROOT_FIELDS = ['assemblyPipelineSummaries', 'assembl
 // field that is evicted must not also be refetched by name, or Apollo fires a repair fetch for the
 // incomplete cache diff on top of the explicit refetch.
 //
-// Refetched. GetMyWork is the assembler's own board and is mounted whenever they are saving from My
-// Work; refetchQueries reaches only mounted instances, so this is a no-op when the save came from
-// the Assemble List instead. Note that recordAssemblyProgress already returns the updated opening
-// with its items, so the modal itself needs neither of these - these lists exist for the *lists*
-// behind it, whose status chip and "5/8 units" column would otherwise sit stale.
-export const ASSEMBLY_PROGRESS_REFETCH_QUERIES = ['GetMyWork'];
+// Refetched, and `assembleList` is refetched here rather than evicted. Both lists behind this modal
+// are refetched by name: GetMyWork is the assembler's own board, GetAssembleList is the other entry
+// point into the same modal. refetchQueries reaches only mounted instances, so naming both is a
+// no-op for whichever one is not live.
+//
+// `assembleList` used to be evicted instead, on the belief that the two views are never mounted
+// together. They are: ManagerAssignPanel runs GET_ASSEMBLE_LIST from inside AssignmentBoard, and the
+// Assemble List page opens this modal over its own grid. Eviction transiently empties `assembleList`
+// for every mounted watcher, so the row this modal is rendered from disappears and the modal
+// unmounts mid-save - the assembler loses the leaf they were working on. A refetch swaps the data in
+// without ever passing through empty.
+//
+// Note that recordAssemblyProgress already returns the updated opening with its items, so the modal
+// itself needs neither of these - these lists exist for the *lists* behind it, whose status chip and
+// "5/8 units" column would otherwise sit stale.
+export const ASSEMBLY_PROGRESS_REFETCH_QUERIES = ['GetMyWork', 'GetAssembleList'];
 
-// Evicted. assembleList is read by the other entry point into the same modal, and the two views are
-// never mounted together (separate routes), so whichever one is live repairs its own diff.
-export const ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS = ['assembleList', ...PIPELINE_STALE_ROOT_FIELDS];
+// There is deliberately no ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS any more. Everything a progress save
+// invalidates and can reach is refetched above; the only thing left to evict is the pipeline, and
+// the call site evicts PIPELINE_STALE_ROOT_FIELDS directly so the disjointness of the two lists is
+// visible at a glance rather than hidden behind a name that once meant something wider.
 
 // What installing a replacement onto a finished leaf invalidates (#341). Same disjointness rule.
 //
@@ -161,6 +172,9 @@ export const PULL_CANCEL_STALE_ROOT_FIELDS = [
   'myWork',
   'projectInventoryAvailability',
   'shopAssemblyRequests',
+  // Cancelling a shipping-out pull returns its request to PENDING too, and that queue lives on
+  // another route entirely - so like shopAssemblyRequests it has to be evicted, not refetched.
+  'shippingOutRequests',
   // A cancellation puts the request back at the start of the ladder and leaves a cancelled pull in
   // its history (#344), which is the reading that stops it looking like it was never accepted.
   ...PIPELINE_STALE_ROOT_FIELDS,

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -1446,6 +1446,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               onTogglePRItem={toggleShippingPRItem}
               availabilityByCombo={availabilityByCombo}
               availabilityShortfalls={availabilityShortfalls}
+              availabilityLoading={availabilityLoading && availabilityData === undefined}
               availabilityError={availabilityError !== undefined}
               onAcknowledgeIncompleteLeaf={() => setAcknowledgedIncompleteLeaves(true)}
               onNext={handleNext}

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -47,6 +47,8 @@ interface ShippingPRsStepProps {
   availabilityByCombo: Map<string, InventoryAvailabilityRow>;
   /** Combos the current selection would over-claim. Non-empty blocks the step. */
   availabilityShortfalls: AvailabilityShortfall[];
+  /** The availability lookup has not answered yet, so the counts below are not final. */
+  availabilityLoading: boolean;
   /** The availability lookup failed; the counts are unknown, not zero. */
   availabilityError: boolean;
   /**
@@ -84,6 +86,7 @@ export default function ShippingPRsStep({
   onTogglePRItem,
   availabilityByCombo,
   availabilityShortfalls,
+  availabilityLoading,
   availabilityError,
   onAcknowledgeIncompleteLeaf,
   onNext,
@@ -119,13 +122,17 @@ export default function ShippingPRsStep({
 
   // Creating the request RESERVES what its LOOSE lines ask for (#342), so an over-selection is
   // blocked here rather than bouncing the whole finalize. A failed availability lookup blocks
-  // too: an unknown count must not read as "fine".
+  // too: an unknown count must not read as "fine" - and neither must an unfinished one, which is
+  // why `availabilityLoading` blocks as well, exactly as it does on the shop-assembly step. Before
+  // the lookup answers every combo reads as 0 available, so an unblocked Next would let a valid
+  // selection through on numbers that were never real.
   const canProceed = useMemo(
     () =>
       shippingPRDrafts.some((d) => d.requestNumber.trim() !== '' && d.items.length > 0) &&
       availabilityShortfalls.length === 0 &&
+      !availabilityLoading &&
       !availabilityError,
-    [shippingPRDrafts, availabilityShortfalls, availabilityError],
+    [shippingPRDrafts, availabilityShortfalls, availabilityLoading, availabilityError],
   );
 
   // An assembled leaf is one physical object, so it can sit on exactly one request. Loose hardware
@@ -173,6 +180,12 @@ export default function ShippingPRsStep({
         <Alert severity="error" sx={{ mb: 2 }}>
           Could not read this project&apos;s available inventory, so the loose-hardware counts below
           are unknown rather than zero. Go back and retry before creating a request.
+        </Alert>
+      )}
+
+      {availabilityLoading && !availabilityError && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Checking available inventory...
         </Alert>
       )}
 
@@ -323,7 +336,11 @@ export default function ShippingPRsStep({
                     const availability = availabilityByCombo.get(itemGroupKey(hi));
                     const available = availability?.availableQuantity ?? 0;
                     const reserved = availability?.reservedQuantity ?? 0;
-                    const overClaimed = !availabilityError && hi.item_quantity > available;
+                    // Not over-claimed until the numbers are real: while the lookup is in flight
+                    // every combo reads 0 available, and a row of red "0 available" captions on a
+                    // perfectly valid selection is a false alarm the user cannot act on.
+                    const overClaimed =
+                      !availabilityError && !availabilityLoading && hi.item_quantity > available;
                     return (
                       <FormControlLabel
                         key={aggregationKey(hi)}
@@ -348,8 +365,12 @@ export default function ShippingPRsStep({
                             >
                               {availabilityError
                                 ? 'Availability unknown'
-                                : `${available} available` +
-                                  (reserved > 0 ? ` (${reserved} reserved by other requests)` : '')}
+                                : availabilityLoading
+                                  ? 'Checking availability...'
+                                  : `${available} available` +
+                                    (reserved > 0
+                                      ? ` (${reserved} reserved by other requests)`
+                                      : '')}
                             </Typography>
                           </Box>
                         }

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -36,6 +36,9 @@ interface AssembleOpeningItem {
   quantity: number;
   installedQuantity: number;
   deficientQuantity: number;
+  // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned
+  // into, and part of the progress rollup's `remaining`.
+  replacementPendingQuantity: number;
 }
 
 interface AssembleOpening {
@@ -268,7 +271,7 @@ export default function AssembleListPage() {
                             variant="outlined"
                           />
                           <Typography variant="body2" color="text.secondary">
-                            {progress.installed + progress.deficient}/{progress.planned} units
+                            {progress.planned - progress.remaining}/{progress.planned} units
                           </Typography>
                         </Stack>
                       </AccordionSummary>

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -22,7 +22,7 @@ import { COMPLETE_OPENING, RECORD_ASSEMBLY_PROGRESS } from '../../graphql/shop-a
 import {
   ASSEMBLY_COMPLETE_STALE_ROOT_FIELDS,
   ASSEMBLY_PROGRESS_REFETCH_QUERIES,
-  ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS,
+  PIPELINE_STALE_ROOT_FIELDS,
 } from '../../graphql/refetch';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -38,6 +38,10 @@ interface OpeningItem {
   quantity: number;
   installedQuantity: number;
   deficientQuantity: number;
+  // Units whose replacement has arrived but has not been fitted yet (#341). Zero while the leaf is
+  // on the bench; carried here so the progress rollup partitions the line the same three ways the
+  // backend does.
+  replacementPendingQuantity: number;
 }
 
 interface MyWorkOpening {
@@ -87,14 +91,21 @@ export default function AssemblyDetailModal({
   const [draftInstalled, setDraftInstalled] = useState<Record<string, string>>(() =>
     Object.fromEntries(opening.items.map((item) => [item.id, String(item.installedQuantity)]))
   );
-  // The line a deficiency is being reported against, if the flag dialog is open.
-  const [flagging, setFlagging] = useState<OpeningItem | null>(null);
+  // The line a deficiency is being reported against, if the flag dialog is open. Held as an id and
+  // resolved against the current props on every render, never captured as an object: flagging writes
+  // inventory, so the dialog has to be reasoning about what the server says now, not about a
+  // snapshot taken when it was opened.
+  const [flaggingId, setFlaggingId] = useState<string | null>(null);
   const [flagQuantity, setFlagQuantity] = useState('1');
   const [flagReason, setFlagReason] = useState('');
 
   const [recordProgress, { loading: saving }] = useMutation(RECORD_ASSEMBLY_PROGRESS, {
+    // Evict the pipeline only - a route of its own, never mounted at the bench. `assembleList` is
+    // deliberately NOT evicted: this modal is rendered from a row of that list (and of the manager
+    // board, which reads the same query), so emptying the field would unmount the modal mid-save.
+    // It is refetched by name instead, which swaps the data in without ever passing through empty.
     update(cache) {
-      for (const fieldName of ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS) {
+      for (const fieldName of PIPELINE_STALE_ROOT_FIELDS) {
         cache.evict({ id: 'ROOT_QUERY', fieldName });
       }
       cache.gc();
@@ -127,7 +138,8 @@ export default function AssemblyDetailModal({
   };
 
   // The most a line can be marked installed: everything not already condemned.
-  const maxInstalled = (item: OpeningItem): number => item.quantity - item.deficientQuantity;
+  const maxInstalled = (item: OpeningItem): number =>
+    item.quantity - item.deficientQuantity - item.replacementPendingQuantity;
 
   const draftFor = (item: OpeningItem): string =>
     draftInstalled[item.id] ?? String(item.installedQuantity);
@@ -154,6 +166,7 @@ export default function AssemblyDetailModal({
           quantity: item.quantity,
           installedQuantity: parsedDraft(item) ?? item.installedQuantity,
           deficientQuantity: item.deficientQuantity,
+          replacementPendingQuantity: item.replacementPendingQuantity,
         }))
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -165,9 +178,15 @@ export default function AssemblyDetailModal({
   const busy = saving || completing;
 
   // Mirrors the backend's completion gate exactly - every unit installed or condemned, and at least
-  // one actually installed - so the button explains itself instead of failing on submit.
+  // one actually installed - so the button explains itself instead of failing on submit. The
+  // all-deficient refusal is scoped to openings that *have* lines: the backend's guard is
+  // `if items and all(installed == 0)`, so an opening with no hardware at all is completable and
+  // requiring `installed > 0` here blocked it permanently with no way out.
   const canComplete =
-    allDraftsValid && draftProgress.complete && draftProgress.installed > 0 && locationValid;
+    allDraftsValid &&
+    draftProgress.complete &&
+    (draftProgress.installed > 0 || opening.items.length === 0) &&
+    locationValid;
 
   const progressPayload = useCallback(
     () =>
@@ -222,13 +241,24 @@ export default function AssemblyDetailModal({
   // --- deficiency flagging -------------------------------------------------------------------
 
   const openFlagDialog = (item: OpeningItem) => {
-    setFlagging(item);
+    setFlaggingId(item.id);
     setFlagQuantity('1');
     setFlagReason('');
   };
 
+  const flagging = flaggingId
+    ? (opening.items.find((item) => item.id === flaggingId) ?? null)
+    : null;
+
+  // What is left to condemn, measured against the count the assembler currently has typed rather
+  // than the last saved one. Flagging N units lowers the line's ceiling to `quantity - deficient`,
+  // so allowing a flag that the unsaved draft has already spoken for would leave the draft above its
+  // own maximum the moment the flag lands - the field turns red and Save Progress refuses it.
   const flagRemaining = flagging
-    ? flagging.quantity - flagging.installedQuantity - flagging.deficientQuantity
+    ? flagging.quantity -
+      (parsedDraft(flagging) ?? flagging.installedQuantity) -
+      flagging.deficientQuantity -
+      flagging.replacementPendingQuantity
     : 0;
   const flagQuantityValue = Number(flagQuantity);
   const flagQuantityValid =
@@ -256,8 +286,13 @@ export default function AssemblyDetailModal({
         },
       },
     });
+    // Close either way. On success that is the obvious thing; on failure it is the safe one. A flag
+    // moves inventory and mints a replacement pull, and a request that errored on the way back may
+    // well have committed - leaving the dialog open with the same quantity still in it invites a
+    // second submit that condemns the units twice. The mutation's refetchQueries have already gone
+    // out, so re-opening the dialog reads the persisted counts rather than the pre-flag ones.
+    setFlaggingId(null);
     if (result.data) {
-      setFlagging(null);
       showToast(
         `${flagQuantity} x ${item.productCode} flagged deficient - replacement pull requested`,
         'success'
@@ -306,7 +341,7 @@ export default function AssemblyDetailModal({
             <Chip
               size="small"
               variant="outlined"
-              label={`${draftProgress.installed + draftProgress.deficient}/${draftProgress.planned} units accounted for`}
+              label={`${draftProgress.planned - draftProgress.remaining}/${draftProgress.planned} units accounted for`}
             />
           </Stack>
 
@@ -336,9 +371,17 @@ export default function AssemblyDetailModal({
                 {opening.items.map((item) => {
                   const parsed = parsedDraft(item);
                   const storedRemaining =
-                    item.quantity - item.installedQuantity - item.deficientQuantity;
+                    item.quantity -
+                    item.installedQuantity -
+                    item.deficientQuantity -
+                    item.replacementPendingQuantity;
                   const remaining =
-                    parsed === null ? storedRemaining : item.quantity - parsed - item.deficientQuantity;
+                    parsed === null
+                      ? storedRemaining
+                      : item.quantity -
+                        parsed -
+                        item.deficientQuantity -
+                        item.replacementPendingQuantity;
                   return (
                     <TableRow key={item.id}>
                       <TableCell>{item.productCode}</TableCell>
@@ -377,7 +420,10 @@ export default function AssemblyDetailModal({
                         <Button
                           size="small"
                           variant="text"
-                          disabled={busy || storedRemaining <= 0}
+                          // Gated on the drafted remaining, the same number the dialog validates
+                          // against: offering the action when there is nothing left to condemn would
+                          // open a dialog whose only possible input is out of range.
+                          disabled={busy || remaining <= 0}
                           onClick={() => openFlagDialog(item)}
                         >
                           Flag deficient
@@ -448,7 +494,7 @@ export default function AssemblyDetailModal({
 
       {/* Flagging is irreversible from the bench and moves inventory the moment it is confirmed, so
           it gets its own dialog and its own confirm rather than an inline control. */}
-      <Dialog open={flagging !== null} onClose={() => setFlagging(null)} maxWidth="xs" fullWidth>
+      <Dialog open={flagging !== null} onClose={() => setFlaggingId(null)} maxWidth="xs" fullWidth>
         <DialogTitle>Flag deficient: {flagging?.productCode}</DialogTitle>
         <DialogContent>
           <Alert severity="warning" sx={{ mb: 2 }}>
@@ -483,9 +529,11 @@ export default function AssemblyDetailModal({
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setFlagging(null)}>Cancel</Button>
+          <Button onClick={() => setFlaggingId(null)}>Cancel</Button>
+          {/* Default emphasis, not `color="error"`: DESIGN.md reserves the status palette for
+              real system state, and a confirm button is an action, not a state. The warning Alert
+              above is what carries the weight here. */}
           <Button
-            color="error"
             variant="contained"
             onClick={handleFlagDeficient}
             disabled={!flagQuantityValid || !flagReasonValid || busy}

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -38,6 +38,9 @@ interface OpeningItem {
   quantity: number;
   installedQuantity: number;
   deficientQuantity: number;
+  // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned
+  // into, and part of the progress rollup's `remaining`.
+  replacementPendingQuantity: number;
 }
 
 interface AssembleOpening {

--- a/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ManagerAssignPanel.tsx
@@ -76,11 +76,14 @@ export default function ManagerAssignPanel() {
 
   const available = useMemo(() => openings.filter(isAvailableForAssignment), [openings]);
 
-  // Current load per member: pending pulled openings already assigned to someone.
+  // Current load per member: pulled openings already assigned to someone and not yet finished.
+  // Unfinished, not PENDING - the same rule `isAvailableForAssignment` uses. A leaf someone is
+  // half-way through is the most load they can be carrying, and counting only PENDING made a member
+  // whose whole queue was IN_PROGRESS vanish from the table entirely, reading as free.
   const loadByMember = useMemo(() => {
     const counts = new Map<string, { id: string; name: string; count: number }>();
     for (const o of openings) {
-      if (o.pullStatus === 'PULLED' && o.assemblyStatus === 'PENDING' && o.assignedToUserId) {
+      if (o.pullStatus === 'PULLED' && o.assemblyStatus !== 'COMPLETED' && o.assignedToUserId) {
         const id = o.assignedToUserId;
         const prev = counts.get(id);
         counts.set(id, {

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -18,6 +18,9 @@ interface OpeningItem {
   quantity: number;
   installedQuantity: number;
   deficientQuantity: number;
+  // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned
+  // into, and part of the progress rollup's `remaining`.
+  replacementPendingQuantity: number;
 }
 
 interface MyWorkOpening {
@@ -68,8 +71,11 @@ const columns: GridColDef[] = [
     // Units, not lines: a line of 8 hinges with 5 fitted is most of the job, and a line count would
     // report it as untouched.
     valueGetter: (_value: unknown, row: MyWorkOpening) => {
-      const { installed, deficient, planned } = assemblyProgress(row.items ?? []);
-      return `${installed + deficient}/${planned} units`;
+      // Accounted-for is planned minus remaining, so the three buckets a line is partitioned into
+      // (installed, condemned, replacement arrived but not yet fitted) all count - a finished leaf
+      // never reads as 3/4 because its replacement turned up.
+      const { planned, remaining } = assemblyProgress(row.items ?? []);
+      return `${planned - remaining}/${planned} units`;
     },
   },
   {

--- a/frontend/src/modules/shop-assembly/PipelinePage.tsx
+++ b/frontend/src/modules/shop-assembly/PipelinePage.tsx
@@ -235,17 +235,25 @@ export default function PipelinePage() {
 }
 
 function PipelineDetailModal({ requestId, onClose }: { requestId: string; onClose: () => void }) {
-  const { data, loading } = useQuery<{
+  const { data, loading, error } = useQuery<{
     assemblyPipeline: { summary: PipelineSummary; openings: PipelineOpeningRow[] };
   }>(GET_ASSEMBLY_PIPELINE, { variables: { requestId }, fetchPolicy: 'cache-and-network' });
 
-  const summary = data?.assemblyPipeline.summary;
-  const openings = data?.assemblyPipeline.openings ?? [];
+  const summary = data?.assemblyPipeline?.summary;
+  const openings = data?.assemblyPipeline?.openings ?? [];
   const progress = summary ? stageProgress(summary.stage) : null;
 
   return (
     <Modal open title={summary ? `Pipeline - ${summary.requestNumber}` : 'Pipeline'} onClose={onClose}>
-      {loading && !summary && <LinearProgress />}
+      {loading && !summary && !error && <LinearProgress />}
+      {/* Without this the resolver failing left an empty dialog: no spinner (loading is false), no
+          body (summary is undefined), and nothing saying why. A request deleted under the list, or a
+          pipeline query that timed out, both land here. */}
+      {error && !summary && (
+        <Alert severity='error'>
+          Could not load this request's pipeline. {error.message}
+        </Alert>
+      )}
       {summary && (
         <Box>
           {/* The request-level doubt (#342) comes first, above everything it casts doubt on. */}

--- a/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
@@ -40,8 +40,9 @@ interface ReplacementWorkPanelProps {
  * to a leaf that is otherwise done" - so it gets its own section rather than reopening a finished
  * work unit or pretending the leaf is in progress.
  *
- * A row whose leaf has already shipped is still listed, because the hardware is real and must not be
- * silently stranded; it just cannot be installed from here.
+ * A row whose leaf has already shipped, or is staged at the dock for a confirmed shipment, is still
+ * listed, because the hardware is real and must not be silently stranded; it just cannot be
+ * installed from here.
  */
 export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: ReplacementWorkPanelProps) {
   const { showToast } = useToast();
@@ -102,6 +103,14 @@ export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: 
       <Stack spacing={1.5}>
         {rows.map((row) => {
           const shipped = row.openingItemState === 'SHIPPED_OUT';
+          // SHIP_READY is the same refusal one step earlier, and the backend enforces it: the leaf is
+          // picked and staged against a confirmed shipping-out pull, and `confirm_shipment` snapshots
+          // its hardware onto the packing slip. Hardware added now would land on a slip for a unit
+          // that was checked without it. Unlike the shipped case it is still recoverable - unwind the
+          // shipping-out request and the button comes back - so it says so rather than reading as
+          // terminal.
+          const shipReady = row.openingItemState === 'SHIP_READY';
+          const blocked = shipped || shipReady;
           return (
             <Paper key={row.shopAssemblyOpeningItemId} variant='outlined' sx={{ p: 2 }}>
               <Box
@@ -124,8 +133,13 @@ export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: 
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <Chip size='small' variant='outlined' label={`${row.pendingQuantity} awaiting install`} />
-                  {shipped ? (
-                    <Chip size='small' variant='outlined' color='warning' label='Leaf already shipped' />
+                  {blocked ? (
+                    <Chip
+                      size='small'
+                      variant='outlined'
+                      color='warning'
+                      label={shipped ? 'Leaf already shipped' : 'Leaf staged for shipment'}
+                    />
                   ) : (
                     <Button
                       size='small'
@@ -142,6 +156,13 @@ export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: 
                 <Alert severity='warning' sx={{ mt: 1.5 }}>
                   This leaf shipped before the replacement arrived, so the hardware cannot go on it
                   here. It needs a reallocation or a site shipment.
+                </Alert>
+              )}
+              {shipReady && (
+                <Alert severity='warning' sx={{ mt: 1.5 }}>
+                  This leaf is staged for shipment, and its packing slip is built from what is on it
+                  now. Unwind the shipping-out request first if the replacement has to go on before
+                  it leaves; otherwise it needs a reallocation or a site shipment.
                 </Alert>
               )}
             </Paper>

--- a/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import AssembleListPage from '../AssembleListPage';
+import { GET_ASSEMBLE_LIST, RECORD_ASSEMBLY_PROGRESS } from '../../../graphql/shop-assembly';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// The assembly modal is rendered *from a row of the list* (`openings.find(o => o.id ===
+// completingId)`), so anything that empties `assembleList` takes the modal down with it. A progress
+// save used to evict that root field; it is refetched by name now instead (see refetch.ts, whose
+// own test pins the lists).
+//
+// This walks the real path end to end - list, row, modal, save, refetch - and asserts the dialog and
+// everything typed into it survive. The MockedProvider harness resolves the repair fetch too
+// promptly to reproduce the transient empty state on its own, so treat this as the integration half
+// of the guarantee and `refetch.test.ts` as the half that fails on the offending edit.
+
+vi.mock('@clerk/clerk-react', () => ({
+  useUser: () => ({ user: { id: 'u1', fullName: 'Ada Lovelace', publicMetadata: {} } }),
+}));
+
+vi.mock('../../../components/OpeningLeafStatusPanel', () => ({ default: () => null }));
+
+function line(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'ShopAssemblyOpeningItem',
+    id: 'i1',
+    shopAssemblyOpeningId: 'o1',
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    quantity: 4,
+    installedQuantity: 0,
+    deficientQuantity: 0,
+    replacementPendingQuantity: 0,
+    ...overrides,
+  };
+}
+
+function opening(items: ReturnType<typeof line>[]) {
+  return {
+    __typename: 'ShopAssemblyOpening',
+    id: 'o1',
+    shopAssemblyRequestId: null,
+    pullRequestId: 'pr1',
+    openingId: 'op1',
+    pullStatus: 'PULLED',
+    assignedToUserId: 'u1',
+    assignedTo: 'Ada Lovelace',
+    assemblyStatus: 'IN_PROGRESS',
+    completedAt: null,
+    openingNumber: '0019-EX',
+    building: 'A',
+    floor: '2',
+    leaf: 1,
+    items,
+  };
+}
+
+const listMock = (items = [line()]): MockedResponse => ({
+  request: { query: GET_ASSEMBLE_LIST },
+  result: { data: { assembleList: [opening(items)] } },
+});
+
+const saveMock: MockedResponse = {
+  request: {
+    query: RECORD_ASSEMBLY_PROGRESS,
+    variables: {
+      input: {
+        openingId: 'o1',
+        items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
+        performedBy: 'Ada Lovelace',
+      },
+    },
+  },
+  result: { data: { recordAssemblyProgress: opening([line({ installedQuantity: 2 })]) } },
+};
+
+function renderPage(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <AssembleListPage />
+      </ToastProvider>
+    </MockedProvider>
+  );
+}
+
+it('keeps the assembly modal open across a Save Progress from the Assemble List', async () => {
+  // Listed three times: the initial read, the refetch the save fires, and one spare so a repair
+  // fetch cannot starve the test of data and mask the very thing being asserted.
+  renderPage([listMock(), saveMock, listMock([line({ installedQuantity: 2 })]), listMock()]);
+
+  // The row's actions live inside the accordion, which starts collapsed.
+  fireEvent.click(await screen.findByRole('button', { name: /Opening: 0019-EX/i }));
+  fireEvent.click(await screen.findByRole('button', { name: /continue assembly/i }));
+
+  const input = await screen.findByLabelText('Installed units: HG-100');
+  fireEvent.change(input, { target: { value: '2' } });
+
+  // Local, unsaved modal state. A progress save never sends the put-away location, and the modal
+  // seeds it empty on mount - so if the dialog is torn down and rebuilt this is what is lost.
+  const aisle = screen.getByLabelText('Aisle') as HTMLInputElement;
+  fireEvent.change(aisle, { target: { value: 'A1' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /save progress/i }));
+
+  // The save resolves, the list refetches - and the modal is still on screen, still holding the
+  // leaf and everything typed into it. Before the fix the eviction emptied `assembleList`,
+  // `completing` became null, and the dialog was unmounted and re-mounted mid-job.
+  await waitFor(() =>
+    expect(screen.getByLabelText('Installed units: HG-100')).toHaveValue(2)
+  );
+  expect(screen.getByText(/Shop Hardware Checklist/i)).toBeInTheDocument();
+  expect(screen.getByLabelText('Aisle')).toHaveValue('A1');
+});

--- a/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
@@ -18,6 +18,7 @@ function item(overrides: Record<string, unknown> = {}) {
     quantity: 4,
     installedQuantity: 0,
     deficientQuantity: 0,
+    replacementPendingQuantity: 0,
     ...overrides,
   };
 }
@@ -85,6 +86,31 @@ describe('AssemblyDetailModal progress editor', () => {
 
     expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
     expect(screen.getByText(/nothing assembled to complete/i)).toBeInTheDocument();
+  });
+
+  it('lets an opening with no hardware lines at all be completed', () => {
+    // The backend's all-deficient refusal is `if items and all(installed == 0)`, so an opening with
+    // no lines is completable there. Requiring `installed > 0` here blocked it permanently, with no
+    // action available to the assembler that could ever unblock it.
+    renderModal([]);
+
+    expect(screen.getByRole('button', { name: /mark complete/i })).toBeEnabled();
+    expect(screen.getByText(/no hardware items/i)).toBeInTheDocument();
+    // ...and none of the "unaccounted for" / "nothing assembled" captions apply to it.
+    expect(screen.queryByText(/unaccounted for/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/nothing assembled to complete/i)).not.toBeInTheDocument();
+  });
+
+  it('counts arrived-but-unfitted replacement units as accounted for', () => {
+    // A finished 4-unit leaf whose replacement has landed: 3 installed, 1 waiting to be fitted. The
+    // line is fully dispositioned - installed + deficient + replacementPending == quantity - so it
+    // must not read as 3/4 with a unit still owed.
+    renderModal([
+      item({ quantity: 4, installedQuantity: 3, deficientQuantity: 0, replacementPendingQuantity: 1 }),
+    ]);
+
+    expect(screen.getByText('4/4 units accounted for')).toBeInTheDocument();
+    expect(screen.queryByText(/unaccounted for/i)).not.toBeInTheDocument();
   });
 
   it('rejects an installed count above what is left after deficiencies', () => {

--- a/frontend/src/modules/shop-assembly/openingFilters.ts
+++ b/frontend/src/modules/shop-assembly/openingFilters.ts
@@ -18,29 +18,42 @@ export function isAvailableForAssignment(o: AssignableFields): boolean {
   return o.pullStatus === 'PULLED' && o.assignedToUserId === null && o.assemblyStatus !== 'COMPLETED';
 }
 
-/** Progress rollup for one opening: units installed, condemned, and still unaccounted for.
+/** Progress rollup for one opening: units installed, condemned, awaiting a replacement install, and
+ * still unaccounted for.
  *
  * The whole gating story reduces to `remaining === 0`. Kept here rather than in a component so the
  * modal's Mark Complete gate and the lists' "5/8 units" column cannot drift apart.
+ *
+ * A line is partitioned three ways, not two (#341): `installed + deficient + replacementPending`
+ * always sums to `quantity`. When a replacement arrives for a leaf that is already finished, the
+ * unit moves `deficient -> replacementPending` - the leaf is complete, with a known unit of work
+ * outstanding. Leaving that bucket out of `remaining` made a finished 4-unit leaf read as 3/4 the
+ * moment its replacement landed, which is the one thing this rollup is on screen to prevent.
  */
 export function assemblyProgress(items: ProgressFields[]): {
   planned: number;
   installed: number;
   deficient: number;
+  replacementPending: number;
   remaining: number;
   complete: boolean;
 } {
   const planned = items.reduce((sum, i) => sum + i.quantity, 0);
   const installed = items.reduce((sum, i) => sum + i.installedQuantity, 0);
   const deficient = items.reduce((sum, i) => sum + i.deficientQuantity, 0);
-  const remaining = planned - installed - deficient;
-  return { planned, installed, deficient, remaining, complete: remaining === 0 };
+  const replacementPending = items.reduce((sum, i) => sum + (i.replacementPendingQuantity ?? 0), 0);
+  const remaining = planned - installed - deficient - replacementPending;
+  return { planned, installed, deficient, replacementPending, remaining, complete: remaining === 0 };
 }
 
 interface ProgressFields {
   quantity: number;
   installedQuantity: number;
   deficientQuantity: number;
+  // Optional so a caller that has deliberately projected the line (the assembly modal, which
+  // substitutes its unsaved draft for installedQuantity) need not restate a field it does not touch;
+  // every query that feeds this rollup selects it.
+  replacementPendingQuantity?: number;
 }
 
 /** Chip label for an opening's assembly status. */

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import {
   Box,
   Typography,
@@ -135,6 +135,10 @@ export default function PullRequestDetailModal({
   // one message, so it is shown verbatim and the dialog stays open - the user is being told what to
   // go and finish, not just that it failed.
   const [cancelBlockedMessage, setCancelBlockedMessage] = useState<string | null>(null);
+  const closeCancelDialog = useCallback(() => {
+    setCancelOpen(false);
+    setCancelBlockedMessage(null);
+  }, []);
 
   // #224 gate 2: the shortfall the server returned when an approve was blocked for insufficient
   // inventory. The PR is left PENDING; we show this inline instead of cancelling.
@@ -584,15 +588,17 @@ export default function PullRequestDetailModal({
       />
 
       {/* Cancel: its own dialog rather than ConfirmDialog, because it takes a reason and has to be
-          able to show the server's blocker list without closing. */}
+          able to show the server's blocker list without closing. Closing clears that blocker list:
+          it names openings as they were at the moment of the refusal, and re-opening the dialog
+          after somebody has gone and finished them would otherwise re-assert a stale accusation. */}
       <Modal
         open={cancelOpen}
         title={`Cancel ${pr.requestNumber}`}
-        onClose={() => setCancelOpen(false)}
+        onClose={closeCancelDialog}
         maxWidth="sm"
         actions={
           <Stack direction="row" spacing={1}>
-            <Button onClick={() => setCancelOpen(false)}>Keep pull</Button>
+            <Button onClick={closeCancelDialog}>Keep pull</Button>
             <Button variant="contained" color="error" onClick={handleCancel} disabled={cancelLoading}>
               {cancelLoading ? 'Cancelling...' : 'Cancel pull and restock'}
             </Button>

--- a/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
@@ -230,7 +230,18 @@ it('offers cancel on an approved pull, and on a fully staged shop-assembly one',
   expect(isCancellable({ status: 'IN_PROGRESS', source: 'SHOP_ASSEMBLY' })).toBe(true);
   expect(isCancellable({ status: 'IN_PROGRESS', source: 'SHIPPING_OUT' })).toBe(true);
   // "Completed" for a shop-assembly pull now means only "every cart is built".
-  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY' })).toBe(true);
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY', totalOpeningCount: 2 })).toBe(
+    true,
+  );
+  // ...but only if it has carts at all. A completed PR-REPL pull is a SHOP_ASSEMBLY pull with no
+  // openings, and the server refuses it every time, so the button must not be offered.
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY', totalOpeningCount: 0 })).toBe(
+    false,
+  );
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY', totalOpeningCount: null })).toBe(
+    false,
+  );
+  expect(isCancellable({ status: 'COMPLETED', source: 'SHOP_ASSEMBLY' })).toBe(false);
   // A completed shipping-out pull has already flipped its leaves to ship-ready.
   expect(isCancellable({ status: 'COMPLETED', source: 'SHIPPING_OUT' })).toBe(false);
   expect(isCancellable({ status: 'CANCELLED', source: 'SHOP_ASSEMBLY' })).toBe(false);

--- a/frontend/src/modules/warehouse/pullStaging.ts
+++ b/frontend/src/modules/warehouse/pullStaging.ts
@@ -64,8 +64,19 @@ export function isStageable(opening: PullStagingOpening): boolean {
  * A pull that has not been approved has moved no inventory (reopen or reject the source request
  * instead), and a cancelled one is terminal. A COMPLETED shop-assembly pull *is* cancellable, since
  * per-opening staging means "completed" there is no more than "every cart is built" - the backend
- * still refuses if assembly has started on any opening, and names which ones. */
-export function isCancellable(pr: { status: string; source: string }): boolean {
+ * still refuses if assembly has started on any opening, and names which ones.
+ *
+ * The completed case additionally requires the pull to *have* openings, because that is the whole
+ * reason it is allowed: the backend's rule is `SHOP_ASSEMBLY and bool(openings)`, so on a completed
+ * PR-REPL or otherwise opening-less pull the button was offered and the server always said no. A
+ * control that cannot succeed is worse than an absent one. */
+export function isCancellable(pr: {
+  status: string;
+  source: string;
+  totalOpeningCount?: number | null;
+}): boolean {
   if (pr.status === 'IN_PROGRESS') return true;
-  return pr.status === 'COMPLETED' && pr.source === 'SHOP_ASSEMBLY';
+  return (
+    pr.status === 'COMPLETED' && pr.source === 'SHOP_ASSEMBLY' && (pr.totalOpeningCount ?? 0) > 0
+  );
 }

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -373,7 +373,14 @@ Installed / Deficient / Remaining, with the Installed cell an editable number sp
 - **Flag deficient** opens a nested dialog (quantity + reason, both required) with a warning alert.
   Confirming it is irreversible from this screen: the units go back to inventory flagged deficient and
   a PR-REPL replacement pull is minted immediately, before the leaf is finished. Watch for the
-  spinbutton-append gotcha on the quantity field - clear it before typing.
+  spinbutton-append gotcha on the quantity field - clear it before typing. The dialog closes on
+  failure as well as on success, deliberately: a flag that errored may still have committed, so it
+  makes you re-open and re-read rather than offering you the same submit twice.
+- **Replacement pull numbers.** The first replacement pull for a source pull is
+  `PR-REPL-<source pull number>`. Flag again while that pull is still **Pending** and the units are
+  added to its existing line - same pull, bigger quantity. Flag again after it has been approved or
+  completed and you get a **second** pull, `PR-REPL-<source pull number>-2` (then `-3`, ...). Do not
+  read the missing `-1` as a bug; do expect to search for the suffixed number in the pull queue.
 - Both number inputs are MUI spinbuttons, so the usual "fill appends to the existing value" trap
   applies; the deficiency quantity is capped at the line's remaining units and the flag button stays
   disabled if you exceed it.
@@ -393,6 +400,10 @@ replacement pull is *completed* in the warehouse for a leaf the assembler alread
   That is the intended behaviour, not a missing feature.
 - "Mark Installed" is confirm-gated and installs the whole arrived quantity at once. Afterwards the
   leaf's `installedHardware` carries the extra units; the card disappears.
+- A leaf that has **shipped** shows a "Leaf already shipped" chip and no button; one that is
+  **SHIP_READY** (staged at the dock by a completed shipping-out pull) shows "Leaf staged for
+  shipment" and no button either. The second case is recoverable - unwind the shipping-out request
+  and the button comes back - which the caption says. The backend refuses both.
 - A card whose leaf already shipped shows a "Leaf already shipped" chip and a warning alert instead
   of the button - it cannot be installed, only reallocated. A `REPLACEMENT_AFTER_SHIPMENT`
   notification was also raised for the SHIPPING role when the pull completed.
@@ -430,7 +441,7 @@ so you will see all of them regardless of your role):
 | `ASSEMBLY_WORK_AVAILABLE` | You confirm a staging batch, or complete a pull that still had un-staged openings | **One per confirmation, not per opening.** Staging three carts in one action gives one notification naming them. Re-staging an already-staged opening gives none |
 | `REPLACEMENT_ARRIVED` | A `PR-REPL-*` pull completes for a leaf that has **not** shipped | Addressed to the assembler's Clerk user id, so `recipientRole` looks like `user_2ab...`. None is raised if nobody is holding the leaf |
 | `REPLACEMENT_AFTER_SHIPMENT` | Same, but the leaf has already shipped | Exactly one of these two fires, never both |
-| `PULL_UNBLOCKED` | A receive lands stock that makes a blocked `PR-REPL-*` pull fully coverable | Deduped three ways: only pulls wanting a combo you actually received; only when the shortfall is *closed*, not narrowed; and only one **unread** one per pull. Mark it read and receive again to get a second |
+| `PULL_UNBLOCKED` | A receive lands stock that makes a blocked `PR-REPL-*` pull fully coverable | Deduped three ways: only pulls wanting a combo you actually received; only if the pull is coverable *after* the receive; and only one **unread** one per pull. Mark it read and receive again to get a second. A receive is the only path that raises it - a cancel-restock can also make a pull coverable and stays silent |
 
 ### Shipping Module
 


### PR DESCRIPTION
Consolidated fixes from the six-agent review of the slice stack (#345-#350), on top of `feat/sa-slice-6-observability`. Grouped by root cause, because most of the findings are the same three mistakes seen from different screens.

## Root cause 1 - a replacement pull's identity was its *number*

`report_deficiency_at_assembly` reused `PR-REPL-{basis}` whenever a pull with that number was PENDING **or IN_PROGRESS**. Three separate reported failures fall out of that one decision, and one fix closes all three.

| Finding | Fix |
| --- | --- |
| #347/#349: a second deficiency after the first replacement pull COMPLETED crashes with IntegrityError - the number is unique among live pulls | Reuse only a **PENDING** pull; otherwise mint `PR-REPL-{basis}-2`, `-3`, ... The basis is truncated (never the suffix) to stay inside `request_number`'s varchar(50) |
| #347: a line appended to an already-approved pull is never deducted or sufficiency-checked, yet `_apply_replacement_arrivals` counts it as delivered | Same fix. An approved pull is closed to new lines, because approval is where the claim on stock is settled |
| #347: `cancel_pull_request` restocks `sum(requested_quantity)`, so an appended-after-approval line conjures inventory on cancel | Same fix |
| #347: repeated flags stack one-unit rows the replacement loop must re-aggregate | A flag against the same checklist line + product **increments** the existing line on a reused PENDING pull |
| #350: migration 063's downgrade dedupe suffix is `left(number, 41)` + `-X` + 8 chars = 51 > varchar(50) | `left(number, 40)`. Verified by seeding a 50-char cancelled/live pair and running the downgrade |

Every consumer of the `PR-REPL-` prefix was checked: `find_pending_replacement_pulls` is structural (`sa_opening_item_id`, not the prefix), and `find_reservation_holder` / `_find_source_request` correctly resolve nothing for a suffixed number.

## Root cause 2 - writes without the row lock every other mutator takes

| Finding | Fix |
| --- | --- |
| #347: `_apply_replacement_arrivals` writes `deficient_quantity` / `replacement_pending_quantity` without locking the owning `ShopAssemblyOpening`, racing `install_replacement` | `lock_rows(ShopAssemblyOpening, ...)` from an id-only pass, taken **before** the checklist lines are read (`populate_existing` so the read is under the lock) |
| #343 review: `cancel_pull_request`'s all-or-nothing blocker check reads openings with a plain SELECT | `lock_rows` on the opening ids. Lock order stays pull-then-openings, matching `stage_pull_openings` - no new cycle |
| #350: `complete_pull_request` takes no lock, and staging gave it a second entry point (double completion -> duplicate notifications) | `lock_rows(PullRequestModel, [pr_id])` at the top; re-locking inside `stage_pull_openings`' transaction is a no-op |
| #350: `notify_unblocked_replacement_pulls` is check-then-insert without a lock -> duplicate `PULL_UNBLOCKED` on concurrent receives | `lock_rows` on the pull before the unread check, taken only for pulls that are relevant and coverable |

## Root cause 3 - `(opening_id, leaf)` carries no request lineage

| Finding | Fix |
| --- | --- |
| #350: a re-requested previously-shipped leaf reads as SHIPPED in the *new* request's pipeline (shipped count, after-ship count, and the leaf's stage) | `ShopAssemblyOpening.assembly_status == COMPLETED` in `_shipped_counts`' join, and the detail skips the leaf lookup for openings that are not COMPLETED |
| #347: `get_awaiting_replacement_quantities` lets a ship-then-reassemble leaf inherit the previous assembly's outstanding units | A lateral picking the completed opening that produced *that* leaf (latest completion, bounded by the leaf's own `assembly_completed_at`) |
| #347: `get_replacement_work` calls `find_assembled_leaf` per leaf while claiming one batched lookup | One `select(OpeningItem)` over `(project, opening)` pairs; live-preferred / latest-wins resolved in Python via `_leaf_wins`, so both call sites agree (and a legacy null leaf still matches only a null leaf, which a tuple `IN` cannot express) |

## Reservations (#348)

| Finding | Fix |
| --- | --- |
| **HIGH**: the self-coverage exclusion was `column != request_id`, which is NULL for every opposite-source row - so it silently dropped **all** reservations of the other request type from the aggregate | `not_(and_(source == exclude_source, column == id))`. New tests cover both directions plus an end-to-end approval refused because a shipping-out request holds the stock |
| `RESERVED_PULL_SHORT` integrity audit fires for holders with zero reservation rows - the backfill population, i.e. the *expected* shortfall case | Gated on `get_reserved_total(...) > 0` (new scalar aggregate). Tests pin both branches |
| The PO backfill notification forwards `Shortfall.short` verbatim, telling purchasing to buy stock that exists but is claimed | Forwards `max(0, short - reserved)` |

## Completion guard as a DB invariant + auth (#345)

- **Migration 065** (chain head, `down_revision = 064`):
  - partial unique index `uq_opening_items_live_leaf` on `(project_id, opening_id, coalesce(leaf, 0)) WHERE state <> 'SHIPPED_OUT'`, making `complete_opening`'s read-then-write duplicate guard structural. The upgrade **refuses loudly** on a violating database, naming offenders, rather than picking a row to keep. `complete_opening` catches the `IntegrityError` and raises the same typed `ConflictError` its guard raises.
  - ride-along CHECK `pull_status IN ('NOT_PULLED','PULLED')` on `shop_assembly_openings` (#350 nit), making "PARTIAL is never persisted" structural.
  - Working downgrade for both; matching model `__table_args__`, so `alembic check` stays clean.
- `reportInventoryDeficiency`, `reportStockDeficiency`, `reportDeficiencyAtAssembly` and `resolveDeficiency` were writing inventory and minting replacement pulls **unauthenticated**. All four now take `info` and call `require_user`.
- New `tests/test_resolver_auth_gates.py` pins every gated resolver in `schemas/shop_assembly.py` plus those four: the gate is replaced with a sentinel-raiser and the sentinel must come back out, so a refactor cannot silently drop one.

## Docs and SDL

- `models/shop_assembly.py`: the comment calling `shop_assembly_request_id` "legacy ... unused for new rows" was false - the import stamps it and the whole pipeline groups on it. Rewritten to say it is load-bearing.
- `warehouse.graphql`: `notifications(recipientRole: String! = "")` (the default is load-bearing) and `CreateReceiveInput` field order plus `line_items: [ReceiveLineItemInput!]! = []`, both matched to the printed Strawberry SDL.
- `receiving.py`: softened the "receiving is the only thing that can unblock" comment (cancel-restock can too) and aligned the dedupe docstring with what rule 2 actually implements.
- `docs/HARDWARE_IDENTITY_LIFECYCLE.md` and `testing/CLAUDE.md` updated for the replacement-pull numbering, the SHIP_READY refusal, and the two new invariants.

## Frontend

| Finding | Fix |
| --- | --- |
| **#346 HIGH**: evicting `assembleList` after a progress save transiently empties the field, unmounting the assembly modal mid-save (it is rendered *from a row* of that list, and `ManagerAssignPanel` runs `GET_ASSEMBLE_LIST` inside `AssignmentBoard` - so the header comment's "never mounted together" was false) | `GetAssembleList` moved into `ASSEMBLY_PROGRESS_REFETCH_QUERIES`; `ASSEMBLY_PROGRESS_STALE_ROOT_FIELDS` deleted and the call site evicts `PIPELINE_STALE_ROOT_FIELDS` directly. Header comment corrected; new `refetch.test.ts` pins the disjointness rule across every pair |
| #346: the manager workload table counts only `assemblyStatus === 'PENDING'`, so a member whose queue is all IN_PROGRESS vanishes and reads as free | `!== 'COMPLETED'`, matching `isAvailableForAssignment` |
| #346: `canComplete` requires `installed > 0`, permanently blocking zero-item openings the backend allows | `installed > 0` OR the opening has no lines |
| #346: the flag-deficient dialog stays open on error with the same quantity, inviting a double-book | Closes either way; the mutation's refetches have already gone out, so re-opening reads persisted state. The flagged line is also held by id and re-resolved from props rather than captured as an object |
| #346: `flagRemaining` uses stored installed, ignoring the unsaved draft, so a flag can strand the draft out of range | Based on the drafted value; the row's Flag button is gated on the same number |
| #346: the flag-confirm button uses `color="error"` | Default emphasis - DESIGN.md reserves status colours for system state |
| #349: `assemblyProgress`'s `remaining` ignores `replacementPendingQuantity`, so a finished leaf reads 3/4 after an arrival | Added to `ProgressFields` and subtracted; the "accounted for" readings in the modal, My Work and the Assemble List now all derive from `planned - remaining` |
| #349: the SHIP_READY install refusal had no UI mirror | `ReplacementWorkPanel` treats SHIP_READY like shipped for the button, with its own caption saying it is recoverable by unwinding the shipping-out request |
| #343 review: `isCancellable` offers Cancel on pulls the server always refuses (completed PR-REPL / zero-opening) | Also requires a non-zero `totalOpeningCount`; `cancelBlockedMessage` is cleared when the dialog closes |
| #348: `ShippingPRsStep` does not gate Next on `availabilityLoading` and shows red "0 available" captions while loading | Gated and suppressed, mirroring `ShopAssemblyStep` |
| #350: the pipeline detail modal renders empty on resolver error | Error state added |

## Verification

- Backend: `uvx ruff check .` and `uvx ruff format --check .` clean; **429 pytest passing** (394 before, +35) against a throwaway PostgreSQL 16.
- Migrations: full integrity cycle (upgrade -> downgrade to base -> re-upgrade -> `alembic check` clean), plus a **data-present** downgrade/re-upgrade of 065, a check that 065's pre-flight refuses a violating database, and a check that 063's downgrade dedupe now fits varchar(50) at the boundary.
- Frontend: `npm run lint` (0 errors, 17 warnings - unchanged from the base branch), `npm run test:run` **241 passing** (231 before, +10), `npm run build` clean.
