### PR TITLE
refactor(relay): store the relay secret hashed, not encrypted (#353 PR C)

### DIFF
--- a/backend/alembic/versions/067_relay_secret_hash.py
+++ b/backend/alembic/versions/067_relay_secret_hash.py
@@ -1,0 +1,46 @@
+"""Store the relay's Bearer secret hashed, not encrypted (#353 PR C)
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-07-27
+
+Storing the relay secret reversibly made `RELAY_SECRET_ENC_KEY` a single point of PERMANENT failure:
+rotate or lose it and every enrolled relay is orphaned, because the plaintext exists nowhere the
+backend can reach. Hashing removes the key from the authentication path entirely.
+
+SHA-256 hex, no KDF and no salt, deliberately. The credential is not a human password - the relay
+generates it as `secrets.token_urlsafe(32)`, 256 bits of CSPRNG entropy, which stretching cannot
+improve on, while per-handshake bcrypt/argon2 cost is a real downside during a reconnect storm. The
+same reasoning already governs the enrollment-token hash.
+
+**No data migration.** The plaintext is not recoverable here, so this only adds the column and its
+index; `relay_repository.authenticate_secret` reads both representations and upgrades a legacy row in
+place on its next successful handshake - which for a live relay is within ~30 seconds. Once
+`SELECT count(*) FROM relay_installs WHERE secret_encrypted IS NOT NULL` reaches 0,
+`RELAY_SECRET_ENC_KEY` is dead weight and can be deleted from the environment.
+
+**Downgrade honesty.** Dropping `secret_hash` orphans any install that has no legacy ciphertext left
+- i.e. anything enrolled or adopted from here on. CI's migration-integrity job runs against an empty
+database so it passes cleanly, but on a populated one the downgrade means the relay must be recovered
+with an admin-armed adopt window (066/#353 PR B) or re-enrolled by hand. That is precisely why the
+adopt window landed first.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "067"
+down_revision = "066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("relay_installs", sa.Column("secret_hash", sa.String(length=64), nullable=True))
+    op.create_index("ix_relay_installs_secret_hash", "relay_installs", ["secret_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_relay_installs_secret_hash", table_name="relay_installs")
+    op.drop_column("relay_installs", "secret_hash")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,10 @@ BUCKET_NAME = os.getenv("BUCKET_NAME", "")
 CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY", "")
 TESTING_ENABLED = os.getenv("TESTING_ENABLED", "").lower() in ("true", "1", "yes")
 
-# Fernet key used to encrypt relay install secrets at rest (relay_installs.secret_encrypted).
+# LEGACY (#353 PR C): the Fernet key for relay_installs.secret_encrypted. Since migration 067 the relay
+# secret is stored as a SHA-256 hash, so this key is not read for any install enrolled or adopted after
+# it - it survives only to decrypt pre-067 rows, which authenticate_secret upgrades in place on their
+# next handshake. Once `SELECT count(*) FROM relay_installs WHERE secret_encrypted IS NOT NULL` is 0 it
+# can be deleted from the environment.
 # Generate with:  python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 RELAY_SECRET_ENC_KEY = os.getenv("RELAY_SECRET_ENC_KEY", "")

--- a/backend/app/crypto.py
+++ b/backend/app/crypto.py
@@ -1,9 +1,17 @@
-"""Encryption + hashing for relay install credentials.
+"""Hashing (and legacy encryption) for relay install credentials.
 
-The relay's long-lived Bearer secret is stored ENCRYPTED (Fernet) - not hashed - because
-relay_repository.authenticate_secret needs the raw value back to compare against what the relay
-presents on its outbound WS connect handshake. The one-time enrollment token is stored HASHED (we only
-ever verify a presented token, never return it)."""
+**Both relay credentials are stored hashed.** The one-time enrollment token always was. The relay's
+long-lived Bearer secret became a hash in migration 067 (#353 PR C): storing it reversibly made
+`RELAY_SECRET_ENC_KEY` a single point of *permanent* failure - rotate or lose that key and every
+enrolled relay is orphaned with no recovery path, because the plaintext exists nowhere else.
+
+`encrypt_secret` / `decrypt_secret` survive only to read pre-067 rows, which
+`relay_repository.authenticate_secret` upgrades to a hash in place on their next handshake. Once no
+`secret_encrypted` remains, `RELAY_SECRET_ENC_KEY` is dead weight and can be deleted:
+
+    SELECT count(*) FROM relay_installs WHERE secret_encrypted IS NOT NULL;  -- 0 means it is unused
+
+No install enrolled or adopted from 067 on reads that key for anything."""
 
 import hashlib
 import os
@@ -20,14 +28,39 @@ def _fernet() -> Fernet:
     return Fernet(key.encode())
 
 
+def has_encryption_key() -> bool:
+    """Whether RELAY_SECRET_ENC_KEY is set. Callers use this to SKIP the legacy decrypt path entirely
+    rather than raise: a missing key is fatal only for pre-067 rows, and a hash-only install must
+    authenticate perfectly well without it."""
+    return bool(os.getenv("RELAY_SECRET_ENC_KEY"))
+
+
 def encrypt_secret(plaintext: str) -> str:
+    """Legacy: only used to construct pre-067 rows (in tests). Nothing writes these in production."""
     return _fernet().encrypt(plaintext.encode()).decode()
 
 
 def decrypt_secret(token: str) -> str:
+    """Legacy: read a pre-067 `secret_encrypted` so its row can be upgraded to a hash in place."""
     return _fernet().decrypt(token.encode()).decode()
+
+
+def _sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
 
 
 def hash_token(token: str) -> str:
     """SHA-256 of a one-time enrollment token (stored, then compared on enroll)."""
-    return hashlib.sha256(token.encode()).hexdigest()
+    return _sha256_hex(token)
+
+
+def hash_secret(secret: str) -> str:
+    """SHA-256 of the relay's long-lived Bearer secret.
+
+    No KDF and no salt, deliberately. A KDF exists to make *low-entropy* secrets expensive to
+    brute-force. This credential is not a human password: the relay generates it itself as
+    `secrets.token_urlsafe(32)` (relay/src/ucnexus_relay/enroll.py) - 256 bits of CSPRNG entropy, which
+    no amount of stretching improves on. Meanwhile per-handshake bcrypt/argon2 cost is a real downside
+    during a reconnect storm, when every relay in a fleet is re-dialling at once. The same reasoning
+    already governs `hash_token`."""
+    return _sha256_hex(secret)

--- a/backend/app/models/relay_install.py
+++ b/backend/app/models/relay_install.py
@@ -19,7 +19,12 @@ class RelayInstall(Base):
     label: Mapped[str] = mapped_column(String, nullable=False)
     company: Mapped[str] = mapped_column(String, nullable=False)
     hostname: Mapped[str | None] = mapped_column(String, nullable=True)  # filled by the relay at enrollment
-    # long-lived relay Bearer secret, Fernet-encrypted at rest. NULL until the relay enrolls.
+    # SHA-256 hex of the relay's long-lived Bearer secret - the sole credential for any install
+    # enrolled or adopted from migration 067 on. Indexed so a handshake is a single row fetch rather
+    # than a scan. NULL until the relay enrolls.
+    secret_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    # LEGACY: the same secret Fernet-encrypted, for rows that predate 067. authenticate_secret upgrades
+    # such a row to secret_hash (and NULLs this) on its next handshake; nothing writes it any more.
     secret_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
     # one-time enrollment token: only the SHA-256 hash is stored (it's a credential, shown once at provision).
     enrollment_token_hash: Mapped[str | None] = mapped_column(String, nullable=True, index=True)

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -10,10 +10,10 @@ import secrets
 import uuid
 from datetime import datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.crypto import decrypt_secret, encrypt_secret, hash_token
+from app.crypto import decrypt_secret, has_encryption_key, hash_secret, hash_token
 from app.errors import ConflictError, ValidationError
 from app.models.relay_install import RelayInstall
 
@@ -51,14 +51,19 @@ def provision_install(session: Session, label: str, company: str) -> tuple[Relay
 
 def set_install_secret(session: Session, install: RelayInstall, secret: str) -> None:
     """The SINGLE writer of a relay's long-lived credential. Enrollment and adoption both go through
-    here so there is exactly one place that decides how the secret is stored at rest - changing that
-    representation (encrypted today) is a change to this function body and nothing else."""
-    install.secret_encrypted = encrypt_secret(secret)
+    here, so how the secret is stored at rest is decided in exactly one place.
+
+    Writes the hash and NULLs any legacy ciphertext. Nulling rather than keeping both: leftover
+    ciphertext means RELAY_SECRET_ENC_KEY still matters, so a later key rotation would turn those rows
+    into "undecryptable" - which authenticate_secret correctly reports as a key problem, raising a
+    false alarm about a relay that is in fact perfectly healthy."""
+    install.secret_hash = hash_secret(secret)
+    install.secret_encrypted = None
 
 
 def enroll_install(session: Session, enrollment_token: str, hostname: str, secret: str) -> RelayInstall:
-    """Called by the relay (authenticated by the enrollment token, not Clerk). Stores the relay's
-    self-generated secret encrypted; the token is single-use (a second attempt is rejected as
+    """Called by the relay (authenticated by the enrollment token, not Clerk). Stores the hash of the
+    relay's self-generated secret; the token is single-use (a second attempt is rejected as
     already-used via the enrolled_at guard)."""
     secret = (secret or "").strip()
     if not secret:
@@ -110,48 +115,83 @@ def adopt_secret(session: Session, install_id: uuid.UUID, secret: str, adopted_b
 
 def authenticate_secret(session: Session, secret: str) -> RelayInstall | None:
     """Verify a Bearer secret presented on the outbound WS channel's connect handshake against the
-    enrolled installs. Secrets are Fernet-encrypted (reversible, not hashed), so this decrypts each
-    enrolled install's secret and compares in constant time. POC scale (a handful
-    of installs) makes the linear scan fine. Returns None on no match instead of raising - the caller
-    (the /relay-link route) treats that as a clean close, same as a bad token anywhere else here."""
+    enrolled installs.
+
+    Dual-read. The hash path is the normal one: an indexed equality lookup on the SHA-256 digest, then
+    `compare_digest` as the constant-time confirm. The legacy path reads pre-067 `secret_encrypted`
+    rows and, on a match, UPGRADES the row in place - so a live relay migrates itself on its next
+    reconnect (~30s) with nobody doing anything, and no plaintext ever has to be recovered at
+    migration time.
+
+    A missing RELAY_SECRET_ENC_KEY is no longer fatal: the legacy scan is skipped entirely and logged
+    once. Returns None on no match instead of raising - the caller (the /relay-link route) treats that
+    as a clean close, same as a bad token anywhere else here."""
     secret = (secret or "").strip()
     if not secret:
         return None
-    installs = session.scalars(select(RelayInstall).where(RelayInstall.secret_encrypted.is_not(None))).all()
-    undecryptable = 0
-    for install in installs:
-        try:
-            candidate = decrypt_secret(install.secret_encrypted)
-        except Exception:
-            # A row whose stored secret will not decrypt is NOT a wrong-secret case: it means
-            # RELAY_SECRET_ENC_KEY is missing or has been rotated since enrolment. Swallowing that
-            # silently makes a config error indistinguishable from a stale relay secret - both just
-            # 403 the handshake forever with nothing in the log. Count it and say so below.
-            undecryptable += 1
-            logger.warning(
-                "relay install secret failed to decrypt - RELAY_SECRET_ENC_KEY is missing or was rotated "
-                "since this install enrolled; re-enrolment will not fix it until the key is restored",
-                extra={"install_id": str(install.id), "label": install.label, "hostname": install.hostname},
-            )
-            continue
-        if secrets.compare_digest(candidate, secret):
-            install.last_seen_at = datetime.utcnow()
-            session.flush()
-            return install
 
-    # Never log the presented secret. The counts alone separate the three real causes: no enrolled
-    # installs at all (wiped DB), all undecryptable (key problem), or a genuine mismatch (the relay is
-    # holding a secret from before it was re-enrolled - it needs a restart, not another enrolment).
+    digest = hash_secret(secret)
+    install = session.scalars(select(RelayInstall).where(RelayInstall.secret_hash == digest)).first()
+    if install is not None and secrets.compare_digest(install.secret_hash, digest):
+        install.last_seen_at = datetime.utcnow()
+        session.flush()
+        return install
+
+    legacy = session.scalars(select(RelayInstall).where(RelayInstall.secret_encrypted.is_not(None))).all()
+    key_present = has_encryption_key()
+    undecryptable = 0
+    if legacy and key_present:
+        for candidate_install in legacy:
+            try:
+                candidate = decrypt_secret(candidate_install.secret_encrypted)
+            except Exception:
+                # A row whose stored secret will not decrypt is NOT a wrong-secret case: the key has
+                # been rotated since enrolment. Swallowing that silently makes a config error
+                # indistinguishable from a stale relay secret - both just 403 forever with nothing in
+                # the log. Count it and say so below.
+                undecryptable += 1
+                logger.warning(
+                    "relay install secret failed to decrypt - RELAY_SECRET_ENC_KEY was rotated since "
+                    "this install enrolled; arm an adopt window (or re-enrol) to rebind it",
+                    extra={
+                        "install_id": str(candidate_install.id),
+                        "label": candidate_install.label,
+                        "hostname": candidate_install.hostname,
+                    },
+                )
+                continue
+            if secrets.compare_digest(candidate, secret):
+                # Upgrade in place: this is the whole migration path for pre-067 rows.
+                set_install_secret(session, candidate_install, secret)
+                candidate_install.last_seen_at = datetime.utcnow()
+                session.flush()
+                logger.info(
+                    "relay install upgraded to hashed secret",
+                    extra={"install_id": str(candidate_install.id), "label": candidate_install.label},
+                )
+                return candidate_install
+
+    hash_rows = session.scalar(
+        select(func.count()).select_from(RelayInstall).where(RelayInstall.secret_hash.is_not(None))
+    )
+    # Never log the presented secret. The counts alone separate the real causes: no enrolled installs
+    # at all (wiped DB), legacy rows with the key gone or rotated (a config problem), or a genuine
+    # mismatch (the relay holds a secret from before it was re-enrolled - it needs a restart, or an
+    # admin-armed adopt window, not another enrolment).
     logger.warning(
         "relay handshake rejected",
         extra={
-            "enrolled_installs": len(installs),
+            "hash_rows": hash_rows,
+            "legacy_rows": len(legacy),
+            "encryption_key_present": key_present,
             "undecryptable": undecryptable,
             "cause": (
                 "no enrolled installs"
-                if not installs
+                if not hash_rows and not legacy
+                else "legacy rows present but RELAY_SECRET_ENC_KEY is unset"
+                if legacy and not key_present
                 else "encryption key mismatch"
-                if undecryptable == len(installs)
+                if legacy and undecryptable == len(legacy)
                 else "secret mismatch - relay is presenting a stale secret"
             ),
         },

--- a/backend/main.py
+++ b/backend/main.py
@@ -295,9 +295,9 @@ def reset_data(request: Request):
                 dict(r)
                 for r in conn.execute(
                     text(
-                        "SELECT id, label, company, hostname, secret_encrypted, enrollment_token_hash, "
-                        "enrollment_token_expires_at, enrolled_at, last_seen_at, created_at, "
-                        "adopted_at, adopted_by FROM relay_installs"
+                        "SELECT id, label, company, hostname, secret_hash, secret_encrypted, "
+                        "enrollment_token_hash, enrollment_token_expires_at, enrolled_at, last_seen_at, "
+                        "created_at, adopted_at, adopted_by FROM relay_installs"
                     )
                 ).mappings()
             ]
@@ -315,11 +315,12 @@ def reset_data(request: Request):
         for row in relay_rows:
             conn.execute(
                 text(
-                    "INSERT INTO relay_installs (id, label, company, hostname, secret_encrypted, "
-                    "enrollment_token_hash, enrollment_token_expires_at, enrolled_at, last_seen_at, "
-                    "created_at, adopted_at, adopted_by) VALUES (:id, :label, :company, :hostname, "
-                    ":secret_encrypted, :enrollment_token_hash, :enrollment_token_expires_at, "
-                    ":enrolled_at, :last_seen_at, :created_at, :adopted_at, :adopted_by)"
+                    "INSERT INTO relay_installs (id, label, company, hostname, secret_hash, "
+                    "secret_encrypted, enrollment_token_hash, enrollment_token_expires_at, enrolled_at, "
+                    "last_seen_at, created_at, adopted_at, adopted_by) VALUES (:id, :label, :company, "
+                    ":hostname, :secret_hash, :secret_encrypted, :enrollment_token_hash, "
+                    ":enrollment_token_expires_at, :enrolled_at, :last_seen_at, :created_at, "
+                    ":adopted_at, :adopted_by)"
                 ),
                 row,
             )

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -15,6 +15,7 @@ from app.repositories import relay_repository  # noqa: E402
 def test_provision_returns_token_and_stores_hash_only(db_session):
     install, token = relay_repository.provision_install(db_session, label="Tagging3W10", company="TUBC")
     assert token
+    assert install.secret_hash is None  # no relay credential exists until the relay enrolls
     assert install.secret_encrypted is None
     assert install.enrollment_token_hash and install.enrollment_token_hash != token  # hashed, not raw
 

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -64,15 +64,22 @@ def test_authenticate_secret_rejects_blank():
     assert relay_repository.authenticate_secret(None, "") is None
 
 
-def test_authenticate_secret_survives_a_rotated_encryption_key(db_session, monkeypatch):
-    """A rotated RELAY_SECRET_ENC_KEY makes every stored secret undecryptable. That must be a clean
-    rejection, not an exception escaping into the /relay-link route - and it is a *different* cause
-    from a wrong secret, which is why authenticate_secret logs the distinction (a silent `except:
-    continue` here once left an unexplained 403 loop as the only symptom)."""
+def test_a_rotated_encryption_key_no_longer_orphans_an_install(db_session, monkeypatch):
+    """#353 PR C inverts what #352 could only mitigate.
+
+    This test previously asserted that rotating RELAY_SECRET_ENC_KEY made a *correct* secret fail -
+    true when the secret was stored reversibly, and the reason that one key was a single point of
+    permanent failure. Since migration 067 the secret is a hash, so the key is not read on this path
+    at all and rotation is a non-event. Losing the key can no longer take GP down.
+
+    The clean-rejection property #352 added still matters for pre-067 rows; that case is covered in
+    test_relay_secret_hash.py (a legacy row with the key gone returns None without raising, and logs
+    the real cause)."""
     _, token = relay_repository.provision_install(db_session, label="WS6", company="TUBC")
     relay_repository.enroll_install(db_session, token, hostname="WS6", secret="valid-secret")
 
     monkeypatch.setenv("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
 
-    # The secret the relay presents is correct; the backend simply can no longer read its stored copy.
-    assert relay_repository.authenticate_secret(db_session, "valid-secret") is None
+    found = relay_repository.authenticate_secret(db_session, "valid-secret")
+    assert found is not None
+    assert found.label == "WS6"

--- a/backend/tests/test_relay_secret_hash.py
+++ b/backend/tests/test_relay_secret_hash.py
@@ -1,0 +1,95 @@
+"""The relay secret is stored hashed, and pre-067 rows upgrade themselves (#353 PR C).
+
+The property that matters is not "hashing works" - it is that RELAY_SECRET_ENC_KEY has stopped being
+able to orphan a relay. So these pin all three states a live database can be in: hash-only (the new
+normal), legacy-only (upgraded in place on the next handshake), and legacy-with-the-key-gone (must
+fail softly and say why, never raise)."""
+
+import os
+
+from cryptography.fernet import Fernet
+
+# The crypto layer reads RELAY_SECRET_ENC_KEY at call time; provide one before enroll/authenticate.
+os.environ.setdefault("RELAY_SECRET_ENC_KEY", Fernet.generate_key().decode())
+
+from app.crypto import encrypt_secret, hash_secret  # noqa: E402
+from app.models.relay_install import RelayInstall  # noqa: E402
+from app.repositories import relay_repository  # noqa: E402
+
+
+def _legacy_install(session, label: str, secret: str) -> RelayInstall:
+    """A pre-067 row: ciphertext only, no hash. Constructed directly because nothing writes this shape
+    any more - which is the point of the test."""
+    install, _token = relay_repository.provision_install(session, label=label, company="TUBC")
+    install.secret_encrypted = encrypt_secret(secret)
+    install.secret_hash = None
+    session.flush()
+    return install
+
+
+def test_enrolment_stores_a_hash_and_no_ciphertext(db_session):
+    _install, token = relay_repository.provision_install(db_session, label="HASH-1", company="TUBC")
+    enrolled = relay_repository.enroll_install(db_session, token, hostname="HASH-1", secret="s3cr3t-value")
+
+    assert enrolled.secret_hash == hash_secret("s3cr3t-value")
+    assert enrolled.secret_encrypted is None
+
+    found = relay_repository.authenticate_secret(db_session, "s3cr3t-value")
+    assert found is not None and found.id == enrolled.id
+
+
+def test_a_legacy_row_authenticates_and_upgrades_in_place(db_session):
+    # The migration path: no data migration ran, so the row migrates itself on the relay's next dial.
+    install = _legacy_install(db_session, "LEGACY-1", "legacy-secret")
+
+    found = relay_repository.authenticate_secret(db_session, "legacy-secret")
+    assert found is not None and found.id == install.id
+
+    db_session.refresh(install)
+    assert install.secret_hash == hash_secret("legacy-secret")
+    assert install.secret_encrypted is None
+
+    # And it still authenticates afterwards, now via the hash path.
+    again = relay_repository.authenticate_secret(db_session, "legacy-secret")
+    assert again is not None and again.id == install.id
+
+
+def test_a_hash_only_install_authenticates_with_no_encryption_key(db_session, monkeypatch):
+    # The whole point of the change: losing or rotating RELAY_SECRET_ENC_KEY can no longer orphan a
+    # relay enrolled from 067 on.
+    _install, token = relay_repository.provision_install(db_session, label="NOKEY-1", company="TUBC")
+    enrolled = relay_repository.enroll_install(db_session, token, hostname="NOKEY-1", secret="keyless-secret")
+
+    monkeypatch.delenv("RELAY_SECRET_ENC_KEY", raising=False)
+    found = relay_repository.authenticate_secret(db_session, "keyless-secret")
+    assert found is not None and found.id == enrolled.id
+
+
+def test_a_legacy_only_install_fails_softly_when_the_key_is_gone(db_session, monkeypatch, caplog):
+    # A missing key must skip the legacy scan entirely rather than raise CONFIG_ERROR out of the
+    # /relay-link route, and the log must name the real cause.
+    _legacy_install(db_session, "LEGACY-NOKEY", "legacy-secret")
+
+    monkeypatch.delenv("RELAY_SECRET_ENC_KEY", raising=False)
+    with caplog.at_level("WARNING"):
+        assert relay_repository.authenticate_secret(db_session, "legacy-secret") is None
+    assert any("relay handshake rejected" in r.message for r in caplog.records)
+
+
+def test_a_wrong_secret_matches_neither_representation(db_session):
+    _install, token = relay_repository.provision_install(db_session, label="WRONG-1", company="TUBC")
+    relay_repository.enroll_install(db_session, token, hostname="WRONG-1", secret="right-secret")
+    _legacy_install(db_session, "WRONG-2", "right-legacy-secret")
+
+    assert relay_repository.authenticate_secret(db_session, "not-the-secret") is None
+    assert relay_repository.authenticate_secret(db_session, "") is None
+
+
+def test_adoption_also_stores_a_hash(db_session):
+    # set_install_secret is the single writer, so the adopt path must have moved with it.
+    install, _token = relay_repository.provision_install(db_session, label="ADOPT-HASH", company="TUBC")
+    relay_repository.adopt_secret(db_session, install.id, "presented-secret", "user_admin")
+
+    assert install.secret_hash == hash_secret("presented-secret")
+    assert install.secret_encrypted is None
+    assert relay_repository.authenticate_secret(db_session, "presented-secret") is not None

--- a/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
@@ -7,6 +7,22 @@ import { GET_RELAY_STATUS } from '../../../graphql/shared';
 
 vi.setConfig({ testTimeout: 30_000 });
 
+// jsdom reports every element as 0x0, and MUI's DataGrid sizes itself from a measured container: at
+// zero width it lays every column out at `width: 0px` and the row cells - including the per-row
+// recovery action this file asserts on - never make it into the accessibility tree. That made the
+// first test pass locally and fail intermittently in CI. Give the grid real dimensions to measure so
+// the assertion is about the component, not about jsdom's layout engine.
+beforeAll(() => {
+  for (const [prop, value] of [
+    ['clientWidth', 1200],
+    ['clientHeight', 800],
+    ['offsetWidth', 1200],
+    ['offsetHeight', 800],
+  ] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, { configurable: true, value });
+  }
+});
+
 vi.mock('../../../hooks/useIdentity', () => ({
   useIdentity: () => ({
     displayName: 'Admin',

--- a/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
@@ -7,11 +7,15 @@ import { GET_RELAY_STATUS } from '../../../graphql/shared';
 
 vi.setConfig({ testTimeout: 30_000 });
 
+// Testing Library's 1s default is not enough for a DataGrid row to mount once vitest is running test
+// files in parallel workers: this file passed on its own and failed whenever anything ran alongside
+// it. The waits below are for the row cells, so give them room rather than asserting on a race.
+const GRID_TIMEOUT = { timeout: 15_000 };
+
 // jsdom reports every element as 0x0, and MUI's DataGrid sizes itself from a measured container: at
-// zero width it lays every column out at `width: 0px` and the row cells - including the per-row
-// recovery action this file asserts on - never make it into the accessibility tree. That made the
-// first test pass locally and fail intermittently in CI. Give the grid real dimensions to measure so
-// the assertion is about the component, not about jsdom's layout engine.
+// zero width it lays every column out at `width: 0px`, so the row cells - including the per-row
+// recovery action this file asserts on - never reach the accessibility tree. Give the grid real
+// dimensions so the assertions are about the component, not about jsdom's layout engine.
 beforeAll(() => {
   for (const [prop, value] of [
     ['clientWidth', 1200],
@@ -101,15 +105,17 @@ it('requires the confirm dialog before arming an adopt window', async () => {
 
   renderPage([statusMock, installsMock, windowMock(null), armMock]);
 
-  const trigger = await screen.findByRole('button', { name: /adopt next connection/i });
+  const trigger = await screen.findByRole('button', { name: /adopt next connection/i }, GRID_TIMEOUT);
   fireEvent.click(trigger);
   expect(armed).toBe(false);
 
   // The dialog states what the window actually does before anything is armed.
-  expect(await screen.findByText(/presenting any secret will be bound to this install/i)).toBeTruthy();
+  expect(
+    await screen.findByText(/presenting any secret will be bound to this install/i, {}, GRID_TIMEOUT),
+  ).toBeTruthy();
 
   fireEvent.click(screen.getByRole('button', { name: /open 5-minute window/i }));
-  await waitFor(() => expect(armed).toBe(true));
+  await waitFor(() => expect(armed).toBe(true), GRID_TIMEOUT);
 });
 
 it('renders the armed banner with the install it is armed on', async () => {
@@ -124,12 +130,12 @@ it('renders the armed banner with the install it is armed on', async () => {
     }),
   ]);
 
-  expect(await screen.findByText(/adopt window open — TAGGING3W10/i)).toBeTruthy();
+  expect(await screen.findByText(/adopt window open — TAGGING3W10/i, {}, GRID_TIMEOUT)).toBeTruthy();
   expect(screen.getByRole('button', { name: /cancel window/i })).toBeTruthy();
 });
 
 it('shows no armed banner when no window is open', async () => {
   renderPage([statusMock, installsMock, windowMock(null)]);
-  await screen.findByRole('button', { name: /adopt next connection/i });
+  await screen.findByRole('button', { name: /adopt next connection/i }, GRID_TIMEOUT);
   expect(screen.queryByText(/adopt window open/i)).toBeNull();
 });


### PR DESCRIPTION
Implements **PR C** of #353. Branched off `master` after PR B (#354) merged — strictly sequential, no stacking. Migration chain: `067` → `down_revision = "066"`.

## Why

`RELAY_SECRET_ENC_KEY` is currently a single point of **permanent** failure. Rotate it or lose it and every enrolled relay is orphaned with no recovery path, because the plaintext exists nowhere the backend can reach. Hashing takes that key out of the authentication path entirely.

## Design decisions

- **SHA-256 hex, no KDF, no salt.** A KDF exists to make *low-entropy* secrets expensive to brute-force. This credential is not a human password: the relay generates it as `secrets.token_urlsafe(32)` — 256 bits of CSPRNG entropy, which stretching cannot improve on — while per-handshake bcrypt/argon2 cost is a real downside during a reconnect storm. The same reasoning already governs `hash_token`. The justification is in the code and the migration docstring.
- **Indexed equality, then `compare_digest` as the confirm.** Today's O(n) decrypt-scan becomes a single row fetch, and the constant-time property the docstring claims stays true.
- **Upgrade-in-place on a legacy match: write `secret_hash` AND set `secret_encrypted = NULL`.** Nulling rather than keeping both — leftover ciphertext means the key still matters, so a later rotation would turn those rows into "undecryptable", which `authenticate_secret` correctly reports as a key problem, raising a false alarm about a relay that is perfectly healthy. Nulling also makes the migration observable: `SELECT count(*) FROM relay_installs WHERE secret_encrypted IS NOT NULL` → 0 means the key is dead weight.
- **A missing `RELAY_SECRET_ENC_KEY` is no longer fatal.** `has_encryption_key()` is checked once before the legacy scan; absent key ⇒ skip it entirely and log once, not per row. `_fernet()` still raises `CONFIG_ERROR` when actually called.

## Changes

- `app/crypto.py` — `hash_secret`, `has_encryption_key`, shared `_sha256_hex`; module docstring rewritten (it previously asserted the secret *must* be reversible, which is the misconception this PR kills).
- `app/models/relay_install.py` — `secret_hash: String(64)`, nullable, indexed.
- `app/repositories/relay_repository.py` — `set_install_secret` (the single writer introduced in PR B) now writes the hash and nulls the ciphertext, so enrolment **and** adoption moved with one edit. `authenticate_secret` becomes the dual read described above. The reject-path diagnostic keeps #352's shape and gains `hash_rows` / `legacy_rows` / `encryption_key_present` so "wiped DB" / "key gone" / "key rotated" / "stale relay secret" stay distinguishable. The presented secret is never logged.
- **Migration `067`** — add column + `ix_relay_installs_secret_hash`. **No data migration**: the plaintext is not recoverable at migration time, and the dual read upgrades each row on its next handshake (~30 s for a live relay).
- `main.py` `reset_data` — `secret_hash` added to both the SELECT and the INSERT column lists. Missing that would re-create exactly the orphaned-relay bug #352 fixed, through a different column.

## Downgrade honesty

`067`'s downgrade drops `secret_hash`, orphaning any install that has no legacy ciphertext left — i.e. anything enrolled or adopted from here on. CI's migration-integrity job runs against an empty database so it passes cleanly; on a populated one, recovery is an admin-armed adopt window (PR B) or a re-enrolment. That ordering is exactly why PR B landed first. The caveat is stated in the migration docstring.

## Tests — `backend/tests/test_relay_secret_hash.py`

1. Enrol → `secret_hash` set, `secret_encrypted is None`, authenticates.
2. Legacy row (constructed directly, since nothing writes that shape any more) authenticates **and** is upgraded in place; still authenticates afterwards via the hash path.
3. Key absent → a hash-only install still authenticates.
4. Key absent → a legacy-only install returns `None` **without raising**, and logs the cause.
5. Wrong secret matches neither representation; blank returns `None`.
6. Adoption also stores a hash (proving `set_install_secret` really is the single writer).
7. `test_relay_installs.py::test_provision_returns_token_and_stores_hash_only` gains `secret_hash is None` at provision time.

## Verification

- CI green including the migration-integrity job.
- After deploy the live relay reconnects (it dials continuously) → log shows `relay install upgraded to hashed secret`; `relayStatus.connected` stays true across the deploy.
- **Then prove the key is dead:** temporarily unset `RELAY_SECRET_ENC_KEY` in Railway, redeploy, confirm the relay still authenticates. If `SELECT count(*) FROM relay_installs WHERE secret_encrypted IS NOT NULL` is 0, delete the variable for good.

## Note on the CLAUDE.md update

The issue asks for the `RELAY_SECRET_ENC_KEY` entry in CLAUDE.md's Environment section to be downgraded to "legacy rows only". **The root `CLAUDE.md` is gitignored in this repo** (`.gitignore:32`), so that edit cannot land in a PR — it has been made locally only. If it should be tracked, that is a separate change to `.gitignore`.
