### PR TITLE
feat(gp): durable outbox so a GP write survives the relay being unreachable (#353 PR E)

### DIFF
--- a/backend/alembic/versions/068_gp_write_outbox.py
+++ b/backend/alembic/versions/068_gp_write_outbox.py
@@ -1,0 +1,77 @@
+"""Durable outbox for GP writes that could not be dispatched (#353 PR E)
+
+Revision ID: 068
+Revises: 067
+Create Date: 2026-07-27
+
+`relay_call` raises the moment the relay socket is gone, so a backend deploy turns an in-flight
+receive or PO registration into a failure a human has to notice and re-click. This table lets the
+write be accepted, queued, and drained automatically when the relay reconnects.
+
+The row carries the whole remainder of the pipeline as data: `payload` is exactly what the
+resolver's `_prepare_*` built (it still runs at submit time, so validation fails fast in front of the
+user), and `persist_context` holds the JSON-safe kwargs for the matching `_persist_*` helper - the
+same helper the online path calls, so there is no second persist implementation.
+
+Two indexes. `ix_gp_write_outbox_claim` on `(status, next_attempt_at)` is what the worker's claim
+query rides. `ix_gp_write_outbox_entity_key` supports the per-entity FIFO subquery, which refuses a
+row while an older unfinished row for the same PO is still queued - the rule that stops a receipt
+being drained ahead of the registration of the PO it is against.
+
+`status` is a String + CHECK rather than a PG enum, following migration 065: a CHECK is trivially
+reversible, and this list will grow. `idempotency_key` is UNIQUE, tying a queued write to its
+`gp_write_idempotency` ledger row and making a resubmit-while-queued return the same entry.
+
+Downgrade drops the table. There is no data component and nothing else references it.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "068"
+down_revision = "067"
+branch_labels = None
+depends_on = None
+
+_CLAIM_INDEX = "ix_gp_write_outbox_claim"
+_ENTITY_INDEX = "ix_gp_write_outbox_entity_key"
+_STATUS_CHECK = "ck_gp_write_outbox_status"
+_STATUS_CONDITION = "status IN ('PENDING', 'IN_FLIGHT', 'SUCCEEDED', 'FAILED', 'CANCELLED')"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gp_write_outbox",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("idempotency_key", sa.String(), nullable=False),
+        sa.Column("op", sa.String(), nullable=False),
+        sa.Column("relay_op", sa.String(), nullable=False),
+        sa.Column("company", sa.String(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("persist_context", sa.JSON(), nullable=False),
+        sa.Column("entity_key", sa.String(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=True),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("requested_by", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(), nullable=False),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("last_error_code", sa.String(), nullable=True),
+        sa.Column("failure_kind", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("succeeded_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("idempotency_key"),
+        sa.CheckConstraint(_STATUS_CONDITION, name=_STATUS_CHECK),
+    )
+    op.create_index(_CLAIM_INDEX, "gp_write_outbox", ["status", "next_attempt_at"])
+    op.create_index(_ENTITY_INDEX, "gp_write_outbox", ["entity_key"])
+
+
+def downgrade() -> None:
+    op.drop_index(_ENTITY_INDEX, table_name="gp_write_outbox")
+    op.drop_index(_CLAIM_INDEX, table_name="gp_write_outbox")
+    op.drop_table("gp_write_outbox")

--- a/backend/alembic/versions/069_add_gp_write_failed_notification.py
+++ b/backend/alembic/versions/069_add_gp_write_failed_notification.py
@@ -1,0 +1,44 @@
+"""Add GP_WRITE_FAILED to the notification_type enum (#353 PR E)
+
+Revision ID: 069
+Revises: 068
+Create Date: 2026-07-27
+
+The outbox absorbs an offline relay silently and by design - that is the point of it. The one
+outcome that must NOT be silent is a queued write that died for good: GP rejected it, it is ambiguous
+(GP may already hold it), the UC Nexus persist refused it after GP committed, or it exhausted its
+retries. Without a signal, "queued" and "quietly dead" look identical from the warehouse floor.
+
+Routed to the PO audience for a register-PO write and the warehouse audience for a receive - whoever
+would have been standing in front of the failure had it happened online.
+
+Downgrade mirrors migration 044 exactly: delete rows of the retiring type first (an enum recast fails
+on a value that is about to stop existing), then recreate notification_type without it.
+"""
+
+from alembic import op
+
+revision = "069"
+down_revision = "068"
+branch_labels = None
+depends_on = None
+
+_NEW_TYPE = "GP_WRITE_FAILED"
+
+_NOTIFICATION_TYPE_WITHOUT = (
+    "'PULL_REQUEST_CANCELLED', 'PULL_REQUEST_COMPLETED', 'SHIPMENT_COMPLETED', "
+    "'INVENTORY_SHORTFALL', 'REPLACEMENT_AFTER_SHIPMENT', 'ASSEMBLY_WORK_AVAILABLE', "
+    "'REPLACEMENT_ARRIVED', 'PULL_UNBLOCKED'"
+)
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TYPE notification_type ADD VALUE IF NOT EXISTS '{_NEW_TYPE}'")
+
+
+def downgrade() -> None:
+    op.execute(f"DELETE FROM notifications WHERE type = '{_NEW_TYPE}'")
+    op.execute("ALTER TYPE notification_type RENAME TO notification_type_old")
+    op.execute(f"CREATE TYPE notification_type AS ENUM ({_NOTIFICATION_TYPE_WITHOUT})")
+    op.execute("ALTER TABLE notifications ALTER COLUMN type TYPE notification_type USING type::text::notification_type")
+    op.execute("DROP TYPE notification_type_old")

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -50,8 +50,18 @@ class LockedError(AppError):
 
 
 class RelayUnavailableError(AppError):
-    def __init__(self, message: str = "no relay is currently connected"):
+    """No usable relay connection for this call.
+
+    `dispatched` is the single most important bit in the GP write path (#353 PR E). It is False when
+    the job never left the backend - no socket, wrong company, send failure - which means GP cannot
+    possibly have run it, so the write is safe to queue and retry. It is True when the job WAS on the
+    wire and the socket then died (`RelayGateway._fail_all`): GP may have committed and the reply was
+    simply lost, so a blind retry could post a second receipt or reserve a second PO number. A
+    dispatched failure must surface to the user exactly as it does today and must never be enqueued."""
+
+    def __init__(self, message: str = "no relay is currently connected", dispatched: bool = False):
         super().__init__(message, "RELAY_UNAVAILABLE")
+        self.dispatched = dispatched
 
 
 class RelayTimeoutError(AppError):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ class Base(DeclarativeBase):
 from .audit_log import InventoryAuditLog  # noqa: E402, F401
 from .buyer_assignment import BuyerAssignment  # noqa: E402, F401
 from .deficiency_review import DeficiencyReview  # noqa: E402, F401
+from .gp_outbox import GpWriteOutbox  # noqa: E402, F401
 from .gp_write import GpWriteIdempotency  # noqa: E402, F401
 from .hardware import HardwareItem  # noqa: E402, F401
 from .inventory import InventoryLocation  # noqa: E402, F401

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -123,6 +123,11 @@ class NotificationType(str, enum.Enum):
     # pull holds no reservation (a deficiency cannot be foreseen), so nothing else was going to tell
     # anybody it had become approvable. Deduped to one *unread* notification per pull.
     PULL_UNBLOCKED = "PULL_UNBLOCKED"
+    # A queued GP write died for good (#353 PR E): GP rejected it, it is ambiguous (GP may hold it),
+    # the UC Nexus persist refused it after GP had already committed, or it exhausted its retries.
+    # The outbox absorbs an offline relay silently and by design, so this is the one outcome a human
+    # has to be told about - without it, "queued" and "quietly dead" look identical from the floor.
+    GP_WRITE_FAILED = "GP_WRITE_FAILED"
 
 
 class AuditEntityType(str, enum.Enum):

--- a/backend/app/models/gp_outbox.py
+++ b/backend/app/models/gp_outbox.py
@@ -1,0 +1,69 @@
+"""Durable queue for GP writes that could not be dispatched (#353 PR E)."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+# Terminal-ish classification for a FAILED row, so the queue UI can say what a human must do.
+FAILURE_KINDS = ("gp_rejected", "ambiguous", "persist_failed", "exhausted")
+STATUSES = ("PENDING", "IN_FLIGHT", "SUCCEEDED", "FAILED", "CANCELLED")
+
+
+class GpWriteOutbox(Base):
+    """One GP write that was accepted from a user but could not reach GP yet.
+
+    Today `relay_call` raises the moment the socket is gone, so a backend deploy turns an in-progress
+    receive into a red toast that a human has to notice and re-click. That is the failure this table
+    removes: the write is accepted, queued, and drained automatically when the relay reconnects.
+
+    **The row carries the whole remainder of the pipeline as data.** Both GP-first resolvers persist
+    the UC Nexus record only AFTER the relay answers - `_persist_create_receive` needs the relay
+    result, and `_persist_register_po` stamps GP's returned PO number - so deferring the relay call
+    means deferring the persist too. `payload` is exactly what `_prepare_*` built (it runs at enqueue
+    time, so validation still fails fast in front of the user), and `persist_context` holds the
+    JSON-safe kwargs the matching `_persist_*` helper takes. The worker rehydrates that blob and calls
+    the SAME helper the online path calls, so there is no second persist implementation to drift.
+
+    Ordering is global age order with per-`entity_key` FIFO enforced in the claim query: `entity_key`
+    is `po:<uuid>` for both ops, so a receipt can never overtake the registration of the PO it is
+    against.
+
+    `idempotency_key` is UNIQUE and ties back to `gp_write_idempotency.key`, so re-submitting the
+    same user action while it is queued returns the existing row rather than queueing it twice."""
+
+    __tablename__ = "gp_write_outbox"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    idempotency_key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    # The resolver-level op, matching gp_write_idempotency.op: register_po_in_gp | create_receive.
+    op: Mapped[str] = mapped_column(String, nullable=False)
+    # The relay-level op the payload is for: create_po | create_receipt.
+    relay_op: Mapped[str] = mapped_column(String, nullable=False)
+    company: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    persist_context: Mapped[dict] = mapped_column(JSON, nullable=False)
+    # FIFO scope. `po:<uuid>` for both ops - see the class docstring.
+    entity_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, nullable=True)
+    # Human line for the queue UI, e.g. "Receive against PO 0000123".
+    label: Mapped[str] = mapped_column(String, nullable=False)
+    requested_by: Mapped[str | None] = mapped_column(String, nullable=True)  # Clerk user id
+
+    # String + CHECK rather than a PG enum (precedent: migration 065): a CHECK is trivially
+    # reversible and this list will grow.
+    status: Mapped[str] = mapped_column(String, nullable=False, default="PENDING", index=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_attempt_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error_code: Mapped[str | None] = mapped_column(String, nullable=True)
+    failure_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    succeeded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/models/gp_outbox.py
+++ b/backend/app/models/gp_outbox.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, Integer, String, Text, Uuid
+from sqlalchemy import JSON, DateTime, Index, Integer, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 from . import Base
@@ -36,6 +36,10 @@ class GpWriteOutbox(Base):
     same user action while it is queued returns the existing row rather than queueing it twice."""
 
     __tablename__ = "gp_write_outbox"
+    # The index the worker's claim query rides. Declared here (rather than `index=True` on `status`)
+    # so `alembic check` sees the same composite index migration 068 creates - the two must agree, or
+    # CI's migration-integrity job fails on a model/schema drift that would otherwise go unnoticed.
+    __table_args__ = (Index("ix_gp_write_outbox_claim", "status", "next_attempt_at"),)
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     idempotency_key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
@@ -54,8 +58,9 @@ class GpWriteOutbox(Base):
     requested_by: Mapped[str | None] = mapped_column(String, nullable=True)  # Clerk user id
 
     # String + CHECK rather than a PG enum (precedent: migration 065): a CHECK is trivially
-    # reversible and this list will grow.
-    status: Mapped[str] = mapped_column(String, nullable=False, default="PENDING", index=True)
+    # reversible and this list will grow. Indexed by the composite claim index below, not on its own -
+    # every read of this column is together with next_attempt_at.
+    status: Mapped[str] = mapped_column(String, nullable=False, default="PENDING")
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     next_attempt_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/repositories/gp_outbox_repository.py
+++ b/backend/app/repositories/gp_outbox_repository.py
@@ -1,0 +1,212 @@
+"""All data access for the GP write outbox (#353 PR E).
+
+The claim query is the interesting part; everything else is bookkeeping. See `claim_next`."""
+
+import random
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import func, select, text
+from sqlalchemy.orm import Session
+
+from app.models.gp_outbox import GpWriteOutbox
+
+# Backoff for a retryable failure. Capped at 30 minutes so a long outage does not push the next
+# attempt beyond the point where anybody is still watching; jittered so a queue that backed up behind
+# one outage does not come back as a thundering herd.
+_BACKOFF_BASE_SECONDS = 15
+_BACKOFF_CAP_SECONDS = 1800
+_BACKOFF_JITTER = 0.2
+
+# A row that has failed this many times is not going to succeed by being tried again.
+MAX_ATTEMPTS = 8
+
+
+def _backoff_seconds(attempts: int, rng: random.Random | None = None) -> float:
+    rng = rng or random
+    base = min(_BACKOFF_BASE_SECONDS * (2**attempts), _BACKOFF_CAP_SECONDS)
+    return base * (1 + rng.uniform(-_BACKOFF_JITTER, _BACKOFF_JITTER))
+
+
+def enqueue(
+    session: Session,
+    *,
+    idempotency_key: str,
+    op: str,
+    relay_op: str,
+    company: str,
+    payload: dict,
+    persist_context: dict,
+    entity_key: str,
+    label: str,
+    project_id: uuid.UUID | None = None,
+    requested_by: str | None = None,
+) -> GpWriteOutbox:
+    """Queue a GP write, or return the row that is already queued under this idempotency key.
+
+    Returning the existing row rather than raising is what makes a resubmit-while-queued a no-op: the
+    user pressing the button again gets the same entry, not a second GP write."""
+    existing = session.scalars(select(GpWriteOutbox).where(GpWriteOutbox.idempotency_key == idempotency_key)).first()
+    if existing is not None:
+        return existing
+
+    row = GpWriteOutbox(
+        id=uuid.uuid4(),
+        idempotency_key=idempotency_key,
+        op=op,
+        relay_op=relay_op,
+        company=company,
+        payload=payload,
+        persist_context=persist_context,
+        entity_key=entity_key,
+        project_id=project_id,
+        label=label,
+        requested_by=requested_by,
+        status="PENDING",
+        attempts=0,
+        next_attempt_at=datetime.utcnow(),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def claim_next(session: Session, company: str) -> GpWriteOutbox | None:
+    """Take the oldest due PENDING row for `company`, marking it IN_FLIGHT.
+
+    Two things this query enforces that a plain ORDER BY would not:
+
+    - **Per-entity FIFO.** The NOT EXISTS refuses a row while an OLDER unfinished row for the same
+      `entity_key` is still queued. Both ops key on `po:<id>`, so a receipt can never overtake the
+      registration of the PO it is against - which would fail, because the PO is not in GP yet.
+    - **`FOR UPDATE SKIP LOCKED`.** There is one worker on one replica today, so this costs nothing;
+      it is here so that the day a second replica exists, two workers cannot claim the same row."""
+    row_id = session.execute(
+        text(
+            """
+            SELECT o.id
+              FROM gp_write_outbox o
+             WHERE o.status = 'PENDING'
+               AND o.company = :company
+               AND o.next_attempt_at <= :now
+               AND NOT EXISTS (
+                   SELECT 1 FROM gp_write_outbox p
+                    WHERE p.entity_key = o.entity_key
+                      AND p.status IN ('PENDING', 'IN_FLIGHT')
+                      AND (p.created_at, p.id) < (o.created_at, o.id)
+               )
+             ORDER BY o.created_at, o.id
+             LIMIT 1
+               FOR UPDATE SKIP LOCKED
+            """
+        ),
+        {"company": company, "now": datetime.utcnow()},
+    ).scalar()
+    if row_id is None:
+        return None
+
+    row = session.get(GpWriteOutbox, row_id)
+    if row is None:
+        return None
+    row.status = "IN_FLIGHT"
+    session.flush()
+    return row
+
+
+def mark_succeeded(session: Session, row: GpWriteOutbox) -> None:
+    row.status = "SUCCEEDED"
+    row.succeeded_at = datetime.utcnow()
+    row.last_error = None
+    row.last_error_code = None
+    row.failure_kind = None
+    session.flush()
+
+
+def mark_retry(
+    session: Session,
+    row: GpWriteOutbox,
+    *,
+    error: str,
+    error_code: str | None = None,
+    bump_attempts: bool = True,
+    retry_in_seconds: float | None = None,
+) -> None:
+    """Put a row back on the queue.
+
+    `bump_attempts=False` is the load-bearing option: "the relay is still down" is not a failure of
+    this row, and counting it would let a week-long outage exhaust the attempt budget of every queued
+    write and fail them all the moment they became deliverable again."""
+    if bump_attempts:
+        row.attempts += 1
+    delay = retry_in_seconds if retry_in_seconds is not None else _backoff_seconds(row.attempts)
+    row.status = "PENDING"
+    row.next_attempt_at = datetime.utcnow() + timedelta(seconds=delay)
+    row.last_error = error
+    row.last_error_code = error_code
+    session.flush()
+
+
+def mark_failed(session: Session, row: GpWriteOutbox, *, kind: str, error: str, error_code: str | None = None) -> None:
+    row.status = "FAILED"
+    row.failure_kind = kind
+    row.last_error = error
+    row.last_error_code = error_code
+    session.flush()
+
+
+def list_entries(session: Session, status: str | None = None, limit: int = 100) -> list[GpWriteOutbox]:
+    stmt = select(GpWriteOutbox).order_by(GpWriteOutbox.created_at.desc()).limit(limit)
+    if status:
+        stmt = stmt.where(GpWriteOutbox.status == status)
+    return list(session.scalars(stmt).all())
+
+
+def get_entry(session: Session, entry_id: uuid.UUID) -> GpWriteOutbox | None:
+    return session.get(GpWriteOutbox, entry_id)
+
+
+def summary(session: Session) -> dict:
+    """Scalar aggregates only - this is polled by every browser with the app open, so it must never
+    load rows (see the GraphQL/SQLAlchemy performance rules in CLAUDE.md)."""
+    counts = dict(
+        session.execute(
+            select(GpWriteOutbox.status, func.count())
+            .where(GpWriteOutbox.status.in_(("PENDING", "IN_FLIGHT", "FAILED")))
+            .group_by(GpWriteOutbox.status)
+        ).all()
+    )
+    oldest_pending_at = session.scalar(
+        select(func.min(GpWriteOutbox.created_at)).where(GpWriteOutbox.status == "PENDING")
+    )
+    last_drained_at = session.scalar(select(func.max(GpWriteOutbox.succeeded_at)))
+    return {
+        "pending": counts.get("PENDING", 0),
+        "in_flight": counts.get("IN_FLIGHT", 0),
+        "failed": counts.get("FAILED", 0),
+        "oldest_pending_at": oldest_pending_at,
+        "last_drained_at": last_drained_at,
+    }
+
+
+def retry_entry(session: Session, entry_id: uuid.UUID) -> GpWriteOutbox | None:
+    """Admin: put a FAILED row back on the queue immediately, with a fresh attempt budget."""
+    row = session.get(GpWriteOutbox, entry_id)
+    if row is None or row.status not in ("FAILED", "CANCELLED"):
+        return None
+    row.status = "PENDING"
+    row.attempts = 0
+    row.next_attempt_at = datetime.utcnow()
+    row.failure_kind = None
+    session.flush()
+    return row
+
+
+def cancel_entry(session: Session, entry_id: uuid.UUID) -> GpWriteOutbox | None:
+    """Admin: abandon a queued write. Only a row that is not currently on the wire may be cancelled -
+    cancelling an IN_FLIGHT row would leave the worker writing to a row a human believes is dead."""
+    row = session.get(GpWriteOutbox, entry_id)
+    if row is None or row.status not in ("PENDING", "FAILED"):
+        return None
+    row.status = "CANCELLED"
+    session.flush()
+    return row

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -8,7 +8,7 @@ import strawberry
 
 from app.models.project import Project as ProjectModel
 
-from .enums import PipelineStage
+from .enums import GpOutboxStatus, PipelineStage
 from .types import (
     AssemblyPipeline,
     AssemblyPipelineSummary,
@@ -19,6 +19,8 @@ from .types import (
     DeficientItemRow,
     GpCostCode,
     GpJob,
+    GpOutboxEntry,
+    GpOutboxSummary,
     GpTaxDetail,
     GpVendor,
     InventoryLocation,
@@ -826,4 +828,32 @@ def deficient_item_row_to_type(row: dict) -> DeficientItemRow:
         aisle=row["aisle"],
         row=row["row"],
         bay=row["bay"],
+    )
+
+
+def gp_outbox_entry_to_type(row) -> GpOutboxEntry:
+    """Reads only the row's own scalar columns - no relationships, so nothing here can trigger a
+    lazy load (see the GraphQL/SQLAlchemy rules in CLAUDE.md)."""
+    return GpOutboxEntry(
+        id=strawberry.ID(str(row.id)),
+        label=row.label,
+        op=row.op,
+        company=row.company,
+        status=GpOutboxStatus(row.status),
+        attempts=row.attempts,
+        next_attempt_at=row.next_attempt_at,
+        created_at=row.created_at,
+        entity_key=row.entity_key,
+        last_error=row.last_error,
+        failure_kind=row.failure_kind,
+    )
+
+
+def gp_outbox_summary_to_type(data: dict) -> GpOutboxSummary:
+    return GpOutboxSummary(
+        pending=data["pending"],
+        in_flight=data["in_flight"],
+        failed=data["failed"],
+        oldest_pending_at=data["oldest_pending_at"],
+        last_drained_at=data["last_drained_at"],
     )

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -168,3 +168,15 @@ class LeafStatus(enum.Enum):
     IN_INVENTORY = "IN_INVENTORY"
     SHIP_READY = "SHIP_READY"
     SHIPPED_OUT = "SHIPPED_OUT"
+
+
+@strawberry.enum
+class GpOutboxStatus(enum.Enum):
+    """Where a queued GP write has got to (#353 PR E). Stored as a String + CHECK rather than a PG
+    enum (precedent: migration 065), so this list can grow without an ALTER TYPE."""
+
+    PENDING = "PENDING"
+    IN_FLIGHT = "IN_FLIGHT"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"

--- a/backend/app/schemas/gp_outbox.py
+++ b/backend/app/schemas/gp_outbox.py
@@ -1,0 +1,76 @@
+"""Read + admin surface for the GP write queue (#353 PR E).
+
+Composed into the root Query/Mutation via schemas/queries.py and schemas/mutations.py, never added
+to the root types directly (see CLAUDE.md)."""
+
+import uuid
+
+import strawberry
+
+from app.auth import require_admin, require_user
+from app.database import SessionLocal
+from app.errors import NotFoundError
+from app.repositories import gp_outbox_repository
+
+from .converters import gp_outbox_entry_to_type, gp_outbox_summary_to_type
+from .enums import GpOutboxStatus
+from .types import GpOutboxEntry, GpOutboxSummary
+
+
+@strawberry.type
+class GpOutboxQueries:
+    @strawberry.field
+    def gp_outbox_summary(self, info: strawberry.Info) -> GpOutboxSummary:
+        """Counts behind the queue chip, polled by every open browser - scalar aggregates only."""
+        require_user(info)
+        with SessionLocal() as session:
+            return gp_outbox_summary_to_type(gp_outbox_repository.summary(session))
+
+    @strawberry.field
+    def gp_outbox(
+        self, info: strawberry.Info, status: GpOutboxStatus | None = None, limit: int = 100
+    ) -> list[GpOutboxEntry]:
+        """The queue itself. Readable by any signed-in user because the PO and receiving lists join
+        pending entries onto their rows client-side; only retry/cancel are admin-gated."""
+        require_user(info)
+        with SessionLocal() as session:
+            rows = gp_outbox_repository.list_entries(
+                session, status=status.value if status else None, limit=max(1, min(limit, 500))
+            )
+            return [gp_outbox_entry_to_type(r) for r in rows]
+
+
+@strawberry.type
+class GpOutboxMutations:
+    @strawberry.mutation
+    def retry_gp_outbox_entry(self, info: strawberry.Info, id: strawberry.ID) -> GpOutboxEntry:
+        """Admin: put a failed write back on the queue with a fresh attempt budget.
+
+        For `failureKind == 'ambiguous'` this is a genuinely dangerous button - GP may already hold
+        the write - which is why the UI's confirm text says to check GP first. The backend cannot
+        know, so it does not pretend to."""
+        require_admin(info)
+        with SessionLocal() as session:
+            row = gp_outbox_repository.retry_entry(session, uuid.UUID(str(id)))
+            if row is None:
+                raise NotFoundError("No retryable GP write queue entry with that id")
+            entry = gp_outbox_entry_to_type(row)
+            session.commit()
+        # Drain immediately rather than waiting for the next poll tick.
+        from app.services import gp_outbox_worker
+
+        gp_outbox_worker.wake()
+        return entry
+
+    @strawberry.mutation
+    def cancel_gp_outbox_entry(self, info: strawberry.Info, id: strawberry.ID) -> GpOutboxEntry:
+        """Admin: abandon a queued write. Refused for an IN_FLIGHT row - cancelling one would leave
+        the worker still writing to a row a human believes is dead."""
+        require_admin(info)
+        with SessionLocal() as session:
+            row = gp_outbox_repository.cancel_entry(session, uuid.UUID(str(id)))
+            if row is None:
+                raise NotFoundError("No cancellable GP write queue entry with that id")
+            entry = gp_outbox_entry_to_type(row)
+            session.commit()
+            return entry

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -7,6 +7,7 @@ mirroring app/repositories/. DTO builders live in schemas/converters.py.
 import strawberry
 
 from .buyer import BuyerMutations
+from .gp_outbox import GpOutboxMutations
 from .imports import ImportMutations
 from .notification import NotificationMutations
 from .po import POMutations
@@ -23,6 +24,7 @@ from .warehouse import WarehouseMutations
 @strawberry.type
 class Mutation(
     BuyerMutations,
+    GpOutboxMutations,
     ImportMutations,
     NotificationMutations,
     POMutations,

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -9,9 +9,9 @@ import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.errors import InvalidStateTransitionError, NotFoundError, ValidationError
+from app.errors import InvalidStateTransitionError, NotFoundError, RelayUnavailableError, ValidationError
 from app.repositories import buyer_repository, po_document_settings_repository, po_repository, user_repository
-from app.services import gp_idempotency, gp_po
+from app.services import gp_idempotency, gp_outbox_enqueue, gp_po
 from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
@@ -29,6 +29,7 @@ from .types import (
     POStatistics,
     PriorOrderAsForProduct,
     PurchaseOrder,
+    RegisterPOResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,24 @@ logger = logging.getLogger(__name__)
 def _load_po_type(po_id: uuid.UUID) -> PurchaseOrder:
     with SessionLocal() as session:
         return po_to_type(po_repository.reload_po(session, po_id))
+
+
+def _po_outbox_identity(po_id: uuid.UUID) -> tuple[uuid.UUID | None, str]:
+    """(project_id, label) for a queued register-PO write (#353 PR E).
+
+    project_id routes a terminal failure to a notification; a PO with no project yields None and the
+    worker falls back to the queue UI rather than inventing a placeholder project. The label is the
+    human line in that queue - a DRAFT being registered has no GP number yet (GP assigns it), so the
+    PO's own number, or its id, is the only stable handle. One row, two scalars, one round trip."""
+    from sqlalchemy import select
+
+    from app.models.purchase_order import PurchaseOrder as POModel
+
+    with SessionLocal() as session:
+        row = session.execute(select(POModel.project_id, POModel.po_number).where(POModel.id == po_id)).first()
+    project_id = row.project_id if row is not None else None
+    number = row.po_number if row is not None else None
+    return project_id, f"Register PO {number or po_id} in GP"
 
 
 def _resolve_line_manufacturers(session, project_id, line_items_data) -> list[str | None]:
@@ -315,7 +334,7 @@ class POMutations:
             return po_to_type(po_repository.reload_po(session, po.id))
 
     @strawberry.mutation
-    async def register_po_in_gp(self, info: strawberry.Info, input: RegisterPOInput) -> PurchaseOrder:
+    async def register_po_in_gp(self, info: strawberry.Info, input: RegisterPOInput) -> RegisterPOResult:
         """Register an imported DRAFT PO into GP (issue #175, the import-acceptance path; brokered
         server-side as of issue #199). Pushes the PO to GP via relay_call (create_po) BEFORE persisting
         anything, then maps the PO to the chosen GP vendor + cost code, replaces the draft's line items
@@ -350,7 +369,8 @@ class POMutations:
 
         state = await asyncio.to_thread(gp_idempotency.load, key)
         if state is not None and state.result_id is not None:
-            return await asyncio.to_thread(_load_po_type, uuid.UUID(state.result_id))
+            po = await asyncio.to_thread(_load_po_type, uuid.UUID(state.result_id))
+            return RegisterPOResult(queued=False, outbox_entry_id=None, purchase_order=po)
 
         payload = await asyncio.to_thread(
             _prepare_register_po,
@@ -366,13 +386,50 @@ class POMutations:
             trade_discount=input.trade_discount,
         )
 
+        persist_context = {
+            "po_id": str(pid),
+            "gp_vendor_id": input.gp_vendor_id,
+            "vendor_name_snapshot": input.gp_vendor_name,
+            "line_items_data": line_items_data,
+            "vendor_id": str(vendor_id) if vendor_id else None,
+            "cost_code": input.cost_code,
+            "buyer_id": input.buyer_id,
+            "shipping_cost": input.shipping_cost,
+            "tariff_amount": input.tariff_amount,
+        }
+
         if state is not None and state.relay_result is not None:
             gp_result = state.relay_result
         else:
-            gp_result = await relay_gateway.relay_call(input.gp_company, "create_po", payload)
+            try:
+                gp_result = await relay_gateway.relay_call(input.gp_company, "create_po", payload)
+            except RelayUnavailableError as e:
+                # #353 PR E: the relay is unreachable but the job never left the backend, so GP cannot
+                # have run it - queue it and tell the user it will post itself. A DISPATCHED failure
+                # is re-raised: GP may hold the write, and a blind retry would reserve a second PO
+                # number.
+                if not gp_outbox_enqueue.may_enqueue(e):
+                    raise
+                project_id, label = await asyncio.to_thread(_po_outbox_identity, pid)
+                entry_id = await asyncio.to_thread(
+                    gp_outbox_enqueue.enqueue,
+                    idempotency_key=key,
+                    op="register_po_in_gp",
+                    relay_op="create_po",
+                    company=input.gp_company,
+                    payload=payload,
+                    persist_context=persist_context,
+                    entity_key=f"po:{pid}",
+                    label=label,
+                    project_id=project_id,
+                    requested_by=auth["user_id"],
+                )
+                # The PO is still DRAFT; the list shows it as queued until the worker drains it.
+                po = await asyncio.to_thread(_load_po_type, pid)
+                return RegisterPOResult(queued=True, outbox_entry_id=strawberry.ID(entry_id), purchase_order=po)
             await asyncio.to_thread(gp_idempotency.record_relay_result, key, "register_po_in_gp", gp_result)
 
-        return await asyncio.to_thread(
+        po = await asyncio.to_thread(
             _persist_register_po,
             key=key,
             po_id=pid,
@@ -386,6 +443,7 @@ class POMutations:
             shipping_cost=input.shipping_cost,
             tariff_amount=input.tariff_amount,
         )
+        return RegisterPOResult(queued=False, outbox_entry_id=None, purchase_order=po)
 
     @strawberry.mutation
     def update_po(

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -9,6 +9,7 @@ import strawberry
 from .admin import AdminQueries
 from .buyer import BuyerQueries
 from .dashboard import DashboardQueries
+from .gp_outbox import GpOutboxQueries
 from .imports import ImportQueries
 from .notification import NotificationQueries
 from .po import POQueries
@@ -27,6 +28,7 @@ class Query(
     AdminQueries,
     BuyerQueries,
     DashboardQueries,
+    GpOutboxQueries,
     ImportQueries,
     NotificationQueries,
     POQueries,

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -10,6 +10,7 @@ from .enums import (
     Classification,
     DeficiencyResolution,
     DeficientItemSource,
+    GpOutboxStatus,
     HardwareItemState,
     LeafStatus,
     NotificationType,
@@ -1285,3 +1286,60 @@ class AdminStats:
     user_count: int
     hardware_item_count: int
     opening_count: int
+
+
+# --- GP write outbox (#353 PR E) ----------------------------------------------------------------------
+
+
+@strawberry.type
+class GpOutboxEntry:
+    """One queued GP write, for the admin queue and the pending chips on the PO lists."""
+
+    id: strawberry.ID
+    label: str
+    op: str
+    company: str
+    status: GpOutboxStatus
+    attempts: int
+    next_attempt_at: datetime
+    created_at: datetime
+    # Which PO this write is against, as `po:<uuid>` - the lists join on it client-side rather than
+    # exposing a per-row field on PurchaseOrder, which would be an N+1 on the All-Projects list.
+    entity_key: str
+    last_error: str | None = None
+    failure_kind: str | None = None
+
+
+@strawberry.type
+class GpOutboxSummary:
+    """Counts for the queue chip. Scalar aggregates only - this is polled by every open browser."""
+
+    pending: int
+    in_flight: int
+    failed: int
+    oldest_pending_at: datetime | None = None
+    # The most recent successful drain. The browser watches this to know a background drain changed
+    # data underneath whatever route it happens to be on.
+    last_drained_at: datetime | None = None
+
+
+@strawberry.type
+class RegisterPOResult:
+    """#353 PR E: registering a PO can now be ACCEPTED without reaching GP.
+
+    `queued` true means the relay was unreachable and the write is on the outbox; the returned PO is
+    still DRAFT and will advance itself when the queue drains. False is the old behaviour verbatim."""
+
+    queued: bool
+    purchase_order: PurchaseOrder
+    outbox_entry_id: strawberry.ID | None = None
+
+
+@strawberry.type
+class CreateReceiveResult:
+    """#353 PR E. `receiveRecord` is null when `queued` - the UC Nexus receive is persisted with the
+    GP write, so nothing is in inventory yet."""
+
+    queued: bool
+    receive_record: ReceiveRecord | None = None
+    outbox_entry_id: strawberry.ID | None = None

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -7,9 +7,10 @@ import strawberry
 
 from app.auth import require_user, resolve_display_name
 from app.database import SessionLocal
+from app.errors import RelayUnavailableError
 from app.repositories import warehouse as warehouse_repository
 from app.repositories import warehouse_admin_repository
-from app.services import gp_idempotency, gp_po
+from app.services import gp_idempotency, gp_outbox_enqueue, gp_po
 from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
@@ -38,6 +39,7 @@ from .types import (
     AuditLogEntry,
     BackOrderedItem,
     CancelPullRequestResult,
+    CreateReceiveResult,
     InventoryAvailability,
     InventoryHierarchyNode,
     InventoryItemDetail,
@@ -98,6 +100,21 @@ def _prepare_create_receive(*, po_id, received_by, line_items_data) -> tuple[str
         po_number=po_number, received_by=received_by, line_items=receipt_line_items
     )
     return gp_company, payload
+
+
+def _receive_outbox_identity(po_id: uuid.UUID) -> tuple[uuid.UUID | None, str]:
+    """(project_id, label) for a queued receive (#353 PR E). project_id routes a terminal failure to
+    a notification (None when the PO has no project - the worker then relies on the queue UI rather
+    than inventing a placeholder project); the label is the human line in that queue. One row."""
+    from sqlalchemy import select
+
+    from app.models.purchase_order import PurchaseOrder as POModel
+
+    with SessionLocal() as session:
+        row = session.execute(select(POModel.project_id, POModel.po_number).where(POModel.id == po_id)).first()
+    project_id = row.project_id if row is not None else None
+    number = row.po_number if row is not None else None
+    return project_id, f"Receive against PO {number or po_id}"
 
 
 def _persist_create_receive(*, key, po_id, received_by, line_items_data, warehouse_id, relay_result) -> ReceiveRecord:
@@ -540,7 +557,7 @@ class WarehouseQueries:
 class WarehouseMutations:
     # Receiving
     @strawberry.mutation
-    async def create_receive(self, info: strawberry.Info, input: CreateReceiveInput) -> ReceiveRecord:
+    async def create_receive(self, info: strawberry.Info, input: CreateReceiveInput) -> CreateReceiveResult:
         """Issue #199: GP-first, server-side. Posts the GP receipt via relay_call (create_receipt)
         BEFORE persisting the UC Nexus receive, and received_by is the acting UC Nexus user resolved
         from the Clerk token - not a client-supplied string, and not the relay's Windows account.
@@ -574,7 +591,8 @@ class WarehouseMutations:
 
         state = await asyncio.to_thread(gp_idempotency.load, key)
         if state is not None and state.result_id is not None:
-            return await asyncio.to_thread(_load_receive_type, uuid.UUID(state.result_id))
+            record = await asyncio.to_thread(_load_receive_type, uuid.UUID(state.result_id))
+            return CreateReceiveResult(queued=False, outbox_entry_id=None, receive_record=record)
 
         received_by = await asyncio.to_thread(resolve_display_name, user["user_id"])
         gp_company, payload = await asyncio.to_thread(
@@ -584,10 +602,48 @@ class WarehouseMutations:
         if state is not None and state.relay_result is not None:
             relay_result = state.relay_result
         else:
-            relay_result = await relay_gateway.relay_call(gp_company, "create_receipt", payload)
+            try:
+                relay_result = await relay_gateway.relay_call(gp_company, "create_receipt", payload)
+            except RelayUnavailableError as e:
+                # #353 PR E: the receipt never left the backend, so GP cannot have posted it - queue
+                # it rather than failing a warehouse user who has already counted the hardware. A
+                # DISPATCHED failure is re-raised: GP may hold the receipt, and a blind retry would
+                # double-count inventory.
+                if not gp_outbox_enqueue.may_enqueue(e):
+                    raise
+                project_id, label = await asyncio.to_thread(_receive_outbox_identity, po_id)
+                entry_id = await asyncio.to_thread(
+                    gp_outbox_enqueue.enqueue,
+                    idempotency_key=key,
+                    op="create_receive",
+                    relay_op="create_receipt",
+                    company=gp_company,
+                    payload=payload,
+                    persist_context={
+                        "po_id": str(po_id),
+                        "received_by": received_by,
+                        "warehouse_id": str(warehouse_id) if warehouse_id else None,
+                        "line_items_data": [
+                            {
+                                "po_line_item_id": str(li["po_line_item_id"]),
+                                "quantity_received": li["quantity_received"],
+                                "locations": li["locations"],
+                            }
+                            for li in line_items_data
+                        ],
+                    },
+                    # Same entity_key as register_po_in_gp so a receipt can never be drained ahead of
+                    # the registration of the PO it is against.
+                    entity_key=f"po:{po_id}",
+                    label=label,
+                    project_id=project_id,
+                    requested_by=user["user_id"],
+                )
+                # Nothing is in inventory yet - the persist is deferred with the GP write.
+                return CreateReceiveResult(queued=True, outbox_entry_id=strawberry.ID(entry_id), receive_record=None)
             await asyncio.to_thread(gp_idempotency.record_relay_result, key, "create_receive", relay_result)
 
-        return await asyncio.to_thread(
+        record = await asyncio.to_thread(
             _persist_create_receive,
             key=key,
             po_id=po_id,
@@ -596,6 +652,7 @@ class WarehouseMutations:
             warehouse_id=warehouse_id,
             relay_result=relay_result,
         )
+        return CreateReceiveResult(queued=False, outbox_entry_id=None, receive_record=record)
 
     # Pull Requests
     @strawberry.mutation

--- a/backend/app/services/gp_outbox_enqueue.py
+++ b/backend/app/services/gp_outbox_enqueue.py
@@ -1,0 +1,63 @@
+"""Enqueue-side helper shared by the two GP-first resolvers (#353 PR E).
+
+Kept out of `gp_outbox_worker` so the resolvers do not import the worker (and its lazy schema
+imports) just to queue a row, and out of the repository so the "which failures may be queued" rule
+lives in exactly one place rather than being restated at each call site."""
+
+import logging
+import uuid
+
+from app.database import SessionLocal
+from app.errors import RelayUnavailableError
+from app.repositories import gp_outbox_repository
+from app.services import gp_outbox_worker
+
+logger = logging.getLogger(__name__)
+
+
+def may_enqueue(error: RelayUnavailableError) -> bool:
+    """Whether this failure is safe to queue.
+
+    Only an UNDISPATCHED RelayUnavailableError qualifies: the job never left the backend, so GP
+    cannot have run it. A dispatched failure (the socket died with the job on the wire) and a timeout
+    are both ambiguous - GP may hold the write - and must surface to the user instead."""
+    return not error.dispatched
+
+
+def enqueue(
+    *,
+    idempotency_key: str,
+    op: str,
+    relay_op: str,
+    company: str,
+    payload: dict,
+    persist_context: dict,
+    entity_key: str,
+    label: str,
+    project_id: uuid.UUID | None = None,
+    requested_by: str | None = None,
+) -> str:
+    """Queue the write in its own session and return the outbox entry id (as a string).
+
+    Idempotent by `idempotency_key`: re-submitting the same user action while it is queued returns
+    the existing entry, so the user sees one queued item and GP will see one write."""
+    with SessionLocal() as session:
+        row = gp_outbox_repository.enqueue(
+            session,
+            idempotency_key=idempotency_key,
+            op=op,
+            relay_op=relay_op,
+            company=company,
+            payload=payload,
+            persist_context=persist_context,
+            entity_key=entity_key,
+            label=label,
+            project_id=project_id,
+            requested_by=requested_by,
+        )
+        entry_id = str(row.id)
+        session.commit()
+    logger.info("gp outbox: queued", extra={"op": op, "label": label, "entry_id": entry_id})
+    # The relay may have come back between the failure and this commit; a nudge costs nothing.
+    gp_outbox_worker.wake()
+    return entry_id

--- a/backend/app/services/gp_outbox_worker.py
+++ b/backend/app/services/gp_outbox_worker.py
@@ -1,0 +1,284 @@
+"""Background drainer for the GP write outbox (#353 PR E).
+
+Runs as a single asyncio task started from the FastAPI lifespan. Per row it runs the SAME pipeline
+the online resolver runs - idempotency short-circuit, relay_call, record the relay result in its own
+commit, persist - by rehydrating `persist_context` and calling the very `_persist_*` helper the
+resolver calls. There is deliberately no second persist implementation to drift.
+
+The handler imports those helpers INSIDE the function body: `app.schemas.*` imports services, so a
+module-level import here would create a services <-> schemas cycle."""
+
+import asyncio
+import logging
+import os
+import uuid
+from collections.abc import Callable
+
+from app.database import SessionLocal
+from app.errors import (
+    AppError,
+    RelayCallError,
+    RelayOpUnsupportedError,
+    RelayTimeoutError,
+    RelayUnavailableError,
+)
+from app.repositories import gp_outbox_repository
+from app.services import gp_idempotency
+from app.services.relay_gateway import gateway as relay_gateway
+
+logger = logging.getLogger(__name__)
+
+POLL_SECONDS = 5.0
+
+_wake_event: asyncio.Event | None = None
+
+
+def enabled() -> bool:
+    """Env kill switch, default on, so the worker can be stopped without a code deploy."""
+    return os.getenv("GP_OUTBOX_ENABLED", "true").lower() not in ("false", "0", "no")
+
+
+def wake() -> None:
+    """Nudge the loop out of its sleep. Called by /relay-link right after a successful try_register,
+    so a reconnect drains within milliseconds instead of up to POLL_SECONDS later."""
+    if _wake_event is not None:
+        try:
+            _wake_event.set()
+        except Exception:  # noqa: BLE001 - never let a wake-up break the caller's request path
+            logger.exception("gp outbox: failed to signal the worker")
+
+
+def _persist_register_po_from_context(context: dict, relay_result: dict, key: str) -> None:
+    from app.schemas.po import _persist_register_po
+
+    _persist_register_po(
+        key=key,
+        po_id=uuid.UUID(context["po_id"]),
+        gp_vendor_id=context["gp_vendor_id"],
+        vendor_name_snapshot=context.get("vendor_name_snapshot"),
+        gp_result=relay_result,
+        line_items_data=context["line_items_data"],
+        vendor_id=uuid.UUID(context["vendor_id"]) if context.get("vendor_id") else None,
+        cost_code=context.get("cost_code"),
+        buyer_id=context.get("buyer_id"),
+        shipping_cost=context.get("shipping_cost"),
+        tariff_amount=context.get("tariff_amount"),
+    )
+
+
+def _persist_create_receive_from_context(context: dict, relay_result: dict, key: str) -> None:
+    from app.schemas.warehouse import _persist_create_receive
+
+    line_items_data = [
+        {
+            "po_line_item_id": uuid.UUID(li["po_line_item_id"]),
+            "quantity_received": li["quantity_received"],
+            "locations": li["locations"],
+        }
+        for li in context["line_items_data"]
+    ]
+    _persist_create_receive(
+        key=key,
+        po_id=uuid.UUID(context["po_id"]),
+        received_by=context["received_by"],
+        line_items_data=line_items_data,
+        warehouse_id=uuid.UUID(context["warehouse_id"]) if context.get("warehouse_id") else None,
+        relay_result=relay_result,
+    )
+
+
+# op -> adapter. The adapters return the resolver's Strawberry DTO; the worker discards it.
+_HANDLERS: dict[str, Callable[[dict, dict, str], None]] = {
+    "register_po_in_gp": _persist_register_po_from_context,
+    "create_receive": _persist_create_receive_from_context,
+}
+
+
+def _notify_failure(row_id: uuid.UUID) -> None:
+    """Tell somebody a queued GP write has died for good.
+
+    `Notification.project_id` is NOT NULL, so a row without a project (a PO with no project attached)
+    gets no notification - deliberately, because inventing a placeholder project would put the signal
+    in front of the wrong people. Those rows are still visible in the queue UI and still counted on
+    the failed chip, which is the backstop."""
+    from app.models.enums import NotificationType
+    from app.services import notification_service
+
+    with SessionLocal() as session:
+        row = gp_outbox_repository.get_entry(session, row_id)
+        if row is None or row.project_id is None:
+            return
+        recipient = (
+            notification_service.PO_RECIPIENT_ROLE
+            if row.op == "register_po_in_gp"
+            else notification_service.WAREHOUSE_RECIPIENT_ROLE
+        )
+        notification_service.create_notification(
+            session,
+            project_id=row.project_id,
+            recipient_role=recipient,
+            notification_type=NotificationType.GP_WRITE_FAILED,
+            message=f"{row.label} could not be posted to GP: {row.last_error or 'unknown error'}",
+        )
+        session.commit()
+
+
+def _load_row(row_id: uuid.UUID):
+    with SessionLocal() as session:
+        return gp_outbox_repository.get_entry(session, row_id)
+
+
+def _finish(row_id: uuid.UUID, action: str, **kwargs) -> None:
+    with SessionLocal() as session:
+        row = gp_outbox_repository.get_entry(session, row_id)
+        if row is None:
+            return
+        getattr(gp_outbox_repository, action)(session, row, **kwargs)
+        session.commit()
+
+
+async def _drain_one(row_id: uuid.UUID) -> None:
+    """Run one claimed row all the way through, and record where it got to.
+
+    Mirrors the resolver exactly: a ledger that already holds `result_id` means the whole thing was
+    finished by someone else, and a ledger that already holds `relay_result` means GP has ALREADY
+    run - reusing it rather than calling again is what stops a queued retry from double-posting."""
+    row = await asyncio.to_thread(_load_row, row_id)
+    if row is None:
+        return
+    key, op, relay_op, company = row.idempotency_key, row.op, row.relay_op, row.company
+    payload, context, label = row.payload, row.persist_context, row.label
+
+    state = await asyncio.to_thread(gp_idempotency.load, key)
+    if state is not None and state.result_id is not None:
+        await asyncio.to_thread(_finish, row_id, "mark_succeeded")
+        return
+
+    try:
+        if state is not None and state.relay_result is not None:
+            relay_result = state.relay_result
+        else:
+            relay_result = await relay_gateway.relay_call(company, relay_op, payload)
+            await asyncio.to_thread(gp_idempotency.record_relay_result, key, op, relay_result)
+    except RelayUnavailableError as e:
+        if e.dispatched:
+            # The job was on the wire when the socket died: GP may hold the write. Retrying could
+            # duplicate it, so this needs a human who can look in GP.
+            await asyncio.to_thread(
+                _finish, row_id, "mark_failed", kind="ambiguous", error=str(e.message), error_code=e.code
+            )
+            await asyncio.to_thread(_notify_failure, row_id)
+            return
+        # Relay simply not there. Deliberately does NOT count against the attempt budget: a week-long
+        # outage must not poison the queue.
+        await asyncio.to_thread(
+            _finish,
+            row_id,
+            "mark_retry",
+            error=str(e.message),
+            error_code=e.code,
+            bump_attempts=False,
+            retry_in_seconds=POLL_SECONDS,
+        )
+        return
+    except RelayTimeoutError as e:
+        # Same ambiguity as a dispatched disconnect - the job reached the relay and we do not know
+        # what GP did with it.
+        await asyncio.to_thread(
+            _finish, row_id, "mark_failed", kind="ambiguous", error=str(e.message), error_code=e.code
+        )
+        await asyncio.to_thread(_notify_failure, row_id)
+        return
+    except RelayOpUnsupportedError as e:
+        # The relay is too old for this op. Retryable: PR D's auto-update poller will fix it.
+        await asyncio.to_thread(
+            _finish, row_id, "mark_retry", error=str(e.message), error_code=e.code, bump_attempts=True
+        )
+        await _fail_if_exhausted(row_id)
+        return
+    except RelayCallError as e:
+        # GP itself said no. Deterministic - retrying never helps.
+        await asyncio.to_thread(
+            _finish, row_id, "mark_failed", kind="gp_rejected", error=str(e.message), error_code=e.code
+        )
+        await asyncio.to_thread(_notify_failure, row_id)
+        return
+
+    handler = _HANDLERS.get(op)
+    if handler is None:
+        await asyncio.to_thread(
+            _finish, row_id, "mark_failed", kind="persist_failed", error=f"unknown outbox op {op!r}"
+        )
+        return
+
+    try:
+        await asyncio.to_thread(handler, context, relay_result, key)
+    except AppError as e:
+        # GP has already committed but the UC Nexus side will not take it (the PO left DRAFT, the
+        # receive is no longer eligible, ...). No retry can fix a state disagreement; a human must.
+        logger.exception("gp outbox: persist failed after GP committed", extra={"label": label})
+        await asyncio.to_thread(
+            _finish, row_id, "mark_failed", kind="persist_failed", error=str(e.message), error_code=e.code
+        )
+        await asyncio.to_thread(_notify_failure, row_id)
+        return
+    except Exception as e:  # noqa: BLE001 - a transient DB error should come back around
+        logger.exception("gp outbox: persist raised; will retry", extra={"label": label})
+        await asyncio.to_thread(_finish, row_id, "mark_retry", error=str(e), bump_attempts=True)
+        await _fail_if_exhausted(row_id)
+        return
+
+    await asyncio.to_thread(_finish, row_id, "mark_succeeded")
+    logger.info("gp outbox: drained", extra={"label": label, "op": op})
+
+
+async def _fail_if_exhausted(row_id: uuid.UUID) -> None:
+    row = await asyncio.to_thread(_load_row, row_id)
+    if row is None or row.attempts <= gp_outbox_repository.MAX_ATTEMPTS:
+        return
+    await asyncio.to_thread(
+        _finish,
+        row_id,
+        "mark_failed",
+        kind="exhausted",
+        error=row.last_error or "retry budget exhausted",
+        error_code=row.last_error_code,
+    )
+    await asyncio.to_thread(_notify_failure, row_id)
+
+
+def _claim(company: str) -> uuid.UUID | None:
+    with SessionLocal() as session:
+        row = gp_outbox_repository.claim_next(session, company)
+        row_id = row.id if row is not None else None
+        session.commit()
+    return row_id
+
+
+async def run_forever() -> None:
+    """The lifespan task. Every iteration is wrapped so no error can kill it - a dead worker is a
+    silently non-draining queue, which is worse than the failure it is trying to absorb."""
+    global _wake_event
+    _wake_event = asyncio.Event()
+    logger.info("gp outbox worker started")
+    while True:
+        try:
+            # No relay, or a relay for another company: nothing claimable, so do not even open a
+            # transaction. This is the steady state during an outage and must be cheap.
+            company = relay_gateway.company if relay_gateway.connected else None
+            if company is not None:
+                row_id = await asyncio.to_thread(_claim, company)
+                if row_id is not None:
+                    await _drain_one(row_id)
+                    continue  # keep draining while there is work
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.exception("gp outbox worker iteration failed")
+
+        try:
+            await asyncio.wait_for(_wake_event.wait(), timeout=POLL_SECONDS)
+        except TimeoutError:
+            pass
+        finally:
+            _wake_event.clear()

--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -120,10 +120,13 @@ class RelayGateway:
         return self._heartbeat_armed and self._unanswered_pings >= HEARTBEAT_MAX_MISSED
 
     def _fail_all(self, message: str) -> None:
+        # dispatched=True: every job in `_pending` was already sent to the relay, so GP may have run
+        # it and the reply was lost with the socket. The outbox (#353 PR E) must NOT queue these - a
+        # blind retry would post a second receipt or reserve a second PO number.
         pending, self._pending = self._pending, {}
         for future in pending.values():
             if not future.done():
-                future.set_exception(RelayUnavailableError(message))
+                future.set_exception(RelayUnavailableError(message, dispatched=True))
 
     def resolve(self, reply: dict) -> None:
         """Called by the /relay-link route's read loop with each {id, ok, result|error} reply."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,9 @@
 import asyncio
+import contextlib
 import inspect
 import logging
 from collections.abc import Callable
+from contextlib import asynccontextmanager
 from typing import Any
 
 import strawberry
@@ -18,7 +20,7 @@ from app.errors import AppError
 from app.repositories import relay_repository
 from app.schemas.mutations import Mutation
 from app.schemas.queries import Query
-from app.services import relay_adopt
+from app.services import gp_outbox_worker, relay_adopt
 from app.services.relay_gateway import HEARTBEAT_INTERVAL_SECONDS
 from app.services.relay_gateway import gateway as relay_gateway
 
@@ -76,7 +78,27 @@ schema = strawberry.Schema(
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)
 
-app = FastAPI(title="UC Nexus - Hardware Management System")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Own the background GP outbox drainer (#353 PR E).
+
+    Started here rather than lazily on first use so a queue that filled during a deploy starts
+    draining as soon as the new container is up, with nobody having to visit a page. Under
+    TestClient(app) this runs too, and is harmless: with no relay registered the loop never queries."""
+    worker: asyncio.Task | None = None
+    if gp_outbox_worker.enabled():
+        worker = asyncio.create_task(gp_outbox_worker.run_forever())
+    try:
+        yield
+    finally:
+        if worker is not None:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
+
+
+app = FastAPI(title="UC Nexus - Hardware Management System", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -241,6 +263,9 @@ async def relay_link(websocket: WebSocket):
     if not relay_gateway.try_register(company, websocket):
         await websocket.close(code=4409)
         return
+    # A relay just came back: drain anything that queued while it was gone, now, rather than up to a
+    # poll interval later (#353 PR E).
+    gp_outbox_worker.wake()
     try:
         await _serve_relay_link(websocket, require_hello=adopted)
     except WebSocketDisconnect:

--- a/backend/tests/test_gp_outbox.py
+++ b/backend/tests/test_gp_outbox.py
@@ -1,0 +1,138 @@
+"""The GP write outbox table and its claim rules (#353 PR E).
+
+The claim query is the part with real consequences: per-entity FIFO is what stops a queued receipt
+being drained ahead of the registration of the PO it is against (which would fail, because the PO is
+not in GP yet), and not counting a relay-down retry against the attempt budget is what stops a long
+outage from failing every queued write the moment it becomes deliverable again."""
+
+import uuid
+from datetime import datetime, timedelta
+
+from app.repositories import gp_outbox_repository
+
+
+def _enqueue(session, *, key=None, entity_key="po:1", company="TUBC", op="create_receive", label="Receive"):
+    return gp_outbox_repository.enqueue(
+        session,
+        idempotency_key=key or str(uuid.uuid4()),
+        op=op,
+        relay_op="create_receipt" if op == "create_receive" else "create_po",
+        company=company,
+        payload={"po_number": "0000123"},
+        persist_context={"po_id": str(uuid.uuid4())},
+        entity_key=entity_key,
+        label=label,
+    )
+
+
+def test_enqueue_twice_under_one_key_returns_the_same_row(db_session):
+    # This is what makes a resubmit-while-queued a no-op instead of a second GP write.
+    key = str(uuid.uuid4())
+    first = _enqueue(db_session, key=key)
+    second = _enqueue(db_session, key=key)
+    assert first.id == second.id
+
+
+def test_claim_next_takes_the_oldest_due_row_and_marks_it_in_flight(db_session):
+    older = _enqueue(db_session, entity_key="po:a")
+    older.created_at = datetime.utcnow() - timedelta(minutes=5)
+    newer = _enqueue(db_session, entity_key="po:b")
+    newer.created_at = datetime.utcnow()
+    db_session.flush()
+
+    claimed = gp_outbox_repository.claim_next(db_session, "TUBC")
+    assert claimed is not None
+    assert claimed.id == older.id
+    assert claimed.status == "IN_FLIGHT"
+
+
+def test_claim_next_respects_per_entity_fifo(db_session):
+    # Two writes against the SAME PO: the second must not be claimable while the first is unfinished.
+    first = _enqueue(db_session, entity_key="po:same", op="register_po_in_gp", label="Register")
+    first.created_at = datetime.utcnow() - timedelta(minutes=5)
+    second = _enqueue(db_session, entity_key="po:same", label="Receive")
+    second.created_at = datetime.utcnow()
+    db_session.flush()
+
+    claimed = gp_outbox_repository.claim_next(db_session, "TUBC")
+    assert claimed is not None and claimed.id == first.id
+
+    # first is now IN_FLIGHT, so the receipt behind it is still blocked.
+    assert gp_outbox_repository.claim_next(db_session, "TUBC") is None
+
+    gp_outbox_repository.mark_succeeded(db_session, first)
+    unblocked = gp_outbox_repository.claim_next(db_session, "TUBC")
+    assert unblocked is not None and unblocked.id == second.id
+
+
+def test_claim_next_skips_another_companys_rows(db_session):
+    _enqueue(db_session, company="TUCSH", entity_key="po:other")
+    assert gp_outbox_repository.claim_next(db_session, "TUBC") is None
+
+
+def test_claim_next_respects_next_attempt_at(db_session):
+    row = _enqueue(db_session, entity_key="po:later")
+    row.next_attempt_at = datetime.utcnow() + timedelta(minutes=10)
+    db_session.flush()
+    assert gp_outbox_repository.claim_next(db_session, "TUBC") is None
+
+
+def test_mark_retry_without_bumping_attempts_leaves_the_budget_alone(db_session):
+    # "The relay is still down" is not a failure of this row. Counting it would let a week-long
+    # outage exhaust every queued write's budget.
+    row = _enqueue(db_session, entity_key="po:retry")
+    gp_outbox_repository.mark_retry(db_session, row, error="relay down", bump_attempts=False)
+    assert row.attempts == 0
+    assert row.status == "PENDING"
+
+    gp_outbox_repository.mark_retry(db_session, row, error="transient", bump_attempts=True)
+    assert row.attempts == 1
+
+
+def test_mark_failed_removes_the_row_from_the_claimable_set(db_session):
+    row = _enqueue(db_session, entity_key="po:dead")
+    gp_outbox_repository.mark_failed(db_session, row, kind="gp_rejected", error="eConnect said no")
+    assert row.status == "FAILED"
+    assert gp_outbox_repository.claim_next(db_session, "TUBC") is None
+
+
+def test_summary_counts_by_status(db_session):
+    pending = _enqueue(db_session, entity_key="po:s1")
+    failed = _enqueue(db_session, entity_key="po:s2")
+    gp_outbox_repository.mark_failed(db_session, failed, kind="gp_rejected", error="no")
+    done = _enqueue(db_session, entity_key="po:s3")
+    gp_outbox_repository.mark_succeeded(db_session, done)
+
+    data = gp_outbox_repository.summary(db_session)
+    assert data["pending"] >= 1
+    assert data["failed"] >= 1
+    assert data["oldest_pending_at"] is not None
+    assert data["last_drained_at"] is not None
+    assert pending.status == "PENDING"
+
+
+def test_retry_entry_resets_the_attempt_budget_and_requeues(db_session):
+    row = _enqueue(db_session, entity_key="po:manual")
+    row.attempts = 5
+    gp_outbox_repository.mark_failed(db_session, row, kind="exhausted", error="gave up")
+
+    requeued = gp_outbox_repository.retry_entry(db_session, row.id)
+    assert requeued is not None
+    assert requeued.status == "PENDING"
+    assert requeued.attempts == 0
+    assert requeued.failure_kind is None
+
+
+def test_cancel_entry_refuses_a_row_that_is_on_the_wire(db_session):
+    # Cancelling an IN_FLIGHT row would leave the worker writing to a row a human believes is dead.
+    row = _enqueue(db_session, entity_key="po:inflight")
+    claimed = gp_outbox_repository.claim_next(db_session, "TUBC")
+    assert claimed is not None and claimed.id == row.id
+    assert gp_outbox_repository.cancel_entry(db_session, row.id) is None
+
+
+def test_cancel_entry_abandons_a_pending_row(db_session):
+    row = _enqueue(db_session, entity_key="po:abandon")
+    cancelled = gp_outbox_repository.cancel_entry(db_session, row.id)
+    assert cancelled is not None and cancelled.status == "CANCELLED"
+    assert gp_outbox_repository.claim_next(db_session, "TUBC") is None

--- a/backend/tests/test_gp_outbox_enqueue.py
+++ b/backend/tests/test_gp_outbox_enqueue.py
@@ -1,0 +1,46 @@
+"""Which relay failures may be queued (#353 PR E).
+
+One bit decides whether a failed GP write is safe to retry automatically, and getting it wrong posts
+a duplicate receipt into GP. It is worth a test of its own."""
+
+from app.errors import RelayUnavailableError
+from app.services import gp_outbox_enqueue
+from app.services.relay_gateway import RelayGateway
+
+
+def test_an_undispatched_failure_may_be_queued():
+    # No socket / wrong company / send failure: the job never left the backend, so GP cannot have run it.
+    assert gp_outbox_enqueue.may_enqueue(RelayUnavailableError("no relay is currently connected")) is True
+    assert gp_outbox_enqueue.may_enqueue(RelayUnavailableError("wrong company", dispatched=False)) is True
+
+
+def test_a_dispatched_failure_may_not_be_queued():
+    # The job was on the wire when the socket died: GP may have committed and the reply was lost.
+    assert gp_outbox_enqueue.may_enqueue(RelayUnavailableError("relay disconnected", dispatched=True)) is False
+
+
+def test_the_gateway_marks_a_lost_in_flight_job_as_dispatched():
+    """`_fail_all` runs when a socket with jobs on it disconnects. Every one of those futures must
+    carry dispatched=True, or the outbox would queue writes GP may already hold."""
+    import asyncio
+
+    async def run():
+        gateway = RelayGateway()
+        future = asyncio.get_running_loop().create_future()
+        gateway._pending["job-1"] = future
+        gateway._fail_all("relay disconnected")
+        with_error = None
+        try:
+            await future
+        except RelayUnavailableError as e:
+            with_error = e
+        assert with_error is not None
+        assert with_error.dispatched is True
+
+    asyncio.run(run())
+
+
+def test_a_plain_unavailable_error_defaults_to_not_dispatched():
+    # The default matters: relay_call raises bare RelayUnavailableError() for the no-socket case,
+    # which is exactly the case the outbox exists to absorb.
+    assert RelayUnavailableError().dispatched is False

--- a/backend/tests/test_gp_outbox_worker.py
+++ b/backend/tests/test_gp_outbox_worker.py
@@ -1,0 +1,209 @@
+"""The outbox drainer's failure taxonomy (#353 PR E).
+
+**Never touches GP.** `relay_gateway.relay_call` is stubbed in every test here, which is the same
+rule the online GP tests follow.
+
+The classification is the whole point of the worker: which failures may be retried automatically,
+which must stop and wait for a human, and which must never count against the retry budget. Getting
+`ambiguous` wrong means an automatic retry posts a second GP receipt."""
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.errors import RelayCallError, RelayTimeoutError, RelayUnavailableError
+from app.repositories import gp_outbox_repository
+from app.services import gp_outbox_worker
+
+
+def _enqueue_committed(op: str = "create_receive", company: str = "TUBC") -> tuple[uuid.UUID, str]:
+    """The worker opens its own sessions, so the row has to be committed, not just flushed."""
+    from app.database import SessionLocal
+
+    key = str(uuid.uuid4())
+    with SessionLocal() as session:
+        row = gp_outbox_repository.enqueue(
+            session,
+            idempotency_key=key,
+            op=op,
+            relay_op="create_receipt" if op == "create_receive" else "create_po",
+            company=company,
+            payload={"po_number": "0000123"},
+            persist_context={"po_id": str(uuid.uuid4())},
+            entity_key=f"po:{uuid.uuid4()}",
+            label="Receive against PO 0000123",
+        )
+        row_id = row.id
+        session.commit()
+    return row_id, key
+
+
+def _delete(row_id: uuid.UUID) -> None:
+    from app.database import SessionLocal
+    from app.models.gp_outbox import GpWriteOutbox
+
+    with SessionLocal() as session:
+        row = session.get(GpWriteOutbox, row_id)
+        if row is not None:
+            session.delete(row)
+            session.commit()
+
+
+def _read(row_id: uuid.UUID):
+    from app.database import SessionLocal
+
+    with SessionLocal() as session:
+        row = gp_outbox_repository.get_entry(session, row_id)
+        if row is None:
+            return None
+        return {
+            "status": row.status,
+            "attempts": row.attempts,
+            "failure_kind": row.failure_kind,
+            "last_error": row.last_error,
+        }
+
+
+def _stub_relay(monkeypatch, result=None, raises=None, calls=None):
+    async def _call(company, op, payload=None, timeout=30.0):
+        if calls is not None:
+            calls.append((company, op))
+        if raises is not None:
+            raise raises
+        return result
+
+    monkeypatch.setattr(gp_outbox_worker.relay_gateway, "relay_call", _call)
+
+
+def _stub_persist(monkeypatch, raises=None, seen=None):
+    def _handler(context, relay_result, key):
+        if seen is not None:
+            seen.append((context, relay_result, key))
+        if raises is not None:
+            raise raises
+
+    monkeypatch.setitem(gp_outbox_worker._HANDLERS, "create_receive", _handler)
+
+
+def test_a_relay_down_row_stays_pending_and_does_not_burn_an_attempt(_migrate_database, monkeypatch):
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, raises=RelayUnavailableError("no relay", dispatched=False))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        state = _read(row_id)
+        assert state["status"] == "PENDING"
+        assert state["attempts"] == 0  # a week-long outage must not poison the queue
+    finally:
+        _delete(row_id)
+
+
+def test_a_dispatched_disconnect_fails_as_ambiguous_and_is_never_retried(_migrate_database, monkeypatch):
+    # The job was already on the wire: GP may hold the write, so an automatic retry could double-post.
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, raises=RelayUnavailableError("relay disconnected", dispatched=True))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        state = _read(row_id)
+        assert state["status"] == "FAILED"
+        assert state["failure_kind"] == "ambiguous"
+    finally:
+        _delete(row_id)
+
+
+def test_a_timeout_fails_as_ambiguous(_migrate_database, monkeypatch):
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, raises=RelayTimeoutError("relay did not answer"))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        assert _read(row_id)["failure_kind"] == "ambiguous"
+    finally:
+        _delete(row_id)
+
+
+def test_a_gp_rejection_fails_as_gp_rejected(_migrate_database, monkeypatch):
+    # eConnect said no. Deterministic: retrying never helps.
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, raises=RelayCallError("eConnect rejected the receipt", detail={"error": "x"}))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        state = _read(row_id)
+        assert state["status"] == "FAILED"
+        assert state["failure_kind"] == "gp_rejected"
+    finally:
+        _delete(row_id)
+
+
+def test_a_successful_drain_calls_the_persist_helper_and_marks_succeeded(_migrate_database, monkeypatch):
+    row_id, key = _enqueue_committed()
+    try:
+        seen: list = []
+        _stub_relay(monkeypatch, result={"receipt": "R1"})
+        _stub_persist(monkeypatch, seen=seen)
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        assert _read(row_id)["status"] == "SUCCEEDED"
+        # The worker rehydrates persist_context and hands it to the SAME helper the resolver uses.
+        assert len(seen) == 1
+        assert seen[0][1] == {"receipt": "R1"}
+        assert seen[0][2] == key
+    finally:
+        _delete(row_id)
+
+
+def test_a_ledger_that_already_holds_a_relay_result_skips_the_relay_call(_migrate_database, monkeypatch):
+    # GP has already run for this key. Calling again would post a second receipt.
+    row_id, key = _enqueue_committed()
+    try:
+        from app.services import gp_idempotency
+
+        gp_idempotency.record_relay_result(key, "create_receive", {"receipt": "already"})
+        calls: list = []
+        _stub_relay(monkeypatch, result={"receipt": "should-not-happen"}, calls=calls)
+        _stub_persist(monkeypatch)
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        assert calls == []
+        assert _read(row_id)["status"] == "SUCCEEDED"
+    finally:
+        _delete(row_id)
+
+
+def test_a_persist_that_raises_an_app_error_fails_as_persist_failed(_migrate_database, monkeypatch):
+    # GP committed but UC Nexus will not take it (the PO left DRAFT, the receive is no longer
+    # eligible). No retry can fix a state disagreement.
+    from app.errors import InvalidStateTransitionError
+
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, result={"receipt": "R1"})
+        _stub_persist(monkeypatch, raises=InvalidStateTransitionError("PO is no longer a draft"))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        state = _read(row_id)
+        assert state["status"] == "FAILED"
+        assert state["failure_kind"] == "persist_failed"
+    finally:
+        _delete(row_id)
+
+
+def test_a_transient_persist_error_is_retried(_migrate_database, monkeypatch):
+    row_id, _key = _enqueue_committed()
+    try:
+        _stub_relay(monkeypatch, result={"receipt": "R1"})
+        _stub_persist(monkeypatch, raises=RuntimeError("connection reset"))
+        asyncio.run(gp_outbox_worker._drain_one(row_id))
+        state = _read(row_id)
+        assert state["status"] == "PENDING"
+        assert state["attempts"] == 1
+    finally:
+        _delete(row_id)
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [("true", True), ("1", True), ("", True), ("false", False), ("0", False), ("no", False)],
+)
+def test_the_worker_can_be_disabled_without_a_deploy(monkeypatch, env, expected):
+    if env:
+        monkeypatch.setenv("GP_OUTBOX_ENABLED", env)
+    else:
+        monkeypatch.delenv("GP_OUTBOX_ENABLED", raising=False)
+    assert gp_outbox_worker.enabled() is expected

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -19,10 +19,12 @@ import uuid
 
 import pytest
 
+from app.schemas import gp_outbox as gp_outbox_module
 from app.schemas import relay as relay_module
 from app.schemas import shop_assembly as shop_assembly_module
 from app.schemas import stock as stock_module
 from app.schemas.enums import DeficiencyResolution
+from app.schemas.gp_outbox import GpOutboxMutations, GpOutboxQueries
 from app.schemas.inputs import (
     AssignOpeningsInput,
     CompleteOpeningInput,
@@ -161,6 +163,24 @@ _ADMIN_GATED = [
     ("relayAdoptWindow", relay_module, lambda: RelayQueries().relay_adopt_window(FakeInfo())),
     ("armRelayAdopt", relay_module, lambda: RelayMutations().arm_relay_adopt(FakeInfo(), _id())),
     ("disarmRelayAdopt", relay_module, lambda: RelayMutations().disarm_relay_adopt(FakeInfo())),
+    # #353 PR E: retrying an `ambiguous` queued write can duplicate a GP posting, and cancelling one
+    # abandons work somebody has already done. Both are admin-only.
+    (
+        "retryGpOutboxEntry",
+        gp_outbox_module,
+        lambda: GpOutboxMutations().retry_gp_outbox_entry(FakeInfo(), _id()),
+    ),
+    (
+        "cancelGpOutboxEntry",
+        gp_outbox_module,
+        lambda: GpOutboxMutations().cancel_gp_outbox_entry(FakeInfo(), _id()),
+    ),
+]
+
+# Any signed-in user; the PO and receiving lists read the queue to show pending chips.
+_OUTBOX_USER_GATED = [
+    ("gpOutboxSummary", gp_outbox_module, lambda: GpOutboxQueries().gp_outbox_summary(FakeInfo())),
+    ("gpOutbox", gp_outbox_module, lambda: GpOutboxQueries().gp_outbox(FakeInfo())),
 ]
 
 
@@ -181,6 +201,17 @@ def test_resolver_requires_an_admin(label, module, call, monkeypatch):
         raise _GateReached(label)
 
     monkeypatch.setattr(module, "require_admin", _gate)
+
+    with pytest.raises(_GateReached):
+        call()
+
+
+@pytest.mark.parametrize("label, module, call", _OUTBOX_USER_GATED, ids=[row[0] for row in _OUTBOX_USER_GATED])
+def test_outbox_read_requires_a_signed_in_user(label, module, call, monkeypatch):
+    def _gate(info):
+        raise _GateReached(label)
+
+    monkeypatch.setattr(module, "require_user", _gate)
 
     with pytest.raises(_GateReached):
         call()

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -20,6 +20,8 @@ import { useColorScheme } from '@mui/material/styles';
 import { UserButton } from '@clerk/clerk-react';
 import { useCart } from '../contexts/CartContext';
 import NotificationBell from './NotificationBell';
+import GpQueueChip from '../relay/GpQueueChip';
+import GpOutboxWatcher from '../relay/GpOutboxWatcher';
 import ConfirmDialog from './ConfirmDialog';
 import Sidebar from './Sidebar';
 
@@ -97,6 +99,12 @@ export default function AppLayout() {
             </IconButton>
           )}
 
+          {/* #353 PR E: only renders when the GP write queue is non-empty, so the bar is unchanged
+              in the normal case. */}
+          <Box sx={{ mr: 1 }}>
+            <GpQueueChip />
+          </Box>
+
           <NotificationBell />
 
           <IconButton
@@ -148,6 +156,10 @@ export default function AppLayout() {
           </Breadcrumbs>
         </Box>
       )}
+
+      {/* Renders nothing; watches for a background GP-outbox drain and evicts what it invalidates,
+          which is the browser's only signal that a queued write posted itself (#353 PR E). */}
+      <GpOutboxWatcher />
 
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Outlet />

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -373,3 +373,32 @@ export const DELETE_BUYER_ASSIGNMENT = gql`
     deleteBuyerAssignment(buyerId: $buyerId)
   }
 `;
+
+// GP write queue admin actions (#353 PR E). Both are admin-gated on the backend; retrying an
+// `ambiguous` entry is genuinely dangerous (GP may already hold the write), which is why the UI
+// puts it behind a ConfirmDialog that says to check GP first.
+export const RETRY_GP_OUTBOX_ENTRY = gql`
+  mutation RetryGpOutboxEntry($id: ID!) {
+    retryGpOutboxEntry(id: $id) {
+      id
+      status
+      attempts
+      failureKind
+      lastError
+      nextAttemptAt
+    }
+  }
+`;
+
+export const CANCEL_GP_OUTBOX_ENTRY = gql`
+  mutation CancelGpOutboxEntry($id: ID!) {
+    cancelGpOutboxEntry(id: $id) {
+      id
+      status
+      attempts
+      failureKind
+      lastError
+      nextAttemptAt
+    }
+  }
+`;

--- a/frontend/src/graphql/po.ts
+++ b/frontend/src/graphql/po.ts
@@ -314,19 +314,26 @@ export const CANCEL_PO = gql`
 // Register an imported Draft PO into GP (issue #175). Called only after the relay /po push succeeds:
 // stamps GP's PO number + company, maps the chosen GP vendor + cost code, replaces the line items with
 // the pushed set, and advances Draft -> GP-Registered.
+// #353 PR E: the result is now a wrapper. `queued` true means the GP relay was unreachable and the
+// registration is on the durable outbox - the PO comes back still DRAFT and advances itself when the
+// queue drains, so the caller must not treat it as registered.
 export const REGISTER_PO_IN_GP = gql`
   mutation RegisterPoInGp($input: RegisterPOInput!) {
     registerPoInGp(input: $input) {
-      id
-      poNumber
-      status
-      gpCompany
-      costCode
-      gpVendorId
-      vendorNameSnapshot
-      vendor {
+      queued
+      outboxEntryId
+      purchaseOrder {
         id
-        name
+        poNumber
+        status
+        gpCompany
+        costCode
+        gpVendorId
+        vendorNameSnapshot
+        vendor {
+          id
+          name
+        }
       }
     }
   }

--- a/frontend/src/graphql/refetch.ts
+++ b/frontend/src/graphql/refetch.ts
@@ -179,3 +179,27 @@ export const PULL_CANCEL_STALE_ROOT_FIELDS = [
   // its history (#344), which is the reading that stops it looking like it was never accepted.
   ...PIPELINE_STALE_ROOT_FIELDS,
 ];
+
+// What a background GP-outbox drain invalidates (#353 PR E). A queued receive or PO registration
+// lands minutes or hours after the user submitted it, while the browser is sitting on an arbitrary
+// route - which is precisely the case `refetchQueries` cannot reach, since it only touches mounted
+// instances of queries it can name.
+//
+// Eviction-only, and deliberately nothing paired to refetch by name: pairing an evict with a refetch
+// is the double-run this whole file exists to prevent (see the disjointness note above). The
+// GpOutboxWatcher evicts these when `lastDrainedAt` advances, and whichever watchers are mounted
+// repair their own incomplete cache diffs.
+//
+// The set is "everything a receive or a PO registration changes": the PO lists and the PO's own
+// detail/receiving view (status moves DRAFT -> GP_REGISTERED, received quantities move), the recent
+// receives feed, and the warehouse inventory reads that a drained receipt has just added stock to.
+export const GP_OUTBOX_DRAINED_STALE_ROOT_FIELDS = [
+  'purchaseOrders',
+  'purchaseOrder',
+  'poReceivingDetails',
+  'recentReceiveRecords',
+  'warehouseDashboard',
+  'inventoryHierarchy',
+  'inventoryByVendor',
+  'projectInventoryAvailability',
+];

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -61,6 +61,38 @@ export const GET_RELAY_STATUS = gql`
   }
 `;
 
+// The GP write queue (#353 PR E). The summary is polled by the queue chip; the list is read by the
+// admin queue table and by the PO lists, which join entries onto rows client-side on `entityKey`.
+export const GET_GP_OUTBOX_SUMMARY = gql`
+  query GetGpOutboxSummary {
+    gpOutboxSummary {
+      pending
+      inFlight
+      failed
+      oldestPendingAt
+      lastDrainedAt
+    }
+  }
+`;
+
+export const GET_GP_OUTBOX = gql`
+  query GetGpOutbox($status: GpOutboxStatus, $limit: Int) {
+    gpOutbox(status: $status, limit: $limit) {
+      id
+      label
+      op
+      company
+      status
+      attempts
+      nextAttemptAt
+      lastError
+      failureKind
+      entityKey
+      createdAt
+    }
+  }
+`;
+
 export const GET_WAREHOUSES = gql`
   query GetWarehouses($includeInactive: Boolean) {
     warehouses(includeInactive: $includeInactive) {

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -511,22 +511,29 @@ export const ADJUST_INVENTORY_QUANTITY = gql`
   }
 `;
 
+// #353 PR E: the result is now a wrapper. `queued` true means the GP relay was unreachable and the
+// receipt is on the durable outbox - `receiveRecord` is null because the UC Nexus receive is
+// persisted together with the GP write, so nothing is in inventory yet.
 export const CREATE_RECEIVE = gql`
   mutation CreateReceive($input: CreateReceiveInput!) {
     createReceive(input: $input) {
-      id
-      poId
-      receivedAt
-      receivedBy
-      createdAt
-      lineItems {
+      queued
+      outboxEntryId
+      receiveRecord {
         id
-        receiveRecordId
-        poLineItemId
-        hardwareCategory
-        productCode
-        quantityReceived
+        poId
+        receivedAt
+        receivedBy
         createdAt
+        lineItems {
+          id
+          receiveRecordId
+          poLineItemId
+          hardwareCategory
+          productCode
+          quantityReceived
+          createdAt
+        }
       }
     }
   }

--- a/frontend/src/modules/admin/GpWriteQueuePanel.tsx
+++ b/frontend/src/modules/admin/GpWriteQueuePanel.tsx
@@ -1,0 +1,186 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { GET_GP_OUTBOX, GET_GP_OUTBOX_SUMMARY } from '../../graphql/shared';
+import { RETRY_GP_OUTBOX_ENTRY, CANCEL_GP_OUTBOX_ENTRY } from '../../graphql/admin';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useToast } from '../../components/Toast';
+
+interface OutboxEntry {
+  id: string;
+  label: string;
+  op: string;
+  company: string;
+  status: string;
+  attempts: number;
+  nextAttemptAt: string;
+  lastError: string | null;
+  failureKind: string | null;
+  entityKey: string;
+  createdAt: string;
+}
+
+function fmtDate(v: string | null | undefined): string {
+  return v ? new Date(v).toLocaleString() : '—';
+}
+
+const STATUS_COLOR: Record<string, 'default' | 'warning' | 'success' | 'error'> = {
+  PENDING: 'warning',
+  IN_FLIGHT: 'warning',
+  SUCCEEDED: 'success',
+  FAILED: 'error',
+  CANCELLED: 'default',
+};
+
+// An `ambiguous` write reached the relay and we do not know what GP did with it. Retrying it can
+// genuinely create a duplicate receipt or a second PO number, so the confirm text has to say so -
+// the backend cannot know, and must not pretend to.
+const AMBIGUOUS_RETRY_WARNING =
+  'This write may already have posted in GP. Retrying could create a duplicate. Check GP first.';
+const NORMAL_RETRY_WARNING =
+  'This puts the write back on the queue with a fresh attempt budget. It will be sent as soon as the GP relay is connected.';
+
+export default function GpWriteQueuePanel() {
+  const { showToast } = useToast();
+  const [retryTarget, setRetryTarget] = useState<OutboxEntry | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<OutboxEntry | null>(null);
+
+  const { data, loading } = useQuery<{ gpOutbox: OutboxEntry[] }>(GET_GP_OUTBOX, {
+    fetchPolicy: 'cache-and-network',
+    // Long enough not to be chatty, short enough that a drain shows up while an admin is watching.
+    pollInterval: 15_000,
+  });
+  const entries = useMemo(() => data?.gpOutbox ?? [], [data]);
+
+  const refetchAfterAction = [{ query: GET_GP_OUTBOX }, { query: GET_GP_OUTBOX_SUMMARY }];
+
+  const [retryEntry, { loading: retrying }] = useMutation(RETRY_GP_OUTBOX_ENTRY, {
+    refetchQueries: refetchAfterAction,
+    onCompleted: () => {
+      setRetryTarget(null);
+      showToast('Queued for retry', 'success');
+    },
+    onError: (err) => {
+      setRetryTarget(null);
+      showToast(err.message, 'error');
+    },
+  });
+
+  const [cancelEntry, { loading: cancelling }] = useMutation(CANCEL_GP_OUTBOX_ENTRY, {
+    refetchQueries: refetchAfterAction,
+    onCompleted: () => {
+      setCancelTarget(null);
+      showToast('Queue entry cancelled', 'success');
+    },
+    onError: (err) => {
+      setCancelTarget(null);
+      showToast(err.message, 'error');
+    },
+  });
+
+  const columns: GridColDef[] = useMemo(
+    () => [
+      { field: 'label', headerName: 'Write', flex: 1, minWidth: 220 },
+      { field: 'company', headerName: 'Company', width: 100 },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 120,
+        renderCell: (p) => (
+          <Chip size="small" label={p.row.status} color={STATUS_COLOR[p.row.status] ?? 'default'} />
+        ),
+      },
+      { field: 'attempts', headerName: 'Tries', width: 80 },
+      {
+        field: 'failureKind',
+        headerName: 'Failure',
+        width: 130,
+        valueFormatter: (v: string | null) => v ?? '—',
+      },
+      { field: 'lastError', headerName: 'Last error', flex: 1, minWidth: 220, valueFormatter: (v: string | null) => v ?? '—' },
+      {
+        field: 'nextAttemptAt',
+        headerName: 'Next attempt',
+        flex: 1,
+        minWidth: 170,
+        valueFormatter: (v: string) => fmtDate(v),
+      },
+      { field: 'createdAt', headerName: 'Queued at', flex: 1, minWidth: 170, valueFormatter: (v: string) => fmtDate(v) },
+      {
+        field: 'actions',
+        headerName: 'Actions',
+        width: 170,
+        sortable: false,
+        filterable: false,
+        renderCell: (p) => {
+          const row = p.row as OutboxEntry;
+          const canRetry = row.status === 'FAILED' || row.status === 'CANCELLED';
+          const canCancel = row.status === 'PENDING' || row.status === 'FAILED';
+          return (
+            <Stack direction="row" spacing={1}>
+              <Button size="small" disabled={!canRetry} onClick={() => setRetryTarget(row)}>
+                Retry
+              </Button>
+              <Button size="small" color="error" disabled={!canCancel} onClick={() => setCancelTarget(row)}>
+                Cancel
+              </Button>
+            </Stack>
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  const handleRetry = useCallback(() => {
+    if (retryTarget) retryEntry({ variables: { id: retryTarget.id } });
+  }, [retryTarget, retryEntry]);
+
+  const handleCancel = useCallback(() => {
+    if (cancelTarget) cancelEntry({ variables: { id: cancelTarget.id } });
+  }, [cancelTarget, cancelEntry]);
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        GP write queue
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Receives and PO registrations that were accepted while the GP relay was unreachable. These post
+        themselves when it reconnects; only a failed entry needs a person.
+      </Typography>
+
+      <DataGrid
+        rows={entries}
+        columns={columns}
+        loading={loading}
+        autoHeight
+        // A handful of rows in the normal case, and the row actions must always be reachable - see
+        // the same note on the installs grid.
+        disableVirtualization
+        disableRowSelectionOnClick
+        pageSizeOptions={[10, 25, 50]}
+        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+      />
+
+      <ConfirmDialog
+        open={retryTarget !== null}
+        title={`Retry "${retryTarget?.label ?? ''}"?`}
+        message={retryTarget?.failureKind === 'ambiguous' ? AMBIGUOUS_RETRY_WARNING : NORMAL_RETRY_WARNING}
+        confirmLabel={retrying ? 'Queueing…' : 'Retry'}
+        onConfirm={handleRetry}
+        onCancel={() => setRetryTarget(null)}
+      />
+
+      <ConfirmDialog
+        open={cancelTarget !== null}
+        title={`Cancel "${cancelTarget?.label ?? ''}"?`}
+        message="This abandons the write. It will never reach GP, and whoever submitted it will have to redo it."
+        confirmLabel={cancelling ? 'Cancelling…' : 'Cancel the write'}
+        onConfirm={handleCancel}
+        onCancel={() => setCancelTarget(null)}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -27,6 +27,7 @@ import {
   DISARM_RELAY_ADOPT,
 } from '../../graphql/admin';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import GpWriteQueuePanel from './GpWriteQueuePanel';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useRelayStatus } from '../../relay/useRelayStatus';
@@ -354,6 +355,10 @@ export default function RelayInstallsPage() {
         pageSizeOptions={[10, 25, 50]}
         initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
       />
+
+      {/* #353 PR E: the GP writes that were accepted while the relay was down live here, next to the
+          relay whose absence queued them. */}
+      <GpWriteQueuePanel />
 
       <ConfirmDialog
         open={adoptTarget !== null}

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -161,9 +161,11 @@ export default function GpPurchaseOrderDialog({
   const [createDraftPo, { loading: createLoading }] = useMutation<{ createDraftPo: { requestNumber: string } }>(
     CREATE_DRAFT_PO,
   );
-  const [registerPoInGp, { loading: registerLoading }] = useMutation<{ registerPoInGp: { poNumber: string | null } }>(
-    REGISTER_PO_IN_GP,
-  );
+  const [registerPoInGp, { loading: registerLoading }] = useMutation<{
+    // #353 PR E: `queued` true means the GP relay was unreachable and the registration is on the
+    // durable outbox; the PO comes back still DRAFT.
+    registerPoInGp: { queued: boolean; outboxEntryId: string | null; purchaseOrder: { poNumber: string | null } };
+  }>(REGISTER_PO_IN_GP);
 
   // One idempotency key per user action (create or register), reused across retries so a retry is a
   // no-op in GP instead of a second PO. Reset on a fresh open and after a successful submit; kept on
@@ -543,6 +545,8 @@ export default function GpPurchaseOrderDialog({
 
     setGpError(null);
     setGpBusy(true);
+    // Set when the registration went onto the GP outbox instead of reaching GP (#353 PR E).
+    let queued = false;
     try {
       // GP-first, server-side (issue #199): the resolver pushes to GP via the relay before persisting
       // anything, so a GP rejection changes nothing in UC Nexus.
@@ -569,7 +573,19 @@ export default function GpPurchaseOrderDialog({
             },
           },
         });
-        showToast(`PO ${resp.data?.registerPoInGp?.poNumber} registered in GP`, 'success');
+        const result = resp.data?.registerPoInGp;
+        queued = Boolean(result?.queued);
+        if (queued) {
+          // #353 PR E: accepted but not in GP yet. The PO stays DRAFT and the list shows it as
+          // queued; the idempotency key is now owned by the outbox row, so a resubmit is a no-op
+          // rather than a second registration.
+          showToast(
+            "Queued — the GP relay is offline. This PO will register itself when it reconnects; you don't need to redo it.",
+            'info',
+          );
+        } else {
+          showToast(`PO ${result?.purchaseOrder?.poNumber} registered in GP`, 'success');
+        }
       } else {
         // Issue #256: manual creation lands as a plain DRAFT - no relay, no GP fields. Registering
         // it into GP is a separate, conscious action on the draft row.
@@ -589,8 +605,12 @@ export default function GpPurchaseOrderDialog({
         showToast(`PO request ${resp.data?.createDraftPo?.requestNumber} created as draft`, 'success');
       }
 
-      // Succeeded: clear the key so a later reopen starts a new action.
-      idempotencyKeyRef.current = null;
+      // Succeeded: clear the key so a later reopen starts a new action. NOT when the write was
+      // queued (#353 PR E) - the outbox row owns that key, and reusing it is exactly what makes a
+      // resubmit-while-queued return the same entry instead of registering the PO twice.
+      if (!queued) {
+        idempotencyKeyRef.current = null;
+      }
       onSubmitted();
     } catch (err: unknown) {
       // Keep idempotencyKeyRef so a retry reuses the same key - the GP write may have committed even if

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -240,18 +240,47 @@ function costCodesMock(): MockedResponse {
   };
 }
 
+// #353 PR E: registerPoInGp returns a wrapper. `queued` false is the online path - the PO reached
+// GP and came back GP_REGISTERED.
 function registerData() {
   return {
     registerPoInGp: {
-      __typename: 'PurchaseOrder',
-      id: 'po-1',
-      poNumber: 'PO-2001',
-      status: 'GP_REGISTERED',
-      gpCompany: 'UCS',
-      costCode: '310-000-3',
-      gpVendorId: 'V-ACE',
-      vendorNameSnapshot: 'Ace Hardware Co',
-      vendor: null,
+      __typename: 'RegisterPOResult',
+      queued: false,
+      outboxEntryId: null,
+      purchaseOrder: {
+        __typename: 'PurchaseOrder',
+        id: 'po-1',
+        poNumber: 'PO-2001',
+        status: 'GP_REGISTERED',
+        gpCompany: 'UCS',
+        costCode: '310-000-3',
+        gpVendorId: 'V-ACE',
+        vendorNameSnapshot: 'Ace Hardware Co',
+        vendor: null,
+      },
+    },
+  };
+}
+
+// The offline path: accepted onto the durable outbox, PO still DRAFT.
+function queuedRegisterData() {
+  return {
+    registerPoInGp: {
+      __typename: 'RegisterPOResult',
+      queued: true,
+      outboxEntryId: 'outbox-1',
+      purchaseOrder: {
+        __typename: 'PurchaseOrder',
+        id: 'po-1',
+        poNumber: null,
+        status: 'DRAFT',
+        gpCompany: null,
+        costCode: '310-000-3',
+        gpVendorId: 'V-ACE',
+        vendorNameSnapshot: 'Ace Hardware Co',
+        vendor: null,
+      },
     },
   };
 }
@@ -755,6 +784,35 @@ describe('GpPurchaseOrderDialog', () => {
     const retryKey = (calls[1].input as Record<string, unknown>).idempotencyKey;
     expect(firstKey).toMatch(UUID_RE);
     expect(retryKey).toBe(firstKey);
+  });
+
+  it('keeps the idempotency key when the registration is queued on the GP outbox', async () => {
+    // #353 PR E: a queued registration is accepted, not failed - but the outbox row now owns the
+    // idempotency key. Clearing it would make a resubmit mint a new key and queue the PO twice, so
+    // a second submit must carry the same key.
+    const calls: Record<string, unknown>[] = [];
+    const queuedMock: MockedResponse = {
+      request: { query: REGISTER_PO_IN_GP, variables: () => true },
+      maxUsageCount: 2,
+      result: (vars) => {
+        calls.push(vars as Record<string, unknown>);
+        return { data: queuedRegisterData() };
+      },
+    };
+    const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [...baseMocks(), queuedMock]);
+    await waitForVendorPreselect();
+    await selectTaxDetail();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+    await waitFor(() => expect(calls).toHaveLength(2));
+
+    const firstKey = (calls[0].input as Record<string, unknown>).idempotencyKey;
+    const secondKey = (calls[1].input as Record<string, unknown>).idempotencyKey;
+    expect(firstKey).toMatch(UUID_RE);
+    expect(secondKey).toBe(firstKey);
   });
 
   it('blocks submission entirely while the GP relay is down', async () => {

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -34,6 +34,7 @@ import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import { useQuery } from '@apollo/client/react';
 import { GET_PURCHASE_ORDERS, GET_PO_STATISTICS } from '../../graphql/po';
+import { GET_GP_OUTBOX } from '../../graphql/shared';
 import { GET_PROJECTS } from '../../graphql/shared';
 import type { Project } from '../../types/project';
 import PODetailModal from './PODetailModal';
@@ -545,6 +546,9 @@ interface POTableRowProps {
   onOpen: () => void;
   onRegister: () => void;
   relayConnected: boolean;
+  // #353 PR E: this PO has a GP write sitting on the outbox. Passed down rather than resolved per
+  // row: a field on PurchaseOrder would make the All-Projects list an N+1.
+  gpWriteQueued: boolean;
 }
 
 function POTableRow({
@@ -556,6 +560,7 @@ function POTableRow({
   onOpen,
   onRegister,
   relayConnected,
+  gpWriteQueued,
 }: POTableRowProps) {
   const dataCellSx = { cursor: 'pointer' };
   return (
@@ -605,7 +610,14 @@ function POTableRow({
               color={poStatusChipColor(po.status)}
               size="small"
             />
-            {po.status === 'DRAFT' && (
+            {/* #353 PR E: the registration was accepted but has not reached GP yet, so the PO is
+                still DRAFT. Saying so stops it reading as "nobody has done this". */}
+            {gpWriteQueued && (
+              <Tooltip title="Waiting for the GP relay. This will post automatically when it reconnects." arrow>
+                <Chip label="GP registration queued" color="warning" size="small" variant="outlined" />
+              </Tooltip>
+            )}
+            {po.status === 'DRAFT' && !gpWriteQueued && (
               <Tooltip
                 title={relayConnected ? '' : 'GP relay not detected on this machine - it must be running to register a PO'}
                 arrow
@@ -678,6 +690,22 @@ function POListPage() {
   // This is the main PO page, so it polls continuously (no skip) - it's the single relay poller the
   // detail/create/register dialogs read through their relayConnected prop.
   const { connected: relayConnected } = useRelayStatus();
+
+  // #353 PR E: which POs have a GP write still on the outbox. Read as ONE list query and joined onto
+  // rows client-side on `entityKey` (`po:<id>`), deliberately not as a field on PurchaseOrder - a
+  // per-row resolver would be an N+1 on this all-projects list, and converters must not query.
+  const { data: outboxData } = useQuery<{ gpOutbox: { id: string; entityKey: string; status: string }[] }>(
+    GET_GP_OUTBOX,
+    { variables: { limit: 200 }, fetchPolicy: 'cache-and-network', pollInterval: 15_000 },
+  );
+  const queuedPoIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const entry of outboxData?.gpOutbox ?? []) {
+      if (entry.status !== 'PENDING' && entry.status !== 'IN_FLIGHT') continue;
+      if (entry.entityKey?.startsWith('po:')) ids.add(entry.entityKey.slice(3));
+    }
+    return ids;
+  }, [outboxData]);
 
   const toggleExpand = (id: string) => {
     setExpandedIds((prev) => {
@@ -923,6 +951,7 @@ function POListPage() {
                   onOpen={() => handleOpenPO(po.id)}
                   onRegister={() => setRegisterPO(po)}
                   relayConnected={relayConnected === true}
+                  gpWriteQueued={queuedPoIds.has(po.id)}
                 />
               ))}
           </TableBody>

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -111,6 +111,9 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   // after receiveQuantities is cleared (so a committed PO can't be re-posted), which would otherwise make
   // the live totalItemsToReceive read 0.
   const [receivedCount, setReceivedCount] = useState(0);
+  // How many POs' receipts went onto the GP outbox instead of posting (#353 PR E). Drives the amber
+  // success copy: the work is accepted and must not be redone, but nothing is in inventory yet.
+  const [queuedCount, setQueuedCount] = useState(0);
   const [mutationError, setMutationError] = useState<string | null>(null);
   // Structured GP/eConnect detail for a failed receipt, shown persistently (issue #187) so the user can
   // screenshot it; mutationError carries the which-PO + retry-safe context line.
@@ -123,7 +126,11 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
   const [submitting, setSubmitting] = useState(false);
 
-  const [createReceive] = useMutation(CREATE_RECEIVE);
+  // #353 PR E: `queued` true means the GP relay was unreachable and the receipt is on the durable
+  // outbox; `receiveRecord` is null because the UC Nexus receive is persisted with the GP write.
+  const [createReceive] = useMutation<{
+    createReceive: { queued: boolean; outboxEntryId: string | null; receiveRecord: { id: string } | null };
+  }>(CREATE_RECEIVE);
 
   // One idempotency key per PO, reused across retries so re-posting a PO that already committed in GP is
   // a no-op (no duplicate receipt). Cleared per-PO on success; a failed PO keeps its key for the retry.
@@ -380,6 +387,9 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     // dropped from the form and a refetch runs regardless, so the user sees what landed and can't
     // re-post them.
     const completed: string[] = [];
+    // POs whose receipt was accepted but is waiting on the GP relay (#353 PR E). Tracked separately
+    // from `completed` because nothing has been persisted for these yet - no inventory, no refetch.
+    const queued: string[] = [];
     let failureMessage: string | null = null;
     let capturedGpError: GpError | null = null;
 
@@ -422,7 +432,15 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         };
 
         try {
-          await createReceive({ variables: { input } });
+          const res = await createReceive({ variables: { input } });
+          if (res.data?.createReceive?.queued) {
+            // #353 PR E: the GP relay was unreachable, so the receipt is on the durable outbox and
+            // will post itself. Deliberately do NOT delete this PO's idempotency key - the outbox row
+            // now owns it, and reusing it on a resubmit is what makes that resubmit a no-op instead
+            // of a second queued receipt. Nothing is in inventory yet, so no refetch either.
+            queued.push(poId);
+            continue;
+          }
         } catch (err: unknown) {
           // Keep this PO's key so the retry reuses it - the GP receipt may have committed even if the
           // mutation reported failure, and reusing the key makes the retry safe.
@@ -470,7 +488,15 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     }
 
     setReceivedCount(totalItemsToReceive);
-    showToast(`Receive completed successfully. ${totalItemsToReceive} items added to inventory.`, 'success');
+    setQueuedCount(queued.length);
+    if (queued.length > 0) {
+      showToast(
+        `Queued — the GP relay is offline. ${queued.length === 1 ? 'This receipt' : 'These receipts'} will post automatically when it reconnects.`,
+        'info',
+      );
+    } else {
+      showToast(`Receive completed successfully. ${totalItemsToReceive} items added to inventory.`, 'success');
+    }
     setSucceeded(true);
   }, [
     poIds,
@@ -694,7 +720,14 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
             Error loading PO details: {poDetailsError}
           </Alert>
         )}
-        {succeeded && (
+        {succeeded && queuedCount > 0 && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Queued — the GP relay is offline. {queuedCount === 1 ? 'This receipt' : `These ${queuedCount} receipts`} will
+            post automatically when it reconnects; you don't need to redo it. The hardware will appear in inventory
+            once it posts.
+          </Alert>
+        )}
+        {succeeded && queuedCount === 0 && (
           <Alert severity="success" sx={{ mb: 2 }}>
             Receive completed successfully! {receivedCount} items added to inventory.
           </Alert>

--- a/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
@@ -110,27 +110,34 @@ function poDetailsMock(overrides: Record<string, unknown> = {}): MockedResponse 
   };
 }
 
+// #353 PR E: createReceive returns a wrapper. `queued` false is the online path - the receipt
+// reached GP and the UC Nexus receive was persisted with it.
 function createReceiveData(quantityReceived: number) {
   return {
     createReceive: {
-      __typename: 'ReceiveRecord',
-      id: 'rr-1',
-      poId: 'po-1',
-      receivedAt: '2026-07-16T10:00:00Z',
-      receivedBy: 'Warehouse',
-      createdAt: '2026-07-16T10:00:00Z',
-      lineItems: [
-        {
-          __typename: 'ReceiveLineItem',
-          id: 'rli-1',
-          receiveRecordId: 'rr-1',
-          poLineItemId: 'li-1',
-          hardwareCategory: 'Hinges',
-          productCode: 'HG-100',
-          quantityReceived,
-          createdAt: '2026-07-16T10:00:00Z',
-        },
-      ],
+      __typename: 'CreateReceiveResult',
+      queued: false,
+      outboxEntryId: null,
+      receiveRecord: {
+        __typename: 'ReceiveRecord',
+        id: 'rr-1',
+        poId: 'po-1',
+        receivedAt: '2026-07-16T10:00:00Z',
+        receivedBy: 'Warehouse',
+        createdAt: '2026-07-16T10:00:00Z',
+        lineItems: [
+          {
+            __typename: 'ReceiveLineItem',
+            id: 'rli-1',
+            receiveRecordId: 'rr-1',
+            poLineItemId: 'li-1',
+            hardwareCategory: 'Hinges',
+            productCode: 'HG-100',
+            quantityReceived,
+            createdAt: '2026-07-16T10:00:00Z',
+          },
+        ],
+      },
     },
   };
 }
@@ -345,6 +352,41 @@ describe('ReceiveModal', () => {
     expect(keys).toHaveLength(2);
     expect(keys[0]).toMatch(UUID_RE);
     expect(keys[1]).toBe(keys[0]);
+  });
+
+  it('shows the queued outcome and keeps the idempotency key when the GP relay is offline', async () => {
+    // #353 PR E: an offline relay no longer fails the receive - it is accepted onto the outbox. The
+    // key must NOT be cleared: the outbox row owns it, and reusing it is what makes a resubmit return
+    // the same queued entry instead of queueing a second receipt.
+    const keys: string[] = [];
+    const queuedMock: MockedResponse<Record<string, unknown>, CreateReceiveVars> = {
+      request: { query: CREATE_RECEIVE, variables: () => true },
+      maxUsageCount: 2,
+      result: (vars) => {
+        keys.push(vars.input.idempotencyKey);
+        return {
+          data: {
+            createReceive: {
+              __typename: 'CreateReceiveResult',
+              queued: true,
+              outboxEntryId: 'outbox-1',
+              receiveRecord: null,
+            },
+          },
+        };
+      },
+    };
+    await openModal([poDetailsMock(), queuedMock]);
+
+    setReceiveQty('3');
+    fillLocation(0, 'A1', 'B2', 'C3');
+    await submitViaConfirm();
+
+    await screen.findByText(/Queued — the GP relay is offline/, undefined, SLOW);
+    // Not an inventory claim: nothing has been persisted yet.
+    expect(screen.queryByText(/items added to inventory/)).toBeNull();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toMatch(UUID_RE);
   });
 
   it('blocks receiving a PO that is not GP-registered', async () => {

--- a/frontend/src/relay/GpOutboxWatcher.tsx
+++ b/frontend/src/relay/GpOutboxWatcher.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import { useApolloClient } from '@apollo/client/react';
+import { useGpOutbox } from './useGpOutbox';
+import { GP_OUTBOX_DRAINED_STALE_ROOT_FIELDS } from '../graphql/refetch';
+
+// Mounted once, in AppLayout (#353 PR E).
+//
+// A queued GP write drains in the background - minutes or hours after the user submitted it, while
+// the browser is sitting on whatever route it happens to be on. `lastDrainedAt` advancing is the
+// only signal the browser gets that data changed underneath it; without this, a receive that posted
+// itself while the user was on the warehouse page would stay invisible until a manual refresh.
+//
+// Eviction only. Evicting a root field makes every mounted watcher with an incomplete cache diff
+// repair itself, which reaches the unmounted case that refetchQueries cannot - and pairing an evict
+// with a refetch by name is the concurrent double-run that graphql/refetch.ts exists to prevent.
+export default function GpOutboxWatcher() {
+  const client = useApolloClient();
+  const { lastDrainedAt } = useGpOutbox();
+  const seen = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!lastDrainedAt) return;
+    // First observation is the baseline, not a drain: on a fresh page load lastDrainedAt is whatever
+    // the last drain ever was, and evicting on it would fire a wave of refetches on every mount.
+    if (seen.current === null) {
+      seen.current = lastDrainedAt;
+      return;
+    }
+    if (seen.current === lastDrainedAt) return;
+    seen.current = lastDrainedAt;
+    for (const fieldName of GP_OUTBOX_DRAINED_STALE_ROOT_FIELDS) {
+      client.cache.evict({ id: 'ROOT_QUERY', fieldName });
+    }
+    client.cache.gc();
+  }, [lastDrainedAt, client]);
+
+  return null;
+}

--- a/frontend/src/relay/GpQueueChip.tsx
+++ b/frontend/src/relay/GpQueueChip.tsx
@@ -1,0 +1,24 @@
+import { Chip, Tooltip } from '@mui/material';
+import { useGpOutbox } from './useGpOutbox';
+
+// The GP write queue indicator (#353 PR E). Renders nothing when the queue is empty, which is the
+// normal state - a chip that is always there stops being read. Status colour is reserved for real
+// system state (DESIGN.md), and "your receipt has not reached GP yet" is exactly that.
+export default function GpQueueChip() {
+  const { pending, inFlight, failed } = useGpOutbox();
+  const queued = pending + inFlight;
+  if (queued + failed === 0) return null;
+
+  if (failed > 0) {
+    return (
+      <Tooltip title="These GP writes could not be posted and need a person. Admin → Relay Installs → GP write queue.">
+        <Chip size="small" color="error" label={`${failed} GP write${failed === 1 ? '' : 's'} failed`} />
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip title="Waiting for the GP relay. These will post automatically when it reconnects - nothing needs redoing.">
+      <Chip size="small" color="warning" label={`${queued} GP write${queued === 1 ? '' : 's'} queued`} />
+    </Tooltip>
+  );
+}

--- a/frontend/src/relay/useGpOutbox.ts
+++ b/frontend/src/relay/useGpOutbox.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@apollo/client/react';
+import { GET_GP_OUTBOX_SUMMARY } from '../graphql/shared';
+
+export interface GpOutboxSummary {
+  pending: number;
+  inFlight: number;
+  failed: number;
+  oldestPendingAt: string | null;
+  // Advances every time the worker drains something. The browser's only signal that a background
+  // drain changed data underneath whatever route it happens to be on.
+  lastDrainedAt: string | null;
+}
+
+const EMPTY: GpOutboxSummary = {
+  pending: 0,
+  inFlight: 0,
+  failed: 0,
+  oldestPendingAt: null,
+  lastDrainedAt: null,
+};
+
+// Single definition of the GP write-queue poll (#353 PR E), mirroring useRelayStatus. 15s rather
+// than the relay chip's 10s: a queued write is not a live status, it is a background job, and this
+// is polled by every open browser - the resolver is scalar aggregates only for the same reason.
+export function useGpOutbox(options?: { skip?: boolean }): GpOutboxSummary {
+  const { data } = useQuery<{ gpOutboxSummary: GpOutboxSummary }>(GET_GP_OUTBOX_SUMMARY, {
+    pollInterval: 15_000,
+    fetchPolicy: 'cache-and-network',
+    skip: options?.skip,
+  });
+  return data?.gpOutboxSummary ?? EMPTY;
+}

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -51,13 +51,47 @@ with `relayInstalls { label enrolled enrolledAt lastSeenAt }` and the Railway ba
   proves `RELAY_SECRET_ENC_KEY` was valid at that moment; if auth still 403s seconds later, the
   mismatch is in the secret, not the key. Usual cause: enrolment rewrote `[auth] shared_secret` in
   `config.toml` while the **already-running relay service kept dialling with its old in-memory
-  secret**. It needs a *restart*, not another enrol. Only reachable on the workstation - the relay's
-  inbound server is bound to `127.0.0.1:7321`, so there is no remote restart.
-- Beware the silent path: `authenticate_secret` decrypts inside a bare `except Exception: continue`
-  (`:92-93`), so a genuinely rotated `RELAY_SECRET_ENC_KEY` fails **identically and logs nothing**.
-  Distinguish the two with the enrolment-timing argument above rather than by reading the key.
-- `POST /admin/reset-data` drops the `relay_installs` rows along with everything else, so a schema
-  rebuild orphans the on-prem relay every time.
+  secret**. It needs a *restart*, not another enrol. The relay's inbound server is bound to
+  `127.0.0.1:7321`, so there is no remote restart — **but since #353 PR B there is a remote fix.**
+  Admin → Relay Installs → **Adopt next connection** on that install opens a 5-minute, single-use
+  window in which the relay's next dial is accepted with whatever secret it is already presenting,
+  and the secret is rebound. Watch for `relay adopt: presented secret bound to install` at WARNING,
+  then an accepted `/relay-link`. The adoption is stamped on the row as `adoptedAt` / `adoptedBy`.
+- The silent-decrypt path is gone (#352 logs the cause; #353 PR C removed the key from the
+  authentication path entirely). Since migration `067` the relay secret is a SHA-256 hash, so a
+  rotated or missing `RELAY_SECRET_ENC_KEY` can no longer orphan a relay — if you still see a
+  `relay handshake rejected` line, read its `hash_rows` / `legacy_rows` / `encryption_key_present`
+  fields, which name the actual cause.
+- `POST /admin/reset-data` **preserves** the `relay_installs` rows across the rebuild (#352), so a
+  schema reset no longer orphans the on-prem relay.
+
+### A queued GP write is not a failed one
+
+Since #353 PR E, a `createReceive` or `registerPoInGp` submitted while the relay is unreachable is
+**accepted onto a durable outbox** instead of failing. Recognise it before you conclude anything
+about GP:
+
+- The receive modal shows an amber *"Queued — the GP relay is offline"* panel, not the green
+  "items added to inventory" one, and **nothing is in inventory yet** — the UC Nexus persist is
+  deferred along with the GP write.
+- A queued-writes chip appears in the app bar. Read the queue with:
+
+```
+{ gpOutboxSummary { pending inFlight failed oldestPendingAt lastDrainedAt } }
+{ gpOutbox(limit: 20) { label op status attempts failureKind lastError } }
+```
+
+- **Bring the relay back and it drains itself** within about a second of `/relay-link` accepting
+  (the route wakes the worker). `pending` goes to 0, `lastDrainedAt` advances, and the browser
+  refreshes the affected lists on its own. Do not re-submit — the idempotency key belongs to the
+  queued row, so a resubmit returns the same entry rather than posting twice.
+- A `FAILED` entry is the one that needs a person: Admin → Relay Installs → **GP write queue**.
+  `failureKind` says which kind of trouble it is — `gp_rejected` (eConnect said no; fix the input),
+  `persist_failed` (GP committed but UC Nexus refused the state change), `exhausted` (retry budget
+  gone), and `ambiguous`, which means the job reached the relay and **GP may already hold the
+  write** — check GP before retrying, because a retry there can genuinely duplicate a receipt.
+- If a scenario needs inventory *now* and the queue is stuck, the blocker is still the relay: seeding
+  stock has no non-relay path. Re-scope the session rather than improvising.
 
 Verified in this state on 2026-07-26: install `TAGGING3W10 (re-enroll after schema rebuild)` (company
 TUBC), one row, enrolled 7/24 22:54:27.662369Z with `lastSeenAt` byte-identical to `enrolledAt`. The


### PR DESCRIPTION
Implements **PR E** of #353. Branched off `master` after PR C (#356) merged, so the migration chain stays linear: `068` → `067`, `069` → `068`.

## Why

`relay_call` raises the moment the relay socket is gone. A backend deploy — which by definition kills that socket — therefore turns an in-flight receive or PO registration into a red toast that a human has to notice and re-click. This is the change that makes the deploy window invisible: the write is **accepted**, queued, and drained automatically when the relay reconnects.

## The central design problem, and how the row solves it

Both GP-first resolvers persist the UC Nexus record **only after** the relay answers — `_persist_create_receive` needs the relay result, `_persist_register_po` stamps GP's returned `po_number`. So deferring the relay call means deferring the persist too.

The outbox row therefore **carries the whole remainder of the pipeline as data**: the already-built relay payload from `_prepare_*` (which still runs at submit time, so validation fails fast in front of the user) plus a `persist_context` blob holding exactly the kwargs the matching `_persist_*` helper takes. The worker rehydrates that blob and calls the **same** helper the online path calls. There is deliberately no second persist implementation to drift.

Per row the worker runs the identical pipeline: ledger short-circuit (`result_id` → already done; `relay_result` → GP already ran, skip the call) → `relay_call` → record the relay result in its own commit → persist → `SUCCEEDED`.

## The one bit that prevents double-posting

`RelayUnavailableError` gains `dispatched`:

| Raised by | dispatched | Queued? |
|---|---|---|
| no socket / wrong company / send failure | `False` | **yes** — the job never left the backend, GP cannot have run it |
| `RelayGateway._fail_all` (socket died with the job on the wire) | `True` | **no** — GP may have committed and the reply was lost |

A blind retry of a dispatched failure would post a second receipt or reserve a second PO number. `RelayTimeoutError` is never queued for the same ambiguity, and `RelayCallError` never is because GP said no.

## Retry policy (by failure class)

| Outcome | attempts++ | Next state |
|---|---|---|
| relay still down (`dispatched=False`) | **no** | `PENDING`, retried at the poll interval |
| transient DB error during persist | yes | `PENDING`, backoff |
| `RelayOpUnsupportedError` (relay too old) | yes | `PENDING`, backoff — PR D's poller will update it |
| `RelayCallError` | — | `FAILED / gp_rejected` |
| `RelayTimeoutError` or `dispatched=True` | — | `FAILED / ambiguous`, **never auto-retried** |
| persist raised an `AppError` | — | `FAILED / persist_failed` (GP committed; needs a human) |
| attempts > 8 | — | `FAILED / exhausted` |

Not counting relay-down against the budget is the key choice: a week-long outage must not poison the queue.

## Ordering

Global age order with **per-`entity_key` FIFO** enforced in the claim query. Both ops key on `po:<uuid>`, so a receipt can never be drained ahead of the registration of the PO it is against (which would fail — the PO isn't in GP yet). `FOR UPDATE SKIP LOCKED` costs nothing on one replica and makes the table correct on two.

## Changes

**Backend** — new `models/gp_outbox.py`, `repositories/gp_outbox_repository.py`, `services/gp_outbox_worker.py`, `services/gp_outbox_enqueue.py`, `schemas/gp_outbox.py` (composed into the root types, never added to them). `main.py` gains an `asynccontextmanager` lifespan that owns the worker task — gated on `GP_OUTBOX_ENABLED` so it can be stopped without a code deploy, every iteration wrapped so nothing can kill it — and `/relay-link` calls `wake()` right after a successful `try_register` so a reconnect drains within milliseconds. Migrations `068` (table, two indexes, status CHECK per migration 065's precedent) and `069` (`GP_WRITE_FAILED`, following `044`'s recreate-the-enum downgrade). The worker's handlers import the `_persist_*` helpers **inside** the function body — a module-level import would create a services↔schemas cycle.

**GraphQL** — `registerPoInGp` → `RegisterPOResult { queued, outboxEntryId, purchaseOrder }`, `createReceive` → `CreateReceiveResult { queued, outboxEntryId, receiveRecord }` (`receiveRecord` null when queued: nothing is in inventory yet). `gpOutboxSummary` / `gpOutbox` are `require_user`; retry/cancel are `require_admin`.

**Frontend** — queue chip in the app bar (renders **only** when the queue is non-empty); `GpOutboxWatcher` mounted once in `AppLayout`, evicting `GP_OUTBOX_DRAINED_STALE_ROOT_FIELDS` when `lastDrainedAt` advances — **eviction-only**, per the disjointness rule `refetch.ts` exists to enforce, because a background drain happens while an arbitrary route is mounted; amber queued copy in `ReceiveModal` and `GpPurchaseOrderDialog`; a "GP registration queued" chip joined onto PO rows **client-side on `entityKey`** (a field on `PurchaseOrder` would be an N+1 on the all-projects list, and converters must not query); and the admin **GP write queue** table with Retry / Cancel behind confirms.

**Both call sites now KEEP their idempotency key when queued.** The outbox row owns it, and reusing it is exactly what makes a resubmit-while-queued return the same entry instead of queueing a second write. Clearing it — which the success path still does — would mint a new key and queue the write twice.

## Tests

- `test_gp_outbox.py` — enqueue-twice returns one row; claim respects `next_attempt_at`, status, company and **per-entity FIFO** (a receipt stays blocked until the registration ahead of it finishes); `mark_retry(bump_attempts=False)` leaves the budget alone; `mark_failed` leaves the claimable set; summary counts; cancel refuses an `IN_FLIGHT` row.
- `test_gp_outbox_worker.py` — the full failure taxonomy end to end, **always with `relay_call` stubbed, never touching GP**: relay-down stays `PENDING` at `attempts == 0`; dispatched-disconnect and timeout → `ambiguous`; `RelayCallError` → `gp_rejected`; success calls the persist helper with the rehydrated context and the right key; a ledger already holding `relay_result` **skips the relay call entirely**; an `AppError` from persist → `persist_failed`; a transient one retries.
- `test_gp_outbox_enqueue.py` — the dispatched bit itself, including that `_fail_all` really does mark lost in-flight jobs dispatched.
- `test_resolver_auth_gates.py` — the two admin-gated mutations and the two user-gated reads.
- Frontend — `ReceiveModal` and `GpPurchaseOrderDialog` mocks updated to the wrapper shapes (the old shapes can no longer occur), plus new queued-path tests asserting the amber copy, that no inventory claim is made, and that the idempotency key is **not** rotated on a resubmit.

## Verification

1. CI green (both migration jobs).
2. With the relay disconnected, submit a receive → modal shows "Queued", `gpOutboxSummary.pending == 1`, chip appears.
3. Bring the relay back → within ~1s of `/relay-link` accepting, the log shows the drain; `pending → 0`, `lastDrainedAt` advances, the receive appears in inventory with no page reload.
4. Re-submit the same receive while queued → same `outboxEntryId`, one row, no duplicate GP receipt.
5. Redeploy mid-submit → the submit either succeeds or queues, never a red error toast.

## Note on CLAUDE.md

The issue asks for the root `CLAUDE.md` GP/relay section to describe the outbox. **That file is gitignored in this repo** (`.gitignore:32`), so it cannot land in a PR; `testing/CLAUDE.md` (which *is* tracked) gained the section on recognising and clearing a queued outbox instead.
