### PR TITLE
feat(relay): admin-armed adopt window to recover a drifted relay secret (#353 PR B)

### DIFF
--- a/backend/alembic/versions/066_relay_adopt_columns.py
+++ b/backend/alembic/versions/066_relay_adopt_columns.py
@@ -1,0 +1,36 @@
+"""Durable audit for an adopted relay install (#353 PR B)
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-07-27
+
+The admin-armed adopt window rebinds a relay's credential from a connection that could not
+authenticate. The window itself is in-memory and vanishes on the next deploy, so the only lasting
+record of "this install was adopted, by whom, when" has to live on the row. Two nullable columns,
+rendered in the admin grid.
+
+Deliberately NOT an `inventory_audit_log` entry: that would need `RELAY_INSTALL` added to the
+`audit_entity_type` PG enum, an ALTER TYPE with an awkward downgrade, to record exactly two facts
+that belong on the install anyway.
+
+Downgrade drops both columns; no data component, so it is exact.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "066"
+down_revision = "065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("relay_installs", sa.Column("adopted_at", sa.DateTime(), nullable=True))
+    op.add_column("relay_installs", sa.Column("adopted_by", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("relay_installs", "adopted_by")
+    op.drop_column("relay_installs", "adopted_at")

--- a/backend/app/models/relay_install.py
+++ b/backend/app/models/relay_install.py
@@ -27,3 +27,9 @@ class RelayInstall(Base):
     enrolled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Durable audit of an admin-armed adopt window being used against this install (#353 PR B).
+    # Adoption rebinds the credential from an unauthenticated connection, so "was this install ever
+    # adopted, by whom, when" has to survive on the row - the window itself is in-memory and gone on
+    # the next deploy. Rendered in the admin grid.
+    adopted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    adopted_by: Mapped[str | None] = mapped_column(String, nullable=True)  # Clerk user id of the arming admin

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -49,6 +49,13 @@ def provision_install(session: Session, label: str, company: str) -> tuple[Relay
     return install, token
 
 
+def set_install_secret(session: Session, install: RelayInstall, secret: str) -> None:
+    """The SINGLE writer of a relay's long-lived credential. Enrollment and adoption both go through
+    here so there is exactly one place that decides how the secret is stored at rest - changing that
+    representation (encrypted today) is a change to this function body and nothing else."""
+    install.secret_encrypted = encrypt_secret(secret)
+
+
 def enroll_install(session: Session, enrollment_token: str, hostname: str, secret: str) -> RelayInstall:
     """Called by the relay (authenticated by the enrollment token, not Clerk). Stores the relay's
     self-generated secret encrypted; the token is single-use (a second attempt is rejected as
@@ -69,12 +76,34 @@ def enroll_install(session: Session, enrollment_token: str, hostname: str, secre
 
     now = datetime.utcnow()
     install.hostname = (hostname or "").strip() or None
-    install.secret_encrypted = encrypt_secret(secret)
+    set_install_secret(session, install, secret)
     install.enrolled_at = now
     install.last_seen_at = now
     # single use is enforced by the enrolled_at guard above: a second attempt with the same token finds
     # this now-enrolled row and is rejected as already-used. (Keeping the hash makes that a clear error
     # rather than a generic "invalid token".)
+    session.flush()
+    return install
+
+
+def adopt_secret(session: Session, install_id: uuid.UUID, secret: str, adopted_by: str) -> RelayInstall | None:
+    """Bind a presented (otherwise unrecognised) secret to an install, under an admin-armed adopt
+    window. Called from the /relay-link route ONLY after relay_adopt.peek() returned a window for
+    this install - this function does not itself decide whether adoption is allowed.
+
+    Sets enrolled_at when it is still null so a never-enrolled row does not stay "pending" forever
+    after a relay has in fact paired with it. Returns None if the row has been deleted since the
+    window was armed."""
+    install = session.get(RelayInstall, install_id)
+    if install is None:
+        return None
+    now = datetime.utcnow()
+    set_install_secret(session, install, secret)
+    if install.enrolled_at is None:
+        install.enrolled_at = now
+    install.adopted_at = now
+    install.adopted_by = adopted_by
+    install.last_seen_at = now
     session.flush()
     return install
 

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -149,6 +149,8 @@ def relay_install_to_type(ri) -> RelayInstallInfo:
         enrolled_at=ri.enrolled_at,
         last_seen_at=ri.last_seen_at,
         created_at=ri.created_at,
+        adopted_at=ri.adopted_at,
+        adopted_by=ri.adopted_by,
     )
 
 

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -1,10 +1,15 @@
 """Relay installs + live GP reads via the connected relay."""
 
+import uuid
+
 import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
+from app.errors import NotFoundError
+from app.models.relay_install import RelayInstall
 from app.repositories import relay_repository
+from app.services import relay_adopt
 from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
@@ -21,6 +26,7 @@ from .types import (
     GpPoTotals,
     GpTaxDetail,
     GpVendor,
+    RelayAdoptWindow,
     RelayEnrollResult,
     RelayInstallInfo,
     RelayInstallProvision,
@@ -37,6 +43,22 @@ class RelayQueries:
         require_admin(info)
         with SessionLocal() as session:
             return [relay_install_to_type(ri) for ri in relay_repository.list_installs(session)]
+
+    @strawberry.field
+    def relay_adopt_window(self, info: strawberry.Info) -> RelayAdoptWindow | None:
+        """The currently armed adopt window, or null. Admin-only, and polled by the Relay Installs page
+        so the warning banner and its countdown reflect the real (single-replica, in-memory) state
+        rather than what the browser that armed it happens to remember."""
+        require_admin(info)
+        window = relay_adopt.peek()
+        if window is None:
+            return None
+        return RelayAdoptWindow(
+            install_id=strawberry.ID(str(window.install_id)),
+            label=window.label,
+            expires_at=window.expires_at,
+            armed_by=window.armed_by,
+        )
 
     @strawberry.field
     def relay_status(self, info: strawberry.Info) -> RelayStatus:
@@ -164,6 +186,35 @@ class RelayMutations:
                 enrollment_token=token,
                 enrollment_token_expires_at=install.enrollment_token_expires_at,
             )
+
+    @strawberry.mutation
+    def arm_relay_adopt(self, info: strawberry.Info, install_id: strawberry.ID) -> RelayAdoptWindow:
+        """Admin: open a 5-minute, single-use window in which the next relay connection is accepted
+        with WHATEVER secret it presents and bound to this install (#353 PR B).
+
+        This deliberately weakens the /relay-link auth boundary while it is open. It exists because a
+        relay whose in-memory secret has drifted from the stored one cannot be recovered any other way
+        without physical access to the workstation - and the relay binds localhost, so there is no
+        remote restart. Arm it only when a relay you own is dialling in, and disarm as soon as it
+        reconnects."""
+        identity = require_admin(info)
+        with SessionLocal() as session:
+            install = session.get(RelayInstall, uuid.UUID(str(install_id)))
+            if install is None:
+                raise NotFoundError("Relay install not found", field="install_id")
+            window = relay_adopt.arm(install_id=install.id, label=install.label, armed_by=identity["user_id"])
+        return RelayAdoptWindow(
+            install_id=strawberry.ID(str(window.install_id)),
+            label=window.label,
+            expires_at=window.expires_at,
+            armed_by=window.armed_by,
+        )
+
+    @strawberry.mutation
+    def disarm_relay_adopt(self, info: strawberry.Info) -> bool:
+        """Admin: close an open adopt window early. Returns whether one was open."""
+        require_admin(info)
+        return relay_adopt.disarm()
 
     @strawberry.mutation
     def enroll_relay_install(self, input: EnrollRelayInstallInput) -> RelayEnrollResult:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -130,6 +130,22 @@ class RelayInstallInfo:
     enrolled_at: datetime | None
     last_seen_at: datetime | None
     created_at: datetime
+    # Stamped when an admin-armed adopt window rebound this install's credential (#353 PR B). Kept on
+    # the row (and shown in the grid) because adoption accepts a connection that could not otherwise
+    # authenticate - that has to stay visible long after the in-memory window is gone.
+    adopted_at: datetime | None = None
+    adopted_by: str | None = None
+
+
+@strawberry.type
+class RelayAdoptWindow:
+    """An open "adopt the next relay connection" window. While one is armed, the first /relay-link
+    handshake presenting ANY secret is bound to this install."""
+
+    install_id: strawberry.ID
+    label: str
+    expires_at: datetime
+    armed_by: str
 
 
 @strawberry.type

--- a/backend/app/services/relay_adopt.py
+++ b/backend/app/services/relay_adopt.py
@@ -1,0 +1,111 @@
+"""Admin-armed pairing window: "adopt the next relay connection" (#353 PR B).
+
+Recovers a relay whose stored secret has drifted from the one it is actually presenting, WITHOUT
+physical access to the workstation. That is not a hypothetical: `enroll` rewrites `[auth]
+shared_secret` in config.toml, but an already-running relay process keeps dialling with the secret it
+read at startup, so the DB and the live process disagree until someone restarts the relay. The relay
+binds 127.0.0.1, so there is no remote restart path - and if nobody can reach the machine, every GP
+write stays broken.
+
+With a window armed, the next /relay-link handshake is accepted with whatever secret it presents and
+that secret is bound to the named install. The relay is already dialling every ~30s, so recovery is
+automatic within one reconnect cycle.
+
+**This deliberately weakens an auth boundary while it is open.** The mitigations are all here or in
+the route: admin-gated arming, a 300s TTL, single use, WARNING-level logging of who armed it,
+adopted_at/adopted_by stamped on the row forever, and a 5s hello-frame gate on the adopted socket.
+
+The armed state is module-level and in-memory on purpose. Railway runs a single replica, the same
+constraint that already governs relay_gateway's single-socket registry, and a window that survived a
+deploy would be a window nobody remembers arming - a restart clearing it is the desired behaviour,
+not a limitation."""
+
+import logging
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+ADOPT_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class ArmedWindow:
+    install_id: uuid.UUID
+    label: str
+    expires_at: datetime
+    armed_by: str
+
+
+# The /relay-link route coroutine and the GraphQL resolvers can touch this from different threads
+# (uvicorn runs sync resolvers on a threadpool), so guard the swap rather than relying on the GIL to
+# make a check-then-clear atomic.
+_LOCK = threading.Lock()
+_window: ArmedWindow | None = None
+
+
+def arm(install_id: uuid.UUID, label: str, armed_by: str) -> ArmedWindow:
+    """Open a window on one install, replacing any existing one. One window at a time, scoped to a
+    single install id: two simultaneous windows would double the exposure for no operational gain."""
+    global _window
+    window = ArmedWindow(
+        install_id=install_id,
+        label=label,
+        expires_at=datetime.utcnow() + timedelta(seconds=ADOPT_TTL_SECONDS),
+        armed_by=armed_by,
+    )
+    with _LOCK:
+        _window = window
+    logger.warning(
+        "relay adopt window armed - the next /relay-link connection presenting ANY secret will be "
+        "bound to this install",
+        extra={
+            "install_id": str(install_id),
+            "label": label,
+            "armed_by": armed_by,
+            "expires_at": window.expires_at.isoformat(),
+        },
+    )
+    return window
+
+
+def peek() -> ArmedWindow | None:
+    """The currently armed window, or None. An expired window is cleared here rather than left for a
+    reaper: expiry is only ever observed on a read, so a lazy clear is exact."""
+    global _window
+    with _LOCK:
+        window = _window
+        if window is not None and window.expires_at <= datetime.utcnow():
+            _window = None
+            return None
+        return window
+
+
+def consume(install_id: uuid.UUID) -> bool:
+    """Single use: burn the window for `install_id`. Returns False when it has expired, was already
+    consumed, or is armed on a different install. Consumed on the first successful adoption whether
+    or not that socket then survives the hello gate - an adopted connection has already rewritten the
+    credential, so leaving the window open would let a second unknown secret overwrite it again."""
+    global _window
+    with _LOCK:
+        window = _window
+        if window is None or window.install_id != install_id:
+            return False
+        if window.expires_at <= datetime.utcnow():
+            _window = None
+            return False
+        _window = None
+        return True
+
+
+def disarm() -> bool:
+    """Close the window early. Returns whether one was open."""
+    global _window
+    with _LOCK:
+        was_armed = _window is not None
+        _window = None
+    if was_armed:
+        logger.warning("relay adopt window disarmed")
+    return was_armed

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -17,8 +18,16 @@ from app.errors import AppError
 from app.repositories import relay_repository
 from app.schemas.mutations import Mutation
 from app.schemas.queries import Query
+from app.services import relay_adopt
 from app.services.relay_gateway import HEARTBEAT_INTERVAL_SECONDS
 from app.services.relay_gateway import gateway as relay_gateway
+
+logger = logging.getLogger(__name__)
+
+# An adopted socket has to prove it is a relay before it is trusted with the connection slot: a
+# legitimate relay always sends {"type": "hello"} as its first frame (channel.py `_run_once` sends it
+# before entering the read loop), so a short wait for one costs a real relay nothing.
+ADOPT_HELLO_TIMEOUT_SECONDS = 5.0
 
 
 class ErrorHandlerExtension(SchemaExtension):
@@ -121,10 +130,37 @@ async def _relay_heartbeat_loop(websocket: WebSocket) -> None:
             return
 
 
-async def _serve_relay_link(websocket: WebSocket) -> None:
+async def _await_hello(websocket: WebSocket) -> bool:
+    """Read one frame and require it to be the relay's hello. Used only for connections accepted
+    through an adopt window (#353 PR B), where the presented secret was unknown until an admin armed
+    the window - so the socket must still show it speaks the relay protocol before it is trusted with
+    the single connection slot. The hello is fed to the gateway exactly as the read loop would, so an
+    adopted relay reports its build like any other. Returns False (socket closed 4403) on a timeout or
+    a first frame that is not a hello."""
+    try:
+        message = await asyncio.wait_for(websocket.receive_json(), timeout=ADOPT_HELLO_TIMEOUT_SECONDS)
+    except Exception:
+        message = None
+    if not isinstance(message, dict) or message.get("type") != "hello":
+        logger.warning("relay adopt: connection did not send a hello frame; closing")
+        try:
+            await websocket.close(code=4403)
+        except Exception:
+            pass
+        return False
+    relay_gateway.note_hello(message.get("build"), message.get("ops"))
+    return True
+
+
+async def _serve_relay_link(websocket: WebSocket, require_hello: bool = False) -> None:
     """Run the relay read loop and the heartbeat concurrently. Whichever finishes first (a disconnect,
     or the heartbeat reaping a silent relay) cancels the other; a read-loop disconnect is re-raised so
-    the route's `except WebSocketDisconnect` handles it exactly as before the heartbeat existed."""
+    the route's `except WebSocketDisconnect` handles it exactly as before the heartbeat existed.
+
+    `require_hello` gates an adopted connection on a hello frame first; it is never set for a normally
+    authenticated relay, so the ordinary handshake cannot regress."""
+    if require_hello and not await _await_hello(websocket):
+        return
     reader = asyncio.create_task(_relay_read_loop(websocket))
     heartbeat = asyncio.create_task(_relay_heartbeat_loop(websocket))
     try:
@@ -160,8 +196,33 @@ async def relay_link(websocket: WebSocket):
         await websocket.close(code=4401)
         return
 
+    adopted = False
     with SessionLocal() as session:
         install = relay_repository.authenticate_secret(session, secret.strip())
+        if install is None:
+            # No install matched. If an admin has armed an adopt window, bind the presented secret to
+            # that install instead of refusing (#353 PR B): this is the only recovery path for a relay
+            # whose stored secret has drifted from the one it is dialling with, when nobody can reach
+            # the workstation to restart it. Adoption is consumed here, single-use.
+            window = relay_adopt.peek()
+            if window is not None:
+                install = relay_repository.adopt_secret(session, window.install_id, secret.strip(), window.armed_by)
+                if install is not None and relay_adopt.consume(window.install_id):
+                    adopted = True
+                    logger.warning(
+                        "relay adopt: presented secret bound to install",
+                        extra={
+                            "install_id": str(window.install_id),
+                            "label": window.label,
+                            "hostname": install.hostname,
+                            "armed_by": window.armed_by,
+                        },
+                    )
+                else:
+                    # The window was consumed by a racing connection (or the row vanished): fall back
+                    # to a plain rejection and let the rebind roll back with the session.
+                    install = None
+                    session.rollback()
         # Read the company while the row is still bound to the session. session.commit() below expires
         # every attribute (expire_on_commit), and leaving the `with` block detaches `install` - so any
         # later install.company access raises DetachedInstanceError. Because that access sat AFTER
@@ -181,7 +242,7 @@ async def relay_link(websocket: WebSocket):
         await websocket.close(code=4409)
         return
     try:
-        await _serve_relay_link(websocket)
+        await _serve_relay_link(websocket, require_hello=adopted)
     except WebSocketDisconnect:
         pass
     except asyncio.CancelledError:
@@ -235,7 +296,8 @@ def reset_data(request: Request):
                 for r in conn.execute(
                     text(
                         "SELECT id, label, company, hostname, secret_encrypted, enrollment_token_hash, "
-                        "enrollment_token_expires_at, enrolled_at, last_seen_at, created_at FROM relay_installs"
+                        "enrollment_token_expires_at, enrolled_at, last_seen_at, created_at, "
+                        "adopted_at, adopted_by FROM relay_installs"
                     )
                 ).mappings()
             ]
@@ -255,9 +317,9 @@ def reset_data(request: Request):
                 text(
                     "INSERT INTO relay_installs (id, label, company, hostname, secret_encrypted, "
                     "enrollment_token_hash, enrollment_token_expires_at, enrolled_at, last_seen_at, "
-                    "created_at) VALUES (:id, :label, :company, :hostname, :secret_encrypted, "
-                    ":enrollment_token_hash, :enrollment_token_expires_at, :enrolled_at, :last_seen_at, "
-                    ":created_at)"
+                    "created_at, adopted_at, adopted_by) VALUES (:id, :label, :company, :hostname, "
+                    ":secret_encrypted, :enrollment_token_hash, :enrollment_token_expires_at, "
+                    ":enrolled_at, :last_seen_at, :created_at, :adopted_at, :adopted_by)"
                 ),
                 row,
             )

--- a/backend/tests/test_relay_adopt.py
+++ b/backend/tests/test_relay_adopt.py
@@ -1,0 +1,118 @@
+"""The admin-armed adopt window (#353 PR B).
+
+Adoption deliberately accepts a /relay-link connection whose secret matches nothing, so the parts
+that bound that exposure - a TTL, single use, one install at a time - are the parts that need pinning.
+A regression here would not fail any GP flow; it would silently leave the door open."""
+
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from cryptography.fernet import Fernet
+
+# The crypto layer reads RELAY_SECRET_ENC_KEY at call time; provide one before enroll/adopt.
+os.environ.setdefault("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
+
+from app.repositories import relay_repository  # noqa: E402
+from app.services import relay_adopt  # noqa: E402
+
+
+def _fresh_window_state():
+    relay_adopt.disarm()
+
+
+def test_arm_then_peek_returns_the_window():
+    _fresh_window_state()
+    install_id = uuid.uuid4()
+    armed = relay_adopt.arm(install_id, "TAGGING3W10", "user_admin")
+    seen = relay_adopt.peek()
+    assert seen is not None
+    assert seen.install_id == install_id
+    assert seen.label == "TAGGING3W10"
+    assert seen.armed_by == "user_admin"
+    assert seen == armed
+    relay_adopt.disarm()
+
+
+def test_peek_clears_an_expired_window():
+    # Expiry is only ever observed on a read, so an expired window must not linger as "armed" in the
+    # admin UI - and must not be adoptable.
+    _fresh_window_state()
+    install_id = uuid.uuid4()
+    relay_adopt.arm(install_id, "STALE", "user_admin")
+    relay_adopt._window = relay_adopt.ArmedWindow(
+        install_id=install_id,
+        label="STALE",
+        expires_at=datetime.utcnow() - timedelta(seconds=1),
+        armed_by="user_admin",
+    )
+    assert relay_adopt.peek() is None
+    assert relay_adopt.consume(install_id) is False
+
+
+def test_consume_is_single_use():
+    _fresh_window_state()
+    install_id = uuid.uuid4()
+    relay_adopt.arm(install_id, "ONE-SHOT", "user_admin")
+    assert relay_adopt.consume(install_id) is True
+    assert relay_adopt.consume(install_id) is False
+    assert relay_adopt.peek() is None
+
+
+def test_consume_rejects_a_different_install():
+    _fresh_window_state()
+    armed_id = uuid.uuid4()
+    relay_adopt.arm(armed_id, "ARMED", "user_admin")
+    assert relay_adopt.consume(uuid.uuid4()) is False
+    assert relay_adopt.peek() is not None  # the real window is untouched
+    relay_adopt.disarm()
+
+
+def test_arming_a_second_install_replaces_the_first():
+    _fresh_window_state()
+    first, second = uuid.uuid4(), uuid.uuid4()
+    relay_adopt.arm(first, "FIRST", "user_admin")
+    relay_adopt.arm(second, "SECOND", "user_admin")
+    seen = relay_adopt.peek()
+    assert seen is not None and seen.install_id == second
+    assert relay_adopt.consume(first) is False
+    relay_adopt.disarm()
+
+
+def test_disarm_reports_whether_a_window_was_open():
+    _fresh_window_state()
+    assert relay_adopt.disarm() is False
+    relay_adopt.arm(uuid.uuid4(), "X", "user_admin")
+    assert relay_adopt.disarm() is True
+    assert relay_adopt.peek() is None
+
+
+def test_adopt_secret_binds_the_presented_secret_and_stamps_the_audit(db_session):
+    # The whole point: after adoption, the secret the relay is ALREADY dialling with authenticates.
+    install, _token = relay_repository.provision_install(db_session, label="ADOPT-ME", company="TUBC")
+    presented = "the-secret-the-relay-still-holds"
+    assert relay_repository.authenticate_secret(db_session, presented) is None
+
+    adopted = relay_repository.adopt_secret(db_session, install.id, presented, "user_admin")
+    assert adopted is not None and adopted.id == install.id
+    assert adopted.adopted_by == "user_admin"
+    assert adopted.adopted_at is not None
+    assert adopted.enrolled_at is not None  # a never-enrolled row stops reading as "pending"
+
+    found = relay_repository.authenticate_secret(db_session, presented)
+    assert found is not None and found.id == install.id
+
+
+def test_adopt_secret_returns_none_when_the_row_is_gone(db_session):
+    assert relay_repository.adopt_secret(db_session, uuid.uuid4(), "whatever", "user_admin") is None
+
+
+def test_adopt_secret_replaces_an_existing_credential(db_session):
+    # The recovery case: the row already holds a secret, but the running relay is presenting an older
+    # one. Adoption must rebind to what is being presented, and the superseded secret must stop working.
+    install, token = relay_repository.provision_install(db_session, label="DRIFTED", company="TUBC")
+    relay_repository.enroll_install(db_session, token, hostname="DRIFTED", secret="new-but-unused")
+    relay_repository.adopt_secret(db_session, install.id, "old-in-memory-secret", "user_admin")
+
+    assert relay_repository.authenticate_secret(db_session, "old-in-memory-secret") is not None
+    assert relay_repository.authenticate_secret(db_session, "new-but-unused") is None

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -26,6 +26,7 @@ import main  # noqa: E402
 from app.database import SessionLocal  # noqa: E402
 from app.models.relay_install import RelayInstall  # noqa: E402
 from app.repositories import relay_repository  # noqa: E402
+from app.services import relay_adopt  # noqa: E402
 from app.services.relay_gateway import gateway  # noqa: E402
 from main import app  # noqa: E402
 
@@ -261,6 +262,98 @@ def test_serve_relay_link_swallows_a_cancelled_reader():
         gateway.try_register("TEST", ws)
         try:
             await main._serve_relay_link(ws)  # must not raise
+        finally:
+            gateway.unregister(ws)
+
+    asyncio.run(run())
+
+
+def _read_install(install_id):
+    with SessionLocal() as session:
+        return session.get(RelayInstall, install_id)
+
+
+def test_relay_link_adopts_an_unknown_secret_while_a_window_is_armed(_migrate_database):
+    # #353 PR B: the live recovery path. The install's stored secret does NOT match what the relay is
+    # dialling with; with a window armed, that connection is accepted and the presented secret is bound.
+    relay_adopt.disarm()
+    install_id = _enroll_committed("WS-ADOPT", "TUBC", "the-secret-the-backend-has")
+    try:
+        relay_adopt.arm(install_id, "WS-ADOPT", "user_admin")
+        with TestClient(app) as client:
+            headers = {"Authorization": "Bearer what-the-relay-is-actually-presenting"}
+            with client.websocket_connect("/relay-link", headers=headers) as ws:
+                # An adopted socket must prove it speaks the relay protocol before it is trusted.
+                ws.send_json({"type": "hello", "build": "relay-v0.1.0-build.42", "ops": ["list_vendors"]})
+                _wait_until(lambda: gateway.connected)
+                assert gateway.connected is True
+                assert gateway.company == "TUBC"
+                _wait_until(lambda: gateway.build == "relay-v0.1.0-build.42")
+                assert gateway.build == "relay-v0.1.0-build.42"
+                ws.close()
+                _wait_until(lambda: not gateway.connected)
+
+        # The adoption is durable on the row, and the window is spent.
+        row = _read_install(install_id)
+        assert row.adopted_at is not None
+        assert row.adopted_by == "user_admin"
+        assert relay_adopt.peek() is None
+
+        # A second unknown secret is refused now that the flag is consumed.
+        with TestClient(app) as client:
+            try:
+                with client.websocket_connect("/relay-link", headers={"Authorization": "Bearer another-one"}):
+                    pass
+            except WebSocketDisconnect:
+                pass
+        assert gateway.connected is False
+    finally:
+        relay_adopt.disarm()
+        _delete_install(install_id)
+
+
+def test_relay_link_still_rejects_an_unknown_secret_with_no_window_armed(_migrate_database):
+    # The gate only opens when an admin opens it: no window means the pre-adopt behaviour, verbatim.
+    relay_adopt.disarm()
+    install_id = _enroll_committed("WS-NO-ADOPT", "TUBC", "stored-secret")
+    try:
+        with TestClient(app) as client:
+            try:
+                with client.websocket_connect("/relay-link", headers={"Authorization": "Bearer drifted"}):
+                    pass
+            except WebSocketDisconnect:
+                pass
+        assert gateway.connected is False
+        row = _read_install(install_id)
+        assert row.adopted_at is None
+    finally:
+        _delete_install(install_id)
+
+
+def test_serve_relay_link_closes_an_adopted_socket_that_does_not_say_hello():
+    # The hello gate: an adopted connection that is not a relay gets 4403 and never reaches the read loop.
+    async def run():
+        ws = _FakeRelaySocket([{"id": "1", "ok": True, "result": {}}])
+        await main._serve_relay_link(ws, require_hello=True)
+        assert ws.closed_code == 4403
+
+    asyncio.run(run())
+
+
+def test_serve_relay_link_accepts_an_adopted_socket_that_says_hello():
+    async def run():
+        ws = _FakeRelaySocket(
+            [
+                {"type": "hello", "build": "relay-v0.1.0-build.42", "ops": ["list_vendors"]},
+                WebSocketDisconnect(),
+            ]
+        )
+        gateway.try_register("TEST", ws)
+        try:
+            with pytest.raises(WebSocketDisconnect):
+                await main._serve_relay_link(ws, require_hello=True)
+            assert gateway.build == "relay-v0.1.0-build.42"
+            assert ws.closed_code is None
         finally:
             gateway.unregister(ws)
 

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -19,6 +19,7 @@ import uuid
 
 import pytest
 
+from app.schemas import relay as relay_module
 from app.schemas import shop_assembly as shop_assembly_module
 from app.schemas import stock as stock_module
 from app.schemas.enums import DeficiencyResolution
@@ -32,6 +33,7 @@ from app.schemas.inputs import (
     ReportStockDeficiencyInput,
     ResolveDeficiencyInput,
 )
+from app.schemas.relay import RelayMutations, RelayQueries
 from app.schemas.shop_assembly import ShopAssemblyMutations, ShopAssemblyQueries
 from app.schemas.stock import StockMutations
 
@@ -153,12 +155,32 @@ _USER_GATED = [
 ]
 
 
+# Admin-only resolvers. The adopt window (#353 PR B) deliberately weakens the /relay-link auth
+# boundary while it is open, so "is this actually admin-gated" is a security property, not a nicety.
+_ADMIN_GATED = [
+    ("relayAdoptWindow", relay_module, lambda: RelayQueries().relay_adopt_window(FakeInfo())),
+    ("armRelayAdopt", relay_module, lambda: RelayMutations().arm_relay_adopt(FakeInfo(), _id())),
+    ("disarmRelayAdopt", relay_module, lambda: RelayMutations().disarm_relay_adopt(FakeInfo())),
+]
+
+
 @pytest.mark.parametrize("label, module, call", _USER_GATED, ids=[row[0] for row in _USER_GATED])
 def test_resolver_requires_a_signed_in_user(label, module, call, monkeypatch):
     def _gate(info):
         raise _GateReached(label)
 
     monkeypatch.setattr(module, "require_user", _gate)
+
+    with pytest.raises(_GateReached):
+        call()
+
+
+@pytest.mark.parametrize("label, module, call", _ADMIN_GATED, ids=[row[0] for row in _ADMIN_GATED])
+def test_resolver_requires_an_admin(label, module, call, monkeypatch):
+    def _gate(info):
+        raise _GateReached(label)
+
+    monkeypatch.setattr(module, "require_admin", _gate)
 
     with pytest.raises(_GateReached):
         call()

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -72,7 +72,40 @@ export const RELAY_INSTALLS = gql`
       enrolledAt
       lastSeenAt
       createdAt
+      adoptedAt
+      adoptedBy
     }
+  }
+`;
+
+// The admin-armed "adopt next relay connection" window (#353). While one is open, the next relay to
+// dial /relay-link is accepted with whatever secret it presents - the only way to recover a relay
+// whose in-memory secret has drifted when nobody can reach the workstation.
+export const RELAY_ADOPT_WINDOW = gql`
+  query RelayAdoptWindow {
+    relayAdoptWindow {
+      installId
+      label
+      expiresAt
+      armedBy
+    }
+  }
+`;
+
+export const ARM_RELAY_ADOPT = gql`
+  mutation ArmRelayAdopt($installId: ID!) {
+    armRelayAdopt(installId: $installId) {
+      installId
+      label
+      expiresAt
+      armedBy
+    }
+  }
+`;
+
+export const DISARM_RELAY_ADOPT = gql`
+  mutation DisarmRelayAdopt {
+    disarmRelayAdopt
   }
 `;
 

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Box,
   Button,
@@ -19,7 +19,14 @@ import {
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useQuery, useMutation } from '@apollo/client/react';
-import { RELAY_INSTALLS, PROVISION_RELAY_INSTALL } from '../../graphql/admin';
+import {
+  RELAY_INSTALLS,
+  PROVISION_RELAY_INSTALL,
+  RELAY_ADOPT_WINDOW,
+  ARM_RELAY_ADOPT,
+  DISARM_RELAY_ADOPT,
+} from '../../graphql/admin';
+import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useRelayStatus } from '../../relay/useRelayStatus';
@@ -38,6 +45,8 @@ interface RelayInstall {
   enrolledAt: string | null;
   lastSeenAt: string | null;
   createdAt: string;
+  adoptedAt: string | null;
+  adoptedBy: string | null;
 }
 
 interface Provisioned {
@@ -48,9 +57,28 @@ interface Provisioned {
   enrollmentTokenExpiresAt: string;
 }
 
+interface AdoptWindow {
+  installId: string;
+  label: string;
+  expiresAt: string;
+  armedBy: string;
+}
+
 function fmtDate(v: string | null | undefined): string {
   return v ? new Date(v).toLocaleString() : '—';
 }
+
+function fmtCountdown(expiresAt: string): string {
+  const ms = new Date(expiresAt).getTime() - Date.now();
+  if (ms <= 0) return 'expired';
+  const total = Math.floor(ms / 1000);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}
+
+const ADOPT_WARNING =
+  'For the next 5 minutes, the first relay that connects presenting any secret will be bound to this ' +
+  'install and accepted. Only do this when a relay you own is dialling in with a secret the backend has ' +
+  'lost. Cancel the window as soon as the relay reconnects.';
 
 export default function RelayInstallsPage() {
   const { isAdmin } = useIdentity();
@@ -78,6 +106,49 @@ export default function RelayInstallsPage() {
         setLabel('');
         showToast('Enrollment token created', 'success');
       },
+      onError: (err) => showToast(err.message, 'error'),
+    },
+  );
+
+  // The window lives in the backend's memory (single replica), not in this component: another admin's
+  // arming, an expiry, and a consumption by a reconnecting relay all have to show up here. Poll only
+  // while one is open - there is nothing to watch otherwise.
+  const { data: windowData, refetch: refetchWindow } = useQuery<{ relayAdoptWindow: AdoptWindow | null }>(
+    RELAY_ADOPT_WINDOW,
+    { skip: !isAdmin, fetchPolicy: 'cache-and-network' },
+  );
+  const adoptWindow = windowData?.relayAdoptWindow ?? null;
+  const [adoptTarget, setAdoptTarget] = useState<RelayInstall | null>(null);
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!adoptWindow) return;
+    // One timer drives both the countdown and the re-poll: when the window is consumed by the relay
+    // reconnecting (the expected ending) only the server knows, so the banner must not outlive it.
+    const id = setInterval(() => {
+      setTick((t) => t + 1);
+      refetchWindow();
+    }, 5000);
+    return () => clearInterval(id);
+  }, [adoptWindow, refetchWindow]);
+
+  const [armAdopt, { loading: arming }] = useMutation<{ armRelayAdopt: AdoptWindow }>(ARM_RELAY_ADOPT, {
+    refetchQueries: [{ query: RELAY_ADOPT_WINDOW }, { query: RELAY_INSTALLS }],
+    onCompleted: (d) => {
+      setAdoptTarget(null);
+      showToast(`Adopt window open for ${d.armRelayAdopt.label} — 5 minutes`, 'success');
+    },
+    onError: (err) => {
+      setAdoptTarget(null);
+      showToast(err.message, 'error');
+    },
+  });
+
+  const [disarmAdopt, { loading: disarming }] = useMutation<{ disarmRelayAdopt: boolean }>(
+    DISARM_RELAY_ADOPT,
+    {
+      refetchQueries: [{ query: RELAY_ADOPT_WINDOW }],
+      onCompleted: () => showToast('Adopt window closed', 'success'),
       onError: (err) => showToast(err.message, 'error'),
     },
   );
@@ -134,6 +205,32 @@ export default function RelayInstallsPage() {
       { field: 'enrolledAt', headerName: 'Enrolled at', flex: 1, minWidth: 160, valueFormatter: (v: string | null) => fmtDate(v) },
       { field: 'lastSeenAt', headerName: 'Last seen', flex: 1, minWidth: 160, valueFormatter: (v: string | null) => fmtDate(v) },
       { field: 'createdAt', headerName: 'Created', flex: 1, minWidth: 160, valueFormatter: (v: string) => fmtDate(v) },
+      {
+        field: 'adoptedAt',
+        headerName: 'Adopted at',
+        flex: 1,
+        minWidth: 160,
+        valueFormatter: (v: string | null) => fmtDate(v),
+      },
+      {
+        field: 'adoptedBy',
+        headerName: 'Adopted by',
+        flex: 1,
+        minWidth: 140,
+        valueFormatter: (v: string | null) => v ?? '—',
+      },
+      {
+        field: 'adopt',
+        headerName: 'Recovery',
+        width: 190,
+        sortable: false,
+        filterable: false,
+        renderCell: (p) => (
+          <Button size="small" variant="outlined" onClick={() => setAdoptTarget(p.row as RelayInstall)}>
+            Adopt next connection
+          </Button>
+        ),
+      },
     ],
     [],
   );
@@ -166,6 +263,26 @@ export default function RelayInstallsPage() {
           </Button>
         </Stack>
       </Stack>
+
+      {/* An open adopt window is real system state with a real security cost, which DESIGN.md reserves
+          status colour for: it stays loud until it is consumed or cancelled. */}
+      {adoptWindow && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 2 }}
+          action={
+            <Button color="inherit" size="small" onClick={() => disarmAdopt()} disabled={disarming}>
+              Cancel window
+            </Button>
+          }
+        >
+          <AlertTitle>Adopt window open — {adoptWindow.label}</AlertTitle>
+          <Typography variant="body2">
+            The next relay connection presenting any secret will be bound to this install. Closes in{' '}
+            <strong>{fmtCountdown(adoptWindow.expiresAt)}</strong>. Armed by {adoptWindow.armedBy}.
+          </Typography>
+        </Alert>
+      )}
 
       {provisioned && (
         <Alert severity="success" onClose={() => setProvisioned(null)} sx={{ mb: 2 }}>
@@ -232,6 +349,17 @@ export default function RelayInstallsPage() {
         disableRowSelectionOnClick
         pageSizeOptions={[10, 25, 50]}
         initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+      />
+
+      <ConfirmDialog
+        open={adoptTarget !== null}
+        title={`Adopt the next relay connection as ${adoptTarget?.label ?? ''}?`}
+        message={ADOPT_WARNING}
+        confirmLabel={arming ? 'Arming…' : 'Open 5-minute window'}
+        onConfirm={() => {
+          if (adoptTarget) armAdopt({ variables: { installId: adoptTarget.id } });
+        }}
+        onCancel={() => setAdoptTarget(null)}
       />
 
       <Dialog open={provisionOpen} onClose={() => setProvisionOpen(false)} maxWidth="xs" fullWidth>

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -346,6 +346,10 @@ export default function RelayInstallsPage() {
         columns={columns}
         loading={loading}
         autoHeight
+        // A handful of rows, ever - one per relay workstation. Virtualization buys nothing here and
+        // costs something real: at a narrow (or zero, under jsdom) measured width the grid renders no
+        // cells at all, which silently hides the per-row recovery action.
+        disableVirtualization
         disableRowSelectionOnClick
         pageSizeOptions={[10, 25, 50]}
         initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}

--- a/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import RelayInstallsPage from '../RelayInstallsPage';
+import { RELAY_INSTALLS, RELAY_ADOPT_WINDOW, ARM_RELAY_ADOPT } from '../../../graphql/admin';
+import { GET_RELAY_STATUS } from '../../../graphql/shared';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Admin',
+    userId: 'user_admin',
+    roles: ['Admin/Manager'],
+    hasRole: () => true,
+    isAdmin: true,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+const INSTALL = {
+  id: 'install-1',
+  label: 'TAGGING3W10',
+  company: 'TUBC',
+  hostname: 'Tagging3W10',
+  enrolled: true,
+  enrolledAt: '2026-07-24T22:54:27.662Z',
+  lastSeenAt: '2026-07-24T22:54:27.662Z',
+  createdAt: '2026-07-24T22:50:00.000Z',
+  adoptedAt: null,
+  adoptedBy: null,
+};
+
+const statusMock: MockedResponse = {
+  request: { query: GET_RELAY_STATUS },
+  result: { data: { relayStatus: { connected: false, company: null, build: null } } },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+};
+
+const installsMock: MockedResponse = {
+  request: { query: RELAY_INSTALLS },
+  result: { data: { relayInstalls: [INSTALL] } },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+};
+
+function windowMock(armed: unknown): MockedResponse {
+  return {
+    request: { query: RELAY_ADOPT_WINDOW },
+    result: { data: { relayAdoptWindow: armed } },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+  };
+}
+
+function renderPage(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <RelayInstallsPage />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+it('requires the confirm dialog before arming an adopt window', async () => {
+  // Arming weakens the /relay-link auth boundary for 5 minutes, so the one-click path must not exist:
+  // the mutation may only fire after the warning has been shown and accepted.
+  let armed = false;
+  const armMock: MockedResponse = {
+    request: { query: ARM_RELAY_ADOPT, variables: { installId: 'install-1' } },
+    result: () => {
+      armed = true;
+      return {
+        data: {
+          armRelayAdopt: {
+            installId: 'install-1',
+            label: 'TAGGING3W10',
+            expiresAt: new Date(Date.now() + 300_000).toISOString(),
+            armedBy: 'user_admin',
+          },
+        },
+      };
+    },
+  };
+
+  renderPage([statusMock, installsMock, windowMock(null), armMock]);
+
+  const trigger = await screen.findByRole('button', { name: /adopt next connection/i });
+  fireEvent.click(trigger);
+  expect(armed).toBe(false);
+
+  // The dialog states what the window actually does before anything is armed.
+  expect(await screen.findByText(/presenting any secret will be bound to this install/i)).toBeTruthy();
+
+  fireEvent.click(screen.getByRole('button', { name: /open 5-minute window/i }));
+  await waitFor(() => expect(armed).toBe(true));
+});
+
+it('renders the armed banner with the install it is armed on', async () => {
+  renderPage([
+    statusMock,
+    installsMock,
+    windowMock({
+      installId: 'install-1',
+      label: 'TAGGING3W10',
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+      armedBy: 'user_admin',
+    }),
+  ]);
+
+  expect(await screen.findByText(/adopt window open — TAGGING3W10/i)).toBeTruthy();
+  expect(screen.getByRole('button', { name: /cancel window/i })).toBeTruthy();
+});
+
+it('shows no armed banner when no window is open', async () => {
+  renderPage([statusMock, installsMock, windowMock(null)]);
+  await screen.findByRole('button', { name: /adopt next connection/i });
+  expect(screen.queryByText(/adopt window open/i)).toBeNull();
+});


### PR DESCRIPTION
Implements **PR B** of #353. Branched off `master` after #352 merged (strictly sequential, no stacking).

## Why

A relay whose *in-memory* secret has drifted from the stored one cannot be recovered today without physical access. `enroll` rewrites `[auth] shared_secret` in `config.toml`, but the already-running relay process keeps dialling with the secret it read at startup — and the relay's inbound server binds `127.0.0.1`, so there is no remote restart path. That is the live outage: `/relay-link` 403s every ~30s, `lastSeenAt` never advances, and every GP write fails.

With a window armed, the relay's *next dial* is accepted with the secret it is **already presenting**. No workstation access, no re-enrolment, no restart.

## ⚠️ This PR deliberately weakens an auth boundary

While a window is open, a connection presenting **any** secret is adopted onto that install row. An attacker would need to know the backend URL and be polling `/relay-link` inside that 5-minute window.

Mitigations, all in this PR:
- arming is `require_admin`
- 300 s TTL, **single use** (consumed on the first adoption)
- one window at a time, scoped to one install id
- `WARNING` logs on arm and on adoption, naming install id / label / hostname / the arming admin's Clerk user id — **never the secret**
- adopted sockets must send a valid `hello` frame within 5 s or close `4403`
- `adoptedAt` / `adoptedBy` stamped on the row permanently and shown in the admin grid

## What changed

**Backend**
- new `app/services/relay_adopt.py` — module-level, lock-guarded armed state (`arm` / `peek` / `consume` / `disarm`). In-memory on purpose: single Railway replica, same constraint that governs `relay_gateway`, and a restart clearing the window is desirable.
- `relay_repository.set_install_secret` is now the **single writer** of the relay credential; `enroll_install` (unchanged behaviour) and the new `adopt_secret` both call it.
- `/relay-link`: on an authentication miss, attempt adoption inside the same session block, reading `company` before `commit()` (the DetachedInstanceError footgun documented in that route applies verbatim). `_serve_relay_link(ws, require_hello=...)` + `_await_hello`; `require_hello` is set **only** for adopted connections, so the normal handshake cannot regress.
- migration `066` adds `adopted_at` / `adopted_by`, trivially reversible.
- `reset_data`'s hardcoded `relay_installs` SELECT **and** INSERT column lists both extended — missing that would silently drop the adoption audit on every dev reset.
- admin-gated `relayAdoptWindow`, `armRelayAdopt`, `disarmRelayAdopt`.

**Frontend**
- `RelayInstallsPage`: per-row **Adopt next connection** behind a `ConfirmDialog` spelling out what the window does; a warning `Alert` banner with a live countdown and **Cancel window**; new `adoptedAt` / `adoptedBy` columns. Polls `relayAdoptWindow` only while one is armed — the window is server state, so another admin's arming, an expiry, or a consumption by the reconnecting relay all have to surface here.

## Tests

- `backend/tests/test_relay_adopt.py` — TTL expiry clears on read, `consume` single-use, wrong-install consume refused, arming replaces, `adopt_secret` binds + stamps + supersedes an existing credential.
- `backend/tests/test_relay_link_route.py` — with no window, an unknown secret is refused exactly as before; with a window armed on a committed install, the same unknown secret connects, registers the right company, records the build via the gated hello, stamps the row, and a second unknown secret is then refused. Plus direct `require_hello` coverage (no hello → `4403`; hello → proceeds).
- `backend/tests/test_resolver_auth_gates.py` — new admin-gate pin set covering all three new resolvers.
- `frontend/.../RelayInstallsPage.test.tsx` — the mutation cannot fire before the confirm dialog is accepted; the armed banner renders.

## Verification after deploy (recovers the live outage)

1. Confirm the repeating `"WebSocket /relay-link" 403` in Railway logs — that is the relay dialling with the drifted secret.
2. Admin → Relay Installs → **Adopt next connection** on `TAGGING3W10`, confirm.
3. Within ~30 s: `relay adopt: presented secret bound to install` at WARNING, then an accepted `/relay-link`.
4. `relayStatus` → `connected: true`, `company: "TUBC"`, `build` populated (proves the hello gate passed); banner gone (flag consumed); `adoptedAt`/`adoptedBy` on the row.
5. Read-only proof: `gpBuyers(company: "TUBC")` returns rows.
