### PR TITLE
chore(relay): drop the stale localhost relay POC and gitignore relay.log (#307)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ desktop.ini
 # Alembic
 backend/alembic/versions/__pycache__/
 
+# Relay runtime output. The relay writes relay.log next to wherever it is run from, so a dev run
+# started at the repo root leaves one there; the packaged install writes to %LOCALAPPDATA% instead.
+# dist/ and build/ above already cover the PyInstaller output under relay/.
+relay.log
+relay/relay.log
+
 # Dev Planning (not tracked)
 Dev Planning/
 


### PR DESCRIPTION
Closes #307.

deleted from this workstation, none tracked in git:
localhost relay/ (POC ancestor, superseded by relay/ in #270)
localhost relay/config.toml (held an old dev shared secret)
config.toml.bak-prerelay-20260707235753
relay/dist
relay/build
relay.log at repo root

.gitignore is the only tracked change, adding relay.log and relay/relay.log. dist/ and build/ already covered. the relay writes relay.log next to wherever it is run from, so a dev run started at the repo root leaves one there; the packaged install writes to %LOCALAPPDATA% instead.

POC docs stay. localhost-relay.md still at relay/docs/relay-to-from-gp/localhost-relay.md.

per-machine cleanup. other dev checkouts still hold their own copies.
