### PR TITLE
feat(relay): let admins remove a relay install (#366)

### DIFF
--- a/ADMIN_RELAY_PROVISIONING_UI.md
+++ b/ADMIN_RELAY_PROVISIONING_UI.md
@@ -1,0 +1,56 @@
+# Admin UI: provision relay enrollment tokens + list relay installs
+
+Closes the deferred nexus-side relay-installs admin view (#204).
+
+**Why:** the relay's Setup tab (guided first-run) asks the operator to paste an enrollment token, but Nexus has no UI to mint one - today an admin must call the provisionRelayInstall GraphQL mutation directly. This is the missing Nexus half of guided setup.
+
+frontend-only. backend already provides these, unchanged:
+- relayInstalls -> [RelayInstallInfo] { id label company hostname enrolled enrolledAt lastSeenAt createdAt }, require_admin (backend/app/schemas/types.py:116; queries.py:1039).
+- relayStatus -> { connected company }, require_user (used by useRelayStatus).
+- provisionRelayInstall(label, company) -> RelayInstallProvision { installId label company enrollmentToken enrollmentTokenExpiresAt }, require_admin (mutations.py:1254).
+- token one-time (enrolled_at guard), 24h TTL (enrollment_token_expires_at). consumed via relay Setup tab or enroll CLI.
+
+## admin gating
+- isAdmin = useIdentity().hasRole('Admin/Manager') (src/hooks/useIdentity.ts, reads Clerk user.publicMetadata.roles). existing pages gate via const { isAdmin } = useIdentity() (VendorsPage.tsx:34).
+- sidebar nav requiredRoles: ['Admin/Manager'] (Sidebar.tsx:89).
+- backend enforces require_admin on query + mutation.
+- new page gates render on isAdmin, else "Admins only". nav item carries same requiredRoles.
+
+## graphql documents
+- src/graphql/queries.ts add RELAY_INSTALLS (relayInstalls { id label company hostname enrolled enrolledAt lastSeenAt createdAt }). GET_RELAY_STATUS exists.
+- src/graphql/mutations.ts add PROVISION_RELAY_INSTALL (provisionRelayInstall(label, company) { installId label company enrollmentToken enrollmentTokenExpiresAt }).
+
+## new page src/modules/admin/RelayInstallsPage.tsx
+- gate on const { isAdmin } = useIdentity(); non-admin -> "Admins only" notice, stop.
+- header - title + live relay-status chip (RelayStatusChip + useRelayStatus).
+- "Provision install" button opens Modal (label text field + company - Select of known GP companies or text field w/ hint). submit runs PROVISION_RELAY_INSTALL.
+- on success show persistent copyable panel (pattern like GpErrorAlert), containing:
+  - one-time token, monospace + Copy token button.
+  - warning it is shown ONCE, expires 24h (show enrollmentTokenExpiresAt).
+  - next step "paste this token into the relay's Setup tab (Enroll step)".
+  - CLI alternative `ucnexus-relay.exe enroll --token <TOKEN> --backend-url https://<backend-host>/graphql` + Copy command button (derive <backend-host> from import.meta.env.VITE_GRAPHQL_URL).
+- DataGrid of relayInstalls -> columns Label, Company, Hostname, Enrolled (chip), Enrolled at, Last seen, Created. refetch after provision. empty state when none.
+- useToast on success/failure; surface GraphQL error message on failure.
+
+## routing + nav
+- src/modules/admin/index.tsx add `<Route path="relay-installs" element={<AdminSubLayout><RelayInstallsPage/></AdminSubLayout>} />`.
+- src/modules/admin/AdminLanding.tsx add SUB_ROUTES entry { label: 'Relay Installs', path: '/app/admin/relay-installs', icon: <RouterIcon> }.
+- src/components/Sidebar.tsx add subItem { label: 'Relay Installs', path: '/app/admin/relay-installs' } under Admin (requiredRoles: ['Admin/Manager']).
+
+## conventions
+- match VendorsPage / UserManagementPage: DataGrid + Modal + useQuery/useMutation + refetch + useToast. wrap in AdminSubLayout (BackToModule).
+- company field Select seeded from TUBC, TUCSH, UBC, UCSH or free text w/ hint. confirm list with user.
+
+## edge cases
+- each provision creates a NEW pending un-enrolled install row; re-provision does not reuse a prior row. list shows pending (enrolled=false) vs enrolled.
+- no backend delete/revoke mutation -> install can't be removed from UI. possible follow-up - add revoke mutation if stale pending rows become noise.
+- last_seen_at updates on enroll + each channel authenticate -> doubles as liveness signal.
+
+## Simulated User Testing
+against Railway (frontend-production-34fc, backend-production-7866), signed in as Admin/Manager (jayp has role):
+1. https://frontend-production-34fc.up.railway.app/app/admin -> confirm "Relay Installs" card -> click -> lands /app/admin/relay-installs.
+2. confirm page renders: relay-status chip (reads "relay connected", TUBC relay enrolled/running) + DataGrid listing existing enrolled install (TUBC, enrolled=true, recent last-seen).
+3. "Provision install" -> label "test-install" + company "TUBC" -> submit. expect one-time token panel (token, 24h expiry, paste-into-Setup-tab instruction + enroll command, Copy buttons); verify Copy token puts token on clipboard. expect DataGrid refetch showing new install enrolled=false (pending), company TUBC.
+4. reload -> token NOT shown again, pending install still appears.
+5. sidebar shows "Relay Installs" only under Admin. if non-admin test user available, page shows "Admins only" + nav item hidden; else verify backend rejects relayInstalls / provisionRelayInstall without admin.
+6. optional full loop: relay Setup tab, paste provisioned token + enroll -> back on Relay Installs, refetch -> pending install flips enrolled=true with fresh last-seen.

--- a/MANUFACTURER_VENDOR_ORDERING_SPEC.md
+++ b/MANUFACTURER_VENDOR_ORDERING_SPEC.md
@@ -1,0 +1,101 @@
+manufacturer + vendor ordering (issue #228) - implementation spec
+
+TITAN hardware schedules carry a manufacturer name per product. PO users order hardware from the manufacturer (buy direct) or a distributor/vendor.
+
+ground truth (read-only TUBC exploration, full findings on #228)
+- GP has no separate populated manufacturer entity. every orderable party is a vendor in PM00200.
+- Allegion, ASSA ABLOY, Dormakaba exist in PM00200 as vendors, indistinguishable by class from distributors.
+- a GP PO is cut to exactly one VENDORID. order-from-manufacturer vs order-from-vendor = same taPoHdr/taPoLine flow, different VENDORID.
+- TITAN manufacturer name maps to GP only as a fuzzy match against PM00200 vendor names, only when that manufacturer is set up as a vendor. not exact (case, "INC.", ASSA ABLOY = 2 records, DORMAKABA = 2 records). manufacturers with no vendor record can't be matched.
+- Nexus PO carries one gp_vendor_id + name snapshot.
+- vendor list fetched live from relay /vendors (PM00200).
+- vendor mirror dropped in migration 040.
+- current parser drops TITAN manufacturer.
+- HardwareItem stores vendor_no, no manufacturer field.
+- eConnect public API can't set per-line manufacturer. taPoLine has 71 params, none for manufacturer. POP10140 (native per-line Manufacturer field) has only internal zDP_POP10140 helpers, no public taXxx entity proc.
+
+locked decisions
+1. capture TITAN manufacturer + use it to suggest/auto-pick the ordering vendor, user override.
+2. write manufacturer into GP too.
+
+open decision, settle before write-back phase
+
+POP10140 (GP native per-line Manufacturer) is not writable through the sanctioned eConnect entity API. pick one:
+- A. taPoLine @I_vUSRDEFND1 (char 50). no new proc. does NOT populate GP native manufacturer window. recommended default.
+- B. taPoLine line comment @I_vCMMTTEXT (varchar 500). prints on the PO.
+- C. call internal zDP_POP10140SI directly to populate native POP10140. conflicts with eConnect-only rule. needs explicit sign-off.
+- D. Nexus-only, no GP write.
+
+ship phases 1-2 first, settle A vs B vs C for phase 3. default A unless purchasing needs it on the printed PO (then B or A+B), or the native field is a hard requirement (then C, with sign-off).
+
+part 1 - capture manufacturer from TITAN
+- parser (frontend/src/workers/parserLogic.ts, extractHardwareItems) reads manufacturer from Material_List_Fields alongside Vendor_No, adds to ParsedHardwareItem.
+  - confirm the XML element name against a real TITAN export. legacy UC Connects stored it as column "MFG" / property Manufacturer. test fixtures don't include it. likely mlf.Manufacturer or mlf.MFG.
+- add manufacturer (String, nullable) to HardwareItem (backend/app/models/hardware.py) next to vendor_no.
+- migration adds hardware_items.manufacturer (nullable, no backfill).
+- import path persists manufacturer from parsed items (same path that persists vendor_no).
+- GraphQL exposes HardwareItem.manufacturer on the type, adds it to the import input.
+
+part 2 - manufacturer -> vendor suggestion (learned mapping + fuzzy fallback)
+- new table manufacturer_vendor_map holds:
+  - id
+  - gp_company
+  - manufacturer_key (normalized)
+  - manufacturer_label (as seen)
+  - gp_vendor_id (char 15)
+  - gp_vendor_name (snapshot)
+  - source (confirmed | imported)
+  - created_at
+  - updated_at
+- unique (gp_company, manufacturer_key). one preferred vendor per manufacturer per company, user override at PO time updates it. multi-candidate mapping later if needed.
+- normalize TITAN manufacturer + GP vendor name (both mapping key + fuzzy match):
+  - uppercase
+  - collapse whitespace
+  - strip punctuation
+  - strip trailing legal suffixes (INC, LTD, LTEE, CORP, CO, "OF CANADA", "CANADA")
+- resolver suggestVendorForManufacturer(gpCompany, manufacturer):
+  1. mapping-table hit on (company, normalized) -> return that gp_vendor as pre-selected suggestion (high confidence).
+  2. else fuzzy-match normalized manufacturer against live PM00200 list (relay /vendors) -> return top N ranked candidates with scores.
+  3. return { savedMapping: bool, candidates: [...] }.
+- dependency rapidfuzz (backend) for token_set_ratio scoring, or hand-rolled ratio for no new dep.
+- on PO create/register, upsert (company, manufacturer_key) -> chosen gp_vendor_id, source=confirmed.
+
+part 3 - PO creation UX
+- PO items share a manufacturer -> pre-select suggested vendor, label it ("suggested: manufacturer = X"). show fuzzy alternatives. user accepts or overrides with any vendor from the live list.
+- selected items span manufacturers mapping to different vendors -> warn, require explicit vendor pick. don't silently pick one.
+- manufacturer with no GP vendor record -> suggestion empty, user picks manually, soft note ("manufacturer not set up as a GP vendor").
+- on confirm, persist the mapping (part 2 learn step).
+
+part 4 - GP write-back (relay), default A
+- add manufacturer (str | None, max 50) to relay models.POLine.
+- relay econnect.create_po_line adds @I_vUSRDEFND1 = ? (RTRIM + truncate to 50).
+- backend _prepare_create_po / _prepare_register_po include per-line manufacturer in the relay payload, derived from each line's hardware item.
+- tests for the new param.
+- confirm @I_vUSRDEFND1 at this customer is free + not read/printed anywhere before phase 3.
+- B instead -> write @I_vCMMTTEXT and/or @I_vCOMMENT_1.
+- C -> separate spike, validate zDP_POP10140SI against TUBC with sign-off, isolated from the proven taPoLine path.
+
+sequencing
+1. phase 1 - capture manufacturer (parser + model + migration + import + display). independent, shippable alone.
+2. phase 2 - mapping table + suggestion query + PO UI suggestion/override + learn-on-confirm.
+3. phase 3 - GP write-back, after A/B/C settled.
+
+simulated user testing
+
+Chrome DevTools MCP against Railway, after each phase deploys.
+
+phase 1
+- navigate to import module URL, import a hardware schedule containing manufacturers.
+- verify each hardware item shows its manufacturer (list/detail view).
+- verify an item whose product had no manufacturer shows blank, not an error.
+
+phase 2
+- navigate to the PO creation flow for a project with Allegion items.
+- verify the vendor picker pre-selects the suggested vendor (mapping hit or top fuzzy candidate) and labels why.
+- override to a different vendor, confirm the PO.
+- start a second PO for another Allegion project, verify it now auto-picks the vendor learned from the override.
+- select items spanning two manufacturers that map to different vendors, verify the mixed-manufacturer warning and that an explicit pick is required.
+- select an item whose manufacturer is not a GP vendor, verify the empty-suggestion soft note.
+
+phase 3
+- create a PO through the relay, verify the GP PO line carries the manufacturer in the chosen field (read back via the relay PO read, or check TUBC POP10110 USRDEFND1 for option A / POP10140 for option C).

--- a/backend/app/repositories/relay_repository.py
+++ b/backend/app/repositories/relay_repository.py
@@ -113,6 +113,33 @@ def adopt_secret(session: Session, install_id: uuid.UUID, secret: str, adopted_b
     return install
 
 
+def delete_install(session: Session, install_id: uuid.UUID) -> dict | None:
+    """Remove a relay install row outright (#366). Returns a plain dict of the fields worth logging, or
+    None when the row is already gone (the resolver turns that into NotFoundError).
+
+    Hard delete, not a soft-delete flag. A flag would have to be honoured by `authenticate_secret` too or
+    the "deleted" install keeps authenticating - a new filter on the handshake hot path and a new way to
+    be silently wrong - and it would leave `secret_encrypted` populated, which is the very thing blocking
+    the RELAY_SECRET_ENC_KEY retirement (see app/config.py). Nothing references relay_installs by foreign
+    key, so this is a clean single-row delete.
+
+    The dict is built BEFORE the delete because the caller logs those values afterwards, and the instance
+    is unusable by then."""
+    install = session.get(RelayInstall, install_id)
+    if install is None:
+        return None
+    snapshot = {
+        "id": str(install.id),
+        "label": install.label,
+        "company": install.company,
+        "hostname": install.hostname,
+        "enrolled_at": install.enrolled_at.isoformat() if install.enrolled_at else None,
+    }
+    session.delete(install)
+    session.flush()
+    return snapshot
+
+
 def authenticate_secret(session: Session, secret: str) -> RelayInstall | None:
     """Verify a Bearer secret presented on the outbound WS channel's connect handshake against the
     enrolled installs.

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -1,12 +1,13 @@
 """Relay installs + live GP reads via the connected relay."""
 
+import logging
 import uuid
 
 import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.errors import NotFoundError
+from app.errors import ConflictError, NotFoundError
 from app.models.relay_install import RelayInstall
 from app.repositories import relay_repository
 from app.services import relay_adopt
@@ -34,6 +35,8 @@ from .types import (
     VendorCandidate,
     VendorSuggestion,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @strawberry.type
@@ -65,7 +68,13 @@ class RelayQueries:
         """Whether the outbound relay WS channel is currently connected (and, if so, the GP company it is
         enrolled for), for the relay status chip and the company-aware PO/receive/adopt dialogs."""
         require_user(info)
-        return RelayStatus(connected=relay_gateway.connected, company=relay_gateway.company, build=relay_gateway.build)
+        live_install = relay_gateway.install_id
+        return RelayStatus(
+            connected=relay_gateway.connected,
+            company=relay_gateway.company,
+            build=relay_gateway.build,
+            install_id=strawberry.ID(str(live_install)) if live_install else None,
+        )
 
     @strawberry.field
     async def gp_jobs(self, info: strawberry.Info, company: str) -> list[GpJob]:
@@ -209,6 +218,42 @@ class RelayMutations:
             expires_at=window.expires_at,
             armed_by=window.armed_by,
         )
+
+    @strawberry.mutation
+    def delete_relay_install(self, info: strawberry.Info, install_id: strawberry.ID) -> bool:
+        """Admin: remove a relay install row and revoke its secret (#366).
+
+        Rows pile up from every abandoned provisioning attempt - a token minted and never used, a
+        re-enrolment that superseded an earlier row, a retired workstation - and until now the only way
+        to remove one was hand-written SQL against Railway Postgres. Two things made that worse than
+        clutter: a stale pre-067 row keeps `secret_encrypted` forever, so the count that gates retiring
+        RELAY_SECRET_ENC_KEY never reaches 0; and the row is a live credential `authenticate_secret`
+        would still accept.
+
+        Refuses the install currently holding the connection - revoking the credential under a live relay
+        would take GP down. A merely switched-off relay deletes fine; that is the retire-a-workstation
+        case, and the confirm dialog carries the warning."""
+        identity = require_admin(info)
+        target = uuid.UUID(str(install_id))
+        if relay_gateway.install_id == target:
+            raise ConflictError("That relay is currently connected. Disconnect it before removing the install.")
+        with SessionLocal() as session:
+            snapshot = relay_repository.delete_install(session, target)
+            if snapshot is None:
+                raise NotFoundError("Relay install not found", field="install_id")
+            session.commit()
+        # The row is gone, so this log is the only remaining record of it - and revoking a relay
+        # credential is exactly the kind of act worth being able to grep for afterwards.
+        logger.warning(
+            "relay install deleted: %s (label=%s company=%s hostname=%s enrolled_at=%s) by %s",
+            snapshot["id"],
+            snapshot["label"],
+            snapshot["company"],
+            snapshot["hostname"],
+            snapshot["enrolled_at"],
+            identity["user_id"],
+        )
+        return True
 
     @strawberry.mutation
     def disarm_relay_adopt(self, info: strawberry.Info) -> bool:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -160,6 +160,10 @@ class RelayStatus:
     # Null when disconnected, or when an older relay that predates the hello frame is connected. Shown on
     # the Admin -> Relay Installs page so an out-of-date relay is visible before an op fails.
     build: str | None = None
+    # Which relay_installs row is holding the live connection (#366). The Relay Installs grid used to
+    # infer this from company + last_seen_at; now it can say so outright, and it is what disables Remove
+    # on the connected row.
+    install_id: strawberry.ID | None = None
 
 
 @strawberry.type

--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -46,6 +46,10 @@ class RelayGateway:
     def __init__(self) -> None:
         self._socket: WebSocket | None = None
         self._company: str | None = None
+        # Which relay_installs row authenticated the live connection (#366). Without it the backend knows
+        # a relay is connected but not WHICH install it is, so delete_relay_install cannot refuse to
+        # revoke the credential currently holding the connection.
+        self._install_id: uuid.UUID | None = None
         self._pending: dict[str, asyncio.Future] = {}
         # Relay identity advertised on the connect `hello` frame (issue #315). `_build` is the relay's
         # build tag (e.g. 'relay-v0.1.0-build.30'); `_ops` is its supported op-set. Both stay None for an
@@ -72,13 +76,20 @@ class RelayGateway:
         return self._company
 
     @property
+    def install_id(self) -> uuid.UUID | None:
+        """The relay_installs row backing the live connection (None when disconnected). Lets
+        delete_relay_install refuse to revoke the credential that is currently holding the connection,
+        and lets RelayStatus name which install is live instead of the grid inferring it (#366)."""
+        return self._install_id
+
+    @property
     def build(self) -> str | None:
         """The connected relay's build tag from its hello frame (issue #315), None when disconnected or
         when an older relay that predates the hello frame is connected. Surfaced on RelayStatus so the
         Admin -> Relay Installs page can show which build is live."""
         return self._build
 
-    def try_register(self, company: str, websocket: WebSocket) -> bool:
+    def try_register(self, company: str, websocket: WebSocket, install_id: uuid.UUID | None = None) -> bool:
         """Called by the /relay-link route once a connecting socket has authenticated. Returns True and
         takes the single connection slot when it's free; returns False (route closes the socket) when a
         relay is already connected, so the incumbent's in-flight calls are never disturbed."""
@@ -86,6 +97,7 @@ class RelayGateway:
             return False
         self._socket = websocket
         self._company = company
+        self._install_id = install_id
         self._build = None
         self._ops = None
         self._unanswered_pings = 0
@@ -97,6 +109,7 @@ class RelayGateway:
         if self._socket is websocket:
             self._socket = None
             self._company = None
+            self._install_id = None
             self._build = None
             self._ops = None
             self._unanswered_pings = 0

--- a/backend/main.py
+++ b/backend/main.py
@@ -255,6 +255,8 @@ async def relay_link(websocket: WebSocket):
         # websocket.accept(), the exception tore down every already-accepted relay socket, so no relay
         # could ever register (relayStatus stayed false).
         company = install.company if install is not None else None
+        # Same rule for the id (#366): read it here, beside company, while the row is still attached.
+        install_id = install.id if install is not None else None
         session.commit()
     if company is None:
         await websocket.close(code=4401)
@@ -264,7 +266,7 @@ async def relay_link(websocket: WebSocket):
     # POC scope: one relay at a time, incumbent wins (issue #202 #6). If a relay is already connected,
     # reject this one rather than superseding - superseding could drop an in-flight reply for a GP write
     # that committed, and two enrolled relays would otherwise thrash by force-closing each other.
-    if not relay_gateway.try_register(company, websocket):
+    if not relay_gateway.try_register(company, websocket, install_id):
         await websocket.close(code=4409)
         return
     # A relay just came back: drain anything that queued while it was gone, now, rather than up to a

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -359,3 +359,37 @@ def test_relay_call_maps_an_unknown_op_reply_to_op_unsupported():
         assert exc_info.value.detail["error"] == "unknown_op"
 
     asyncio.run(run())
+
+
+# --- which install is live (#366) ---------------------------------------------------------------------
+# The gateway knew a relay was connected but not WHICH install it was, so nothing could refuse to delete
+# the row backing the live connection - deleting it revokes the secret out from under a running relay.
+
+
+def test_try_register_records_the_install_backing_the_connection():
+    import uuid
+
+    gateway = RelayGateway()
+    assert gateway.install_id is None
+    install_id = uuid.uuid4()
+    assert gateway.try_register("TUBC", FakeWebSocket(), install_id) is True
+    assert gateway.install_id == install_id
+
+
+def test_unregister_clears_the_install_id():
+    import uuid
+
+    gateway = RelayGateway()
+    ws = FakeWebSocket()
+    gateway.try_register("TUBC", ws, uuid.uuid4())
+    gateway.unregister(ws)
+    assert gateway.install_id is None
+    assert gateway.connected is False
+
+
+def test_an_older_caller_that_omits_the_install_id_still_registers():
+    # try_register is also reached from tests and any path that has no row in hand; a missing id must
+    # read as "unknown", never block the connection.
+    gateway = RelayGateway()
+    assert gateway.try_register("TUBC", FakeWebSocket()) is True
+    assert gateway.install_id is None

--- a/backend/tests/test_relay_installs.py
+++ b/backend/tests/test_relay_installs.py
@@ -83,3 +83,41 @@ def test_a_rotated_encryption_key_no_longer_orphans_an_install(db_session, monke
     found = relay_repository.authenticate_secret(db_session, "valid-secret")
     assert found is not None
     assert found.label == "WS6"
+
+
+# --- deletion (#366) ----------------------------------------------------------------------------------
+# Rows accumulate from every abandoned provisioning attempt, and until this existed the only way to
+# remove one was hand-written SQL. Two properties matter: the credential is genuinely revoked (not just
+# hidden from the grid), and removing one install does not disturb the others.
+
+
+def test_delete_install_revokes_the_credential(db_session):
+    install, token = relay_repository.provision_install(db_session, label="Retired", company="TUBC")
+    relay_repository.enroll_install(db_session, token, hostname="RETIRED", secret="retired-secret")
+    assert relay_repository.authenticate_secret(db_session, "retired-secret") is not None
+
+    snapshot = relay_repository.delete_install(db_session, install.id)
+
+    assert snapshot["label"] == "Retired"
+    assert snapshot["hostname"] == "RETIRED"
+    # The point of a hard delete: the secret stops authenticating, rather than the row merely hiding.
+    assert relay_repository.authenticate_secret(db_session, "retired-secret") is None
+
+
+def test_delete_install_returns_none_for_a_row_that_is_already_gone(db_session):
+    import uuid as _uuid
+
+    assert relay_repository.delete_install(db_session, _uuid.uuid4()) is None
+
+
+def test_delete_install_leaves_the_other_installs_authenticating(db_session):
+    doomed, doomed_token = relay_repository.provision_install(db_session, label="Doomed", company="TUBC")
+    relay_repository.enroll_install(db_session, doomed_token, hostname="D", secret="doomed-secret")
+    _, keeper_token = relay_repository.provision_install(db_session, label="Keeper", company="TUBC")
+    keeper = relay_repository.enroll_install(db_session, keeper_token, hostname="K", secret="keeper-secret")
+
+    relay_repository.delete_install(db_session, doomed.id)
+
+    assert relay_repository.authenticate_secret(db_session, "doomed-secret") is None
+    still_there = relay_repository.authenticate_secret(db_session, "keeper-secret")
+    assert still_there is not None and still_there.id == keeper.id

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -380,3 +380,74 @@ def test_read_loop_records_the_relay_hello_frame(monkeypatch):
         assert gateway.build is None  # cleared on unregister
 
     asyncio.run(run())
+
+
+# --- deleting an install while a relay is live (#366) --------------------------------------------------
+
+
+class _FakeInfo:
+    """A resolver `info` with no real request. require_admin is patched out per test - what is under
+    test here is the connected-install guard, not the auth gate (that lives in
+    test_resolver_auth_gates)."""
+
+    context = {"request": None}
+
+
+def _as_admin(monkeypatch):
+    from app.schemas import relay as relay_module
+
+    monkeypatch.setattr(relay_module, "require_admin", lambda info: {"user_id": "user_admin", "roles": ["Admin"]})
+
+
+def test_delete_refuses_the_install_holding_the_live_connection(_migrate_database, monkeypatch):
+    """Revoking the secret under a running relay would take GP down mid-write, so the resolver refuses
+    it. This drives the real route because the id it compares against is set by the route - reading
+    install.id in the same pre-commit block as install.company, per the DetachedInstanceError rule."""
+    from app.errors import ConflictError
+    from app.schemas.relay import RelayMutations
+
+    _as_admin(monkeypatch)
+    secret = "relay-link-delete-guard-secret"
+    install_id = _enroll_committed("WS-DELETE-GUARD", "TUBC", secret)
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {secret}"}) as ws:
+                _wait_until(lambda: gateway.connected)
+                assert gateway.install_id == install_id  # the route recorded WHICH row authenticated
+
+                with pytest.raises(ConflictError):
+                    RelayMutations().delete_relay_install(_FakeInfo(), str(install_id))
+
+                ws.close()
+                _wait_until(lambda: not gateway.connected)
+        # Refused, not half-done: the row and its credential are still there.
+        with SessionLocal() as session:
+            assert session.get(RelayInstall, install_id) is not None
+    finally:
+        _delete_install(install_id)
+
+
+def test_delete_allows_a_different_disconnected_install_while_one_is_live(_migrate_database, monkeypatch):
+    # Retiring a workstation is the normal case and must not be blocked by an unrelated relay being up.
+    from app.schemas.relay import RelayMutations
+
+    _as_admin(monkeypatch)
+    live_secret = "relay-link-delete-live-secret"
+    live_id = _enroll_committed("WS-DELETE-LIVE", "TUBC", live_secret)
+    other_id = _enroll_committed("WS-DELETE-OTHER", "TUBC", "relay-link-delete-other-secret")
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/relay-link", headers={"Authorization": f"Bearer {live_secret}"}) as ws:
+                _wait_until(lambda: gateway.connected)
+
+                assert RelayMutations().delete_relay_install(_FakeInfo(), str(other_id)) is True
+
+                assert gateway.connected is True  # the live relay is undisturbed
+                assert gateway.install_id == live_id
+                ws.close()
+                _wait_until(lambda: not gateway.connected)
+        with SessionLocal() as session:
+            assert session.get(RelayInstall, other_id) is None
+    finally:
+        _delete_install(live_id)
+        _delete_install(other_id)

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -163,6 +163,9 @@ _ADMIN_GATED = [
     ("relayAdoptWindow", relay_module, lambda: RelayQueries().relay_adopt_window(FakeInfo())),
     ("armRelayAdopt", relay_module, lambda: RelayMutations().arm_relay_adopt(FakeInfo(), _id())),
     ("disarmRelayAdopt", relay_module, lambda: RelayMutations().disarm_relay_adopt(FakeInfo())),
+    # #366: deleting an install revokes a relay credential outright, so the gate is the whole
+    # protection - there is nothing downstream to catch a non-admin caller.
+    ("deleteRelayInstall", relay_module, lambda: RelayMutations().delete_relay_install(FakeInfo(), _id())),
     # #353 PR E: retrying an `ambiguous` queued write can duplicate a GP posting, and cancelling one
     # abandons work somebody has already done. Both are admin-only.
     (

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -109,6 +109,14 @@ export const DISARM_RELAY_ADOPT = gql`
   }
 `;
 
+// Removing an install deletes the row and revokes its secret (#366). Refused by the backend for the
+// install currently holding the connection; the UI disables it there rather than letting it fail.
+export const DELETE_RELAY_INSTALL = gql`
+  mutation DeleteRelayInstall($installId: ID!) {
+    deleteRelayInstall(installId: $installId)
+  }
+`;
+
 export const GET_LOCATION_DUPLICATES = gql`
   query GetLocationDuplicates {
     locationDuplicates {

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -57,6 +57,7 @@ export const GET_RELAY_STATUS = gql`
       connected
       company
       build
+      installId
     }
   }
 `;

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -25,6 +25,7 @@ import {
   RELAY_ADOPT_WINDOW,
   ARM_RELAY_ADOPT,
   DISARM_RELAY_ADOPT,
+  DELETE_RELAY_INSTALL,
 } from '../../graphql/admin';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import GpWriteQueuePanel from './GpWriteQueuePanel';
@@ -81,6 +82,10 @@ const ADOPT_WARNING =
   'install and accepted. Only do this when a relay you own is dialling in with a secret the backend has ' +
   'lost. Cancel the window as soon as the relay reconnects.';
 
+const DELETE_WARNING =
+  'This permanently deletes the install row and revokes its secret. If that relay is still running it ' +
+  'will be refused on every reconnect until it is re-enrolled with a new token. This cannot be undone.';
+
 export default function RelayInstallsPage() {
   const { isAdmin } = useIdentity();
   const { showToast } = useToast();
@@ -120,6 +125,8 @@ export default function RelayInstallsPage() {
   );
   const adoptWindow = windowData?.relayAdoptWindow ?? null;
   const [adoptTarget, setAdoptTarget] = useState<RelayInstall | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<RelayInstall | null>(null);
+  const liveInstallId = relay.installId;
   const [, setTick] = useState(0);
 
   useEffect(() => {
@@ -151,6 +158,21 @@ export default function RelayInstallsPage() {
       refetchQueries: [{ query: RELAY_ADOPT_WINDOW }],
       onCompleted: () => showToast('Adopt window closed', 'success'),
       onError: (err) => showToast(err.message, 'error'),
+    },
+  );
+
+  const [deleteInstall, { loading: deleting }] = useMutation<{ deleteRelayInstall: boolean }>(
+    DELETE_RELAY_INSTALL,
+    {
+      refetchQueries: [{ query: RELAY_INSTALLS }, { query: RELAY_ADOPT_WINDOW }],
+      onCompleted: () => {
+        setDeleteTarget(null);
+        showToast('Relay install removed', 'success');
+      },
+      onError: (err) => {
+        setDeleteTarget(null);
+        showToast(err.message, 'error');
+      },
     },
   );
 
@@ -223,17 +245,38 @@ export default function RelayInstallsPage() {
       {
         field: 'adopt',
         headerName: 'Recovery',
-        width: 190,
+        width: 300,
         sortable: false,
         filterable: false,
-        renderCell: (p) => (
-          <Button size="small" variant="outlined" onClick={() => setAdoptTarget(p.row as RelayInstall)}>
-            Adopt next connection
-          </Button>
-        ),
+        renderCell: (p) => {
+          const isLive = liveInstallId != null && p.row.id === liveInstallId;
+          return (
+            <Stack direction="row" spacing={1}>
+              <Button size="small" variant="outlined" onClick={() => setAdoptTarget(p.row as RelayInstall)}>
+                Adopt next connection
+              </Button>
+              {/* Deleting the row revokes its secret, so doing it to the install currently holding the
+                  connection would take GP down mid-write. The backend refuses it too (#366); this only
+                  saves the admin from an error they can't act on. */}
+              <Tooltip title={isLive ? 'This relay is connected right now. Disconnect it first.' : ''} arrow>
+                <span>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="error"
+                    disabled={isLive}
+                    onClick={() => setDeleteTarget(p.row as RelayInstall)}
+                  >
+                    Remove
+                  </Button>
+                </span>
+              </Tooltip>
+            </Stack>
+          );
+        },
       },
     ],
-    [],
+    [liveInstallId],
   );
 
   if (!isAdmin) {
@@ -369,6 +412,17 @@ export default function RelayInstallsPage() {
           if (adoptTarget) armAdopt({ variables: { installId: adoptTarget.id } });
         }}
         onCancel={() => setAdoptTarget(null)}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={`Remove ${deleteTarget?.label ?? ''}?`}
+        message={DELETE_WARNING}
+        confirmLabel={deleting ? 'Removing…' : 'Remove install'}
+        onConfirm={() => {
+          if (deleteTarget) deleteInstall({ variables: { installId: deleteTarget.id } });
+        }}
+        onCancel={() => setDeleteTarget(null)}
       />
 
       <Dialog open={provisionOpen} onClose={() => setProvisionOpen(false)} maxWidth="xs" fullWidth>

--- a/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/RelayInstallsPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
 import { ToastProvider } from '../../../components/Toast';
 import RelayInstallsPage from '../RelayInstallsPage';
-import { RELAY_INSTALLS, RELAY_ADOPT_WINDOW, ARM_RELAY_ADOPT } from '../../../graphql/admin';
+import { RELAY_INSTALLS, RELAY_ADOPT_WINDOW, ARM_RELAY_ADOPT, DELETE_RELAY_INSTALL } from '../../../graphql/admin';
 import { GET_RELAY_STATUS } from '../../../graphql/shared';
 
 vi.setConfig({ testTimeout: 30_000 });
@@ -54,7 +54,18 @@ const INSTALL = {
 
 const statusMock: MockedResponse = {
   request: { query: GET_RELAY_STATUS },
-  result: { data: { relayStatus: { connected: false, company: null, build: null } } },
+  result: { data: { relayStatus: { connected: false, company: null, build: null, installId: null } } },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+};
+
+// The same status, but with INSTALL holding the live connection (#366) - which is what disables Remove.
+const connectedStatusMock: MockedResponse = {
+  request: { query: GET_RELAY_STATUS },
+  result: {
+    data: {
+      relayStatus: { connected: true, company: 'TUBC', build: 'relay-v0.1.0-build.36', installId: 'install-1' },
+    },
+  },
   maxUsageCount: Number.POSITIVE_INFINITY,
 };
 
@@ -138,4 +149,43 @@ it('shows no armed banner when no window is open', async () => {
   renderPage([statusMock, installsMock, windowMock(null)]);
   await screen.findByRole('button', { name: /adopt next connection/i }, GRID_TIMEOUT);
   expect(screen.queryByText(/adopt window open/i)).toBeNull();
+});
+
+// --- removing an install (#366) ---------------------------------------------------------------------
+
+it('requires the confirm dialog before removing an install', async () => {
+  // Removing revokes the relay's credential permanently, so like arming, the one-click path must not
+  // exist: the warning has to be shown and accepted before the mutation fires.
+  let deleted = false;
+  const deleteMock: MockedResponse = {
+    request: { query: DELETE_RELAY_INSTALL, variables: { installId: 'install-1' } },
+    result: () => {
+      deleted = true;
+      return { data: { deleteRelayInstall: true } };
+    },
+  };
+
+  renderPage([statusMock, installsMock, windowMock(null), deleteMock]);
+
+  const trigger = await screen.findByRole('button', { name: /^remove$/i }, GRID_TIMEOUT);
+  fireEvent.click(trigger);
+  expect(deleted).toBe(false);
+
+  expect(
+    await screen.findByText(/permanently deletes the install row and revokes its secret/i, {}, GRID_TIMEOUT),
+  ).toBeTruthy();
+
+  fireEvent.click(screen.getByRole('button', { name: /remove install/i }));
+  await waitFor(() => expect(deleted).toBe(true), GRID_TIMEOUT);
+});
+
+it('disables Remove on the install that is currently connected', async () => {
+  // Deleting the live install would revoke the secret out from under a running relay and take GP down
+  // mid-write. The backend refuses it; the button must not offer it either.
+  renderPage([connectedStatusMock, installsMock, windowMock(null)]);
+
+  const remove = await screen.findByRole('button', { name: /^remove$/i }, GRID_TIMEOUT);
+  await waitFor(() => expect(remove).toBeDisabled(), GRID_TIMEOUT);
+  // The adopt action stays available - it is the recovery path, not a destructive one.
+  expect(screen.getByRole('button', { name: /adopt next connection/i })).not.toBeDisabled();
 });

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -118,6 +118,7 @@ function baseMocks(
             connected,
             company: connected ? 'UCS' : null,
             build: connected ? 'relay-v0.1.0-build.30' : null,
+            installId: connected ? 'install-1' : null,
             __typename: 'RelayStatus',
           },
         },

--- a/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
@@ -26,7 +26,17 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 function relayMock(): MockedResponse {
   return {
     request: { query: GET_RELAY_STATUS },
-    result: { data: { relayStatus: { __typename: 'RelayStatus', connected: true, company: 'UCSH' } } },
+    result: {
+      data: {
+        relayStatus: {
+          __typename: 'RelayStatus',
+          connected: true,
+          company: 'UCSH',
+          build: null,
+          installId: null,
+        },
+      },
+    },
     maxUsageCount: Number.POSITIVE_INFINITY,
   };
 }

--- a/frontend/src/relay/useRelayStatus.ts
+++ b/frontend/src/relay/useRelayStatus.ts
@@ -9,23 +9,26 @@ export interface RelayStatusInfo {
   // The connected relay's build tag (issue #315), e.g. 'relay-v0.1.0-build.30'. null when disconnected
   // or when an older relay that predates the hello frame is connected.
   build: string | null;
+  // Which relay install is holding the connection (#366); null when disconnected. Lets the Relay
+  // Installs grid disable Remove on the live row instead of letting the backend reject it.
+  installId: string | null;
 }
 
 // Single definition of the relay-status poll (backend relayStatus field, the relay-to-backend WS
 // channel - not a browser probe). Consumers pass skip: !open on dialogs/modals so a hidden one
 // doesn't poll, which keeps this to one live poller at a time.
 export function useRelayStatus(options?: { skip?: boolean }): RelayStatusInfo {
-  const { data } = useQuery<{ relayStatus: { connected: boolean; company: string | null; build: string | null } }>(
-    GET_RELAY_STATUS,
-    {
-      pollInterval: 10_000,
-      fetchPolicy: 'cache-and-network',
-      skip: options?.skip,
-    },
-  );
+  const { data } = useQuery<{
+    relayStatus: { connected: boolean; company: string | null; build: string | null; installId: string | null };
+  }>(GET_RELAY_STATUS, {
+    pollInterval: 10_000,
+    fetchPolicy: 'cache-and-network',
+    skip: options?.skip,
+  });
   return {
     connected: data ? data.relayStatus.connected : null,
     company: data?.relayStatus.company ?? null,
     build: data?.relayStatus.build ?? null,
+    installId: data?.relayStatus.installId ?? null,
   };
 }


### PR DESCRIPTION
Closes #366.

Admin -> Relay Installs could create rows but never remove one, so every abandoned provisioning attempt was permanent and the only cleanup was hand-written SQL against Railway Postgres.

hard delete for relay installs, no soft-delete flag. a flag would have to be honoured on the handshake hot path too or the deleted install keeps authenticating, and it would leave secret_encrypted populated, so it would not fix the key retirement either. nothing references relay_installs by foreign key. no migration, no reset_data change.

stale pre-067 row keeps secret_encrypted, blocking the count that gates RELAY_SECRET_ENC_KEY retirement from reaching 0
stale row stays a credential authenticate_secret accepts

RelayGateway tracks which install authenticated the live connection. main.py reads install.id in the same pre-commit block as install.company, per the DetachedInstanceError rule at that call site. delete_relay_install refuses the connected install with ConflictError; a switched-off relay deletes fine, which is the retire-a-workstation case. install id also surfaces on relayStatus, so the grid states which install is live rather than inferring it.

deletion logs at WARNING with the row's id, label, company, hostname, enrolled_at, plus the deleting admin's Clerk id. the row is about to stop existing, so the log is the only remaining record.

Remove action in the existing Recovery column, behind ConfirmDialog, disabled with a tooltip on the connected row. the confirm dialog carries the warning.

- 3 repository tests (credential genuinely revoked, missing id returns None, other installs undisturbed)
- 3 gateway tests for install_id tracking
- 2 route-level tests driving the real /relay-link (refuses the connected install, allows a different disconnected one while it stays connected)
- deleteRelayInstall added to the admin-gated set
- 2 frontend tests (confirm dialog required, Remove disabled on the connected row)

backend ruff clean, all frontend tests pass. DB-backed tests skip locally without DATABASE_URL and run in CI.
