### PR TITLE
fix(relay): close the reap gap and hand off cleanly on a deploy (#353 PR F)

### DIFF
--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -27,6 +27,19 @@ DEFAULT_TIMEOUT_SECONDS = 30.0
 # (relay channel.py). Detection is up to HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MAX_MISSED (~40s here).
 HEARTBEAT_INTERVAL_SECONDS = 20.0
 HEARTBEAT_MAX_MISSED = 2
+# Limit for a connection that has NEVER answered a ping (#353 PR F). The original conservatism -
+# never reaping an unarmed connection - existed to protect relay builds that predated the data
+# heartbeat (issue #277). Every shipped build answers it now, and the asymmetry of being wrong is
+# stark: reaping a hypothetical old relay costs one automatic reconnect, while NOT reaping a relay
+# that connected and then went silent wedges the single connection slot for the ~hour the platform
+# takes to reap the dead TCP socket - during which no other relay can take the slot and every GP
+# write fails. A longer limit than the armed one still gives a slow starter room.
+HEARTBEAT_MAX_MISSED_UNARMED = 4
+
+# RFC 6455 close code 1012, "Service Restart". Sent on a graceful backend shutdown so the relay can
+# tell a deploy from a network blip and reconnect immediately instead of backing off (#353 PR F).
+SERVICE_RESTART_CLOSE_CODE = 1012
+_SHUTDOWN_TIMEOUT_SECONDS = 2.0
 
 
 class RelayGateway:
@@ -112,12 +125,42 @@ class RelayGateway:
             self._heartbeat_armed = True
 
     def register_ping_miss(self) -> bool:
-        """Called by the route's heartbeat once per interval, just before it sends the next ping. Counts
-        the pings the relay hasn't answered yet and returns True when it has gone quiet long enough to
-        reap (HEARTBEAT_MAX_MISSED unanswered pings) - but only once armed, so a relay that never answers
-        a ping is left to the disconnect-on-read path rather than being killed on a false positive."""
+        """Called by the route's heartbeat once per interval, just before it sends the next ping.
+        Counts the pings the relay hasn't answered yet and returns True once it has gone quiet long
+        enough to reap.
+
+        Two limits (#353 PR F). An ARMED connection - one that has answered at least one ping - is
+        reaped after HEARTBEAT_MAX_MISSED (~40s), as before. An UNARMED one, which previously could
+        never be reaped at all, is reaped after the longer HEARTBEAT_MAX_MISSED_UNARMED (~80s): a
+        relay that connects, takes the single slot and never pongs used to hold that slot until the
+        platform reaped the dead TCP connection about an hour later, blocking every other relay
+        (try_register -> close 4409) and failing every GP write for the duration."""
         self._unanswered_pings += 1
-        return self._heartbeat_armed and self._unanswered_pings >= HEARTBEAT_MAX_MISSED
+        limit = HEARTBEAT_MAX_MISSED if self._heartbeat_armed else HEARTBEAT_MAX_MISSED_UNARMED
+        return self._unanswered_pings >= limit
+
+    async def close_for_shutdown(self) -> None:
+        """Say goodbye to the relay before the process goes (#353 PR F).
+
+        A container restart otherwise just drops the TCP connection, and the relay treats that like
+        any other drop: it grows its exponential backoff and can sit out the first 30s of the new
+        deployment for no reason. A `going_away` frame plus close code 1012 (Service Restart) tells
+        it this is a restart, so a relay carrying the matching client change reconnects immediately.
+
+        Best-effort throughout, with a short timeout: a half-dead socket must not hold up shutdown,
+        and the relay reconnects either way."""
+        socket = self._socket
+        if socket is None:
+            return
+        try:
+            await asyncio.wait_for(socket.send_json({"type": "going_away"}), timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+        except Exception:
+            pass
+        try:
+            await asyncio.wait_for(socket.close(code=SERVICE_RESTART_CLOSE_CODE), timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+        except Exception:
+            pass
+        self.unregister(socket)
 
     def _fail_all(self, message: str) -> None:
         # dispatched=True: every job in `_pending` was already sent to the relay, so GP may have run

--- a/backend/main.py
+++ b/backend/main.py
@@ -92,6 +92,10 @@ async def lifespan(_app: FastAPI):
     try:
         yield
     finally:
+        # Close the relay socket cleanly BEFORE stopping the worker (#353 PR F). The relay then knows
+        # this is a restart rather than a blip and reconnects at once; anything it was about to send
+        # will queue on the outbox and drain when it does.
+        await relay_gateway.close_for_shutdown()
         if worker is not None:
             worker.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -146,14 +146,18 @@ def test_unregister_fails_any_pending_calls():
     asyncio.run(run())
 
 
-def test_register_ping_miss_does_not_reap_before_the_first_pong():
-    # issue #277: a relay build that doesn't answer the data heartbeat yet must never be reaped on a
-    # false positive - missed pings only count once the relay has proven it speaks the protocol.
+def test_register_ping_miss_gives_an_unarmed_connection_longer_before_reaping():
+    # #353 PR F. issue #277 originally refused to reap an unarmed connection at all, to protect relay
+    # builds predating the data heartbeat. That left a real gap: a relay that connects, takes the
+    # single slot and never pongs held the slot until the platform reaped the dead TCP socket ~an
+    # hour later, blocking every other relay and failing every GP write. The unarmed limit is longer
+    # than the armed one, not absent.
     gateway = RelayGateway()
     gateway.try_register("TUBC", FakeWebSocket())
-    assert gateway.register_ping_miss() is False
-    assert gateway.register_ping_miss() is False
-    assert gateway.register_ping_miss() is False
+    assert gateway.register_ping_miss() is False  # 1
+    assert gateway.register_ping_miss() is False  # 2 - would already reap an ARMED connection
+    assert gateway.register_ping_miss() is False  # 3
+    assert gateway.register_ping_miss() is True  # 4 (~80s) -> reap, freeing the slot
 
 
 def test_register_ping_miss_reaps_after_two_misses_once_armed():
@@ -162,6 +166,60 @@ def test_register_ping_miss_reaps_after_two_misses_once_armed():
     gateway.note_pong()  # the first pong arms the reaper
     assert gateway.register_ping_miss() is False  # 1 unanswered ping
     assert gateway.register_ping_miss() is True  # 2 unanswered pings -> reap
+
+
+def test_a_pong_tightens_the_limit_from_unarmed_to_armed():
+    # Answering once proves the relay speaks the heartbeat, so from then on silence is reaped at the
+    # tighter armed limit rather than the unarmed one.
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket())
+    gateway.register_ping_miss()
+    gateway.note_pong()  # arms and resets
+    assert gateway.register_ping_miss() is False
+    assert gateway.register_ping_miss() is True  # two misses is enough once armed
+
+
+def test_close_for_shutdown_says_going_away_and_closes_1012():
+    # #353 PR F: a deploy must tell the relay it is a restart, so the relay reconnects at once instead
+    # of growing its backoff and sitting out the start of the new deployment.
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        await gateway.close_for_shutdown()
+        assert ws.sent == [{"type": "going_away"}]
+        assert ws.closed_code == 1012
+        assert gateway.connected is False
+
+    asyncio.run(run())
+
+
+def test_close_for_shutdown_is_a_no_op_with_no_relay_connected():
+    async def run():
+        gateway = RelayGateway()
+        await gateway.close_for_shutdown()  # must not raise
+        assert gateway.connected is False
+
+    asyncio.run(run())
+
+
+def test_close_for_shutdown_survives_a_socket_that_will_not_close():
+    # A half-dead socket must not hold up process shutdown; the relay reconnects either way.
+    async def run():
+        class _Stuck(FakeWebSocket):
+            async def send_json(self, data: dict) -> None:
+                raise RuntimeError("socket is gone")
+
+            async def close(self, code: int = 1000) -> None:
+                raise RuntimeError("socket is gone")
+
+        gateway = RelayGateway()
+        ws = _Stuck()
+        gateway.try_register("TUBC", ws)
+        await gateway.close_for_shutdown()  # must not raise
+        assert gateway.connected is False
+
+    asyncio.run(run())
 
 
 def test_note_pong_resets_the_miss_counter():

--- a/docs/relay-multi-replica.md
+++ b/docs/relay-multi-replica.md
@@ -1,0 +1,94 @@
+# Running the relay channel across more than one backend replica
+
+**Status: designed, not built. Do not build it yet.** This document exists so that when the
+prerequisite actually arrives, the work is execution rather than design (#353 PR F).
+
+## Why this is deferred
+
+Railway runs **one** backend replica, there is **one** relay, and the project has **no Redis
+service**. `relay_gateway` holds the single live socket in module memory, and that is correct under
+those conditions — `services/relay_gateway.py` says so explicitly.
+
+Adding Redis today would buy nothing and would put a new hard dependency directly in the auth-and-
+dispatch path of every GP write. A Redis blip would then become a GP outage: a *worse* failure mode
+than the one being fixed, and precisely the kind of trade #353 exists to stop making.
+
+### The prerequisite trigger
+
+Build this when **either** becomes true, and not before:
+
+1. The backend runs more than one replica (horizontal scaling, or a rolling deploy that overlaps
+   two live containers rather than replacing one).
+2. A second relay — a second company, or a second workstation — needs to be connected concurrently.
+
+Until then, the single-socket registry plus the incumbent-wins rule is the simpler correct design.
+
+## Why not sticky routing
+
+The obvious alternative is to pin a relay's WebSocket to one replica at the proxy. Railway's proxy
+offers no WS-aware sticky routing keyed on anything the relay controls, so there is no reliable way
+to make "the replica that holds the socket" and "the replica that received the GraphQL mutation" the
+same process. Pub/sub between replicas is the path.
+
+## Design
+
+### Ownership lease
+
+The replica holding a relay's socket takes a lease:
+
+```
+SET relay:owner:{install_id} {instance_id} NX PX 30000
+```
+
+- Refreshed every 10 s by the owner, on the heartbeat it already runs (`_relay_heartbeat_loop`) — no
+  new timer.
+- Released on `unregister`.
+- **Only the lease holder may write to the socket.** That is the whole invariant.
+
+`NX` plus the incumbent-wins rule already in `try_register` is what stops two replicas both believing
+they own the same relay after a network partition.
+
+### Dispatch
+
+A replica that does *not* own the socket cannot call `relay_call` locally. Instead:
+
+1. Caller **subscribes** to `relay:replies:{job_id}` — **before** publishing. Subscribing after the
+   publish races the reply and loses it intermittently, which would look exactly like a relay
+   timeout.
+2. Caller publishes `{job_id, company, op, payload, reply_to}` to `relay:jobs:{instance_id}` of the
+   owning replica.
+3. The owner runs today's `relay_call` locally and publishes the reply to `relay:replies:{job_id}`.
+
+The timeout, the `unknown_op` mapping and the error taxonomy stay where they are; only the transport
+between the caller and the socket-holder changes.
+
+### Registry read
+
+`relayStatus` stops being a read of local module state and becomes:
+
+- `relay:owner:*` — who is connected, and which replica holds them.
+- `relay:meta:{install_id}` — a hash carrying `company`, `build`, `connected_at`.
+
+### Fallback
+
+**No owner key ⇒ `RelayUnavailableError(dispatched=False)` ⇒ the PR E outbox absorbs the write.**
+
+This is why the outbox landed first. Without it, a multi-replica rollout would turn every "the owner
+lease had just expired" moment into a user-visible failure; with it, those writes queue and drain.
+
+### Failure modes to handle explicitly
+
+| Failure | Required behaviour |
+|---|---|
+| Redis unavailable | **Fail closed to the outbox.** Never bypass the lease and write to a local socket "just in case" — that is how two replicas post the same GP receipt. |
+| Lease expires mid-job | The reply can no longer be delivered, so the caller must treat it with `dispatched=True` semantics: GP may hold the write, so it is `ambiguous` and must not be auto-retried. |
+| Duplicate owners after a partition | The `NX` lease plus incumbent-wins resolves it; the loser must `unregister` rather than keep serving. |
+
+## What stays the same
+
+- Every GP write is still an `EXEC` of an eConnect-registered proc on the relay. Nothing here changes
+  the GP access path.
+- The idempotency ledger (`gp_write_idempotency`) is still the thing that makes a retry safe, and it
+  is already shared state in Postgres — it needs no Redis equivalent.
+- The outbox is still the durability layer; Redis is a routing layer only, and must never become the
+  system of record for a pending write.

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -66,6 +66,11 @@ def _mark_disconnected(state: str = "disconnected") -> None:
 # client sees it as a close frame - distinct from a secret rejection, which is refused pre-accept.
 _SLOT_BUSY_CLOSE_CODE = 4409
 
+# RFC 6455 1012 "Service Restart", sent by the backend's graceful shutdown (#353 PR F). It means the
+# backend is coming straight back, so growing the reconnect backoff is exactly wrong - the socket
+# should be re-established immediately rather than after up to reconnect_max_seconds of waiting.
+_SERVICE_RESTART_CLOSE_CODE = 1012
+
 
 def _classify_connect_failure(exc: Exception) -> tuple[str, str]:
     """Map a failed/dropped channel connection to a (category, operator_message) so the log says WHY,
@@ -95,6 +100,8 @@ def _classify_connect_failure(exc: Exception) -> tuple[str, str]:
             "slot_busy",
             "another relay already holds the backend connection for this company; standing by. still retrying.",
         )
+    if close_code == _SERVICE_RESTART_CLOSE_CODE:
+        return ("server_restarting", "backend is restarting; reconnecting immediately")
     return ("dropped", "channel connection dropped, retrying")
 
 
@@ -362,6 +369,12 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
                 extra={"category": category, "error": str(e), "backoff": backoff},
             )
             _mark_disconnected(category if category in ("secret_rejected", "slot_busy") else "disconnected")
-            backoff = min(backoff * 2, cfg.reconnect_max_seconds)
+            if category == "server_restarting":
+                # A deploy, not a fault: the backend told us it is coming straight back, so dial again
+                # at the minimum interval rather than growing the backoff and sitting out the first
+                # half-minute of the new deployment (#353 PR F).
+                backoff = cfg.reconnect_min_seconds
+            else:
+                backoff = min(backoff * 2, cfg.reconnect_max_seconds)
             prev_category = category
         await asyncio.sleep(backoff)

--- a/relay/tests/test_channel_reconnect.py
+++ b/relay/tests/test_channel_reconnect.py
@@ -77,3 +77,18 @@ def test_channel_state_snapshot_reports_gp_jobs_in_flight():
     assert finished["jobs_in_flight"] == 0
     assert 0 <= finished["last_job_finished_ago"] < 5
     channel._LAST_JOB_AT = None
+
+
+def test_close_code_1012_is_classified_as_a_server_restart():
+    # #353 PR F: the backend's graceful shutdown closes with 1012 (Service Restart). That is a deploy,
+    # not a fault - the relay must recognise it so it can dial again immediately.
+    exc = ConnectionClosedError(Close(1012, "going away"), None)
+    category, message = channel._classify_connect_failure(exc)
+    assert category == "server_restarting"
+    assert "restarting" in message.lower()
+
+
+def test_a_generic_close_is_still_a_plain_drop():
+    # The 1012 case must not swallow ordinary drops, which still deserve a growing backoff.
+    exc = ConnectionClosedError(Close(1006, ""), None)
+    assert channel._classify_connect_failure(exc)[0] == "dropped"


### PR DESCRIPTION
Implements **PR F** of #353, the last one. Branched off `master` after PR E (#364) merged.

Three items: two pragmatics that actually hurt today, and the Redis design written down rather than built.

## (a) Close the never-arming reap gap

`register_ping_miss` returned `True` only once `_heartbeat_armed` was set, and that only happens on the relay's **first pong**. So a relay that connects, takes the single connection slot, and never pongs could not be reaped at all — it held the slot until the platform reaped the dead TCP socket about an hour later. For that whole hour `try_register` closed every other relay `4409` and every GP write failed.

```python
HEARTBEAT_MAX_MISSED = 2              # armed (existing, ~40s)
HEARTBEAT_MAX_MISSED_UNARMED = 4      # never ponged (~80s)
```

The original conservatism (issue #277) existed to protect relay builds predating the data heartbeat. Every shipped build answers it, and the asymmetry is stark: being wrong about a hypothetical old relay costs **one automatic reconnect**, while the gap costs **an hour of wedged connection slot**. The unarmed limit is longer than the armed one, not absent, so a slow starter still has room.

## (b) Graceful shutdown

`relay_gateway.close_for_shutdown()` best-effort sends `{"type": "going_away"}` and closes with **1012 (Service Restart)**, called from the lifespan's `finally` **before** the outbox worker is cancelled. Wrapped in `try/except` with a 2 s `wait_for` each — a half-dead socket must not delay shutdown, and the relay reconnects either way.

Relay side: `_classify_connect_failure` maps close code 1012 to a new `server_restarting` category (*"backend is restarting; reconnecting immediately"*), and `run_forever` **resets** the backoff to `reconnect_min_seconds` for that category instead of doubling it. A redeploy no longer costs the relay the first half-minute of the new deployment.

Note: the relay half only takes effect once a relay build carrying it is delivered — which **PR D now automates**.

With PR E live, a GP write submitted inside that window queues and drains, so the user sees nothing at all.

## (c) `docs/relay-multi-replica.md` — the Redis design, deliberately not built

**Recommendation: do not build Redis now.** Railway runs one replica, there is one relay, and there is no Redis service in the project. Adding one buys nothing today and puts a new hard dependency directly in the auth-and-dispatch path of every GP write — a Redis blip would become a GP outage, a *worse* failure mode than the one being fixed.

The doc is concrete enough that a future PR is execution, not design: the prerequisite trigger, why sticky routing is not the path, the `SET relay:owner:{install_id} … NX PX 30000` ownership lease refreshed on the heartbeat that already runs, the pub/sub dispatch (**subscribe before publish**, or the reply races the subscription), the registry read, and the failure modes — including that a missing owner key must **fail closed to the PR E outbox**, which is exactly why the outbox landed first.

## Tests

- `backend/tests/test_relay_gateway.py` — an unarmed connection survives 3 misses and is reaped on the 4th; a pong tightens the limit so two misses then suffice; `close_for_shutdown` sends the frame, closes 1012 and leaves `connected` False; it is a no-op with nothing connected; and it survives a socket whose `send`/`close` both throw.
- `relay/tests/test_channel_reconnect.py` — close code 1012 classifies as `server_restarting`; an ordinary 1006 close is still a plain `dropped` (the new case must not swallow real drops, which still deserve a growing backoff).

## Verification

- `relayStatus` flips to `false` within ~80 s of killing the relay's network without a clean close (previously ~1 h), and the slot frees so another relay can take it.
- Trigger a Railway redeploy while watching `relay.log`: expect `backend is restarting; reconnecting immediately` followed by `channel connected` within seconds, not a 30 s backoff.
- With PR E live, submit a receive during that window and confirm it queues and drains.
