### PR TITLE
fix(relay): close unauthenticated reset endpoint; make re-enrolment self-healing

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -132,9 +132,11 @@ def resolve_display_name(user_id: str) -> str:
     return full_name or profile["email"] or user_id
 
 
-def require_admin(info) -> dict:
-    """Enforce that the caller holds the Admin/Manager role. Returns {user_id, roles}."""
-    request = info.context["request"]
+def require_admin_request(request) -> dict:
+    """Enforce Admin/Manager on a bare FastAPI Request, for the plain HTTP routes in main.py that have
+    no Strawberry `info` to unwrap. Same verification as require_admin - identity from the Clerk JWT,
+    roles from the Clerk Backend API - so a route and a resolver cannot drift apart on what "admin"
+    means. Returns {user_id, roles}."""
     token = _bearer_token(request)
     if not token:
         raise AuthError("Authentication required")
@@ -148,6 +150,11 @@ def require_admin(info) -> dict:
     if ADMIN_ROLE not in roles:
         raise ForbiddenError("Admin/Manager role required")
     return {"user_id": user_id, "roles": roles}
+
+
+def require_admin(info) -> dict:
+    """Enforce that the caller holds the Admin/Manager role. Returns {user_id, roles}."""
+    return require_admin_request(info.context["request"])
 
 
 def require_role(info, role: str) -> dict:

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -5,6 +5,7 @@ the relay CAN reach the backend. So provisioning mints a one-time enrollment tok
 UC Nexus admin UI); the relay, during its one-time setup, generates its OWN long-lived Bearer secret and
 registers it here with that token. Nothing long-lived is ever hand-copied."""
 
+import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta
@@ -15,6 +16,8 @@ from sqlalchemy.orm import Session
 from app.crypto import decrypt_secret, encrypt_secret, hash_token
 from app.errors import ConflictError, ValidationError
 from app.models.relay_install import RelayInstall
+
+logger = logging.getLogger(__name__)
 
 _ENROLLMENT_TTL = timedelta(hours=24)
 
@@ -86,13 +89,42 @@ def authenticate_secret(session: Session, secret: str) -> RelayInstall | None:
     if not secret:
         return None
     installs = session.scalars(select(RelayInstall).where(RelayInstall.secret_encrypted.is_not(None))).all()
+    undecryptable = 0
     for install in installs:
         try:
             candidate = decrypt_secret(install.secret_encrypted)
         except Exception:
+            # A row whose stored secret will not decrypt is NOT a wrong-secret case: it means
+            # RELAY_SECRET_ENC_KEY is missing or has been rotated since enrolment. Swallowing that
+            # silently makes a config error indistinguishable from a stale relay secret - both just
+            # 403 the handshake forever with nothing in the log. Count it and say so below.
+            undecryptable += 1
+            logger.warning(
+                "relay install secret failed to decrypt - RELAY_SECRET_ENC_KEY is missing or was rotated "
+                "since this install enrolled; re-enrolment will not fix it until the key is restored",
+                extra={"install_id": str(install.id), "label": install.label, "hostname": install.hostname},
+            )
             continue
         if secrets.compare_digest(candidate, secret):
             install.last_seen_at = datetime.utcnow()
             session.flush()
             return install
+
+    # Never log the presented secret. The counts alone separate the three real causes: no enrolled
+    # installs at all (wiped DB), all undecryptable (key problem), or a genuine mismatch (the relay is
+    # holding a secret from before it was re-enrolled - it needs a restart, not another enrolment).
+    logger.warning(
+        "relay handshake rejected",
+        extra={
+            "enrolled_installs": len(installs),
+            "undecryptable": undecryptable,
+            "cause": (
+                "no enrolled installs"
+                if not installs
+                else "encryption key mismatch"
+                if undecryptable == len(installs)
+                else "secret mismatch - relay is presenting a stale secret"
+            ),
+        },
+    )
     return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,13 +4,14 @@ from collections.abc import Callable
 from typing import Any
 
 import strawberry
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from graphql import GraphQLError, GraphQLResolveInfo
 from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 
-from app.auth import get_context
+from app.auth import get_context, require_admin_request
 from app.database import SessionLocal
 from app.errors import AppError
 from app.repositories import relay_repository
@@ -193,15 +194,52 @@ async def relay_link(websocket: WebSocket):
 
 
 @app.post("/admin/reset-data")
-def reset_data():
-    """Drop and rebuild the entire public schema via alembic. Dev use only."""
+def reset_data(request: Request):
+    """Drop and rebuild the entire public schema via alembic. Dev use only.
+
+    Gated twice on purpose. This endpoint is total data loss on one unauthenticated POST, and it was
+    previously reachable by anyone who knew the URL on a public Railway domain - no auth, no
+    environment check. TESTING_ENABLED keeps it off any deployment that isn't a test target, and
+    require_admin_request means it is not enough to merely reach the box.
+
+    It also PRESERVES relay_installs across the rebuild. Dropping those rows silently orphans the
+    on-prem relay: its enrolled secret no longer matches any row, so /relay-link refuses every
+    handshake and all GP writes fail until someone re-enrols on the workstation. A dev-convenience
+    reset must not take GP down as a side effect."""
     from alembic.config import Config
+    from sqlalchemy import inspect as sa_inspect
     from sqlalchemy import text
 
     from alembic import command
+    from app.config import TESTING_ENABLED
     from app.database import engine
 
-    # Drop and recreate schema
+    if not TESTING_ENABLED:
+        return JSONResponse(status_code=403, content={"error": "Data reset is not enabled on this deployment"})
+
+    try:
+        require_admin_request(request)
+    except AppError as e:
+        status = 403 if e.code == "FORBIDDEN" else 401
+        return JSONResponse(status_code=status, content={"error": str(e), "code": e.code})
+
+    # Snapshot the relay enrolments before the schema goes. Read as plain mappings: the ORM model is
+    # about to have its table dropped and recreated, so nothing here may hold a live identity-mapped
+    # instance. The table is absent on a fresh or half-migrated database, which must not block a reset -
+    # that is exactly the state a reset exists to clear.
+    relay_rows: list[dict] = []
+    with engine.connect() as conn:
+        if sa_inspect(conn).has_table("relay_installs"):
+            relay_rows = [
+                dict(r)
+                for r in conn.execute(
+                    text(
+                        "SELECT id, label, company, hostname, secret_encrypted, enrollment_token_hash, "
+                        "enrollment_token_expires_at, enrolled_at, last_seen_at, created_at FROM relay_installs"
+                    )
+                ).mappings()
+            ]
+
     with engine.connect() as conn:
         conn.execute(text("DROP SCHEMA public CASCADE"))
         conn.execute(text("CREATE SCHEMA public"))
@@ -211,14 +249,31 @@ def reset_data():
     alembic_cfg = Config("alembic.ini")
     command.upgrade(alembic_cfg, "head")
 
-    return {"status": "ok", "message": "Schema dropped and rebuilt"}
+    with engine.connect() as conn:
+        for row in relay_rows:
+            conn.execute(
+                text(
+                    "INSERT INTO relay_installs (id, label, company, hostname, secret_encrypted, "
+                    "enrollment_token_hash, enrollment_token_expires_at, enrolled_at, last_seen_at, "
+                    "created_at) VALUES (:id, :label, :company, :hostname, :secret_encrypted, "
+                    ":enrollment_token_hash, :enrollment_token_expires_at, :enrolled_at, :last_seen_at, "
+                    ":created_at)"
+                ),
+                row,
+            )
+        conn.commit()
+
+    return {
+        "status": "ok",
+        "message": "Schema dropped and rebuilt",
+        "relay_installs_preserved": len(relay_rows),
+    }
 
 
 @app.get("/testing/clerk-sign-in")
 def get_clerk_sign_in_token(email: str = "jayp@ucsh.com"):
     """Create a Clerk sign-in token for E2E testing. Only available when TESTING_ENABLED=true."""
     import httpx
-    from fastapi.responses import JSONResponse
 
     from app.config import CLERK_SECRET_KEY, TESTING_ENABLED
 

--- a/backend/tests/test_admin_reset_auth.py
+++ b/backend/tests/test_admin_reset_auth.py
@@ -1,0 +1,55 @@
+"""POST /admin/reset-data must refuse before it can do anything destructive.
+
+This endpoint drops and rebuilds the whole public schema. It shipped with NO auth and no environment
+check on a public Railway domain, so any unauthenticated caller who knew the URL could destroy
+production - including relay_installs, which silently orphans the on-prem relay and takes every GP
+write down with it.
+
+Every test here exercises a REFUSAL path only. None of them may reach the DROP SCHEMA: a test that
+actually ran the reset would wipe the developer's database mid-suite.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A client with the environment gate open, so the tests below land on the AUTH gate. The route
+    does a function-local `from app.config import TESTING_ENABLED`, so patching the module attribute
+    takes effect per call - no reimport of `main`, which would rebuild the app and the relay gateway
+    singleton underneath the rest of the suite."""
+    import app.config
+    import main
+
+    monkeypatch.setattr(app.config, "TESTING_ENABLED", True, raising=False)
+    return TestClient(main.app)
+
+
+def test_reset_is_refused_when_testing_is_disabled(monkeypatch):
+    """The environment gate is checked before auth, so a production deployment refuses the call
+    outright rather than leaking whether the caller's token would have been good enough."""
+    import app.config
+    import main
+
+    monkeypatch.setattr(app.config, "TESTING_ENABLED", False, raising=False)
+    resp = TestClient(main.app).post("/admin/reset-data")
+
+    assert resp.status_code == 403
+    assert "not enabled" in resp.json()["error"].lower()
+
+
+def test_reset_is_refused_without_a_token(client):
+    """No Authorization header: unauthenticated, and nothing is dropped."""
+    resp = client.post("/admin/reset-data")
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "UNAUTHENTICATED"
+
+
+def test_reset_is_refused_with_a_garbage_token(client):
+    """A malformed bearer token fails Clerk verification rather than falling through to the reset."""
+    resp = client.post("/admin/reset-data", headers={"Authorization": "Bearer not-a-real-jwt"})
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "UNAUTHENTICATED"

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -61,3 +61,17 @@ def test_authenticate_secret_rejects_an_unknown_secret(db_session):
 
 def test_authenticate_secret_rejects_blank():
     assert relay_repository.authenticate_secret(None, "") is None
+
+
+def test_authenticate_secret_survives_a_rotated_encryption_key(db_session, monkeypatch):
+    """A rotated RELAY_SECRET_ENC_KEY makes every stored secret undecryptable. That must be a clean
+    rejection, not an exception escaping into the /relay-link route - and it is a *different* cause
+    from a wrong secret, which is why authenticate_secret logs the distinction (a silent `except:
+    continue` here once left an unexplained 403 loop as the only symptom)."""
+    _, token = relay_repository.provision_install(db_session, label="WS6", company="TUBC")
+    relay_repository.enroll_install(db_session, token, hostname="WS6", secret="valid-secret")
+
+    monkeypatch.setenv("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
+
+    # The secret the relay presents is correct; the backend simply can no longer read its stored copy.
+    assert relay_repository.authenticate_secret(db_session, "valid-secret") is None

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -74,7 +74,8 @@ def _classify_connect_failure(exc: Exception) -> tuple[str, str]:
         return (
             "secret_rejected",
             "backend rejected the relay secret - this relay likely needs re-enrollment: provision a new "
-            "token in UC Nexus admin, then re-run `ucnexus-relay enroll` and restart the relay. still retrying.",
+            "token in UC Nexus admin, then re-run `ucnexus-relay enroll`. the new secret is picked up "
+            "automatically on the next reconnect - no restart required. still retrying.",
         )
     rcvd = getattr(exc, "rcvd", None)  # websockets ConnectionClosed: the close frame we received
     close_code = getattr(rcvd, "code", None) if rcvd is not None else getattr(exc, "code", None)
@@ -304,15 +305,22 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
     """Dial the backend channel, reconnecting with exponential backoff on drop. Intended to run as a
     background asyncio task alongside the relay's existing HTTP server (see cli.py). A blank
     [channel].backend_url disables it entirely - the relay just runs the HTTP server, as before."""
-    cfg = get_settings().channel
-    if not cfg.backend_url:
-        logger.info("channel disabled (no [channel] backend_url configured)")
-        return
-
-    secret = get_settings().auth.shared_secret
-    backoff = cfg.reconnect_min_seconds
+    backoff = get_settings().channel.reconnect_min_seconds
     prev_category: str | None = None
     while stop_event is None or not stop_event.is_set():
+        # Re-read config on EVERY attempt, dropping the lru_cache first. Reading the secret once before
+        # the loop meant a re-enrolment could never take effect in a running process: `enroll` rewrites
+        # [auth] shared_secret in config.toml, but this task kept dialling with the stale value forever,
+        # so the backend 403'd every handshake until someone restarted the service by hand - on a
+        # workstation that may be nowhere near whoever is debugging. Now a re-enrolment self-heals on
+        # the next retry. Cost is one small TOML parse per reconnect attempt.
+        get_settings.cache_clear()
+        settings = get_settings()
+        secret = settings.auth.shared_secret
+        cfg = settings.channel
+        if not cfg.backend_url:
+            logger.info("channel disabled (no [channel] backend_url configured)")
+            return
         try:
             await _run_once(cfg.backend_url, secret, cfg)
             backoff = cfg.reconnect_min_seconds  # clean run - reset backoff before the next attempt
@@ -322,10 +330,11 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
             raise
         except Exception as e:
             category, message = _classify_connect_failure(e)
-            # A rejected/orphaned secret can't self-heal until re-enrollment (which restarts serve), so a
-            # de-enrolled relay would otherwise log the same WARNING every ~30s forever. Log it loudly once
-            # on the transition into that state, then at DEBUG. Transient drops and slot-busy stay at
-            # WARNING - each is a real, distinct reconnect event.
+            # A rejected/orphaned secret can't self-heal until someone re-enrols, so a de-enrolled relay
+            # would otherwise log the same WARNING every ~30s forever. Log it loudly once on the
+            # transition into that state, then at DEBUG. Transient drops and slot-busy stay at WARNING -
+            # each is a real, distinct reconnect event. (The re-enrolment itself is now picked up
+            # automatically at the top of this loop; no restart needed.)
             quiet_repeat = category == "secret_rejected" and prev_category == "secret_rejected"
             logger.log(
                 logging.DEBUG if quiet_repeat else logging.WARNING,

--- a/relay/src/ucnexus_relay/enroll.py
+++ b/relay/src/ucnexus_relay/enroll.py
@@ -6,8 +6,13 @@ Run during setup with an enrollment token minted in UC Nexus (admin -> provision
 
 The relay generates its OWN long-lived Bearer secret, registers it with the UC Nexus backend using the
 one-time token (the backend can't reach the relay, but the relay can reach the backend), and writes that
-secret into this install's config.toml [auth] shared_secret. Restart the relay afterwards. Nothing
-long-lived is ever hand-copied - only the throwaway enrollment token is carried from UC Nexus to here.
+secret into this install's config.toml [auth] shared_secret. Nothing long-lived is ever hand-copied -
+only the throwaway enrollment token is carried from UC Nexus to here.
+
+A relay that is already running does NOT need restarting: channel.run_forever re-reads config.toml on
+every reconnect attempt, so it picks the new secret up within one backoff interval. That used to be a
+manual step, and forgetting it stranded the relay in a permanent 403 loop with a valid enrolment row
+in the database.
 """
 
 import argparse
@@ -127,7 +132,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"enrolled install {r['install_id']} as host {r['hostname']} (company {r['company']}); "
-        f"secret written {r['how']} to {args.config}. restart the relay."
+        f"secret written {r['how']} to {args.config}. a running relay picks this up on its next "
+        f"reconnect (within ~30s) - no restart needed."
     )
     return 0
 

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -19,6 +19,53 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
   - Tokens are one-time use; fetch a fresh one each session. Works on any runtime with the same Clerk dev instance.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
 
+### Inventory can only be seeded through the relay - check this first
+
+**Nothing puts new hardware into inventory except `createReceive`, and `createReceive` is
+unconditionally GP-first through the on-prem relay.** If the relay is down there is no supported way
+to seed stock, and every scenario downstream of "hardware exists" (approve a pull, stage a cart,
+assemble a leaf, flag a deficiency, ship) is unrunnable. Do not improvise a workaround - re-scope the
+session instead. Establish this in the first minute:
+
+```
+{ relayStatus { connected company build } }
+{ inventoryHierarchy { hardwareCategory totalQuantity } }
+```
+
+`connected: false` plus `inventoryHierarchy: []` is the signature. Confirm it from the backend side
+with `relayInstalls { label enrolled enrolledAt lastSeenAt }` and the Railway backend deploy log:
+
+- A relay that is **running but not trusted** logs `"WebSocket /relay-link" 403` every ~30s forever.
+  The workstation is dialling out fine; the backend is refusing the handshake.
+- **`lastSeenAt == enrolledAt` is suggestive, NOT proof.** `last_seen_at` is written in two places:
+  `enroll_install` (`relay_repository.py:70-71`) and `authenticate_secret` on a successful match
+  (`:95`, committed by `main.py:170`). But `authenticate_secret` runs *only on the connect handshake* -
+  the liveness heartbeat is an app-level ping/pong that never touches the DB. So a relay that connects
+  once and holds the socket open for two days also shows exactly one write. The timestamp alone cannot
+  tell "never authenticated" from "authenticated once at enrolment and still connected".
+- **The deploy log is what settles it.** A held-open socket silences the ~30s dial cadence for its
+  whole duration, so look for a *gap*: an unbroken 403 cadence with no `[accepted]` line means the
+  channel never came up. Read it across the whole life of the deployment, not a sample window.
+- **A 403 cadence that runs unbroken *through* the enrolment instant means a stale secret, and it
+  also exonerates the Fernet key.** `enroll_install` calls `encrypt_secret`, so a successful enrolment
+  proves `RELAY_SECRET_ENC_KEY` was valid at that moment; if auth still 403s seconds later, the
+  mismatch is in the secret, not the key. Usual cause: enrolment rewrote `[auth] shared_secret` in
+  `config.toml` while the **already-running relay service kept dialling with its old in-memory
+  secret**. It needs a *restart*, not another enrol. Only reachable on the workstation - the relay's
+  inbound server is bound to `127.0.0.1:7321`, so there is no remote restart.
+- Beware the silent path: `authenticate_secret` decrypts inside a bare `except Exception: continue`
+  (`:92-93`), so a genuinely rotated `RELAY_SECRET_ENC_KEY` fails **identically and logs nothing**.
+  Distinguish the two with the enrolment-timing argument above rather than by reading the key.
+- `POST /admin/reset-data` drops the `relay_installs` rows along with everything else, so a schema
+  rebuild orphans the on-prem relay every time.
+
+Verified in this state on 2026-07-26: install `TAGGING3W10 (re-enroll after schema rebuild)` (company
+TUBC), one row, enrolled 7/24 22:54:27.662369Z with `lastSeenAt` byte-identical to `enrolledAt`. The
+403 cadence runs unbroken from 22:53:14Z (i.e. *before* enrolment) through 23:12Z and was still going
+on 7/26, with no `[accepted]` line anywhere - so the WS channel has never once authenticated, while
+the HTTP enrolment plainly succeeded. "The relay was working yesterday" refers to the service being
+up and healthy on `127.0.0.1:7321`; that is independent of whether the backend trusts it.
+
 ## Getting Started (Every Session)
 
 1. **Sign in**: Use `evaluate_script` to fetch a sign-in token and navigate with it. Railway production (default):
@@ -192,6 +239,38 @@ DRAFT -> ORDERED -> VENDOR_CONFIRMED -> PARTIALLY_RECEIVED -> CLOSED
 
 **Result**: Creates a project (or updates existing), openings, hardware items, and the selected output (POs, SAR, shipping PRs).
 
+**You almost never need to upload the XML.** Step 1 offers two cards: "Upload new TITAN XML" and
+**"Use last uploaded hardware schedule"**, the second captioned with what is already persisted
+("1998 openings, 29126 hardware items"). It rebuilds the wizard's working set from
+`projectHardwareSchedule` - the openings and hardware items already in the DB - so every later step
+behaves identically without a multi-megabyte parse. Take it unless the thing under test *is* the
+parser. "Choose Different Source" on the loaded panel gets you back to the two cards.
+
+**Step count depends on the purpose**, and the stepper is the quickest way to tell which flow you are in:
+
+| Purpose | Steps |
+| --- | --- |
+| Create Purchase Orders | Upload File -> Purpose -> Select Openings -> Reconciliation -> Classification -> Purchase Orders -> Finalize (7) |
+| Pull Request for Shop Assembly | Upload File -> Purpose -> Select Openings -> Reconciliation -> Classification -> Shop Assembly -> Finalize (7) |
+| Pull Request for Shipping Out | Upload File -> Purpose -> Select Openings -> Reconciliation -> Shipping PRs -> Finalize (6) |
+
+**Reconciliation is a hard gate on the assembly flow, and it fires before the Shop Assembly step.**
+With nothing in inventory it shows a red alert - `No items have In Inventory status. There is nothing
+available to assemble.` - and **Next is disabled**, so the wizard stops at step 4. The per-combo detail
+is in the table underneath (Hardware Category / Product Code / Qty Needed / Qty Available / Lifecycle
+Breakdown, each short line chipped `Gap Remaining: N`), not in the alert text. Worth knowing because
+the slice-4 shortfall alert everyone quotes (`<CATEGORY> <CODE>: need N, M available (R reserved by
+other requests) - short S`) lives on the **Shop Assembly** step, which you cannot reach at all when
+availability is zero across the board. To exercise *that* message you need stock on the shelf and a
+competing reservation; a bare empty warehouse only ever gets you the Reconciliation gate.
+
+The same step on the **shipping** flow is advisory, not a gate: `Items that are In Inventory or Built
+onto Opening can be included in shipping pull requests. Items with zero availability are excluded. You
+may proceed with partial quantities if needed.` Next stays enabled. The gate for shipping is one step
+later - with nothing shippable, the Shipping PRs step shows `Nothing on the selected openings is in a
+shippable state. Assembled leaves already on another shipping request are not listed.`, an added
+"Shipping PR #1" card lists `Select items (0 selected):` with no rows, and Next is disabled.
+
 **Creating a request RESERVES inventory (#342).** This is the single biggest behavioural change to
 the wizard, and it changes what "it worked" looks like at every downstream step.
 
@@ -332,7 +411,8 @@ Both entry points open a "Transfer <productCode>" MUI dialog with: an "X availab
 
 ### Shop Assembly Module
 
-**Entry**: `/app/shop-assembly` -> Manager view (SAR list) or user view (my work)
+**Entry**: `/app/shop-assembly` -> landing page: one "Active Pull Requests" stat card plus five "Go to"
+cards - Requests, Assemble List, Assignments, My Work, Pipeline.
 
 - Manager creates/approves Shop Assembly Requests (SARs)
 - Approved SARs generate pull requests for warehouse
@@ -550,3 +630,19 @@ Inventory quantity corrections are NOT here — they live in the Warehouse modul
 - Locations page bin panel "Item actions" menu (stock rows): Move / Transfer / Adjust Qty / Unlocate. "Adjust Qty" opens the shared LocationActionDialog - Confirm stays disabled until a non-zero adjustment AND a reason are entered; the helper text under the adjustment shows the computed "New qty: N" and flags negatives. Verified live: adjustment writes an ADJUSTMENT audit row (`auditLog(limit: N)`) with performedBy "Admin/Manager".
 - Draft PO create (issue #256 dialog) works with the relay down end to end: the created draft's `preferredDeliveryDate` round-trips exactly (entered 2026-08-15 -> stored 2026-08-15 -> detail modal renders 8/15/2026, no UTC day shift). Cancelling a draft removes it from the `purchaseOrders` list entirely.
 - `inventoryHierarchy` returns `totalAvailableQuantity` at both category and product-code levels (issue #229): available = quantity - deficient, so a 10-qty row with 7 deficient shows total 10 / available 3. Cross-check against `deficientItems`.
+- `Notification` has no `kind` field - it is `type` (`{ notifications { id type message isRead createdAt recipientRole projectId } }`). Querying `kind` fails the whole document, so a mistyped notification field takes the relay/pull/request fields in the same query down with it.
+- The bell panel is a plain MUI Popover with a "Notifications" heading and one bold row per unread item; the app-bar badge count matches `notifications` where `isRead: false`. It renders every audience regardless of your role, so 4 in the badge means 4 rows in the panel.
+- **Pre-#346 completed leaves read as `0/N units` everywhere.** `installed_quantity` was added with `server_default "0"`, so leaves assembled before slice 2 landed have no per-line progress and `assemblyPipelineSummaries.installedUnitCount` comes back 0 even for openings that are `completedOpeningCount`/`shippedOpeningCount`. The Pipeline grid's Progress column and the detail modal's Units column both render that faithfully - a row reading "Shipped / 2 of 2 assembled / 0/2 units" is legacy data, not a bug. Current code cannot produce it: `complete_assembly` refuses a leaf where every line is `installed_quantity == 0`.
+- Same vintage: the Pipeline detail's per-leaf **Staged** column shows `-` while the pull's own staging panel shows a green "Staged" chip. The panel reads `pull_status`; the pipeline reads `staged_at`/`staged_by`, which the pre-#343 "Mark as Pulled" path never wrote. Not a contradiction, just two fields with different histories.
+- The Shipping browse page's "Door leaves shipped" is a **section label**, not a stat card - there is no count in it. The `0` that lands next to it in `document.body.innerText` on the All-Projects view is the **cart badge** from the app bar. Do not read it as "zero leaves shipped"; the per-opening chips below are the truth (a shipped opening renders as a filled green chip, `Opening 0019-EX: 2 of 2 leaves shipped`).
+- `shopAssemblyRequests` returning `[]` does **not** mean the pipeline is empty - it is the *pending accept queue*. `assemblyPipelineSummaries` covers every request in every state and is the right query for "what exists". A request whose pull is already approved shows up in the second and not the first.
+
+### Driving the app with the Chrome MCP tools
+
+- **`file_upload` caps at 10 MB and `contracterp-74.xml` is 11.5 MB**, so the real fixture cannot be uploaded through the tool at all. Either take the "Use last uploaded schedule" card (almost always right), or build a subset: keep everything up to `<Detail>` (that block holds all 1998 opening/assignment definitions, ~1.07 MB) then append `<Detail>` + the first N `</Material_List>`-delimited blocks + `</Detail></Contract>`. ~600 blocks lands at ~3.5 MB, parses clean, and yields "1998 openings parsed / 12746 hardware items parsed / 22 opening(s) had no hardware items assigned". Parsing is entirely client-side - nothing is persisted until Finalize - so uploading a trimmed file is safe on a database you are trying to preserve.
+- **`navigate` costs a full reload and wipes any instrumentation you injected.** React Router picks up `history.pushState(...)` + `window.dispatchEvent(new PopStateEvent('popstate'))`, so route sweeps can be done client-side with a `fetch` wrapper still installed. That wrapper is far better evidence than `read_network_requests`, which only starts recording when first called and misses everything before it, and it can see GraphQL errors - which come back **HTTP 200** with an `errors` array, so status-code filtering finds nothing.
+- **A `javascript_tool` call that hits the 45s CDP timeout keeps running in the page.** Its `await` chain continues after the tool has given up, so the next call races it and you get results tagged with the wrong route. Keep loops under ~8 route-hops, or step one route per call. If output ever looks mismatched, sleep ~6s and start over.
+- `computer screenshot` times out with "renderer may be frozen" while the Import wizard renders 1998 openings or 26k classification rows. It is not frozen - wait 10s and take it again. Same for the first paint after "Use last uploaded schedule".
+- The screenshot image is scaled down from the real viewport (1568px wide image for a 1918px window), so a card that looks cut off at the right edge usually is not. Check `document.documentElement.scrollWidth === clientWidth` before reporting a horizontal-overflow regression.
+- The Pull Request detail modal does **not** close on Escape. Its only text button is "Cancel Pull" - do not reach for that as a way out. Use the icon close button, or just route away.
+- MUI option cards (import Purpose, module "Go to" cards) are `useNavigate` buttons with no `href`, so there are no anchors to click and `find`'s ref sometimes lands on the inner text node rather than the clickable card. Setting the underlying `input[type=radio]`/`input[name=select_row]` via native `.click()` works reliably and does update React state.


### PR DESCRIPTION
## Why

Chasing why the on-prem relay has been 403ing `/relay-link` every ~30s since 7/24 turned up one security bug and three reliability bugs that share a root: **the relay relationship has failure modes that are silent, and one manual step that nobody can see was missed.**

### 🔴 `POST /admin/reset-data` was unauthenticated

It drops and rebuilds the entire public schema. It had **no auth and no environment gate**, was routed on the public Railway domain, and was advertised in `openapi.json`. Anyone who knew the URL could destroy production with one POST. `main.py` adds only CORS middleware — there was no global dependency backstopping it.

Now gated twice: `TESTING_ENABLED` (checked first, so production refuses outright rather than revealing whether a token would have sufficed) and `require_admin_request`. That helper is extracted from `require_admin` so a plain HTTP route and a Strawberry resolver can't drift on what "admin" means.

### The reset was orphaning the relay

`DROP SCHEMA public CASCADE` takes `relay_installs` with it. The relay's enrolled secret then matches no row, `/relay-link` refuses every handshake, and **every GP write fails** until someone re-enrols on the workstation. The install on this deployment is literally labelled *"re-enroll after schema rebuild"* — this has bitten before. The reset now snapshots and restores those rows (skipped when the table is absent, since a half-migrated DB is what a reset exists to clear).

### A running relay could never pick up a re-enrolment — this is the live outage

`channel.run_forever` read the secret **once, before** the reconnect loop, and `get_settings` is `@lru_cache`d. Two independent reasons the process could never see a new secret. So `enroll` rewrites `[auth] shared_secret` in `config.toml`, the operator sees "enrolled successfully", and the relay keeps dialling with the stale value **forever** — while the database holds a perfectly valid enrolment row. The only cure was a manual restart, on a workstation that may be nowhere near whoever is debugging.

Config is now re-read on every attempt with the cache cleared first, so a re-enrolment self-heals within one backoff interval. The enroll CLI and the 403 classifier no longer tell operators to restart.

### The failure was undiagnosable by design

`authenticate_secret` decrypted inside a bare `except Exception: continue`. A missing or rotated `RELAY_SECRET_ENC_KEY` — an operator error with an obvious fix — produced an **identical** silent 403 loop to a stale secret, with nothing logged. It now counts undecryptable rows and logs which of the three real causes applies (no enrolled installs / key mismatch / stale secret), never logging the presented secret.

## Verification

I could not run `ruff` or `pytest` locally (no Python toolchain on this machine), so **CI is the gate** — please don't merge on red.

Tests added: the rotated-key rejection path, and the reset endpoint's refusal paths. The reset tests exercise **refusals only** — a test that reached `DROP SCHEMA` would wipe the developer's database mid-suite.

## Note on the current outage

This PR does **not** fix the relay that is down right now — that build is already running on `Tagging3W10` and still needs a restart. It ensures this particular trap can't be stepped in again.

Not addressed here, and worth separate issues: the gateway is an in-memory singleton (every redeploy drops the relay; caps the backend at one replica), and `relay_call` fails immediately rather than queueing, so a deploy window becomes failed GP writes rather than delayed ones.
