### PR TITLE
feat(relay): background auto-update polling so relay fixes ship unattended (#353 PR D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,30 @@ jobs:
       - name: Validate migrations
         run: poetry run alembic upgrade head
 
+  relay:
+    name: Relay
+    # Windows because the relay is a Windows-only deployable and its tests touch DPAPI, the HKCU
+    # autostart key, and the single-instance mutex. Health + auth + pure logic only - never GP.
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: relay
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.11"
+
+      - run: pip install poetry
+      - run: poetry install --no-interaction --with dev
+
+      - name: Ruff lint
+        run: poetry run ruff check src tests
+
+      - name: Run tests
+        run: poetry run pytest
+
   migration-integrity:
     name: Migration Integrity
     runs-on: ubuntu-latest

--- a/relay/src/ucnexus_relay/app.py
+++ b/relay/src/ucnexus_relay/app.py
@@ -20,7 +20,7 @@ import sys
 import threading
 import time
 
-from . import setup, single_instance
+from . import setup, single_instance, update_poller
 from .config import DEFAULT_CONFIG_PATH
 from .logging_setup import get_logger
 from .ui import Api, _HTML, config_summary, relay_health
@@ -43,6 +43,7 @@ class RelayApp:
         self._updating = False  # set while an update handoff is in progress, so user_shutdown doesn't cancel it
         self._mutex = None  # single_instance.MutexResult while we own the app slot
         self._control = None  # single_instance.ControlServer answering ping / show / quit_for_upgrade
+        self._update_poller_stop = None  # threading.Event stopping the background update poll
 
     # --- serve child supervision ----------------------------------------------------------------------
 
@@ -70,6 +71,13 @@ class RelayApp:
     # --- lifecycle ------------------------------------------------------------------------------------
 
     def _stop_relay_and_tray(self) -> None:
+        # Stop the update poller FIRST: a poll that started staging mid-teardown would hand this
+        # process off to the apply helper while it is already on its way down.
+        try:
+            if self._update_poller_stop is not None:
+                self._update_poller_stop.set()
+        except Exception:
+            logger.exception("error stopping the update poller")
         try:
             setup.stop_serve(self._install_dir())
         except Exception:
@@ -119,6 +127,36 @@ class RelayApp:
         of relaunching, so closing the relay mid-update is respected."""
         self._cancel_update_if_pending()
         self.shutdown()
+
+    def begin_update(self, url: str, build: str | None = None) -> dict:
+        """Stage an update and hand this process off to the detached apply helper.
+
+        Lives here rather than in the UI layer because it is app-lifecycle logic: `stage_update` needs
+        the APP's pid (the helper waits on it before repointing the `current` junction), and only the
+        app can then shut itself down so the exe unlocks. Both entry points - the Updates tab button
+        and the background poller - call this, so there is exactly one staging path."""
+        if not getattr(sys, "frozen", False):
+            return {"ok": False, "error": "updates can only be applied to the packaged exe"}
+        if not (url or "").strip():
+            return {"ok": False, "error": "no download URL"}
+        from . import updater
+
+        result = updater.stage_update(
+            url.strip(), self._install_dir(), os.getpid(), target_build=(build or "").strip() or None
+        )
+        if result.get("ok"):
+            # Mark this teardown as the update handoff so it is NOT treated as a user cancel
+            # (user_shutdown writes the cancel flag only when _updating is False).
+            self._updating = True
+            self.shutdown()
+            # Guarantee the process exits so the helper's swap can proceed promptly. shutdown() stopped
+            # serve + tray and asked the window to close, but destroy() runs off the GUI thread and does
+            # not always tear down webview.start(); this daemon timer is the fallback (it dies with the
+            # process if we exit cleanly first, so it only ever fires when the GUI loop is stuck).
+            timer = threading.Timer(2.0, lambda: os._exit(0))
+            timer.daemon = True
+            timer.start()
+        return result
 
     def _cancel_update_if_pending(self) -> None:
         if self._updating:
@@ -268,6 +306,9 @@ class RelayApp:
                 return 0
             self._cleanup_old_versions()
         self.ensure_serve()
+        # Auto-update polling (#353 PR D): without it, every relay-side fix needs someone physically at
+        # the workstation to press Update now.
+        self._update_poller_stop = update_poller.start(self)
         self._window = webview.create_window(
             "UC Nexus Relay",
             html=_HTML,

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -20,6 +20,7 @@ within ~a minute (issue #277) - the websockets client auto-answers protocol ping
 import asyncio
 import json
 import logging
+import time
 
 import pyodbc
 import websockets
@@ -37,9 +38,19 @@ logger = get_logger()
 # disconnect line, so the log's last event goes stale). `state` mirrors _classify_connect_failure.
 _STATE: dict = {"connected": False, "state": "unknown"}
 
+# GP jobs currently being dispatched, and when the last one finished. The `jobs` task set below is
+# per-connection and lives in the SERVE child; the auto-update poller lives in the desktop app PARENT
+# and has no way to see it. These module-level counters ride out on /health (the parent already polls
+# it) so the poller can refuse to swap the exe out from under an in-flight GP write.
+_INFLIGHT = 0
+_LAST_JOB_AT: float | None = None
+
 
 def channel_state_snapshot() -> dict:
-    return dict(_STATE)
+    snapshot = dict(_STATE)
+    snapshot["jobs_in_flight"] = _INFLIGHT
+    snapshot["last_job_finished_ago"] = None if _LAST_JOB_AT is None else time.monotonic() - _LAST_JOB_AT
+    return snapshot
 
 
 def _mark_connected() -> None:
@@ -275,8 +286,17 @@ async def _run_once(url: str, secret: str, cfg) -> None:
                     send_queue.task_done()
 
         async def _dispatch_job(job: dict) -> None:
-            reply = await _handle_job(job)
-            await send_queue.put(reply)
+            # try/finally so a crashing or cancelled job cannot leak the counter: a stuck _INFLIGHT
+            # would wedge the update poller into deferring forever, which looks exactly like "updates
+            # silently stopped working".
+            global _INFLIGHT, _LAST_JOB_AT
+            _INFLIGHT += 1
+            try:
+                reply = await _handle_job(job)
+                await send_queue.put(reply)
+            finally:
+                _INFLIGHT -= 1
+                _LAST_JOB_AT = time.monotonic()
 
         writer_task = asyncio.create_task(_writer())
         try:

--- a/relay/src/ucnexus_relay/ui.py
+++ b/relay/src/ucnexus_relay/ui.py
@@ -320,28 +320,9 @@ class Api:
                 # standalone (not the desktop app): the hardened in-process swap
                 return updater.apply_update(url.strip(), DEFAULT_CONFIG_PATH.parent)
             # desktop app: stage the update, then shut ourselves down so the helper can swap the now-
-            # unlocked exe and relaunch - no renaming of a running exe.
-            import os
-
-            result = updater.stage_update(
-                url.strip(), DEFAULT_CONFIG_PATH.parent, os.getpid(), target_build=(build or "").strip() or None
-            )
-            if result.get("ok"):
-                # mark this teardown as the update handoff so it's NOT treated as a user cancel
-                # (RelayApp.user_shutdown writes the cancel flag only when _updating is False).
-                running._updating = True
-                running.shutdown()
-                # Make sure this process actually exits so the helper's swap can proceed promptly.
-                # shutdown() stopped serve + tray and asked the window to close, but destroy() runs from
-                # this pywebview API worker thread and doesn't always tear down webview.start(); a daemon
-                # timer hard-exits as a fallback (it's killed with the process if we exit cleanly first,
-                # so it only fires when the GUI loop is stuck).
-                import threading
-
-                timer = threading.Timer(2.0, lambda: os._exit(0))
-                timer.daemon = True
-                timer.start()
-            return result
+            # unlocked exe and relaunch - no renaming of a running exe. The app owns that sequence
+            # (RelayApp.begin_update) because the background update poller has to run the same one.
+            return running.begin_update(url, build)
         except Exception as e:  # noqa: BLE001
             return {"ok": False, "error": str(e)}
 

--- a/relay/src/ucnexus_relay/update_poller.py
+++ b/relay/src/ucnexus_relay/update_poller.py
@@ -1,0 +1,161 @@
+"""Background auto-update polling for the relay desktop app (#353 PR D).
+
+Until this existed, the self-updater was UI-only: someone had to be at the workstation, open the
+relay window, and press Update now. Every relay-side fix therefore needed physical access to a
+tagging workstation - the exact dependency #353 exists to remove.
+
+The poller runs in the desktop app PARENT process, not the `serve` child, because staging an update
+needs the app's pid and the app must then shut itself down so the exe unlocks (see
+`RelayApp.begin_update`). It reads `/health` to find out whether the child is busy, which is the only
+channel across that process boundary.
+
+Every decision is a pure function over dicts (`should_stage`, `is_busy`, `next_delay`) so the policy
+is testable without a network, a GUI, or GP. `run()` is the only part that touches the world."""
+
+import random
+import threading
+
+from . import updater
+from .logging_setup import get_logger
+
+logger = get_logger()
+
+# First check well after start-up: a relay that just launched is usually a relay someone is watching
+# (or one that just came back from an update), and swapping the exe out from under that is startling.
+# The jitter spreads a fleet so a release is not fetched by every relay in the same second.
+FIRST_DELAY_SECONDS = 600
+FIRST_JITTER_SECONDS = 300
+INTERVAL_SECONDS = 86400
+INTERVAL_JITTER_SECONDS = 7200
+
+# When a check is deferred (a GP job is in flight, or /health is not answering) retry sooner than the
+# daily tick, but give up after MAX_DEFERRALS so a permanently busy or permanently broken relay falls
+# back to the normal cadence instead of polling every 15 minutes forever.
+DEFER_RETRY_SECONDS = 900
+MAX_DEFERRALS = 8
+
+# Treat the relay as busy for this long after the last job finished. The backend records a relay
+# result and then persists the UC Nexus side of the write; killing the relay inside that window is
+# survivable but pointlessly risky when the alternative is waiting two minutes.
+BUSY_GRACE_SECONDS = 120
+
+
+def should_stage(check: dict, ledger: dict, cancel_requested: bool) -> tuple[bool, str]:
+    """Decide whether to stage the update `check` describes. Returns (stage?, reason).
+
+    The ledger rules matter: `updater.apply_staged_update` refuses a target past MAX_ATTEMPTS, and
+    `_stage_ledger` preserves the attempt count for the same unfinished target. A poller that
+    re-staged regardless would burn those attempts on a schedule and end with a relay that can never
+    update again, even to a good build. A HIGHER build resets the count (existing `_stage_ledger`
+    behaviour), which is the escape hatch: publish a fix and the relay tries again."""
+    if not check.get("ok"):
+        return False, f"update check failed: {check.get('error') or 'unknown error'}"
+    if not check.get("update_available"):
+        return False, "already on the latest build"
+    if not (check.get("url") or "").strip():
+        return False, "release has no download URL"
+    if cancel_requested:
+        return False, "an update cancel is pending (the user closed the relay mid-update)"
+
+    status = ledger.get("status")
+    if status in ("staging", "applying"):
+        return False, f"an update is already in progress ({status})"
+
+    latest = check.get("latest")
+    if (
+        status == "failed"
+        and ledger.get("target_build") == latest
+        and int(ledger.get("attempts") or 0) >= updater.MAX_ATTEMPTS
+    ):
+        return False, f"{latest} already failed {updater.MAX_ATTEMPTS} times; waiting for a newer build"
+    return True, f"update available: {latest}"
+
+
+def is_busy(health: dict) -> bool:
+    """Whether the serve child is mid-GP-work (or unreachable). Fail-safe: an empty or malformed
+    /health payload means we cannot tell, and "cannot tell" must never authorise killing the relay
+    while eConnect is holding a transaction open."""
+    if not health:
+        return True
+    channel = health.get("channel")
+    if not isinstance(channel, dict):
+        return True
+    if int(channel.get("jobs_in_flight") or 0) > 0:
+        return True
+    last = channel.get("last_job_finished_ago")
+    if last is not None and float(last) < BUSY_GRACE_SECONDS:
+        return True
+    return False
+
+
+def next_delay(rng: random.Random, first: bool = False) -> float:
+    if first:
+        return FIRST_DELAY_SECONDS + rng.uniform(0, FIRST_JITTER_SECONDS)
+    return INTERVAL_SECONDS + rng.uniform(0, INTERVAL_JITTER_SECONDS)
+
+
+def _read_health() -> dict:
+    """The serve child's /health, or {} if it is not answering (which is_busy treats as busy)."""
+    from .ui import config_summary, relay_health
+
+    try:
+        cfg = config_summary()
+        return relay_health(cfg.get("host", "127.0.0.1"), cfg.get("port", 7321)) or {}
+    except Exception:  # noqa: BLE001
+        logger.exception("update poller: could not read relay health")
+        return {}
+
+
+def run(app, stop: threading.Event, rng: random.Random | None = None) -> None:
+    """The poll loop. Sleeps on `stop` so a shutdown is immediate rather than up to a day late; every
+    iteration is wrapped so a transient failure (GitHub unreachable, health blip) never kills the
+    thread and silently ends auto-updating."""
+    rng = rng or random.Random()
+    install_dir = app._install_dir()
+    deferrals = 0
+    delay = next_delay(rng, first=True)
+
+    while not stop.wait(delay):
+        delay = next_delay(rng)
+        try:
+            if is_busy(_read_health()):
+                if deferrals < MAX_DEFERRALS:
+                    deferrals += 1
+                    delay = DEFER_RETRY_SECONDS
+                    logger.info(
+                        "update poller: relay is busy with GP work; deferring (%s/%s)", deferrals, MAX_DEFERRALS
+                    )
+                else:
+                    deferrals = 0
+                    logger.info("update poller: still busy after %s deferrals; waiting for the next tick", MAX_DEFERRALS)
+                continue
+            deferrals = 0
+
+            check = updater.check_update()
+            ledger = updater.read_ledger(install_dir)
+            stage, reason = should_stage(check, ledger, updater.cancel_requested(install_dir))
+            if not stage:
+                logger.info("update poller: not updating - %s", reason)
+                continue
+
+            logger.info("update poller: %s; staging", reason)
+            result = app.begin_update(check["url"], check.get("latest"))
+            if not result.get("ok"):
+                logger.warning("update poller: staging failed - %s", result.get("error"))
+                continue
+            return  # staged: the app is tearing itself down for the handoff, so stop polling
+        except Exception:  # noqa: BLE001
+            logger.exception("update poller: unexpected error; will retry on the next tick")
+
+
+def start(app) -> threading.Event:
+    """Spawn the poll thread and hand back its stop event (set it first on teardown, so a poll cannot
+    begin staging an update while the app is already shutting down). Frozen builds only: a dev
+    checkout has no exe to swap."""
+    stop = threading.Event()
+    import sys
+
+    if not getattr(sys, "frozen", False):
+        return stop
+    threading.Thread(target=run, args=(app, stop), daemon=True, name="update-poller").start()
+    return stop

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -189,6 +189,13 @@ def _cancel_requested(install_dir: Path) -> bool:
     return (install_dir / _CANCEL_FLAG).exists()
 
 
+def cancel_requested(install_dir: str | Path) -> bool:
+    """Public read of the cancel flag, for callers outside this module. The update poller honours it:
+    a user who closed the relay mid-update asked for the update to stop, and a background poller that
+    re-staged it 15 minutes later would quietly overrule them."""
+    return _cancel_requested(Path(install_dir))
+
+
 def _clear_cancel(install_dir: Path) -> None:
     _unlink_quietly(install_dir / _CANCEL_FLAG)
 

--- a/relay/tests/test_app.py
+++ b/relay/tests/test_app.py
@@ -2,6 +2,8 @@
 verified from the frozen exe; here we cover the serve supervision, the shutdown sequence, the X-close
 decision, and the Api methods that reach the app."""
 
+import threading
+
 from ucnexus_relay import app as appmod
 from ucnexus_relay import setup, ui
 
@@ -88,6 +90,9 @@ def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
     monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
     monkeypatch.setattr(appmod, "_APP", a)
     monkeypatch.setattr(ui, "_frozen", lambda: True)
+    # The staging sequence now lives in RelayApp.begin_update (the update poller runs the same one),
+    # so the frozen guard is checked there too.
+    monkeypatch.setattr(appmod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(os, "_exit", lambda code: None)  # neutralize the hard-exit fallback timer
     passed = {}
     monkeypatch.setattr(
@@ -108,6 +113,7 @@ def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
     monkeypatch.setattr(a, "shutdown", lambda: shut.append(True))
     monkeypatch.setattr(appmod, "_APP", a)
     monkeypatch.setattr(ui, "_frozen", lambda: True)
+    monkeypatch.setattr(appmod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(
         updater, "stage_update", lambda url, d, pid, target_build=None: {"ok": False, "error": "download failed"}
     )
@@ -115,6 +121,29 @@ def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
     assert r["ok"] is False
     assert shut == []  # a failed stage must NOT close the app
     assert a._updating is False  # not marked updating, so a later user shutdown still cancels normally
+
+
+def test_begin_update_refuses_outside_a_frozen_build(monkeypatch):
+    # A dev checkout has no exe to swap; the poller and the UI both reach this guard.
+    a = appmod.RelayApp()
+    monkeypatch.setattr(appmod.sys, "frozen", False, raising=False)
+    r = a.begin_update("https://x/e.exe", "relay-v0.1.0-build.11")
+    assert r["ok"] is False
+    assert "packaged exe" in r["error"]
+
+
+def test_stop_relay_and_tray_stops_the_update_poller_first(monkeypatch):
+    # Ordering matters: a poll that began staging during teardown would hand this process off to the
+    # apply helper while it is already on its way down.
+    a = appmod.RelayApp()
+    order = []
+    stop = threading.Event()
+    monkeypatch.setattr(stop, "set", lambda: order.append("poller"))
+    a._update_poller_stop = stop
+    monkeypatch.setattr(setup, "stop_serve", lambda d: order.append("serve"))
+    monkeypatch.setattr(a, "_release_single_instance", lambda: None)
+    a._stop_relay_and_tray()
+    assert order == ["poller", "serve"]
 
 
 def test_user_shutdown_cancels_a_pending_update(monkeypatch, tmp_path):

--- a/relay/tests/test_channel_reconnect.py
+++ b/relay/tests/test_channel_reconnect.py
@@ -3,6 +3,8 @@
 every failure to a generic "retrying". Uses the real websockets exception types so an upgrade that
 renames the attributes the classifier reads is caught here."""
 
+import time
+
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedError, InvalidStatusCode
 from websockets.frames import Close
@@ -46,10 +48,32 @@ def test_normal_close_is_generic_retry():
 def test_channel_state_snapshot_reflects_the_mark_helpers():
     # the live state run_forever maintains + /health exposes (so the UI shows the REAL channel state)
     channel._mark_connected()
-    assert channel.channel_state_snapshot() == {"connected": True, "state": "connected"}
+    snap = channel.channel_state_snapshot()
+    assert snap["connected"] is True
+    assert snap["state"] == "connected"
     channel._mark_disconnected("secret_rejected")
     snap = channel.channel_state_snapshot()
     assert snap["connected"] is False
     assert snap["state"] == "secret_rejected"
     channel._mark_disconnected()
     assert channel.channel_state_snapshot()["state"] == "disconnected"
+
+
+def test_channel_state_snapshot_reports_gp_jobs_in_flight():
+    # #353 PR D: the update poller lives in the app PARENT and the job set lives in the serve CHILD, so
+    # /health is the only place it can learn "a GP write is running - do not swap the exe right now".
+    channel._INFLIGHT = 0
+    channel._LAST_JOB_AT = None
+    idle = channel.channel_state_snapshot()
+    assert idle["jobs_in_flight"] == 0
+    assert idle["last_job_finished_ago"] is None
+
+    channel._INFLIGHT = 2
+    assert channel.channel_state_snapshot()["jobs_in_flight"] == 2
+
+    channel._INFLIGHT = 0
+    channel._LAST_JOB_AT = time.monotonic()
+    finished = channel.channel_state_snapshot()
+    assert finished["jobs_in_flight"] == 0
+    assert 0 <= finished["last_job_finished_ago"] < 5
+    channel._LAST_JOB_AT = None

--- a/relay/tests/test_update_poller.py
+++ b/relay/tests/test_update_poller.py
@@ -1,0 +1,216 @@
+"""The background auto-update poller (#353 PR D).
+
+Health + logic only, never GP and never a real download. Every policy decision is a pure function
+over dicts precisely so it can be pinned here: the failure modes that matter (re-staging a build that
+has already burned its attempt budget, and swapping the exe out from under an in-flight GP write) are
+both invisible until they bite somebody at a workstation nobody can reach."""
+
+import random
+import threading
+
+from ucnexus_relay import update_poller, updater
+
+
+def _check(**overrides) -> dict:
+    base = {
+        "ok": True,
+        "current": "relay-v0.1.0-build.40",
+        "latest": "relay-v0.1.0-build.41",
+        "update_available": True,
+        "url": "https://example.invalid/ucnexus-relay.zip",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- should_stage -------------------------------------------------------------------------------------
+
+
+def test_stages_when_an_update_is_available_and_the_ledger_is_clean():
+    stage, reason = update_poller.should_stage(_check(), {}, cancel_requested=False)
+    assert stage is True
+    assert "build.41" in reason
+
+
+def test_does_not_stage_when_the_check_failed():
+    stage, _ = update_poller.should_stage({"ok": False, "error": "no network"}, {}, cancel_requested=False)
+    assert stage is False
+
+
+def test_does_not_stage_when_already_current():
+    stage, _ = update_poller.should_stage(_check(update_available=False), {}, cancel_requested=False)
+    assert stage is False
+
+
+def test_does_not_stage_without_a_download_url():
+    stage, _ = update_poller.should_stage(_check(url=""), {}, cancel_requested=False)
+    assert stage is False
+
+
+def test_does_not_stage_while_a_cancel_is_pending():
+    # The user closed the relay mid-update; a poller that re-staged 15 minutes later would overrule them.
+    stage, _ = update_poller.should_stage(_check(), {}, cancel_requested=True)
+    assert stage is False
+
+
+def test_does_not_stage_while_an_update_is_already_in_progress():
+    for status in ("staging", "applying"):
+        stage, _ = update_poller.should_stage(_check(), {"status": status}, cancel_requested=False)
+        assert stage is False, status
+
+
+def test_does_not_restage_a_target_that_exhausted_its_attempts():
+    # apply_staged_update refuses past MAX_ATTEMPTS; re-staging on a schedule would burn the budget and
+    # leave a relay that can never update again.
+    ledger = {
+        "status": "failed",
+        "target_build": "relay-v0.1.0-build.41",
+        "attempts": updater.MAX_ATTEMPTS,
+    }
+    stage, reason = update_poller.should_stage(_check(), ledger, cancel_requested=False)
+    assert stage is False
+    assert "failed" in reason
+
+
+def test_retries_a_target_that_has_attempts_left():
+    ledger = {"status": "failed", "target_build": "relay-v0.1.0-build.41", "attempts": 1}
+    stage, _ = update_poller.should_stage(_check(), ledger, cancel_requested=False)
+    assert stage is True
+
+
+def test_a_newer_build_escapes_an_exhausted_target():
+    # The escape hatch: publish a fix and the relay tries again (_stage_ledger resets attempts).
+    ledger = {
+        "status": "failed",
+        "target_build": "relay-v0.1.0-build.41",
+        "attempts": updater.MAX_ATTEMPTS,
+    }
+    stage, _ = update_poller.should_stage(_check(latest="relay-v0.1.0-build.42"), ledger, cancel_requested=False)
+    assert stage is True
+
+
+# --- is_busy ------------------------------------------------------------------------------------------
+
+
+def test_busy_while_a_job_is_in_flight():
+    assert update_poller.is_busy({"channel": {"jobs_in_flight": 1, "last_job_finished_ago": None}}) is True
+
+
+def test_busy_inside_the_grace_window_after_the_last_job():
+    assert update_poller.is_busy({"channel": {"jobs_in_flight": 0, "last_job_finished_ago": 5}}) is True
+
+
+def test_not_busy_once_the_grace_window_has_passed():
+    assert update_poller.is_busy({"channel": {"jobs_in_flight": 0, "last_job_finished_ago": 200}}) is False
+
+
+def test_not_busy_when_no_job_has_ever_run():
+    assert update_poller.is_busy({"channel": {"jobs_in_flight": 0, "last_job_finished_ago": None}}) is False
+
+
+def test_unreachable_health_counts_as_busy():
+    # Fail-safe: "cannot tell" must never authorise killing a relay that might be mid-eConnect.
+    assert update_poller.is_busy({}) is True
+    assert update_poller.is_busy({"running": False}) is True
+
+
+# --- next_delay ---------------------------------------------------------------------------------------
+
+
+def test_delays_stay_within_their_windows():
+    rng = random.Random(7)
+    first = update_poller.next_delay(rng, first=True)
+    assert update_poller.FIRST_DELAY_SECONDS <= first <= (
+        update_poller.FIRST_DELAY_SECONDS + update_poller.FIRST_JITTER_SECONDS
+    )
+    later = update_poller.next_delay(rng)
+    assert update_poller.INTERVAL_SECONDS <= later <= (
+        update_poller.INTERVAL_SECONDS + update_poller.INTERVAL_JITTER_SECONDS
+    )
+
+
+# --- run ----------------------------------------------------------------------------------------------
+
+
+class _FakeApp:
+    def __init__(self, tmp_path):
+        self._dir = tmp_path
+        self.staged: list[tuple] = []
+
+    def _install_dir(self):
+        return self._dir
+
+    def begin_update(self, url, build=None):
+        self.staged.append((url, build))
+        return {"ok": True}
+
+
+class _NoWait(threading.Event):
+    """A stop event that lets the loop run `iterations` times, then stops it. wait() returns False
+    (keep going) that many times and True afterwards, so the loop never actually sleeps."""
+
+    def __init__(self, iterations: int):
+        super().__init__()
+        self._left = iterations
+
+    def wait(self, timeout=None):
+        # The timeout is deliberately ignored: the point is to run the loop without real sleeping.
+        if self._left <= 0:
+            return True
+        self._left -= 1
+        return False
+
+
+def test_run_stages_the_release_and_stops(monkeypatch, tmp_path):
+    app = _FakeApp(tmp_path)
+    monkeypatch.setattr(update_poller, "_read_health", lambda: {"channel": {"jobs_in_flight": 0}})
+    monkeypatch.setattr(updater, "check_update", lambda: _check())
+    monkeypatch.setattr(updater, "read_ledger", lambda d: {})
+    monkeypatch.setattr(updater, "cancel_requested", lambda d: False)
+
+    update_poller.run(app, _NoWait(3))
+
+    # Exactly once: staging hands the process off, so the loop must return rather than stage again.
+    assert app.staged == [("https://example.invalid/ucnexus-relay.zip", "relay-v0.1.0-build.41")]
+
+
+def test_run_defers_while_a_gp_job_is_in_flight(monkeypatch, tmp_path):
+    app = _FakeApp(tmp_path)
+    monkeypatch.setattr(update_poller, "_read_health", lambda: {"channel": {"jobs_in_flight": 1}})
+    monkeypatch.setattr(updater, "check_update", lambda: _check())
+    monkeypatch.setattr(updater, "read_ledger", lambda d: {})
+    monkeypatch.setattr(updater, "cancel_requested", lambda d: False)
+
+    update_poller.run(app, _NoWait(2))
+
+    assert app.staged == []
+
+
+def test_run_survives_an_exception_and_keeps_polling(monkeypatch, tmp_path):
+    # A GitHub blip must not kill the thread: that would silently end auto-updating with no signal.
+    app = _FakeApp(tmp_path)
+    calls = {"n": 0}
+
+    def _flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("boom")
+        return _check()
+
+    monkeypatch.setattr(update_poller, "_read_health", lambda: {"channel": {"jobs_in_flight": 0}})
+    monkeypatch.setattr(updater, "check_update", _flaky)
+    monkeypatch.setattr(updater, "read_ledger", lambda d: {})
+    monkeypatch.setattr(updater, "cancel_requested", lambda d: False)
+
+    update_poller.run(app, _NoWait(3))
+
+    assert calls["n"] == 2
+    assert len(app.staged) == 1
+
+
+def test_start_does_not_spawn_a_thread_outside_a_frozen_build(monkeypatch, tmp_path):
+    spawned = []
+    monkeypatch.setattr(threading, "Thread", lambda **kw: spawned.append(kw))
+    stop = update_poller.start(_FakeApp(tmp_path))
+    assert spawned == []
+    assert isinstance(stop, threading.Event)


### PR DESCRIPTION
Implements **PR D** of #353. Relay-only and explicitly independent of B/C/E/F — branched off `master`, mergeable at any point.

## Why

The self-updater is UI-only today (`ui.py` `check_update` / `apply_update`, driven by a button). So every relay-side fix requires someone physically at a tagging workstation — the exact dependency #353 exists to remove. Until a poller ships, the rest of the issue's relay-side work can never be delivered unattended.

## What changed

**New `relay/src/ucnexus_relay/update_poller.py`**
- First check at `600s + rand(0,300)` after start; then `86400s ± rand(0,7200)`. Deferral retry `900s`, max 8, then back to the daily tick.
- All policy is pure and dict-driven — `should_stage(check, ledger, cancel_requested)`, `is_busy(health)`, `next_delay(rng)` — so the tests need no network, no GUI and no GP.
- **Never re-stages a target the ledger gave up on.** `apply_staged_update` refuses past `MAX_ATTEMPTS = 3` and `_stage_ledger` preserves the count for the same unfinished target; a poller that re-staged on a schedule would burn the budget and leave a relay that can never update again. A *higher* build resets the count — the escape hatch.
- **Honours `update-cancel`** via a new public `updater.cancel_requested()`. A user who closed the relay mid-update is not overruled 15 minutes later.

**Never updates while a GP job is in flight.** The per-connection `jobs` set lives in the **serve child**; the poller lives in the app **parent**. Bridged through the existing `/health` payload: `channel.py` gains module-level `_INFLIGHT` / `_LAST_JOB_AT`, incremented around `_dispatch_job` in a `try/finally` (a crash must not leak the counter and wedge updates off forever), surfaced as `jobs_in_flight` / `last_job_finished_ago` on `channel_state_snapshot()`. The poller defers while a job is in flight, within the 120 s grace after the last one (the backend may still be persisting), **and when `/health` does not answer at all** — "cannot tell" must never authorise swapping the exe.

**`RelayApp.begin_update(url, build)`** lifts the staging + self-shutdown sequence out of the UI layer, where it never belonged: it needs the *app's* pid (the helper waits on it before repointing the `current` junction) and the app's own teardown. `ui.Api.apply_update` keeps the standalone branch and delegates the desktop branch to it, so the button and the poller share exactly one staging path. The poller's stop event is set **first** in `_stop_relay_and_tray`, so a poll cannot begin staging during teardown.

**Frozen-only** — a dev checkout has no exe to swap.

## Also: a Relay CI job

Relay tests were not running in CI at all (`ci.yml` had frontend / backend / migration-integrity only; `relay-release.yml` just builds the exe). For a PR whose entire subject is unattended relay updates, that is the wrong place to have no gate. Added a `Relay` job on `windows-latest` running `ruff check src tests` + `pytest` — Windows because the suite touches DPAPI, the HKCU autostart key and the single-instance mutex. Health + auth + pure logic only; it never touches GP.

## Tests

`relay/tests/test_update_poller.py` — the `should_stage` truth table (no update / clean ledger / exhausted attempts / attempts remaining / newer build after a failure / staging / cancel flag), `is_busy` (in flight, inside grace, past grace, never-run, unreachable), delay windows, and `run()`: stages exactly once then returns, defers with no staging while busy, and survives a thrown exception to keep polling. Plus `begin_update`'s frozen guard, the poller-stopped-first teardown ordering, and `channel_state_snapshot()` reporting in-flight jobs.

## Verification

- CI (now including the new Relay job) green.
- **Bootstrap, one-time:** the currently-installed build has no poller, so the first hop to a poller-carrying build is applied by hand from the Updates tab at whatever hands-on moment next occurs. After that hop, never again.
- **Prove it:** publish build N+1; within 24 h `update.log` shows `update-apply start: target=…build.N+1` then `update applied`, and backend `relayStatus.build` advances with no human action.
- Regression: after a build that fails the health gate, `update-state.json` shows `status: failed, attempts: 3` and no further staging for that target.
