### PR TITLE
feat(po): show which openings a PO's hardware was bought for (#302)

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -938,3 +938,79 @@ def upsert_po_document_data(session: Session, po_id: uuid.UUID, **fields) -> POD
 
     session.flush()
     return data
+
+
+def get_po_openings(session: Session, po_id: uuid.UUID) -> list[dict]:
+    """Which door openings (and leaves) this PO's hardware was bought for (#302).
+
+    The PO user orders off the hardware schedule but the PO itself only carries fungible
+    (category, product) lines, so by the time they are registering it into GP there is nothing on
+    screen saying which doors the order is FOR. The link survives on HardwareItem, which the import
+    path stamps with po_line_item_id: opening_id -> Opening, plus the #311 leaf.
+
+    ONE grouped query, joined and aggregated in the database, returning plain dicts. A relationship
+    walk here would be the classic resolver N+1 (see CLAUDE.md): a PO with 40 lines would issue 40
+    SELECTs against Railway's managed Postgres and read as a frozen page.
+
+    Rows come back ordered by opening then leaf, already summed per (opening, leaf, category, code),
+    so the resolver only has to group consecutive rows - no second pass over the whole set.
+    """
+    from app.models.hardware import HardwareItem
+    from app.models.project import Opening
+
+    rows = session.execute(
+        select(
+            Opening.opening_number,
+            Opening.building,
+            Opening.floor,
+            Opening.location,
+            HardwareItem.leaf,
+            HardwareItem.hardware_category,
+            HardwareItem.product_code,
+            func.sum(HardwareItem.item_quantity).label("quantity"),
+        )
+        .join(Opening, Opening.id == HardwareItem.opening_id)
+        .join(POLineItem, POLineItem.id == HardwareItem.po_line_item_id)
+        .where(POLineItem.po_id == po_id)
+        .group_by(
+            Opening.opening_number,
+            Opening.building,
+            Opening.floor,
+            Opening.location,
+            HardwareItem.leaf,
+            HardwareItem.hardware_category,
+            HardwareItem.product_code,
+        )
+        # NULLS FIRST is not portable enough to rely on and a frame's leaf IS null, so sort the null
+        # leaf explicitly to the front rather than letting the backend decide where frames land.
+        .order_by(
+            Opening.opening_number,
+            HardwareItem.leaf.is_(None).desc(),
+            HardwareItem.leaf,
+            HardwareItem.hardware_category,
+            HardwareItem.product_code,
+        )
+    ).all()
+
+    grouped: list[dict] = []
+    for r in rows:
+        key = (r.opening_number, r.leaf)
+        if not grouped or (grouped[-1]["opening_number"], grouped[-1]["leaf"]) != key:
+            grouped.append(
+                {
+                    "opening_number": r.opening_number,
+                    "leaf": r.leaf,
+                    "building": r.building,
+                    "floor": r.floor,
+                    "location": r.location,
+                    "items": [],
+                }
+            )
+        grouped[-1]["items"].append(
+            {
+                "hardware_category": r.hardware_category,
+                "product_code": r.product_code,
+                "quantity": int(r.quantity or 0),
+            }
+        )
+    return grouped

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -26,6 +26,8 @@ from .types import (
     PODocumentInfo,
     PODocumentSettings,
     POLineItem,
+    POOpening,
+    POOpeningItem,
     POStatistics,
     PriorOrderAsForProduct,
     PurchaseOrder,
@@ -256,6 +258,33 @@ class POQueries:
                 return None
             receive_records = po_repository.get_receive_records_for_po(session, po.id)
             return po_to_type(po, receive_records)
+
+    @strawberry.field
+    def po_openings(self, info: strawberry.Info, po_id: strawberry.ID) -> list[POOpening]:
+        """Which door openings and leaves this PO's hardware was bought for (#302).
+
+        Its own field rather than a list on PurchaseOrder: the PO list renders dozens of POs and must
+        never pay for this join, and the detail modal is the only place it is read."""
+        require_user(info)
+        with SessionLocal() as session:
+            return [
+                POOpening(
+                    opening_number=row["opening_number"],
+                    leaf=row["leaf"],
+                    building=row["building"],
+                    floor=row["floor"],
+                    location=row["location"],
+                    items=[
+                        POOpeningItem(
+                            hardware_category=i["hardware_category"],
+                            product_code=i["product_code"],
+                            quantity=i["quantity"],
+                        )
+                        for i in row["items"]
+                    ],
+                )
+                for row in po_repository.get_po_openings(session, uuid.UUID(str(po_id)))
+            ]
 
     @strawberry.field
     def prior_order_as_values(

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -351,6 +351,27 @@ class ProjectShipTo:
 
 
 @strawberry.type
+class POOpeningItem:
+    hardware_category: str
+    product_code: str
+    quantity: int
+
+
+@strawberry.type
+class POOpening:
+    """One (opening, leaf) this PO's hardware was bought for (#302). The PO carries only fungible
+    (category, product) lines, so this is the only place the buyer can see which doors the order is
+    for. leaf is null for a frame or a legacy item that predates #311."""
+
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    location: str | None
+    items: list[POOpeningItem]
+
+
+@strawberry.type
 class PurchaseOrder:
     id: strawberry.ID
     po_number: str | None

--- a/backend/tests/test_po_openings.py
+++ b/backend/tests/test_po_openings.py
@@ -1,0 +1,204 @@
+"""Which openings a PO's hardware was bought for (#302): po_repository.get_po_openings.
+
+The PO carries only fungible (category, product) lines; the link back to a door survives on
+HardwareItem.po_line_item_id, which the import stamps. These pin the grouping and the ordering,
+because the UI renders consecutive rows without a second pass.
+"""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.models.hardware import HardwareItem
+from app.models.project import Opening, Project
+from app.models.purchase_order import PurchaseOrder
+from app.models.vendor import Vendor
+from app.repositories import import_repository, po_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:6]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _opening_input(opening_number: str) -> dict:
+    return {
+        "opening_number": opening_number,
+        "building": "B1",
+        "floor": "F1",
+        "location": "Lobby",
+        "location_to": None,
+        "location_from": None,
+        "hand": None,
+        "width": None,
+        "length": None,
+        "door_thickness": None,
+        "jamb_thickness": None,
+        "door_type": None,
+        "frame_type": None,
+        "interior_exterior": None,
+        "keying": None,
+        "heading_no": None,
+        "single_pair": None,
+        "assignment_multiplier": None,
+    }
+
+
+def _hw(opening_number: str, product_code: str, qty: int = 1) -> dict:
+    return {
+        "opening_number": opening_number,
+        "product_code": product_code,
+        "hardware_category": "HINGE",
+        "item_quantity": qty,
+        "unit_cost": 10.0,
+        "unit_price": None,
+        "list_price": None,
+        "vendor_discount": None,
+        "markup_pct": None,
+        "vendor_no": "V1",
+        "phase_code": None,
+        "item_category_code": None,
+        "product_group_code": None,
+        "submittal_id": None,
+    }
+
+
+def _import_po(session, project: Project) -> PurchaseOrder:
+    vendor = Vendor(id=uuid.uuid4(), name=f"V-{uuid.uuid4().hex[:6]}")
+    session.add(vendor)
+    session.flush()
+    import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01"), _opening_input("A02")],
+            "hardware_items": [
+                _hw("A01", "HG-100", 3),
+                _hw("A02", "HG-200", 6),
+            ],
+            "po_drafts": [
+                {
+                    "po_number": None,
+                    "vendor_id": str(vendor.id),
+                    "notes": None,
+                    "hardware_item_refs": [
+                        {"opening_number": "A01", "product_code": "HG-100", "hardware_category": "HINGE"},
+                        {"opening_number": "A02", "product_code": "HG-200", "hardware_category": "HINGE"},
+                    ],
+                    "line_item_aliases": [],
+                }
+            ],
+        },
+    )
+    session.flush()
+    po = session.scalars(select(PurchaseOrder).where(PurchaseOrder.project_id == project.id)).first()
+    assert po is not None
+    return po
+
+
+def test_groups_the_pos_hardware_by_opening(db_session):
+    project = _make_project(db_session)
+    po = _import_po(db_session, project)
+
+    rows = po_repository.get_po_openings(db_session, po.id)
+
+    assert [r["opening_number"] for r in rows] == ["A01", "A02"]
+    assert rows[0]["items"] == [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 3}]
+    assert rows[1]["items"] == [{"hardware_category": "HINGE", "product_code": "HG-200", "quantity": 6}]
+    assert rows[0]["building"] == "B1"
+    assert rows[0]["floor"] == "F1"
+    assert rows[0]["location"] == "Lobby"
+
+
+def test_splits_an_opening_by_leaf_and_sorts_the_frame_first(db_session):
+    # An opening's two leaves are separate rows (#311), and a frame - leaf null - sorts ahead of them
+    # rather than wherever the database happens to put nulls.
+    project = _make_project(db_session)
+    po = _import_po(db_session, project)
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    a01 = next(i for i in items if i.product_code == "HG-100")
+    a01.leaf = 2
+
+    frame = HardwareItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=a01.opening_id,
+        hardware_category="FRAME",
+        product_code="FR-001",
+        leaf=None,
+        item_quantity=1,
+        state=a01.state,
+        po_line_item_id=a01.po_line_item_id,
+    )
+    db_session.add(frame)
+    db_session.flush()
+
+    rows = po_repository.get_po_openings(db_session, po.id)
+    a01_rows = [r for r in rows if r["opening_number"] == "A01"]
+
+    assert [r["leaf"] for r in a01_rows] == [None, 2]
+    assert a01_rows[0]["items"][0]["product_code"] == "FR-001"
+
+
+def test_sums_repeated_hardware_within_one_opening_and_leaf(db_session):
+    project = _make_project(db_session)
+    po = _import_po(db_session, project)
+    items = db_session.scalars(select(HardwareItem).where(HardwareItem.project_id == project.id)).all()
+    a01 = next(i for i in items if i.product_code == "HG-100")
+
+    db_session.add(
+        HardwareItem(
+            id=uuid.uuid4(),
+            project_id=project.id,
+            opening_id=a01.opening_id,
+            hardware_category="HINGE",
+            product_code="HG-100",
+            leaf=a01.leaf,
+            item_quantity=4,
+            state=a01.state,
+            po_line_item_id=a01.po_line_item_id,
+        )
+    )
+    db_session.flush()
+
+    rows = po_repository.get_po_openings(db_session, po.id)
+    a01_row = next(r for r in rows if r["opening_number"] == "A01")
+
+    # One line, 3 + 4 - not two rows the UI would have to add up itself.
+    assert a01_row["items"] == [{"hardware_category": "HINGE", "product_code": "HG-100", "quantity": 7}]
+
+
+def test_a_po_with_no_hardware_behind_it_returns_nothing(db_session):
+    # A manually created stock PO has no hardware schedule, so the section renders nothing at all.
+    po = po_repository.create_po(
+        db_session,
+        line_items=[
+            {
+                "hardware_category": "HINGE",
+                "product_code": "HG-100",
+                "ordered_quantity": 2,
+                "unit_cost": 10.0,
+                "classification": None,
+                "order_as": None,
+            }
+        ],
+        project_id=None,
+    )
+    assert po_repository.get_po_openings(db_session, po.id) == []
+
+
+def test_ignores_openings_belonging_to_a_different_po(db_session):
+    project_a = _make_project(db_session)
+    project_b = _make_project(db_session)
+    po_a = _import_po(db_session, project_a)
+    _import_po(db_session, project_b)
+
+    rows = po_repository.get_po_openings(db_session, po_a.id)
+
+    assert {r["opening_number"] for r in rows} == {"A01", "A02"}
+    assert all(
+        db_session.get(Opening, uuid.UUID(str(o.id))) is not None
+        for o in db_session.scalars(select(Opening).where(Opening.project_id == project_a.id))
+    )

--- a/backend/tests/test_po_openings.py
+++ b/backend/tests/test_po_openings.py
@@ -181,7 +181,9 @@ def test_a_po_with_no_hardware_behind_it_returns_nothing(db_session):
                 "ordered_quantity": 2,
                 "unit_cost": 10.0,
                 "classification": None,
-                "order_as": None,
+                # create_po requires an alias on every line; the value is irrelevant here, the point
+                # is that a manual PO has no HardwareItem behind it.
+                "order_as": "ALIAS-100",
             }
         ],
         project_id=None,

--- a/frontend/src/graphql/po.ts
+++ b/frontend/src/graphql/po.ts
@@ -486,3 +486,22 @@ export const UPDATE_PO_DOCUMENT_SETTINGS = gql`
     }
   }
 `;
+
+// Which door openings and leaves this PO's hardware was bought for (#302). Read only by the PO detail
+// modal - the PO list must never pay for this join.
+export const GET_PO_OPENINGS = gql`
+  query GetPoOpenings($poId: ID!) {
+    poOpenings(poId: $poId) {
+      openingNumber
+      leaf
+      building
+      floor
+      location
+      items {
+        hardwareCategory
+        productCode
+        quantity
+      }
+    }
+  }
+`;

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -40,6 +40,7 @@ import { GET_PRIOR_ORDER_AS_VALUES } from '../../graphql/shared';
 import type { PurchaseOrder } from './index';
 import GpPurchaseOrderDialog from './GpPurchaseOrderDialog';
 import POGenerateDialog from './POGenerateDialog';
+import POOpeningsSection from './POOpeningsSection';
 import { poVendorName } from './poVendorName';
 import { formatPoStatus, poStatusChipColor } from './poStatus';
 
@@ -677,6 +678,12 @@ export default function PODetailModal({
             No line items.
           </Typography>
         )}
+
+        {/* Which doors this PO is for (#302). Below the line items, which are the product view of the
+            same hardware - this is the opening view the buyer works from on the schedule. Renders
+            nothing at all for a stock PO, which has no hardware schedule behind it. */}
+        <Divider sx={{ my: 2 }} />
+        <POOpeningsSection poId={po.id} />
 
         {/* Documents Section */}
         <Divider sx={{ my: 2 }} />

--- a/frontend/src/modules/po/POOpeningsSection.tsx
+++ b/frontend/src/modules/po/POOpeningsSection.tsx
@@ -1,0 +1,105 @@
+import { useQuery } from '@apollo/client/react';
+import { Box, Typography, Stack, Chip, Alert, Skeleton } from '@mui/material';
+import { GET_PO_OPENINGS } from '../../graphql/po';
+import { leafLabel } from '../../utils/leaf';
+
+// One (opening, leaf) the PO's hardware was bought for, with the hardware ordered against it.
+interface POOpeningItem {
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+}
+
+interface POOpening {
+  openingNumber: string;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  items: POOpeningItem[];
+}
+
+/** "B1 / F2 / Lobby", skipping whatever the schedule left blank. */
+function placeOf(opening: POOpening): string {
+  return [opening.building, opening.floor, opening.location].filter(Boolean).join(' / ');
+}
+
+/**
+ * The doors a PO is for (#302).
+ *
+ * A PO carries only fungible (category, product) lines, because that is what gets ordered and what GP
+ * receives. But the buyer is working off a hardware schedule, and while a draft moves toward
+ * GP-Registered the question they actually have is "which openings am I buying this for" - which was
+ * answerable nowhere in the PO module. The link survives on HardwareItem, which the import stamps with
+ * po_line_item_id, so the backend can rebuild it in one grouped query.
+ *
+ * Opening-first, not product-first: the line items table directly above is already the product view.
+ */
+export default function POOpeningsSection({ poId }: { poId: string }) {
+  const { data, loading, error } = useQuery<{ poOpenings: POOpening[] }>(GET_PO_OPENINGS, {
+    variables: { poId },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const openings = data?.poOpenings ?? [];
+
+  // Nothing to say on a stock PO or a manually created one: no hardware schedule behind it, so no
+  // openings. An empty section with a heading would imply data is missing rather than absent.
+  if (!loading && !error && openings.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Openings on this PO
+      </Typography>
+
+      {error && (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          Could not load the openings for this PO. The line items above are unaffected.
+        </Alert>
+      )}
+
+      {loading && openings.length === 0 ? (
+        <Stack spacing={0.5}>
+          <Skeleton variant="text" width="60%" />
+          <Skeleton variant="text" width="45%" />
+        </Stack>
+      ) : (
+        <Stack spacing={1}>
+          {openings.map((opening) => {
+            const place = placeOf(opening);
+            const leaf = leafLabel(opening.leaf);
+            return (
+              <Box
+                key={`${opening.openingNumber}|${opening.leaf ?? 'none'}`}
+                sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap' }}
+              >
+                <Typography variant="body2" sx={{ fontWeight: 600, minWidth: 96 }}>
+                  {opening.openingNumber}
+                </Typography>
+                {/* A frame, or an item imported before #311, genuinely has no leaf - say so rather
+                    than printing a misleading "Leaf 1". */}
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={leaf ?? 'No leaf'}
+                  color={leaf ? 'default' : 'warning'}
+                />
+                <Typography variant="body2" color="text.secondary" sx={{ flex: 1, minWidth: 200 }}>
+                  {opening.items
+                    .map((i) => `${i.quantity}x ${i.productCode}`)
+                    .join(', ')}
+                </Typography>
+                {place && (
+                  <Typography variant="caption" color="text.secondary">
+                    {place}
+                  </Typography>
+                )}
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/modules/po/__tests__/POOpeningsSection.test.tsx
+++ b/frontend/src/modules/po/__tests__/POOpeningsSection.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import POOpeningsSection from '../POOpeningsSection';
+import { GET_PO_OPENINGS } from '../../../graphql/po';
+
+// Issue #302: a PO carries only fungible (category, product) lines, so this section is the only place
+// the buyer can see which doors the order is for while a draft moves toward GP-Registered.
+
+function openingsMock(openings: unknown[]): MockedResponse {
+  return {
+    request: { query: GET_PO_OPENINGS, variables: { poId: 'po-1' } },
+    result: { data: { poOpenings: openings } },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+  };
+}
+
+const leafOne = {
+  openingNumber: '0019-EX',
+  leaf: 1,
+  building: 'B1',
+  floor: 'F2',
+  location: 'Lobby',
+  items: [
+    { hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 3, __typename: 'POOpeningItem' },
+    { hardwareCategory: 'LOCKSET', productCode: 'LK-220', quantity: 1, __typename: 'POOpeningItem' },
+  ],
+  __typename: 'POOpening',
+};
+
+function renderSection(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <POOpeningsSection poId="po-1" />
+    </MockedProvider>,
+  );
+}
+
+it('lists each opening with its leaf and the hardware ordered for it', async () => {
+  renderSection([openingsMock([leafOne, { ...leafOne, leaf: 2, items: [leafOne.items[0]] }])]);
+
+  // Gate on the data, not the heading: the heading is up during the loading skeleton too.
+  expect(await screen.findByText('3x HG-100, 1x LK-220')).toBeInTheDocument();
+  expect(screen.getByText('Openings on this PO')).toBeInTheDocument();
+  expect(screen.getAllByText('0019-EX')).toHaveLength(2); // one row per leaf
+  expect(screen.getByText('Leaf 1')).toBeInTheDocument();
+  expect(screen.getByText('Leaf 2')).toBeInTheDocument();
+});
+
+it('says "No leaf" rather than inventing one for a frame', async () => {
+  // leaf is genuinely null for a frame or an item imported before #311; printing "Leaf 1" would be a
+  // claim about a door leaf that nothing in the schedule supports.
+  renderSection([openingsMock([{ ...leafOne, leaf: null }])]);
+
+  expect(await screen.findByText('No leaf')).toBeInTheDocument();
+  expect(screen.queryByText(/Leaf \d/)).toBeNull();
+});
+
+it('renders nothing at all for a PO with no hardware schedule behind it', async () => {
+  // A stock PO has no openings. An empty section with a heading would read as missing data.
+  const { container } = renderSection([openingsMock([])]);
+
+  // The heading is up while loading, so wait for it to go rather than sampling one tick in.
+  await waitFor(() => expect(screen.queryByText('Openings on this PO')).toBeNull());
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('keeps the rest of the PO usable when the openings query fails', async () => {
+  renderSection([
+    {
+      request: { query: GET_PO_OPENINGS, variables: { poId: 'po-1' } },
+      error: new Error('boom'),
+    },
+  ]);
+
+  expect(await screen.findByText(/could not load the openings/i)).toBeInTheDocument();
+  expect(screen.getByText(/line items above are unaffected/i)).toBeInTheDocument();
+});
+
+it('shows the opening location when the schedule has one', async () => {
+  renderSection([openingsMock([leafOne])]);
+  expect(await screen.findByText('B1 / F2 / Lobby')).toBeInTheDocument();
+});
+
+it('omits the location line entirely when the schedule left it blank', async () => {
+  renderSection([openingsMock([{ ...leafOne, building: null, floor: null, location: null }])]);
+
+  expect(await screen.findByText('0019-EX')).toBeInTheDocument();
+  expect(screen.queryByText('B1 / F2 / Lobby')).toBeNull();
+});


### PR DESCRIPTION
Closes #302.

a PO carries only fungible (category, product) lines. the buyer works off the hardware schedule, so while a draft moves toward GP-Registered the question "which doors am I buying this for" was answerable nowhere in the PO module.

the link survives on HardwareItem, stamped by the import path: po_line_item_id -> opening_id -> Opening -> leaf (#311).

get_po_openings rebuilds it in ONE grouped query, joined and aggregated in the database, returning plain dicts. walking the relationship instead would be the resolver N+1 in CLAUDE.md - a PO with 40 lines would issue 40 SELECTs against Railway's managed Postgres.

poOpenings is its own query field, not a list on PurchaseOrder, so the PO list never pays for the join. only the detail modal reads it.

rows come back ordered by opening then leaf and summed per (opening, leaf, category, code). resolver only groups consecutive rows.

opening-first presentation, since the line items table directly above is already the product view.

frames sort ahead of the leaves rather than wherever the database puts nulls.
frame or pre-#311 item says "No leaf", never a misleading "Leaf 1".
stock PO has no hardware schedule behind it, renders nothing, no empty heading.
failed query degrades to a warning, rest of the modal untouched.

5 backend tests
grouping by opening
splitting by leaf with the frame first
summing repeated hardware within one opening and leaf
empty for a stock PO
no bleed between two POs

6 frontend tests
leaf rows
no-leaf case
renders nothing when empty
error path
location line present and absent

full frontend suite passes (27 files), lint no errors, backend ruff clean
DB-backed tests skip locally without DATABASE_URL, run in CI
