### PR TITLE
fix(relay): recover an update ledger a dead helper left mid-flight (#369)

### DIFF
--- a/relay/src/ucnexus_relay/app.py
+++ b/relay/src/ucnexus_relay/app.py
@@ -158,6 +158,16 @@ class RelayApp:
             timer.start()
         return result
 
+    def _reconcile_update_ledger(self) -> None:
+        """Clear a stuck update-state.json at startup (#369). Never fatal: a relay that cannot read its
+        own ledger must still come up and serve GP, so the worst case is the pre-#369 behaviour."""
+        try:
+            from . import updater
+
+            updater.reconcile_ledger(self._install_dir(), logger)
+        except Exception:
+            logger.exception("error reconciling the update ledger on startup")
+
     def _cancel_update_if_pending(self) -> None:
         if self._updating:
             return  # this teardown IS the update handoff, not a user cancel
@@ -306,6 +316,9 @@ class RelayApp:
                 return 0
             self._cleanup_old_versions()
         self.ensure_serve()
+        # Settle a ledger a dead helper left mid-flight (#369) BEFORE the poller reads it - should_stage
+        # treats staging/applying as "already in progress", so a stuck one silently ends auto-updates.
+        self._reconcile_update_ledger()
         # Auto-update polling (#353 PR D): without it, every relay-side fix needs someone physically at
         # the workstation to press Update now.
         self._update_poller_stop = update_poller.start(self)

--- a/relay/src/ucnexus_relay/update_poller.py
+++ b/relay/src/ucnexus_relay/update_poller.py
@@ -59,7 +59,12 @@ def should_stage(check: dict, ledger: dict, cancel_requested: bool) -> tuple[boo
 
     status = ledger.get("status")
     if status in ("staging", "applying"):
-        return False, f"an update is already in progress ({status})"
+        # ...unless nothing has touched it for far longer than a helper can legally run (#369). A helper
+        # that died before writing its terminal status would otherwise pin this branch forever and the
+        # relay would silently never update again. Startup reconciliation normally clears it first; this
+        # is the backstop for a relay that stays up for weeks.
+        if not updater.ledger_is_abandoned(ledger):
+            return False, f"an update is already in progress ({status})"
 
     latest = check.get("latest")
     if (

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -44,6 +44,12 @@ _UPDATE_LOG = "update.log"  # the helper's own log, next to config.toml
 _DOWNLOAD_NAME = "ucnexus-relay-download.zip"
 MAX_ATTEMPTS = 3  # circuit breaker: give up on a target build after this many helper runs
 _GLOBAL_DEADLINE_SECONDS = 90.0  # hard wall-clock cap on the whole sequence
+# How long a staging/applying ledger may sit untouched before it is read as abandoned rather than
+# in-flight (#369). The helper's WHOLE sequence is bounded by _GLOBAL_DEADLINE_SECONDS, so 10x that is
+# far past any real run and cannot race one. Without this, a helper that dies before writing its
+# terminal status - crash, taskkill, power loss, logoff mid-update - leaves the ledger pinned at
+# "applying" and update_poller.should_stage refuses to stage anything ever again.
+ABANDONED_AFTER_SECONDS = 900.0
 _APP_EXIT_WAIT_SECONDS = 20.0  # how long to wait for the app to exit on its own before force-killing
 _HEALTH_WAIT_PER_ATTEMPT = 25.0  # per relaunch attempt, how long to wait for /health before retrying
 _POLL_SECONDS = 0.5
@@ -171,6 +177,69 @@ def _finish_ledger(install_dir: Path, status: str, error: str | None) -> None:
     ledger["last_error"] = error
     ledger["updated_at"] = _now_iso()
     _write_ledger(install_dir, ledger)
+
+
+def ledger_age_seconds(ledger: dict) -> float | None:
+    """Seconds since the ledger was last written, or None if it carries no readable `updated_at`.
+    None means "cannot tell", and every caller must treat that as in-flight rather than abandoned -
+    guessing the other way would let a real helper be raced."""
+    raw = ledger.get("updated_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        stamped = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if stamped.tzinfo is None:
+        stamped = stamped.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - stamped).total_seconds()
+
+
+def ledger_is_abandoned(ledger: dict, now_seconds: float = ABANDONED_AFTER_SECONDS) -> bool:
+    """Whether a staging/applying ledger has sat untouched long enough to be a dead helper's leftovers
+    rather than a live update (#369)."""
+    if ledger.get("status") not in ("staging", "applying"):
+        return False
+    age = ledger_age_seconds(ledger)
+    return age is not None and age >= now_seconds
+
+
+def reconcile_ledger(install_dir: str | Path, log: logging.Logger | None = None) -> str | None:
+    """Resolve a ledger left mid-flight by a helper that never wrote its terminal status (#369). Called
+    at app startup, BEFORE the update poller starts, because `should_stage` reads staging/applying as
+    "an update is already in progress" and would otherwise never stage again on this machine.
+
+    The running build is the evidence: if it already equals the stuck target, the update actually landed
+    and only the bookkeeping was lost, so record the success. Otherwise the attempt genuinely failed, and
+    recording that keeps the MAX_ATTEMPTS circuit breaker honest instead of silently forgiving a build
+    that cannot install. A ledger younger than the abandonment threshold is left alone: it may be a
+    helper still working, and this runs in the newly relaunched app while that helper is health-probing it.
+
+    Returns the status it stamped, or None if it left the ledger as it found it."""
+    install_dir = Path(install_dir)
+    ledger = read_ledger(install_dir)
+    if not ledger_is_abandoned(ledger):
+        return None
+
+    target = ledger.get("target_build") or ""
+    if target and target == current_build():
+        _finish_ledger(install_dir, "success", None)
+        if log is not None:
+            log.info("recovered a stuck update ledger: already running %s, marking it applied", target)
+        return "success"
+
+    _finish_ledger(
+        install_dir,
+        "failed",
+        "the update helper exited without recording a result; recovered on the next start",
+    )
+    if log is not None:
+        log.warning(
+            "recovered a stuck update ledger: helper for %s never finished and this build is %s",
+            target or "(unknown)",
+            current_build(),
+        )
+    return "failed"
 
 
 # --- cancel flag --------------------------------------------------------------------------------------

--- a/relay/tests/test_update_poller.py
+++ b/relay/tests/test_update_poller.py
@@ -7,6 +7,7 @@ both invisible until they bite somebody at a workstation nobody can reach."""
 
 import random
 import threading
+from datetime import datetime, timedelta, timezone
 
 from ucnexus_relay import update_poller, updater
 
@@ -214,3 +215,32 @@ def test_start_does_not_spawn_a_thread_outside_a_frozen_build(monkeypatch, tmp_p
     stop = update_poller.start(_FakeApp(tmp_path))
     assert spawned == []
     assert isinstance(stop, threading.Event)
+
+
+# --- the stuck-ledger backstop (#369) -----------------------------------------------------------------
+# Startup reconciliation normally clears an abandoned ledger, but a relay that stays up for weeks never
+# gets that chance, so should_stage has to be able to see past one on its own.
+
+
+def _applying_ledger(seconds_ago: float) -> dict:
+    stamped = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    return {
+        "status": "applying",
+        "target_build": "relay-v0.1.0-build.36",
+        "attempts": 1,
+        "updated_at": stamped.isoformat(timespec="seconds"),
+    }
+
+
+def test_stages_past_a_ledger_no_helper_could_still_be_working_on():
+    ledger = _applying_ledger(updater.ABANDONED_AFTER_SECONDS + 60)
+    stage, reason = update_poller.should_stage(_check(), ledger, cancel_requested=False)
+    assert stage is True
+    assert "build.41" in reason
+
+
+def test_still_refuses_while_a_helper_could_plausibly_be_running():
+    ledger = _applying_ledger(30)
+    stage, reason = update_poller.should_stage(_check(), ledger, cancel_requested=False)
+    assert stage is False
+    assert "already in progress" in reason

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -4,6 +4,7 @@ zip-download + junction-repoint self-update. No network (urlopen/urlretrieve moc
 import json
 import logging
 import zipfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from ucnexus_relay import layout, single_instance, updater
@@ -387,3 +388,70 @@ def test_apply_staged_update_rolls_back_when_the_repoint_fails(tmp_path, monkeyp
     assert repoints == [ver, old]  # tried the new version, then rolled the junction back to the old one
     assert relaunched == [1]  # relaunched the rolled-back (previous) version so the relay stays up
     assert updater.read_ledger(tmp_path)["status"] == "failed"
+
+
+# --- stuck-ledger reconciliation (#369) ---------------------------------------------------------------
+# A helper that dies before writing its terminal status leaves the ledger on staging/applying forever,
+# and update_poller.should_stage reads that as "an update is already in progress" - so the relay stops
+# updating and nobody finds out. These pin the recovery, including the case that actually happened:
+# the update LANDED and only the bookkeeping was lost.
+
+
+def _aged_ledger(seconds_ago: float, **overrides) -> dict:
+    stamped = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    led = {
+        "status": "applying",
+        "target_build": "relay-v0.1.0-build.36",
+        "attempts": 1,
+        "last_error": None,
+        "updated_at": stamped.isoformat(timespec="seconds"),
+    }
+    led.update(overrides)
+    return led
+
+
+def test_reconcile_marks_a_stuck_ledger_applied_when_that_build_is_already_running(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.36")
+    updater._write_ledger(tmp_path, _aged_ledger(updater.ABANDONED_AFTER_SECONDS + 60))
+
+    assert updater.reconcile_ledger(tmp_path) == "success"
+    assert updater.read_ledger(tmp_path)["status"] == "success"
+
+
+def test_reconcile_marks_a_stuck_ledger_failed_when_the_build_never_took(tmp_path, monkeypatch):
+    # The attempt genuinely failed, so it has to be recorded as such - forgiving it would hide a build
+    # that cannot install from the MAX_ATTEMPTS circuit breaker.
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.32")
+    updater._write_ledger(tmp_path, _aged_ledger(updater.ABANDONED_AFTER_SECONDS + 60))
+
+    assert updater.reconcile_ledger(tmp_path) == "failed"
+    led = updater.read_ledger(tmp_path)
+    assert led["status"] == "failed"
+    assert led["attempts"] == 1  # untouched, so the breaker still counts this attempt
+    assert "without recording a result" in led["last_error"]
+
+
+def test_reconcile_leaves_a_genuinely_in_flight_ledger_alone(tmp_path, monkeypatch):
+    # This runs in the newly relaunched app while the helper that launched it is still health-probing.
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.36")
+    updater._write_ledger(tmp_path, _aged_ledger(5))
+
+    assert updater.reconcile_ledger(tmp_path) is None
+    assert updater.read_ledger(tmp_path)["status"] == "applying"
+
+
+def test_reconcile_ignores_settled_and_missing_ledgers(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater, "current_build", lambda: "relay-v0.1.0-build.36")
+    assert updater.reconcile_ledger(tmp_path) is None  # no file at all
+
+    for status in ("success", "failed", "cancelled"):
+        updater._write_ledger(tmp_path, _aged_ledger(updater.ABANDONED_AFTER_SECONDS + 60, status=status))
+        assert updater.reconcile_ledger(tmp_path) is None, status
+        assert updater.read_ledger(tmp_path)["status"] == status
+
+
+def test_a_ledger_with_no_readable_timestamp_is_never_abandoned(tmp_path):
+    # "Cannot tell how old it is" must read as in-flight; the other way round races a live helper.
+    assert updater.ledger_is_abandoned({"status": "applying"}) is False
+    assert updater.ledger_is_abandoned({"status": "applying", "updated_at": "not-a-date"}) is False
+    assert updater.ledger_age_seconds({"updated_at": "not-a-date"}) is None


### PR DESCRIPTION
Closes #369.

update helper exits before writing its terminal status -> update-state.json pinned at staging/applying -> update_poller.should_stage refuses to stage anything again. workstation stops receiving relay updates, which is what #353 exists to prevent.

found live on TAGGING3W10: build.36 applied, running, healthy, channel connected, ledger still "applying" from four hours earlier.

reconcile_ledger() runs at app startup, before the poller reads the ledger. the running build is the evidence:
running build == stuck target -> the update landed and only the bookkeeping was lost, record success
otherwise -> record failure, MAX_ATTEMPTS circuit breaker still counts it rather than forgiving a build that cannot install
ledger younger than the abandonment threshold -> left alone, it may be a live helper still health-probing the app this runs in

should_stage gets a staleness escape, the backstop for a relay that stays up for weeks and never gets a startup pass.

ABANDONED_AFTER_SECONDS = 900, ten times the helper's own 90s hard cap, so it cannot race a real helper.

unreadable or absent updated_at reads as in-flight, never abandoned; the other way round would race a live helper.

the crash itself is already fixed. helper runs from the old settled version -> the build.36 apply ran build.32 code, which predates the #318/#319 idna fix. builds 28, 31 and 32 all lacked it. this PR is about nothing recovering from it.

test_updater.py adds 5 cases covering landed, failed, still-in-flight, settled, and the unreadable-timestamp guard. test_update_poller.py adds 2 for the staleness escape. full relay suite passes (232 tests), ruff clean.

live ledger on TAGGING3W10 cleared by hand to status success, since the poller was wedged and could not have pulled this fix down on its own.
