### PR TITLE
fix(project): verify a GP job exists before adopting it as a project (#314)

### DIFF
--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,12 +1,15 @@
 """Project queries + mutations."""
 
+import asyncio
 import uuid
 
 import strawberry
 
-from app.auth import require_admin
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
+from app.errors import RelayUnavailableError, ValidationError
 from app.repositories import project_repository
+from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import project_to_type
 from .inputs import AdoptGpJobInput, UpdateProjectInput
@@ -59,18 +62,64 @@ class ProjectQueries:
 @strawberry.type
 class ProjectMutations:
     @strawberry.mutation
-    def adopt_gp_job(self, input: AdoptGpJobInput) -> Project:
-        """Adopt a live GP job as a project (issue #198). The frontend picks the job from the live
-        gpJobs query and posts its number + name here; job_number becomes the project's identity."""
-        with SessionLocal() as session:
-            project = project_repository.adopt_gp_job(
-                session,
-                job_number=input.job_number,
-                job_name=input.job_name,
+    async def adopt_gp_job(self, info: strawberry.Info, input: AdoptGpJobInput) -> Project:
+        """Adopt a live GP job as a project (issue #198), verifying it against GP first (#314).
+
+        GP owns jobs: a Nexus project that does not correspond to a real GP job is invalid state, and
+        POs, inventory, assembly and shipping all hang off it. This used to trust the caller
+        completely - no auth, no `info` parameter at all, and no GP check - so a direct GraphQL call
+        could adopt any string, including a fabricated job number, and get a Nexus-only project GP had
+        never heard of. The "Adopt GP Job" dialog only ever offered real jobs, but that was UI
+        convention, not a guarantee.
+
+        Verification goes through the connected relay's live job master rather than a client-supplied
+        company, so the caller cannot choose which GP to be checked against. It uses list_jobs, which
+        every shipped relay build already serves, so the guard is live on the installed relay instead
+        of waiting on a release (see the op-parity note in #315).
+
+        Refusing when the relay is down is the point, not a limitation: the check is the only thing
+        standing between a typo and an orphan project, and "we could not verify" must not mean
+        "assume it is fine". The open question of an offline path is recorded on #314.
+        """
+        require_user(info)
+        job_number = (input.job_number or "").strip()
+        if not job_number:
+            raise ValidationError("job_number is required", field="job_number")
+
+        company = relay_gateway.company
+        if not company:
+            raise RelayUnavailableError(
+                "The GP relay is not connected, so this job cannot be verified against GP. "
+                "Start the relay and try again."
             )
-            session.commit()
-            session.refresh(project)
-            return project_to_type(project)
+
+        result = await relay_gateway.relay_call(company, "list_jobs")
+        jobs = (result or {}).get("jobs") or []
+        wanted = job_number.upper()
+        match = next((j for j in jobs if str(j.get("job_number") or "").strip().upper() == wanted), None)
+        if match is None:
+            raise ValidationError(
+                f"{job_number} is not a job in GP company {company}. Only an existing GP job can be adopted.",
+                field="job_number",
+            )
+
+        # GP's own name for the job, not the caller's. The client reads it from the same picker, but
+        # it is not the client's to assert - taking GP's keeps the snapshot honest for a direct call.
+        job_name = str(match.get("job_name") or "").strip() or input.job_name
+
+        def _persist() -> Project:
+            with SessionLocal() as session:
+                project = project_repository.adopt_gp_job(
+                    session,
+                    job_number=job_number,
+                    job_name=job_name,
+                )
+                session.commit()
+                session.refresh(project)
+                return project_to_type(project)
+
+        # Off the event loop: the /relay-link read loop runs on it and must not block on Postgres.
+        return await asyncio.to_thread(_persist)
 
     @strawberry.mutation
     def update_project(self, info: strawberry.Info, id: strawberry.ID, input: UpdateProjectInput) -> Project:

--- a/backend/tests/test_adopt_gp_job_guard.py
+++ b/backend/tests/test_adopt_gp_job_guard.py
@@ -1,0 +1,105 @@
+"""adoptGpJob must verify the job against GP before creating a Nexus project (#314).
+
+GP owns jobs: a Nexus project with no GP counterpart is invalid state, and POs, inventory, assembly
+and shipping all hang off it. The resolver previously took no `info` at all - no auth, no GP check -
+so a direct GraphQL call could adopt a fabricated job number. These pin the guard at the resolver,
+which is the layer a direct call reaches; the dialog only ever offered real jobs by convention.
+"""
+
+import asyncio
+
+import pytest
+
+from app.auth import AuthError
+from app.errors import RelayUnavailableError, ValidationError
+from app.schemas import project as project_module
+from app.schemas.inputs import AdoptGpJobInput
+from app.schemas.project import ProjectMutations
+
+
+class _FakeInfo:
+    context = {"request": None}
+
+
+def _as_user(monkeypatch):
+    monkeypatch.setattr(project_module, "require_user", lambda info: {"user_id": "user_1", "roles": []})
+
+
+def _relay(monkeypatch, *, company="TUBC", jobs=None):
+    """Point the resolver at a fake connected relay serving `jobs` from list_jobs."""
+
+    async def _call(_company, op, payload=None, timeout=None):
+        assert op == "list_jobs"
+        return {"jobs": jobs or []}
+
+    monkeypatch.setattr(type(project_module.relay_gateway), "company", property(lambda self: company))
+    monkeypatch.setattr(project_module.relay_gateway, "relay_call", _call)
+
+
+def _adopt(job_number, job_name=None):
+    return asyncio.run(
+        ProjectMutations().adopt_gp_job(_FakeInfo(), AdoptGpJobInput(job_number=job_number, job_name=job_name))
+    )
+
+
+def test_rejects_a_job_number_gp_has_never_heard_of(monkeypatch):
+    # The reproduction on #314: adopting a fabricated number used to create a Nexus-only project.
+    _as_user(monkeypatch)
+    _relay(monkeypatch, jobs=[{"job_number": "80001", "job_name": "Cowichan Dist Hospital"}])
+
+    with pytest.raises(ValidationError) as e:
+        _adopt("99999")
+    assert "99999" in str(e.value)
+
+
+def test_refuses_to_adopt_at_all_when_the_relay_is_down(monkeypatch):
+    # "Cannot verify" must not degrade to "assume it is fine" - that is the whole hole.
+    _as_user(monkeypatch)
+    _relay(monkeypatch, company=None)
+
+    with pytest.raises(RelayUnavailableError):
+        _adopt("80001")
+
+
+def test_requires_a_signed_in_caller(monkeypatch):
+    # The resolver took no `info` parameter at all, so there was nothing to gate on.
+    def _deny(info):
+        raise AuthError("Authentication required")
+
+    monkeypatch.setattr(project_module, "require_user", _deny)
+    _relay(monkeypatch, jobs=[{"job_number": "80001"}])
+
+    with pytest.raises(AuthError):
+        _adopt("80001")
+
+
+def test_rejects_a_blank_job_number_before_touching_the_relay(monkeypatch):
+    _as_user(monkeypatch)
+
+    async def _never(*a, **k):
+        raise AssertionError("the relay must not be called for a blank job number")
+
+    monkeypatch.setattr(type(project_module.relay_gateway), "company", property(lambda self: "TUBC"))
+    monkeypatch.setattr(project_module.relay_gateway, "relay_call", _never)
+
+    with pytest.raises(ValidationError):
+        _adopt("   ")
+
+
+def test_matches_the_gp_job_ignoring_surrounding_whitespace_and_case(monkeypatch, _migrate_database):
+    _as_user(monkeypatch)
+    _relay(monkeypatch, jobs=[{"job_number": " 80001 ", "job_name": "Cowichan Dist Hospital"}])
+
+    project = _adopt("  80001  ")
+
+    assert project.project_id == "80001"
+
+
+def test_snapshots_gps_own_job_name_not_the_callers(monkeypatch, _migrate_database):
+    # A direct call can put anything in job_name; GP's name is the one worth keeping.
+    _as_user(monkeypatch)
+    _relay(monkeypatch, jobs=[{"job_number": "80002", "job_name": "Real GP Name"}])
+
+    project = _adopt("80002", job_name="Whatever The Caller Said")
+
+    assert project.description == "Real GP Name"

--- a/frontend/src/modules/import/AdoptGpJobDialog.tsx
+++ b/frontend/src/modules/import/AdoptGpJobDialog.tsx
@@ -95,11 +95,15 @@ export default function AdoptGpJobDialog({ open, onClose }: AdoptGpJobDialogProp
       handleClose();
     } catch (err) {
       if (CombinedGraphQLErrors.is(err)) {
-        const conflict = err.errors.find(
-          (e) => (e.extensions as { code?: string } | undefined)?.code === 'CONFLICT',
-        );
-        if (conflict) {
-          setJobError(conflict.message);
+        // Both land on the job field: already-adopted (CONFLICT) and, since #314, "GP has no such
+        // job" - the backend now verifies the number against the live job master rather than
+        // trusting what the client posted, so a stale picker or a direct call is rejected here.
+        const onJobField = err.errors.find((e) => {
+          const ext = e.extensions as { code?: string; field?: string } | undefined;
+          return ext?.code === 'CONFLICT' || (ext?.code === 'VALIDATION_ERROR' && ext?.field === 'job_number');
+        });
+        if (onJobField) {
+          setJobError(onJobField.message);
           return;
         }
       }


### PR DESCRIPTION
part of #314, adopt guard only. create-a-job-in-GP path still open.

GP owns jobs. a Nexus project with no GP counterpart is invalid state, and POs, inventory, assembly and shipping all hang off it.

adopt_gp_job had no auth, no `info` param, no GP check. a direct GraphQL call could adopt any string, including a fabricated job number, and get a Nexus-only project GP had never heard of. the Adopt GP Job dialog only ever offered real jobs, but that was UI convention, not a guarantee, and the reproduction on the issue went straight past it.

now require_user -> verify against connected relay's live job master -> write. company comes from the gateway, not the client, so a caller cannot choose which GP to be checked against.

verification uses list_jobs, already served by every shipped relay build, so the guard is live on the installed relay rather than waiting on a release. a job_exists op would be one round trip cheaper but takes effect only after every relay updates.

snapshots GP's job name, not the caller's.

relay unreachable -> refuse. the check is the only thing between a typo and an orphan project, so "we could not verify" must not degrade to "assume it is fine".

GP-has-no-such-job rejection lands on the job field in the dialog, alongside the existing already-adopted conflict.

6 tests cover:
- rejects a job GP has never heard of
- refuses when the relay is down
- requires a signed-in caller
- rejects a blank number without calling the relay
- matches ignoring whitespace and case
- snapshots GP's name rather than the caller's

backend ruff clean, frontend suite passes, typecheck clean
