### PR TITLE
feat(shop-assembly): allocation builder (owed/short) + flag-time replacement reservations (#377)

### DIFF
--- a/backend/alembic/versions/070_sar_allocated_quantity.py
+++ b/backend/alembic/versions/070_sar_allocated_quantity.py
@@ -1,0 +1,78 @@
+"""Shop-assembly checklist lines carry an allocated quantity as well as an owed one
+
+Revision ID: 070
+Revises: 069
+Create Date: 2026-07-27
+
+Shop assembly stops being all-or-nothing at creation. Until now a request that did not fit inside
+available inventory was refused whole, so a leaf that was one hinge short could not be sent at all
+and the twelve leaves behind it waited with it. The requester now assigns what is available to
+leaves, partially-covered leaves stay in the request, and the send/don't-send call is theirs.
+
+That needs two numbers on a checklist line where there was one:
+
+- `quantity` keeps meaning **owed** - what the hardware schedule says this door leaf takes. It is
+  never reduced by scarcity, because the schedule is the authority on what the leaf needs.
+- `allocated_quantity` is what was actually claimed, reserved, pulled and will arrive on the cart.
+
+Short is `quantity - allocated_quantity` and is **derived everywhere, stored nowhere**. There is no
+short column and no short state, because a stored one would immediately start lying: the real
+question "what is this leaf still missing" is answered by comparing the *current* schedule against
+what is physically recorded on the leaf, which is the reallocation module's job. The number here is
+evidence of what one request executed, not a backlog.
+
+The progress buckets move with it. `installed + deficient + replacement_pending` now partitions
+`allocated_quantity` rather than `quantity`: a short unit was never pulled, so there is nothing for
+the assembler to install or condemn, and completion excuses it.
+
+Backfill is exact rather than a default: every pre-feature request passed the all-or-nothing gate,
+so by construction it was fully covered and `allocated_quantity = quantity` for every existing row.
+The column is added with a server_default of 0 only so the NOT NULL add succeeds on a populated
+table; the UPDATE sets the real values and the default is dropped immediately, so nothing later can
+insert a silently-zero row and have it read as "fully short".
+
+Downgrade drops the column and restores the old constraint. It is lossy in the honest direction:
+rows where allocated < quantity would violate the old `... <= quantity` partition only if progress
+had somehow exceeded owed, which it cannot, so no data has to be repaired first.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "070"
+down_revision = "069"
+branch_labels = None
+depends_on = None
+
+_PROGRESS_CHECK = "ck_shop_assembly_opening_items_progress_within_quantity"
+_OLD_CONDITION = (
+    "installed_quantity >= 0 AND deficient_quantity >= 0 AND replacement_pending_quantity >= 0 "
+    "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= quantity"
+)
+_NEW_CONDITION = (
+    "installed_quantity >= 0 AND deficient_quantity >= 0 AND replacement_pending_quantity >= 0 "
+    "AND allocated_quantity >= 0 AND allocated_quantity <= quantity "
+    "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= allocated_quantity"
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shop_assembly_opening_items",
+        sa.Column("allocated_quantity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    # Every row that exists predates partial allocation and therefore cleared the all-or-nothing
+    # creation gate: it was fully covered. Anything less would retroactively invent a shortfall on
+    # hardware that is already on a cart or on a leaf.
+    op.execute("UPDATE shop_assembly_opening_items SET allocated_quantity = quantity")
+    op.alter_column("shop_assembly_opening_items", "allocated_quantity", server_default=None)
+
+    op.drop_constraint(_PROGRESS_CHECK, "shop_assembly_opening_items", type_="check")
+    op.create_check_constraint(_PROGRESS_CHECK, "shop_assembly_opening_items", _NEW_CONDITION)
+
+
+def downgrade() -> None:
+    op.drop_constraint(_PROGRESS_CHECK, "shop_assembly_opening_items", type_="check")
+    op.create_check_constraint(_PROGRESS_CHECK, "shop_assembly_opening_items", _OLD_CONDITION)
+    op.drop_column("shop_assembly_opening_items", "allocated_quantity")

--- a/backend/alembic/versions/071_replacement_pull_reservations.py
+++ b/backend/alembic/versions/071_replacement_pull_reservations.py
@@ -1,0 +1,91 @@
+"""A replacement pull can hold a reservation of its own
+
+Revision ID: 071
+Revises: 070
+Create Date: 2026-07-27
+
+A PR-REPL pull was the one pull in the system that held no claim on inventory. The reasoning was
+that nobody can reserve for a deficiency that has not happened yet - true at the moment the source
+request was created, and irrelevant from the moment the assembler finds the defect. From then on the
+replacement is a known, dated demand competing with requests created *after* it, and it lost every
+time: it sat PENDING while the stock it was waiting for was claimed by somebody else, the approver
+saw INSUFFICIENT, the PO was told to backfill again, and the loop repeated.
+
+So the claim is minted where it becomes real: at the flag. That needs a third kind of holder on
+`inventory_reservations`, because a replacement has no request behind it - the pull *is* the holder.
+
+- `ReservationSource` gains `REPLACEMENT_PULL`.
+- `pull_request_id` (nullable, CASCADE, indexed) is the FK that source writes to. CASCADE because
+  `discard_pending_pull_request` hard-deletes a pull, and a claim outliving the only thing that
+  could spend or release it is a permanently stranded reservation.
+- `ck_inventory_reservations_source_matches_request` becomes three-way: each source requires exactly
+  its own FK and nulls the other two, so the discriminator and the columns still cannot disagree.
+
+The rewritten constraint compares `source::text` rather than the enum directly. PostgreSQL allows
+`ALTER TYPE ... ADD VALUE` inside a transaction but refuses to *use* the new label until that
+transaction commits, and creating a CHECK constraint validates it - so a bare
+`source = 'REPLACEMENT_PULL'` would fail here and force a `COMMIT` in the middle of the migration,
+breaking the atomicity of the whole `upgrade head`. Casting to text never touches the enum type.
+
+A label cannot be dropped, so downgrade leaves the type alone and only unwinds the column, index and
+constraint. It deletes any REPLACEMENT_PULL rows first: the old two-way constraint cannot express
+them and would refuse to be created, and releasing those claims is the correct reading of "this
+version does not reserve for replacements".
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "071"
+down_revision = "070"
+branch_labels = None
+depends_on = None
+
+_TABLE = "inventory_reservations"
+_SOURCE_CHECK = "ck_inventory_reservations_source_matches_request"
+_PULL_FK = "fk_inventory_reservations_pull_request"
+_PULL_INDEX = "ix_inventory_reservations_pull_request"
+
+_OLD_CONDITION = (
+    "(source = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
+    "AND shipping_out_request_id IS NULL) "
+    "OR (source = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
+    "AND shop_assembly_request_id IS NULL)"
+)
+_NEW_CONDITION = (
+    "(source::text = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
+    "AND shipping_out_request_id IS NULL AND pull_request_id IS NULL) "
+    "OR (source::text = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
+    "AND shop_assembly_request_id IS NULL AND pull_request_id IS NULL) "
+    "OR (source::text = 'REPLACEMENT_PULL' AND pull_request_id IS NOT NULL "
+    "AND shop_assembly_request_id IS NULL AND shipping_out_request_id IS NULL)"
+)
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE reservation_source ADD VALUE IF NOT EXISTS 'REPLACEMENT_PULL'")
+
+    op.add_column(_TABLE, sa.Column("pull_request_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        _PULL_FK,
+        _TABLE,
+        "pull_requests",
+        ["pull_request_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(_PULL_INDEX, _TABLE, ["pull_request_id"])
+
+    op.drop_constraint(_SOURCE_CHECK, _TABLE, type_="check")
+    op.create_check_constraint(_SOURCE_CHECK, _TABLE, _NEW_CONDITION)
+
+
+def downgrade() -> None:
+    op.drop_constraint(_SOURCE_CHECK, _TABLE, type_="check")
+    op.execute(f"DELETE FROM {_TABLE} WHERE source::text = 'REPLACEMENT_PULL'")
+    op.create_check_constraint(_SOURCE_CHECK, _TABLE, _OLD_CONDITION)
+
+    op.drop_index(_PULL_INDEX, table_name=_TABLE)
+    op.drop_constraint(_PULL_FK, _TABLE, type_="foreignkey")
+    op.drop_column(_TABLE, "pull_request_id")

--- a/backend/app/graphql/import.graphql
+++ b/backend/app/graphql/import.graphql
@@ -110,7 +110,12 @@ input SAROpeningInput {
 input SAROpeningItemInput {
   hardware_category: String!
   product_code: String!
+  # Owed - the schedule's number for this leaf.
   quantity: Int!
+  # What the allocator step assigned to this line out of available inventory, 0..quantity. Null means
+  # "fully allocated" (= quantity), which keeps every non-allocator caller on the old all-or-nothing
+  # behaviour: ask for the whole line, and bounce if it does not fit.
+  allocated_quantity: Int
 }
 
 input FinalizeImportSessionInput {

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -77,17 +77,24 @@ type ShopAssemblyOpeningItem {
   shop_assembly_opening_id: ID!
   hardware_category: String!
   product_code: String!
-  # Units pulled for this leaf - the plan.
+  # Owed: what the hardware schedule says this leaf takes. Never reduced by scarcity.
   quantity: Int!
-  # Persisted assembly progress (#340). Remaining = quantity - installed - deficient, derived on the
-  # client; completion is refused while any line still has remaining > 0.
+  # Allocated: what the requester could claim out of available inventory when the request was sent,
+  # and therefore what is reserved, pulled and physically arrives on the cart. 0 <= allocated <=
+  # quantity, and 0 is legal on a line whose leaf is covered by its other lines.
+  # Short = quantity - allocated_quantity, derived here and everywhere else - never stored, because
+  # what a leaf is still missing is answered by the current schedule against what is on the leaf.
+  allocated_quantity: Int!
+  # Persisted assembly progress (#340). Remaining = allocated - installed - deficient, derived on the
+  # client; completion is refused while any line still has remaining > 0. Short units sit outside
+  # that sum - they were never pulled, so the bench has nothing to disposition.
   installed_quantity: Int!
   deficient_quantity: Int!
   # Units whose replacement pull has completed but which are not on the leaf yet (#341). Non-zero
   # only on a COMPLETED opening: while the leaf is still on the bench an arrived replacement just
   # lowers deficient_quantity and becomes remaining work again. On a finished leaf that would break
   # the completion invariant, so the unit moves deficient -> replacement_pending instead and
-  # installed + deficient + replacement_pending stays equal to quantity.
+  # installed + deficient + replacement_pending stays equal to allocated_quantity.
   replacement_pending_quantity: Int!
 }
 
@@ -178,7 +185,12 @@ type PipelineOpening {
   assigned_to: String
   assembly_status: AssemblyStatus!
   completed_at: DateTime
+  # Owed by the schedule vs what the request could claim out of inventory. The three progress
+  # counters partition allocated_unit_count; short_unit_count is the rest and was never pulled, so
+  # no work at the bench can account for it and the leaf completes without it.
   planned_unit_count: Int!
+  allocated_unit_count: Int!
+  short_unit_count: Int!
   installed_unit_count: Int!
   deficient_unit_count: Int!
   replacement_pending_unit_count: Int!
@@ -229,11 +241,17 @@ type AssemblyPipelineSummary {
   completed_opening_count: Int!
   shipped_opening_count: Int!
   planned_unit_count: Int!
+  # Sent short: a request can be legitimately complete and still not have delivered its full bill of
+  # hardware, and nothing else on this row would say so.
+  allocated_unit_count: Int!
+  short_unit_count: Int!
   installed_unit_count: Int!
   deficient_unit_count: Int!
   replacement_pending_unit_count: Int!
   awaiting_replacement_opening_count: Int!
   replacement_after_ship_opening_count: Int!
+  # Openings carrying at least one line that was never fully pulled.
+  short_opening_count: Int!
   stage: PipelineStage!
 }
 

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -102,6 +102,11 @@ type OpeningItem {
   # acknowledgment. Populated only by openingItems / openingItemDetails / installReplacement; null
   # elsewhere, which reads as "not evaluated", never as "nothing owed".
   awaiting_replacement_quantity: Int
+  # Units the schedule owed this leaf that its request never pulled - not available to claim when it
+  # was sent, so nothing arrived and nothing is in flight. The other half of the same shipping
+  # decision, kept separate because waiting fixes an awaiting-replacement unit and does nothing for
+  # one of these. Same null-means-not-evaluated convention.
+  never_pulled_quantity: Int
 }
 
 type OpeningItemHardware {

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -64,6 +64,11 @@ class ReservationSource(str, enum.Enum):
 
     SHOP_ASSEMBLY_REQUEST = "SHOP_ASSEMBLY_REQUEST"
     SHIPPING_OUT_REQUEST = "SHIPPING_OUT_REQUEST"
+    # A PR-REPL replacement pull, which holds its claim directly rather than through a request
+    # (there is no request behind a deficiency). Minted the moment a unit is flagged deficient at the
+    # bench, so the replacement is not left competing for stock at approval time against requests
+    # that were created after the defect was found.
+    REPLACEMENT_PULL = "REPLACEMENT_PULL"
 
 
 class PullStatus(str, enum.Enum):

--- a/backend/app/models/inventory_reservation.py
+++ b/backend/app/models/inventory_reservation.py
@@ -29,7 +29,16 @@ class InventoryReservation(Base):
       deduction, which stays exactly as it was: at approval the pull walks the project's rows
       oldest-first, and the reservation only ever governed *how much* was free, never *which* row.
 
-    Exactly one of `shop_assembly_request_id` / `shipping_out_request_id` is set, matching `source`.
+    Exactly one of `shop_assembly_request_id` / `shipping_out_request_id` / `pull_request_id` is set,
+    matching `source`.
+
+    The third holder is a **replacement pull**, and it is the one claim with no request behind it: a
+    deficiency found at the bench is not something anybody could have requested in advance. Before
+    it existed, the PR-REPL pull went to the back of the queue - it held nothing, so any request
+    created after the defect was found could claim the very stock the replacement was waiting on, and
+    the pull stayed blocked while the warehouse watched the hardware walk. Reserving at flag time
+    puts the replacement in the queue at the moment the defect is discovered, which is the moment the
+    claim becomes real.
     """
 
     __tablename__ = "inventory_reservations"
@@ -45,14 +54,23 @@ class InventoryReservation(Base):
         # Release and consumption are both "every reservation of this request".
         Index("ix_inventory_reservations_shop_assembly_request", "shop_assembly_request_id"),
         Index("ix_inventory_reservations_shipping_out_request", "shipping_out_request_id"),
+        Index("ix_inventory_reservations_pull_request", "pull_request_id"),
         CheckConstraint("quantity >= 1", name="ck_inventory_reservations_quantity_positive"),
         # The discriminator and the FKs cannot disagree, and a reservation can never be orphaned
-        # from its request (which is what would strand a claim nothing can ever release).
+        # from its holder (which is what would strand a claim nothing can ever release). Each source
+        # requires exactly its own FK and nulls the other two.
+        #
+        # `source::text` rather than a bare enum comparison: the REPLACEMENT_PULL label and this
+        # constraint were added in one migration, and PostgreSQL refuses to *use* a new enum label in
+        # the transaction that created it. Comparing the column as text never touches the enum type,
+        # so the migration needs no `COMMIT` in the middle of itself.
         CheckConstraint(
-            "(source = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
-            "AND shipping_out_request_id IS NULL) "
-            "OR (source = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
-            "AND shop_assembly_request_id IS NULL)",
+            "(source::text = 'SHOP_ASSEMBLY_REQUEST' AND shop_assembly_request_id IS NOT NULL "
+            "AND shipping_out_request_id IS NULL AND pull_request_id IS NULL) "
+            "OR (source::text = 'SHIPPING_OUT_REQUEST' AND shipping_out_request_id IS NOT NULL "
+            "AND shop_assembly_request_id IS NULL AND pull_request_id IS NULL) "
+            "OR (source::text = 'REPLACEMENT_PULL' AND pull_request_id IS NOT NULL "
+            "AND shop_assembly_request_id IS NULL AND shipping_out_request_id IS NULL)",
             name="ck_inventory_reservations_source_matches_request",
         ),
     )
@@ -71,5 +89,11 @@ class InventoryReservation(Base):
     )
     shipping_out_request_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("shipping_out_requests.id", ondelete="CASCADE"), nullable=True
+    )
+    # The PR-REPL pull a REPLACEMENT_PULL claim is held for. CASCADE for the same reason as the other
+    # two: `discard_pending_pull_request` hard-deletes a pull, and a claim outliving the only thing
+    # that could ever spend or release it is a permanently stranded reservation.
+    pull_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("pull_requests.id", ondelete="CASCADE"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -172,7 +172,13 @@ class ShopAssemblyOpeningItem(Base):
     #
     # 0 is legal: a line can be fully short on a leaf that other lines do cover. A leaf with *every*
     # line at 0 has an empty cart and is dropped before it reaches here.
-    allocated_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    #
+    # **No default, client-side or server-side.** Migration 070 uses a server default only to get the
+    # NOT NULL column onto a populated table and drops it in the same step, and mirroring a default
+    # here would put the footgun straight back: an insert that forgot this column would quietly write
+    # 0, pass the check constraint, and produce a line that reads as entirely short. Omitting it is
+    # meant to fail loudly.
+    allocated_quantity: Mapped[int] = mapped_column(Integer, nullable=False)
     # Per-item assembly progress (#340). The assembler records these incrementally at the bench;
     # completion reads them rather than taking an ephemeral checklist as input.
     #   installed_quantity - units physically fitted to the leaf. Absolute, editable both directions

--- a/backend/app/models/shop_assembly.py
+++ b/backend/app/models/shop_assembly.py
@@ -132,14 +132,17 @@ class ShopAssemblyOpeningItem(Base):
             "shop_assembly_opening_id",
         ),
         CheckConstraint("quantity >= 1", name="ck_shop_assembly_opening_items_quantity_positive"),
-        # Progress can never exceed the planned quantity, and no count can go negative (#340/#341).
-        # The three buckets partition the line: installed + deficient + replacement_pending <=
-        # quantity, and completion requires equality. That is what lets a replacement arriving on an
-        # already-completed leaf move a unit out of `deficient` without the leaf reading as
-        # un-dispositioned - the unit lands in replacement_pending, and the sum is unchanged.
+        # Progress can never exceed what was actually pulled for the line, and no count can go
+        # negative (#340/#341). The three buckets partition `allocated_quantity`, not `quantity`:
+        # installed + deficient + replacement_pending <= allocated, and completion requires
+        # equality. That is what lets a replacement arriving on an already-completed leaf move a unit
+        # out of `deficient` without the leaf reading as un-dispositioned - the unit lands in
+        # replacement_pending, and the sum is unchanged - while the short units (quantity -
+        # allocated) sit outside the partition entirely, because they were never pulled.
         CheckConstraint(
             "installed_quantity >= 0 AND deficient_quantity >= 0 AND replacement_pending_quantity >= 0 "
-            "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= quantity",
+            "AND allocated_quantity >= 0 AND allocated_quantity <= quantity "
+            "AND installed_quantity + deficient_quantity + replacement_pending_quantity <= allocated_quantity",
             name="ck_shop_assembly_opening_items_progress_within_quantity",
         ),
         # The replacement-install work queue and the shipping deficiency guard both scan for lines
@@ -156,6 +159,20 @@ class ShopAssemblyOpeningItem(Base):
     hardware_category: Mapped[str] = mapped_column(String, nullable=False)
     product_code: Mapped[str] = mapped_column(String, nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    # What the schedule says this leaf is owed, vs what the requester could actually claim out of
+    # available inventory when the request was sent. Shop assembly is not all-or-nothing: a partially
+    # covered leaf still goes to the bench, and the requester makes the informed send/don't-send call.
+    #   quantity           - owed. The schedule's number, never reduced by scarcity.
+    #   allocated_quantity - what was reserved, pulled and will physically arrive on the cart.
+    # **Short is derived, never stored**: short = quantity - allocated_quantity. There is no separate
+    # state for it and nothing downstream may write one, because the authority on what is still
+    # missing is the *current* schedule compared against what is physically on the leaf - the short
+    # count here is evidence of what this request executed, not a backlog anybody works off.
+    # Backfilling a short leaf when stock turns up later belongs to the reallocation module.
+    #
+    # 0 is legal: a line can be fully short on a leaf that other lines do cover. A leaf with *every*
+    # line at 0 has an empty cart and is dropped before it reaches here.
+    allocated_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     # Per-item assembly progress (#340). The assembler records these incrementally at the bench;
     # completion reads them rather than taking an ephemeral checklist as input.
     #   installed_quantity - units physically fitted to the leaf. Absolute, editable both directions
@@ -163,8 +180,9 @@ class ShopAssemblyOpeningItem(Base):
     #   deficient_quantity - units found defective and already handed to the deficiency flow
     #     (returned to inventory flagged deficient + a PR-REPL replacement line). Only ever grows;
     #     undoing a deficiency is deficiency review's job, not the assembler's.
-    # Remaining (quantity - installed - deficient) is derived, never stored; completion is refused
-    # while any line still has remaining > 0.
+    # Remaining (allocated - installed - deficient) is derived, never stored; completion is refused
+    # while any line still has remaining > 0. It counts against `allocated_quantity`, not `quantity`:
+    # a short unit was never pulled, so there is nothing for the assembler to disposition.
     installed_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     deficient_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     # Units whose replacement hardware has arrived but is not on the leaf yet (#341). Only ever

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -371,6 +371,44 @@ def _gate_on_available_inventory(
         )
 
 
+def _allocated_quantity(item_input: dict) -> int:
+    """What a checklist line actually claims out of inventory.
+
+    A missing / null `allocated_quantity` means **fully allocated**. That default is what keeps every
+    caller that predates the allocator - tests, scripts, a browser tab loaded before the deploy - on
+    the old all-or-nothing behaviour: it asks for the whole line, and the availability gate bounces
+    the finalize if the whole line does not fit. The allocator step always sends the number.
+    """
+    allocated = item_input.get("allocated_quantity")
+    return item_input["quantity"] if allocated is None else allocated
+
+
+def _validate_leaf_allocation(opening_number: str, sa_opening_input: dict) -> None:
+    """Per-line bounds, and the one leaf-level rule the allocator enforces client-side.
+
+    A leaf with nothing allocated on any line is an empty cart: nothing to pull, nothing to stage,
+    nothing to assemble, and `complete_opening` would refuse it at the far end for having zero
+    installed units. The wizard drops such leaves before submitting, so reaching here means a race
+    (availability collapsed between load and send) or a non-UI caller - both of which are better
+    refused than turned into a work unit that can never be finished.
+    """
+    items = sa_opening_input.get("items", [])
+    for item in items:
+        allocated = _allocated_quantity(item)
+        if allocated < 0 or allocated > item["quantity"]:
+            raise ValidationError(
+                f"{_opening_leaf_label(opening_number, sa_opening_input.get('leaf'))} {item['product_code']}: "
+                f"allocated quantity {allocated} must be between 0 and the {item['quantity']} unit(s) owed.",
+                field="allocated_quantity",
+            )
+    if items and all(_allocated_quantity(item) == 0 for item in items):
+        raise ValidationError(
+            f"{_opening_leaf_label(opening_number, sa_opening_input.get('leaf'))} has no hardware allocated to it, "
+            "so there is nothing to pull for it. Drop it from the request, or wait for stock.",
+            field="allocated_quantity",
+        )
+
+
 def _live_shop_assembly_requests(session: Session, project_id: uuid.UUID) -> list[SARModel]:
     """Shop-assembly requests in a project that are still in flight: PENDING, or APPROVED while the
     pull they minted has not been worked (PENDING). Once the warehouse approves the pull, inventory
@@ -489,7 +527,13 @@ def _handle_schedule_replacement(
                 sar.project_id,
                 ReservationSource.SHOP_ASSEMBLY_REQUEST,
                 sar.id,
-                [(item.hardware_category, item.product_code, item.quantity) for o in sar.openings for item in o.items],
+                # Allocated, not owed: the claim it held was minted from the allocation, and rebuilding
+                # from `quantity` would inflate it into a claim on hardware this request never had.
+                [
+                    (item.hardware_category, item.product_code, item.allocated_quantity)
+                    for o in sar.openings
+                    for item in o.items
+                ],
             )
         sar.integrity_note = SCHEDULE_CHANGED_DROPPED_NOTE if lost else SCHEDULE_CHANGED_NOTE
 
@@ -911,34 +955,46 @@ def finalize_import_session(
                 ).all()
             }
 
-        # Deficiency guard (#341). A leaf whose source checklist still has condemned-and-unreplaced
-        # units - or units whose replacement has arrived but is not fitted yet - is physically short
-        # of the hardware list it ships under. The business decision is warn + confirm, never silent
-        # and never a hard block: deliberate short-shipping is a real workflow (reallocation exists
-        # for it), but it has to be a decision someone made. So it is refused here unless the caller
-        # says explicitly that it knows, and the wizard's confirm is what sets that flag.
+        # Incomplete-leaf guard (#341). A leaf can be physically short of the hardware list it ships
+        # under for two unrelated reasons, and the shipper needs to see both because the remedies are
+        # not the same:
+        #   - **awaiting replacement** - a unit arrived and failed. A replacement pull already exists;
+        #     waiting is a real option.
+        #   - **never pulled** - the unit was never available when the request was sent, so it was
+        #     allocated 0 and no pull was ever raised for it. Waiting does nothing; that gap is
+        #     closed by purchasing and, later, by reallocation.
+        # The business decision is warn + confirm, never silent and never a hard block: deliberate
+        # short-shipping is a real workflow, it just has to be a decision someone made. Refused here
+        # unless the caller says explicitly that it knows, and the wizard's confirm sets that flag.
         #
-        # One grouped scalar aggregate for every referenced leaf, not a per-line count.
+        # Two grouped scalar aggregates for every referenced leaf, not a per-line count.
         if referenced_oi_ids and not acknowledge_incomplete_leaves:
             from app.repositories import shop_assembly_repository
 
-            flagged_leaves = shop_assembly_repository.get_awaiting_replacement_quantities(
-                session, list(referenced_oi_ids)
-            )
-            if flagged_leaves:
+            oi_ids = list(referenced_oi_ids)
+            flagged_leaves = shop_assembly_repository.get_awaiting_replacement_quantities(session, oi_ids)
+            never_pulled = shop_assembly_repository.get_never_pulled_quantities(session, oi_ids)
+            if flagged_leaves or never_pulled:
                 # Name every flagged leaf, not just the first: the user is being asked to make a
-                # decision, and they can only make it once if they can see the whole list.
-                detail = ", ".join(
-                    sorted(
-                        f"{_leaf_label(opening_items_by_id[oi_id])} ({qty} unit(s) awaiting replacement)"
-                        for oi_id, qty in flagged_leaves.items()
-                        if oi_id in opening_items_by_id
-                    )
-                )
+                # decision, and they can only make it once if they can see the whole list. Each leaf
+                # carries whichever of the two counts is non-zero, so "waiting will fix this" and
+                # "waiting will not" are distinguishable per leaf rather than lumped together.
+                labels = []
+                for oi_id in set(flagged_leaves) | set(never_pulled):
+                    oi = opening_items_by_id.get(oi_id)
+                    if oi is None:
+                        continue
+                    parts = []
+                    if oi_id in flagged_leaves:
+                        parts.append(f"{flagged_leaves[oi_id]} unit(s) awaiting replacement")
+                    if oi_id in never_pulled:
+                        parts.append(f"{never_pulled[oi_id]} unit(s) never pulled")
+                    labels.append(f"{_leaf_label(oi)} ({', '.join(parts)})")
+                detail = ", ".join(sorted(labels))
                 raise ValidationError(
-                    "These assembled leaves are incomplete - hardware on them is still awaiting a "
-                    f"replacement: {detail}. Confirm you want to ship them short, or wait for the "
-                    "replacements to be installed.",
+                    "These assembled leaves are incomplete - hardware they should carry is either "
+                    f"awaiting a replacement or was never pulled: {detail}. Confirm you want to ship "
+                    "them short, or wait for the hardware.",
                     field="opening_item_id",
                 )
 
@@ -1143,6 +1199,7 @@ def finalize_import_session(
                     "so it cannot be sent to shop assembly.",
                     field="shop_assembly_openings",
                 )
+            _validate_leaf_allocation(opening_number, sa_opening_input)
             opening_id_by_number[opening_number] = opening_id
             opening_leaf_specs.append((opening_number, opening_id, sa_opening_input.get("leaf")))
 
@@ -1194,12 +1251,21 @@ def finalize_import_session(
                 field="shop_assembly_openings",
             )
 
-        # Reservation gate: every checklist line claims fungible stock, so the whole request must fit
-        # inside what is available right now.
+        # Reservation gate, now over the ALLOCATION rather than the demand. The request no longer has
+        # to fit the schedule's full bill of hardware - the requester already decided what to claim
+        # and what to send short - so what is gated is exactly what will be reserved and pulled.
+        #
+        # `_gate_on_available_inventory` itself is unchanged and still refuses the whole finalize.
+        # It is not the shortfall gate any more; it is the **race** gate. The allocator built its
+        # numbers from a snapshot of availability, and if that snapshot went stale between load and
+        # send (another request took the stock, an admin wrote it off), reserving anyway would write
+        # a claim on hardware that is not there. The wizard catches the refusal, refetches
+        # availability, re-runs auto-assign and asks the user to look again.
         sar_needs = [
-            (item["hardware_category"], item["product_code"], item["quantity"])
+            (item["hardware_category"], item["product_code"], _allocated_quantity(item))
             for sa_opening_input in sar_openings_input
             for item in sa_opening_input.get("items", [])
+            if _allocated_quantity(item) > 0
         ]
         _gate_on_available_inventory(
             session,
@@ -1208,6 +1274,20 @@ def finalize_import_session(
             label="shop-assembly request",
             request_number=sar_request_number,
         )
+        # Everything the schedule owed but the allocation could not cover. Short combos are out of
+        # available stock by construction - the allocator only leaves a line short once the pool for
+        # that combo is exhausted - so this is always a genuine purchasing signal, not a claim
+        # somebody else is holding. It fires *after* the request is created, unlike the refusal path
+        # in app/schemas/imports.py, which stays for the race above.
+        sar_short_by_combo: dict[tuple[str, str], tuple[int, int]] = {}
+        for sa_opening_input in sar_openings_input:
+            for item in sa_opening_input.get("items", []):
+                short = item["quantity"] - _allocated_quantity(item)
+                if short <= 0:
+                    continue
+                key = (item["hardware_category"], item["product_code"])
+                owed, missing = sar_short_by_combo.get(key, (0, 0))
+                sar_short_by_combo[key] = (owed + item["quantity"], missing + short)
 
         sar = SARModel(
             id=uuid.uuid4(),
@@ -1247,12 +1327,17 @@ def finalize_import_session(
                         shop_assembly_opening_id=sa_opening.id,
                         hardware_category=item_input["hardware_category"],
                         product_code=item_input["product_code"],
+                        # Owed stays the schedule's number even when nothing could be claimed for it.
+                        # The checklist is what the leaf takes; the allocation is what turned up.
                         quantity=item_input["quantity"],
+                        allocated_quantity=_allocated_quantity(item_input),
                     )
                 )
 
         # The request holds its claim from here until the warehouse approves the pull that spends it
-        # (#342). One row per combo across the whole request, not per opening.
+        # (#342). One row per combo across the whole request, not per opening - and over the
+        # allocated quantities, so the pull the accept mints asks for exactly what is reserved and
+        # `approve_pull_request` keeps its all-or-nothing property with no warehouse-side change.
         warehouse_repository.create_reservations(
             session,
             project.id,
@@ -1260,6 +1345,26 @@ def finalize_import_session(
             sar.id,
             sar_needs,
         )
+
+        if sar_short_by_combo:
+            from app.services import notification_service
+
+            notification_service.notify_po_shortfall(
+                session,
+                project_id=project.id,
+                request_number=sar_request_number,
+                shortfalls=[
+                    warehouse_repository.Shortfall(
+                        hardware_category=cat,
+                        product_code=code,
+                        requested=owed,
+                        available=owed - missing,
+                        short=missing,
+                        reserved=0,
+                    )
+                    for (cat, code), (owed, missing) in sorted(sar_short_by_combo.items())
+                ],
+            )
 
     session.flush()
 

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -967,28 +967,27 @@ def finalize_import_session(
         # short-shipping is a real workflow, it just has to be a decision someone made. Refused here
         # unless the caller says explicitly that it knows, and the wizard's confirm sets that flag.
         #
-        # Two grouped scalar aggregates for every referenced leaf, not a per-line count.
+        # One grouped scalar aggregate for every referenced leaf, not a per-line count and not one
+        # query per reading.
         if referenced_oi_ids and not acknowledge_incomplete_leaves:
             from app.repositories import shop_assembly_repository
 
-            oi_ids = list(referenced_oi_ids)
-            flagged_leaves = shop_assembly_repository.get_awaiting_replacement_quantities(session, oi_ids)
-            never_pulled = shop_assembly_repository.get_never_pulled_quantities(session, oi_ids)
-            if flagged_leaves or never_pulled:
+            shortfalls = shop_assembly_repository.get_leaf_shortfalls(session, list(referenced_oi_ids))
+            if shortfalls:
                 # Name every flagged leaf, not just the first: the user is being asked to make a
                 # decision, and they can only make it once if they can see the whole list. Each leaf
                 # carries whichever of the two counts is non-zero, so "waiting will fix this" and
                 # "waiting will not" are distinguishable per leaf rather than lumped together.
                 labels = []
-                for oi_id in set(flagged_leaves) | set(never_pulled):
+                for oi_id, shortfall in shortfalls.items():
                     oi = opening_items_by_id.get(oi_id)
                     if oi is None:
                         continue
                     parts = []
-                    if oi_id in flagged_leaves:
-                        parts.append(f"{flagged_leaves[oi_id]} unit(s) awaiting replacement")
-                    if oi_id in never_pulled:
-                        parts.append(f"{never_pulled[oi_id]} unit(s) never pulled")
+                    if shortfall.awaiting_replacement:
+                        parts.append(f"{shortfall.awaiting_replacement} unit(s) awaiting replacement")
+                    if shortfall.never_pulled:
+                        parts.append(f"{shortfall.never_pulled} unit(s) never pulled")
                     labels.append(f"{_leaf_label(oi)} ({', '.join(parts)})")
                 detail = ", ".join(sorted(labels))
                 raise ValidationError(
@@ -1279,15 +1278,21 @@ def finalize_import_session(
         # that combo is exhausted - so this is always a genuine purchasing signal, not a claim
         # somebody else is holding. It fires *after* the request is created, unlike the refusal path
         # in app/schemas/imports.py, which stays for the race above.
-        sar_short_by_combo: dict[tuple[str, str], tuple[int, int]] = {}
+        #
+        # Totals are accumulated over EVERY line of a combo, not only the short ones. Purchasing acts
+        # on the combo, so the number it needs is what this request wanted of that product against
+        # what it got; counting only the short lines would report a request that took 4 hinges on one
+        # leaf and missed 3 on another as "need 4, 1 available", which is true of neither.
+        sar_totals_by_combo: dict[tuple[str, str], list[int]] = {}
         for sa_opening_input in sar_openings_input:
             for item in sa_opening_input.get("items", []):
-                short = item["quantity"] - _allocated_quantity(item)
-                if short <= 0:
-                    continue
                 key = (item["hardware_category"], item["product_code"])
-                owed, missing = sar_short_by_combo.get(key, (0, 0))
-                sar_short_by_combo[key] = (owed + item["quantity"], missing + short)
+                totals = sar_totals_by_combo.setdefault(key, [0, 0])
+                totals[0] += item["quantity"]
+                totals[1] += _allocated_quantity(item)
+        sar_short_by_combo = {
+            key: (owed, allocated) for key, (owed, allocated) in sar_totals_by_combo.items() if owed > allocated
+        }
 
         sar = SARModel(
             id=uuid.uuid4(),
@@ -1358,12 +1363,15 @@ def finalize_import_session(
                         hardware_category=cat,
                         product_code=code,
                         requested=owed,
-                        available=owed - missing,
-                        short=missing,
+                        available=allocated,
+                        short=owed - allocated,
                         reserved=0,
                     )
-                    for (cat, code), (owed, missing) in sorted(sar_short_by_combo.items())
+                    for (cat, code), (owed, allocated) in sorted(sar_short_by_combo.items())
                 ],
+                # The request exists and nothing is blocked - this is "here is what the project is
+                # missing", not "a request failed".
+                sent_short=True,
             )
 
     session.flush()

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -702,31 +702,68 @@ def _latest_assembly_lateral():
     )
 
 
-def _sum_over_source_checklist(session: Session, opening_item_ids: list[uuid.UUID], expression):
-    """Sum `expression` over the checklist lines of each leaf's own source assembly.
+@dataclass(frozen=True)
+class LeafShortfall:
+    """The two ways an assembled leaf can be short of the bill of hardware it ships under (#341).
 
-    One grouped scalar aggregate over the whole id set, never a len() over loaded collections
-    (CLAUDE.md perf rules): the shipping selection lists every assembled leaf in a project, and a
-    per-leaf query here would be an N+1 on the heaviest list in the module. Only non-zero entries are
-    returned, so callers can treat a missing key as "nothing outstanding".
+    They are counted apart because the remedies are not the same, and a shipper deciding whether to
+    send a leaf needs to know which one they are looking at:
+
+    - `awaiting_replacement` - a unit arrived and failed. It was condemned, a PR-REPL pull already
+      exists for it, and waiting is a real option.
+    - `never_pulled` - a unit never arrived at all: the allocator could not claim it out of available
+      inventory when the request was sent, so nothing was ever pulled and nothing is in flight.
+      Waiting achieves nothing; that gap is closed by purchasing and, later, by reallocation.
     """
-    if not opening_item_ids:
+
+    awaiting_replacement: int
+    never_pulled: int
+
+    @property
+    def total(self) -> int:
+        return self.awaiting_replacement + self.never_pulled
+
+
+def get_leaf_shortfalls(
+    session: Session,
+    opening_item_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, LeafShortfall]:
+    """Both shortfall readings per assembled leaf, in ONE grouped aggregate.
+
+    Never a len() over loaded collections, and never one query per reading (CLAUDE.md perf rules):
+    the shipping selection lists every assembled leaf in a project, so a per-leaf query would be an
+    N+1 on the heaviest list in the module, and running the correlated lateral twice to get two sums
+    out of the same rows would double the cost of the heaviest query in it. Only leaves with
+    something outstanding are returned, so callers treat a missing key as "nothing outstanding".
+    """
+    ids = list(opening_item_ids)
+    if not ids:
         return {}
     latest_assembly = _latest_assembly_lateral()
-    total = func.sum(expression)
+    awaiting = func.sum(
+        ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity
+    )
+    never_pulled = func.sum(ShopAssemblyOpeningItem.quantity - ShopAssemblyOpeningItem.allocated_quantity)
     stmt = (
-        select(OpeningItemModel.id, total.label("total"))
+        select(
+            OpeningItemModel.id,
+            awaiting.label("awaiting"),
+            never_pulled.label("never_pulled"),
+        )
         .select_from(OpeningItemModel)
         .join(latest_assembly, true())
         .join(
             ShopAssemblyOpeningItem,
             ShopAssemblyOpeningItem.shop_assembly_opening_id == latest_assembly.c.sa_opening_id,
         )
-        .where(OpeningItemModel.id.in_(opening_item_ids))
+        .where(OpeningItemModel.id.in_(ids))
         .group_by(OpeningItemModel.id)
-        .having(total > 0)
+        .having(or_(awaiting > 0, never_pulled > 0))
     )
-    return {row.id: int(row.total) for row in session.execute(stmt).all()}
+    return {
+        row.id: LeafShortfall(awaiting_replacement=int(row.awaiting), never_pulled=int(row.never_pulled))
+        for row in session.execute(stmt).all()
+    }
 
 
 def get_awaiting_replacement_quantities(
@@ -735,21 +772,15 @@ def get_awaiting_replacement_quantities(
 ) -> dict[uuid.UUID, int]:
     """Per assembled leaf, how many units of its hardware are still owed *and were pulled* (#341):
     units condemned and not yet replaced, plus units whose replacement has arrived but is not fitted
-    yet.
+    yet. Zero entries are dropped, so a missing key means "nothing outstanding".
 
-    This is the shipping deficiency flag. A leaf with a non-zero count is physically short of what
-    its checklist says it carries, so shipping it is a decision, not an accident - the wizard flags
-    it and the shipping-out creation path refuses it without an explicit acknowledgment.
-
-    Units that were **never pulled** are a different kind of short and are counted separately by
-    `get_never_pulled_quantities`: nothing was ever condemned, there is no replacement in flight, and
-    the hardware simply was not available when the leaf was sent to the bench.
+    A named reading of `get_leaf_shortfalls` for the callers that only surface this half.
     """
-    return _sum_over_source_checklist(
-        session,
-        list(opening_item_ids),
-        ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity,
-    )
+    return {
+        oi_id: shortfall.awaiting_replacement
+        for oi_id, shortfall in get_leaf_shortfalls(session, opening_item_ids).items()
+        if shortfall.awaiting_replacement > 0
+    }
 
 
 def get_never_pulled_quantities(
@@ -758,17 +789,13 @@ def get_never_pulled_quantities(
 ) -> dict[uuid.UUID, int]:
     """Per assembled leaf, how many units its schedule owed that the request never pulled.
 
-    The other half of the shipping incomplete-leaf decision. `deficient` says a unit arrived and
-    failed; this says a unit never arrived at all, because the allocator could not claim it out of
-    available inventory when the request was sent. The leaf is legitimately complete either way - the
-    assembler had nothing left to do - but it is physically short of its bill of hardware, and
-    shipping it has to be a decision somebody made rather than something nobody noticed.
+    A named reading of `get_leaf_shortfalls` for the callers that only surface this half.
     """
-    return _sum_over_source_checklist(
-        session,
-        list(opening_item_ids),
-        ShopAssemblyOpeningItem.quantity - ShopAssemblyOpeningItem.allocated_quantity,
-    )
+    return {
+        oi_id: shortfall.never_pulled
+        for oi_id, shortfall in get_leaf_shortfalls(session, opening_item_ids).items()
+        if shortfall.never_pulled > 0
+    }
 
 
 @dataclass(frozen=True)

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -360,10 +360,18 @@ def record_assembly_progress(
         new_deficient = item.deficient_quantity + flagged
         if new_installed < 0:
             raise ValidationError("installed_quantity must be >= 0", field="installed_quantity")
-        if new_installed + new_deficient > item.quantity:
+        # The cap is what was **allocated**, not what the schedule owed. Short units never left
+        # inventory, so there is no unit on the cart for the assembler to install or condemn; letting
+        # progress run to `quantity` would mean recording hardware onto a leaf that never arrived.
+        if new_installed + new_deficient + item.replacement_pending_quantity > item.allocated_quantity:
+            short_note = (
+                f" ({item.quantity - item.allocated_quantity} of the {item.quantity} owed were never pulled)"
+                if item.allocated_quantity < item.quantity
+                else ""
+            )
             raise ValidationError(
                 f"{item.product_code}: {new_installed} installed + {new_deficient} deficient exceeds the "
-                f"{item.quantity} unit(s) pulled for this leaf",
+                f"{item.allocated_quantity} unit(s) pulled for this leaf{short_note}",
                 field="installed_quantity",
             )
         planned.append((item, new_installed, new_deficient, flagged, reason))
@@ -400,11 +408,12 @@ def record_assembly_progress(
                 "hardwareCategory": item.hardware_category,
                 "productCode": item.product_code,
                 "plannedQuantity": item.quantity,
+                "allocatedQuantity": item.allocated_quantity,
                 "previousInstalledQuantity": previous_installed,
                 "installedQuantity": new_installed,
                 "flaggedDeficientQuantity": flagged,
                 "deficientQuantity": new_deficient,
-                "remainingQuantity": item.quantity - new_installed - new_deficient,
+                "remainingQuantity": item.allocated_quantity - new_installed - new_deficient,
                 "reasonText": reason,
                 "openingNumber": sa_opening.opening_number,
                 "leaf": sa_opening.leaf,
@@ -484,16 +493,25 @@ def complete_opening(
             field="opening_id",
         )
 
-    # 4. Every unit must be accounted for (#340). Business decision: block, never auto-default. An
-    #    unrecorded unit is an unanswered question - was it fitted, is it still on the cart, is it
-    #    missing? - and silently treating it as installed is what would put hardware on a leaf that
-    #    was never there, while silently treating it as deficient would mint replacement pulls nobody
-    #    asked for. Name the lines so the assembler knows exactly which ones to go finish.
+    # 4. Every unit that arrived must be accounted for (#340). Business decision: block, never
+    #    auto-default. An unrecorded unit is an unanswered question - was it fitted, is it still on
+    #    the cart, is it missing? - and silently treating it as installed is what would put hardware
+    #    on a leaf that was never there, while silently treating it as deficient would mint
+    #    replacement pulls nobody asked for. Name the lines so the assembler knows which to finish.
+    #
+    #    Accounting is against `allocated_quantity`. **Short units are excused**: they were never
+    #    pulled, so no amount of work at the bench can disposition them, and holding the leaf open
+    #    for them would strand it forever waiting on hardware that was never requested. What is still
+    #    owed is recorded by `quantity - allocated_quantity` and is the reallocation module's
+    #    problem, not this assembler's.
+    def _dispositioned(item) -> int:
+        return item.installed_quantity + item.deficient_quantity + item.replacement_pending_quantity
+
     undispositioned = [
-        f"{item.product_code} ({item.quantity - item.installed_quantity - item.deficient_quantity} of "
-        f"{item.quantity} unrecorded)"
+        f"{item.product_code} ({item.allocated_quantity - _dispositioned(item)} of "
+        f"{item.allocated_quantity} unrecorded)"
         for item in sa_opening.items
-        if item.installed_quantity + item.deficient_quantity != item.quantity
+        if _dispositioned(item) != item.allocated_quantity
     ]
     if undispositioned:
         raise ValidationError(
@@ -502,15 +520,18 @@ def complete_opening(
             field="items",
         )
 
-    # 4b. Refuse an all-deficient completion (#339). If every unit was flagged deficient the
-    #     OpeningItem would be minted with zero OpeningItemHardware rows - an "assembled" leaf that
-    #     had nothing installed on it, which then reads as ship-ready inventory. The deficiencies
-    #     themselves stand (they were recorded when they were found, #340); what is refused is calling
-    #     the leaf assembled. It stays IN_PROGRESS until at least one unit is installed on it.
+    # 4b. Refuse a completion with nothing installed on it (#339). If every unit was flagged
+    #     deficient - or, since partial allocation, if nothing was ever pulled - the OpeningItem would
+    #     be minted with zero OpeningItemHardware rows: an "assembled" leaf that had nothing on it,
+    #     which then reads as ship-ready inventory. The deficiencies themselves stand (they were
+    #     recorded when they were found, #340) and so does the shortfall; what is refused is calling
+    #     the leaf assembled. One guard covers both causes, because the thing that makes it wrong is
+    #     the same either way - an empty leaf is not a leaf.
     if sa_opening.items and all(item.installed_quantity == 0 for item in sa_opening.items):
         raise ValidationError(
-            "Cannot complete an opening with every unit flagged deficient - nothing would be "
-            "assembled. Leave the opening open until replacement hardware is installed.",
+            "Cannot complete an opening with nothing installed on it - every unit was either flagged "
+            "deficient or never pulled, so nothing would be assembled. Leave the opening open until "
+            "hardware is installed on it.",
             field="items",
         )
 
@@ -595,8 +616,12 @@ def complete_opening(
                     "productCode": item.product_code,
                     "hardwareCategory": item.hardware_category,
                     "plannedQuantity": item.quantity,
+                    "allocatedQuantity": item.allocated_quantity,
                     "installedQuantity": item.installed_quantity,
                     "deficientQuantity": item.deficient_quantity,
+                    # What the schedule owed that this request never pulled. Recorded on the leaf's
+                    # completion event so the execution is auditable after the fact.
+                    "shortQuantity": item.quantity - item.allocated_quantity,
                 }
                 for item in sa_opening.items
             ],
@@ -639,36 +664,20 @@ def find_assembled_leaf(
     return sorted(live or rows, key=lambda oi: oi.assembly_completed_at)[-1]
 
 
-def get_awaiting_replacement_quantities(
-    session: Session,
-    opening_item_ids: Iterable[uuid.UUID],
-) -> dict[uuid.UUID, int]:
-    """Per assembled leaf, how many units of its hardware are still owed (#341): units condemned and
-    not yet replaced, plus units whose replacement has arrived but is not fitted yet.
+def _latest_assembly_lateral():
+    """The ShopAssemblyOpening that produced the correlated `OpeningItemModel` row.
 
-    This is the shipping deficiency flag. A leaf with a non-zero count is physically short of what
-    its checklist says it carries, so shipping it is a decision, not an accident - the wizard flags
-    it and the shipping-out creation path refuses it without an explicit acknowledgment.
+    **Exactly one assembly per leaf.** A leaf can be sent to the shop more than once - it shipped and
+    a correction re-assembled it, or a request was reopened and re-imported - and (opening_id, leaf)
+    alone matches every one of those work units. A plain join therefore made a newly assembled leaf
+    inherit the *previous* assembly's counters. This resolves it the way `find_assembled_leaf`
+    resolves the other direction: latest completion wins, bounded by the leaf's own
+    `assembly_completed_at` so each assembled unit reads its own work unit and not a later one.
 
-    One grouped scalar aggregate over the whole id set, never a len() over loaded collections
-    (CLAUDE.md perf rules): the shipping selection lists every assembled leaf in a project, and a
-    per-leaf query here would be an N+1 on the heaviest list in the module. Only non-zero entries are
-    returned, so callers can treat a missing key as "nothing outstanding".
-
-    **Exactly one assembly per leaf is counted: the one that produced that leaf.** A leaf can be sent
-    to the shop more than once - it shipped and a correction re-assembled it, or a request was
-    reopened and re-imported - and (opening_id, leaf) alone matches every one of those work units. A
-    plain join therefore made the newly assembled leaf inherit the *previous* assembly's outstanding
-    units and read as "awaiting replacement" the moment it was built. The lateral resolves it the way
-    `find_assembled_leaf` resolves the other direction: latest completion wins, bounded by the leaf's
-    own `assembly_completed_at` so each assembled unit reads its own work unit and not a later one.
+    Scoped to the leaf's own project, because `opening_id` is a historical stamp, not an FK, and a
+    re-upload can reissue it.
     """
-    ids = list(opening_item_ids)
-    if not ids:
-        return {}
-    # Scope the correlation to the leaf's own project: opening_id is a historical stamp, not an FK,
-    # and a re-upload can reissue it.
-    latest_assembly = (
+    return (
         select(ShopAssemblyOpening.id.label("sa_opening_id"))
         .join(PullRequestModel, PullRequestModel.id == ShopAssemblyOpening.pull_request_id)
         .where(
@@ -691,22 +700,75 @@ def get_awaiting_replacement_quantities(
         .limit(1)
         .lateral("latest_assembly")
     )
-    outstanding = func.sum(
-        ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity
-    )
+
+
+def _sum_over_source_checklist(session: Session, opening_item_ids: list[uuid.UUID], expression):
+    """Sum `expression` over the checklist lines of each leaf's own source assembly.
+
+    One grouped scalar aggregate over the whole id set, never a len() over loaded collections
+    (CLAUDE.md perf rules): the shipping selection lists every assembled leaf in a project, and a
+    per-leaf query here would be an N+1 on the heaviest list in the module. Only non-zero entries are
+    returned, so callers can treat a missing key as "nothing outstanding".
+    """
+    if not opening_item_ids:
+        return {}
+    latest_assembly = _latest_assembly_lateral()
+    total = func.sum(expression)
     stmt = (
-        select(OpeningItemModel.id, outstanding.label("outstanding"))
+        select(OpeningItemModel.id, total.label("total"))
         .select_from(OpeningItemModel)
         .join(latest_assembly, true())
         .join(
             ShopAssemblyOpeningItem,
             ShopAssemblyOpeningItem.shop_assembly_opening_id == latest_assembly.c.sa_opening_id,
         )
-        .where(OpeningItemModel.id.in_(ids))
+        .where(OpeningItemModel.id.in_(opening_item_ids))
         .group_by(OpeningItemModel.id)
-        .having(outstanding > 0)
+        .having(total > 0)
     )
-    return {row.id: int(row.outstanding) for row in session.execute(stmt).all()}
+    return {row.id: int(row.total) for row in session.execute(stmt).all()}
+
+
+def get_awaiting_replacement_quantities(
+    session: Session,
+    opening_item_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """Per assembled leaf, how many units of its hardware are still owed *and were pulled* (#341):
+    units condemned and not yet replaced, plus units whose replacement has arrived but is not fitted
+    yet.
+
+    This is the shipping deficiency flag. A leaf with a non-zero count is physically short of what
+    its checklist says it carries, so shipping it is a decision, not an accident - the wizard flags
+    it and the shipping-out creation path refuses it without an explicit acknowledgment.
+
+    Units that were **never pulled** are a different kind of short and are counted separately by
+    `get_never_pulled_quantities`: nothing was ever condemned, there is no replacement in flight, and
+    the hardware simply was not available when the leaf was sent to the bench.
+    """
+    return _sum_over_source_checklist(
+        session,
+        list(opening_item_ids),
+        ShopAssemblyOpeningItem.deficient_quantity + ShopAssemblyOpeningItem.replacement_pending_quantity,
+    )
+
+
+def get_never_pulled_quantities(
+    session: Session,
+    opening_item_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """Per assembled leaf, how many units its schedule owed that the request never pulled.
+
+    The other half of the shipping incomplete-leaf decision. `deficient` says a unit arrived and
+    failed; this says a unit never arrived at all, because the allocator could not claim it out of
+    available inventory when the request was sent. The leaf is legitimately complete either way - the
+    assembler had nothing left to do - but it is physically short of its bill of hardware, and
+    shipping it has to be a decision somebody made rather than something nobody noticed.
+    """
+    return _sum_over_source_checklist(
+        session,
+        list(opening_item_ids),
+        ShopAssemblyOpeningItem.quantity - ShopAssemblyOpeningItem.allocated_quantity,
+    )
 
 
 @dataclass(frozen=True)
@@ -1066,6 +1128,13 @@ def accept_shop_assembly_request(
     check now happens once, at creation (where the creator can still refine the selection), and the
     claim is spent at pull approval. Accepting does not touch the reservations: the request keeps
     holding them, exactly as it did while PENDING.
+
+    The pull asks for the **allocated** quantity, and a line with nothing allocated mints no pull
+    line at all. That is what keeps the pull equal to the reservation: the request reserved its
+    allocation at creation, so the pull it mints spends exactly that, and `approve_pull_request`
+    stays all-or-nothing by construction. Sending the owed quantity instead would ask the warehouse
+    for stock nobody claimed and the pull would sit blocked - which is the shortfall this whole slice
+    moves back to the requester.
     """
     stmt = (
         select(ShopAssemblyRequest)
@@ -1097,6 +1166,10 @@ def accept_shop_assembly_request(
     for opening in sar.openings:
         opening.pull_request_id = pr.id
         for item in opening.items:
+            if item.allocated_quantity <= 0:
+                # Fully short line: nothing was reserved for it and nothing is coming. A zero-quantity
+                # pull line would put a pick on the sheet the warehouse cannot fill.
+                continue
             session.add(
                 PullRequestItemModel(
                     id=uuid.uuid4(),
@@ -1107,7 +1180,7 @@ def accept_shop_assembly_request(
                     leaf=opening.leaf,
                     hardware_category=item.hardware_category,
                     product_code=item.product_code,
-                    requested_quantity=item.quantity,
+                    requested_quantity=item.allocated_quantity,
                 )
             )
 
@@ -1262,6 +1335,9 @@ class PipelineOpening:
     assembly_status: AssemblyStatus
     completed_at: datetime | None
     planned_unit_count: int
+    # What the request could actually claim for this leaf. The three progress counters partition
+    # this, not `planned_unit_count`; the difference was never pulled.
+    allocated_unit_count: int
     installed_unit_count: int
     deficient_unit_count: int
     replacement_pending_unit_count: int
@@ -1269,6 +1345,13 @@ class PipelineOpening:
     opening_item_state: OpeningItemState | None
     # Where the assembled leaf physically is, once there is one - the "completed (location)" rung.
     assembled_location: str | None
+
+    @property
+    def short_unit_count(self) -> int:
+        """Units the schedule owed this leaf that the request never pulled - it could not claim them
+        out of available inventory when it was sent. Not outstanding *work*: nothing arrived, so the
+        leaf completes without them and closing the gap belongs to purchasing and reallocation."""
+        return self.planned_unit_count - self.allocated_unit_count
 
     @property
     def awaiting_replacement_unit_count(self) -> int:
@@ -1336,6 +1419,11 @@ class AssemblyPipelineSummary:
     shipped_opening_count: int
 
     planned_unit_count: int
+    # Sent short: `planned - allocated` across the whole request. The number the pipeline exists to
+    # surface for this slice - a request can now be legitimately complete and still not have
+    # delivered its full bill of hardware, and nothing else on this row would say so.
+    allocated_unit_count: int
+    short_unit_count: int
     installed_unit_count: int
     deficient_unit_count: int
     replacement_pending_unit_count: int
@@ -1343,6 +1431,8 @@ class AssemblyPipelineSummary:
     # Openings with something still owed to them, and the subset whose leaf has already shipped.
     awaiting_replacement_opening_count: int
     replacement_after_ship_opening_count: int
+    # Openings carrying at least one line that was never fully pulled.
+    short_opening_count: int
 
     stage: str
 
@@ -1519,6 +1609,7 @@ def _unit_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid.UU
             ShopAssemblyOpening.shop_assembly_request_id.label("request_id"),
             ShopAssemblyOpening.id.label("opening_id"),
             func.coalesce(func.sum(ShopAssemblyOpeningItem.quantity), 0).label("planned"),
+            func.coalesce(func.sum(ShopAssemblyOpeningItem.allocated_quantity), 0).label("allocated"),
             func.coalesce(func.sum(ShopAssemblyOpeningItem.installed_quantity), 0).label("installed"),
             func.coalesce(func.sum(ShopAssemblyOpeningItem.deficient_quantity), 0).label("deficient"),
             func.coalesce(func.sum(ShopAssemblyOpeningItem.replacement_pending_quantity), 0).label("pending"),
@@ -1532,23 +1623,29 @@ def _unit_counts(session: Session, request_ids: list[uuid.UUID]) -> dict[uuid.UU
         .subquery()
     )
     outstanding = per_opening.c.deficient + per_opening.c.pending
+    short = per_opening.c.planned - per_opening.c.allocated
     rows = session.execute(
         select(
             per_opening.c.request_id,
             func.coalesce(func.sum(per_opening.c.planned), 0).label("planned"),
+            func.coalesce(func.sum(per_opening.c.allocated), 0).label("allocated"),
             func.coalesce(func.sum(per_opening.c.installed), 0).label("installed"),
             func.coalesce(func.sum(per_opening.c.deficient), 0).label("deficient"),
             func.coalesce(func.sum(per_opening.c.pending), 0).label("pending"),
             func.count(1).filter(outstanding > 0).label("awaiting_openings"),
+            func.count(1).filter(short > 0).label("short_openings"),
         ).group_by(per_opening.c.request_id)
     ).all()
     return {
         row.request_id: {
             "planned_unit_count": int(row.planned),
+            "allocated_unit_count": int(row.allocated),
+            "short_unit_count": int(row.planned) - int(row.allocated),
             "installed_unit_count": int(row.installed),
             "deficient_unit_count": int(row.deficient),
             "replacement_pending_unit_count": int(row.pending),
             "awaiting_replacement_opening_count": int(row.awaiting_openings),
+            "short_opening_count": int(row.short_openings),
         }
         for row in rows
     }
@@ -1624,10 +1721,13 @@ _EMPTY_OPENING_COUNTS = {
 }
 _EMPTY_UNIT_COUNTS = {
     "planned_unit_count": 0,
+    "allocated_unit_count": 0,
+    "short_unit_count": 0,
     "installed_unit_count": 0,
     "deficient_unit_count": 0,
     "replacement_pending_unit_count": 0,
     "awaiting_replacement_opening_count": 0,
+    "short_opening_count": 0,
 }
 _EMPTY_SHIPPED_COUNTS = {"shipped_opening_count": 0, "replacement_after_ship_opening_count": 0}
 
@@ -1741,11 +1841,14 @@ def get_assembly_pipeline_summaries(
                 completed_opening_count=counts["completed_opening_count"],
                 shipped_opening_count=counts["shipped_opening_count"],
                 planned_unit_count=counts["planned_unit_count"],
+                allocated_unit_count=counts["allocated_unit_count"],
+                short_unit_count=counts["short_unit_count"],
                 installed_unit_count=counts["installed_unit_count"],
                 deficient_unit_count=counts["deficient_unit_count"],
                 replacement_pending_unit_count=counts["replacement_pending_unit_count"],
                 awaiting_replacement_opening_count=counts["awaiting_replacement_opening_count"],
                 replacement_after_ship_opening_count=counts["replacement_after_ship_opening_count"],
+                short_opening_count=counts["short_opening_count"],
                 stage=_request_stage(counts, unstaged_stage, sar.status),
             )
         )
@@ -1790,6 +1893,7 @@ def get_assembly_pipeline(session: Session, request_id: uuid.UUID) -> AssemblyPi
             select(
                 ShopAssemblyOpeningItem.shop_assembly_opening_id.label("opening_id"),
                 func.coalesce(func.sum(ShopAssemblyOpeningItem.quantity), 0).label("planned"),
+                func.coalesce(func.sum(ShopAssemblyOpeningItem.allocated_quantity), 0).label("allocated"),
                 func.coalesce(func.sum(ShopAssemblyOpeningItem.installed_quantity), 0).label("installed"),
                 func.coalesce(func.sum(ShopAssemblyOpeningItem.deficient_quantity), 0).label("deficient"),
                 func.coalesce(func.sum(ShopAssemblyOpeningItem.replacement_pending_quantity), 0).label("pending"),
@@ -1853,6 +1957,7 @@ def get_assembly_pipeline(session: Session, request_id: uuid.UUID) -> AssemblyPi
                 assembly_status=opening.assembly_status,
                 completed_at=opening.completed_at,
                 planned_unit_count=int(sums.planned) if sums is not None else 0,
+                allocated_unit_count=int(sums.allocated) if sums is not None else 0,
                 installed_unit_count=int(sums.installed) if sums is not None else 0,
                 deficient_unit_count=int(sums.deficient) if sums is not None else 0,
                 replacement_pending_unit_count=int(sums.pending) if sums is not None else 0,

--- a/backend/app/repositories/stock/deficiency.py
+++ b/backend/app/repositories/stock/deficiency.py
@@ -348,6 +348,23 @@ def report_deficiency_at_assembly(
         session.add(pri)
     session.flush()
 
+    # Claim replacement stock now, not at approval. A deficiency could not be foreseen, so nobody
+    # could reserve for it in advance - but the moment it is found the demand is real and dated, and
+    # leaving the replacement pull holding nothing meant every request created afterwards outranked
+    # it. It reserves min(free stock, what was just condemned); claiming less than that is expected
+    # (the shelf is often empty, which is why a replacement is needed at all) and
+    # `top_up_replacement_reservations` closes the gap when stock is received or a unit is repaired.
+    from app.repositories import warehouse as warehouse_repository
+
+    warehouse_repository.reserve_for_replacement_pull(
+        session,
+        replacement_pr.id,
+        il.project_id,
+        il.hardware_category,
+        il.product_code,
+        quantity,
+    )
+
     return (il, pri)
 
 
@@ -468,6 +485,24 @@ def resolve_deficiency(
     )
     session.add(review)
     session.flush()
+
+    # A REPAIR puts a condemned unit back into the available pool without anything being received,
+    # so it is the other moment project availability rises - and the replacement pull that unit was
+    # condemned *for* is usually the thing waiting on it. Claim it for the waiting replacements, in
+    # the order the defects were found, before a request created since can take it. No PR-REPL line
+    # unwinding is needed or wanted: the replacement pull can now simply pull the repaired unit as
+    # free stock, which is what it was always going to do.
+    #
+    # SEND_TO_STOCK moves the unit off the project onto the shared stock pool, so it does not raise
+    # *project* availability and nothing here can claim it. It is listed as a no-op rather than
+    # omitted silently, because "which resolutions free project stock" is the question this block
+    # answers.
+    if inventory_location_id is not None and resolution == DeficiencyResolution.REPAIR:
+        from app.repositories import warehouse as warehouse_repository
+
+        warehouse_repository.top_up_replacement_reservations(
+            session, project_for_audit, [(hardware_category, product_code)]
+        )
 
     detail = {
         "resolution": resolution.value,

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -74,10 +74,13 @@ from .receiving import (
 )
 from .reservations import (
     create_reservations,
+    get_available_quantities,
     get_project_availability,
     get_reserved_quantities,
     get_reserved_total,
     release_reservations,
+    reserve_for_replacement_pull,
+    top_up_replacement_reservations,
 )
 
 __all__ = [
@@ -104,6 +107,7 @@ __all__ = [
     "find_pending_replacement_pulls",
     "find_reservation_holder",
     "get_audit_log",
+    "get_available_quantities",
     "get_back_ordered_items",
     "get_distinct_location_values",
     "get_expected_deliveries",
@@ -140,6 +144,8 @@ __all__ = [
     "notify_unblocked_replacement_pulls",
     "override_inventory_quantity",
     "release_reservations",
+    "reserve_for_replacement_pull",
     "stage_pull_openings",
+    "top_up_replacement_reservations",
     "validate_receive_eligibility",
 ]

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -1310,10 +1310,13 @@ def discard_pending_pull_request(session: Session, pr_id: uuid.UUID | None) -> N
     unique: a later re-accept re-mints a PR with the same number. A null/missing PR id is a no-op (the
     accept is already effectively undone).
 
-    A PENDING **replacement** pull reaches this the same way, and its own claim goes with it: the pull
-    is the holder, so hard-deleting it without releasing would strand a reservation with nothing left
-    that could ever spend or release it. The FK cascade would take the rows anyway; releasing
-    explicitly keeps the session's identity map honest and makes the intent readable."""
+    The REPLACEMENT_PULL release below is **defence, not a live path**. Both callers reopen a
+    shop-assembly or shipping-out request, so the pull they hand over always has a source request and
+    is never a PR-REPL; a replacement pull holding a claim has no discard route today, and holding it
+    until approval is the intended behaviour - the replacement is genuinely owed that stock. It is
+    written anyway because the alternative, should a discard path ever be added, is a claim stranded
+    with nothing left that could spend or release it. (The FK cascade would take the rows on delete;
+    releasing explicitly keeps the session's identity map honest and states the intent.)"""
     if pr_id is None:
         return
     locked = lock_rows(session, PullRequestModel, [pr_id])

--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -205,22 +205,46 @@ def check_inventory_sufficiency(
     return SufficiencyResult(shortfalls=shortfalls, inventory_by_combo=dict(inv_by_combo))
 
 
+def _is_replacement_pull(session: Session, pr: PullRequestModel) -> bool:
+    """Structural test for a PR-REPL pull: at least one line carries `sa_opening_item_id` (#339).
+
+    Same test as `find_pending_replacement_pulls`, and deliberately not the `PR-REPL-` number prefix
+    - the prefix is a display convention, the FK is what makes the pull a replacement, and a
+    structural test cannot be broken by renaming a request.
+    """
+    return bool(
+        session.scalar(
+            select(PullRequestItemModel.id)
+            .where(
+                PullRequestItemModel.pull_request_id == pr.id,
+                PullRequestItemModel.sa_opening_item_id.is_not(None),
+            )
+            .limit(1)
+        )
+    )
+
+
 def find_reservation_holder(session: Session, pr: PullRequestModel) -> tuple[ReservationSource, uuid.UUID] | None:
-    """The request whose reservations this pull is going to spend, or None if it has none (#342).
+    """Whose reservations this pull is going to spend, or None if it has none (#342).
 
     A shop-assembly accept stamps the minted PR with the request's own `request_number` (unique on
     both tables), and a shipping-out accept stamps `pull_request_id` on the request - so each hop
-    is a single indexed lookup, no string parsing.
+    is a single indexed lookup, no string parsing. A **replacement pull holds its own claim**: there
+    is no request behind a deficiency, so the pull is the holder, found structurally by its
+    `sa_opening_item_id` lines rather than by its number.
 
-    None is the honest answer for three real cases, and they all behave identically downstream (the
+    None is the honest answer for two remaining cases, and they behave identically downstream (the
     pull is checked against on-hand minus *everyone's* reservations, and consumes nothing):
 
-    - a **PR-REPL replacement pull**. Nobody can reserve for a deficiency that has not happened yet,
-      so a replacement genuinely holds no claim; it keeps the reactive check and the PO-backfill
-      loop, and it must not be able to eat stock other requests have reserved.
     - a pull whose source request was **rejected/reopened** after the accept - the claim is gone by
       design.
     - a **legacy pull** minted before this table existed, or one created directly by a non-UI caller.
+
+    The replacement case used to be on that list. It no longer is: a replacement reserves at the
+    moment the defect is flagged (`report_deficiency_at_assembly`), so by approval time it has a
+    claim to spend like anything else. The guarantee that made the old behaviour safe still holds -
+    a replacement only ever reserves *free* stock, so it can no more eat another request's claim
+    than it could before.
     """
     if pr.source == PullRequestSource.SHOP_ASSEMBLY:
         sar_id = session.scalar(
@@ -228,6 +252,8 @@ def find_reservation_holder(session: Session, pr: PullRequestModel) -> tuple[Res
         )
         if sar_id is not None:
             return (ReservationSource.SHOP_ASSEMBLY_REQUEST, sar_id)
+        if _is_replacement_pull(session, pr):
+            return (ReservationSource.REPLACEMENT_PULL, pr.id)
     elif pr.source == PullRequestSource.SHIPPING_OUT:
         sor_id = session.scalar(
             select(ShippingOutRequestModel.id).where(ShippingOutRequestModel.pull_request_id == pr.id)
@@ -306,12 +332,20 @@ def approve_pull_request(session: Session, pr_id: uuid.UUID, approved_by: str) -
             shortfalls=result.shortfalls,
         )
         # The audit below is an *integrity* signal, so it has to fire only for a pull that genuinely
-        # held a claim. Having a source request is not the same as holding reservations: the #342
-        # backfill deliberately left the whole pre-existing in-flight population unreserved and
-        # flagged rather than inventing claims for it, and a cancel that could not re-reserve leaves a
-        # live request in the same state. Those are the *expected* shortfall population - flagging
-        # every one of them as an integrity error is exactly how a real one gets missed.
-        if holder is not None and reservations.get_reserved_total(session, holder[0], holder[1]) > 0:
+        # held a claim for everything it is asking for. Having a source request is not the same as
+        # holding reservations: the #342 backfill deliberately left the whole pre-existing in-flight
+        # population unreserved and flagged rather than inventing claims for it, and a cancel that
+        # could not re-reserve leaves a live request in the same state. Those are the *expected*
+        # shortfall population - flagging every one of them as an integrity error is exactly how a
+        # real one gets missed.
+        #
+        # A replacement pull is expected-shortfall by design and is excluded outright. It reserves
+        # `min(free stock, condemned)` at flag time, so being *partly* covered is its normal resting
+        # state - there was no spare on the shelf, which is why a replacement was needed. It holds a
+        # non-zero claim and still comes up short every time until the backfill lands, and that is
+        # the PO loop working, not an inventory discrepancy.
+        reserved_path = holder is not None and holder[0] is not ReservationSource.REPLACEMENT_PULL
+        if reserved_path and reservations.get_reserved_total(session, holder[0], holder[1]) > 0:
             # The reserved path is not supposed to be able to come up short. Record it against the
             # pull so the discrepancy is investigable rather than indistinguishable from the normal
             # PR-REPL / legacy shortfall the approver sees.
@@ -1010,9 +1044,12 @@ def cancel_pull_request(
     the same honest-and-flagged shape the #342 backfill uses.
 
     **A PR-REPL replacement pull has no source request**, so cancelling one restocks and re-creates
-    nothing: it never held a reservation (a deficiency cannot be foreseen, so nobody could have
-    claimed for it). The leaf's `deficient_quantity` is untouched and the expectation stays on the
-    checklist line - the replacement simply has to be requested again.
+    nothing. It does hold a claim of its own now (minted when the defect was flagged), but by the
+    time it can be cancelled that claim has already been *consumed* at approval - only an approved
+    pull is cancellable, and approval spends the reservation - so there is nothing left to release
+    and nothing to hand back to. The leaf's `deficient_quantity` is untouched and the expectation
+    stays on the checklist line; the replacement simply has to be requested again. A **PENDING**
+    replacement pull is not cancelled but discarded, and that path does release.
     """
     if not cancelled_by:
         raise ValidationError("cancelled_by is required", field="cancelled_by")
@@ -1271,7 +1308,12 @@ def discard_pending_pull_request(session: Session, pr_id: uuid.UUID | None) -> N
     the request would leave the warehouse out of sync, so the caller is told to resolve it in the
     warehouse first. A hard delete (not the soft deleted_at) is required because request_number is
     unique: a later re-accept re-mints a PR with the same number. A null/missing PR id is a no-op (the
-    accept is already effectively undone)."""
+    accept is already effectively undone).
+
+    A PENDING **replacement** pull reaches this the same way, and its own claim goes with it: the pull
+    is the holder, so hard-deleting it without releasing would strand a reservation with nothing left
+    that could ever spend or release it. The FK cascade would take the rows anyway; releasing
+    explicitly keeps the session's identity map honest and makes the intent readable."""
     if pr_id is None:
         return
     locked = lock_rows(session, PullRequestModel, [pr_id])
@@ -1283,6 +1325,7 @@ def discard_pending_pull_request(session: Session, pr_id: uuid.UUID | None) -> N
             f"Cannot reopen - the warehouse has already started this pull request ({pr.status.value}). "
             "Resolve it in the warehouse first."
         )
+    reservations.release_reservations(session, ReservationSource.REPLACEMENT_PULL, pr.id)
     # Bulk-delete the items in one statement (rather than a load + per-row DELETE), then the PR itself.
     session.execute(delete(PullRequestItemModel).where(PullRequestItemModel.pull_request_id == pr.id))
     session.delete(pr)

--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -15,6 +15,7 @@ from app.models.enums import (
     PullRequestItemType,
     PullRequestSource,
     PullRequestStatus,
+    ReservationSource,
 )
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.pull_request import PullRequest as PullRequestModel
@@ -404,25 +405,34 @@ def notify_unblocked_replacement_pulls(
     project_id: uuid.UUID | None,
     received_combos: set[tuple[str, str]],
 ) -> list:
-    """Tell the warehouse that a blocked replacement pull can now be approved (#344).
+    """Claim what just landed for the replacements waiting on it, then tell the warehouse which of
+    them can now be approved (#344).
 
-    A PR-REPL pull is the one kind of pull that holds **no reservation** - nobody can claim stock for
-    a deficiency that has not happened yet (#342) - so it is also the only one whose demand nothing
-    was tracking. It sits PENDING, the approver sees INSUFFICIENT, the PO is told to backfill, and
-    when the backfill finally lands there is no signal that the pull is now approvable. Somebody has
-    to remember to go and retry it. This is that signal.
+    A PR-REPL pull sits PENDING, the approver sees INSUFFICIENT, the PO is told to backfill, and when
+    the backfill finally lands there is no signal that the pull is now approvable. Somebody has to
+    remember to go and retry it. This is that signal.
+
+    **The top-up runs first, and the order matters.** A replacement reserves what it can at flag time
+    and is usually short - that is why it is waiting. If this only announced the receive, the units
+    would stay free until somebody got round to approving, and any request created in the meantime
+    could take them: the pull would be announced as coverable and then come up short at approval,
+    which is exactly the loop the announcement exists to end. Claiming first makes the announcement
+    true when it is read.
 
     **Dedupe, in three parts, and each part is doing different work:**
 
     1. *Relevance.* Only pulls that wanted one of the combos this receive actually landed are
        considered. A receive of door closers cannot change whether a hinge replacement is coverable.
     2. *Coverability.* The pull must now be **fully** coverable, under the same reservation-aware
-       availability the approver will apply (`on-hand - deficient - everyone's reservations`, with no
-       self-exclusion, because a replacement pull holds nothing of its own to exclude). A receive that
-       narrows the gap without closing it changes nothing the warehouse can act on, so it says
-       nothing. Note this is the state *after* the receive only - the prior state is not re-derived,
-       so a pull that was already coverable and gets more stock still qualifies here; what actually
-       stops it being announced twice is rule 3.
+       availability the approver will apply - `on-hand - deficient - everyone's reservations`, with
+       **this pull's own claim excluded**. That exclusion is mandatory, not a refinement: the top-up
+       above has just reserved the received units *for this pull*, so counting them as competing
+       demand would make the pull read as insufficient forever and the notification would never fire
+       again. It is the same self-coverage rule `approve_pull_request` applies for the same reason.
+       A receive that narrows the gap without closing it changes nothing the warehouse can act on, so
+       it says nothing. Note this is the state *after* the receive only - the prior state is not
+       re-derived, so a pull that was already coverable and gets more stock still qualifies here;
+       what actually stops it being announced twice is rule 3.
     3. *Open signal.* One **unread** notification per pull. If the last one has not been read yet,
        the warehouse already knows; raising a second is noise. Once it has been read the signal has
        done its job, so a pull that goes short again and is later covered again gets a fresh one.
@@ -437,6 +447,9 @@ def notify_unblocked_replacement_pulls(
     if project_id is None or not received_combos:
         return []
     from .pull_requests import check_inventory_sufficiency
+    from .reservations import top_up_replacement_reservations
+
+    top_up_replacement_reservations(session, project_id, received_combos)
 
     raised = []
     for pr in find_pending_replacement_pulls(session, project_id, received_combos):
@@ -447,7 +460,13 @@ def notify_unblocked_replacement_pulls(
         ]
         if not needs:
             continue
-        if not check_inventory_sufficiency(session, project_id, needs, reservation_aware=True).sufficient:
+        if not check_inventory_sufficiency(
+            session,
+            project_id,
+            needs,
+            reservation_aware=True,
+            exclude_reservations_of=(ReservationSource.REPLACEMENT_PULL, pr.id),
+        ).sufficient:
             continue
         if not lock_rows(session, PullRequestModel, [pr.id]):
             continue

--- a/backend/app/repositories/warehouse/reservations.py
+++ b/backend/app/repositories/warehouse/reservations.py
@@ -388,6 +388,12 @@ def top_up_replacement_reservations(
     Oldest pull first is the queue the warehouse already works, and it is what makes the outcome
     deterministic when two replacements want the same scarce combo.
 
+    **Fixed query count, whatever the fan-out.** This runs inside the PO receive transaction, which
+    already holds inventory row locks, so it must not turn one receive into a round trip per (pull,
+    combo) against Railway's managed Postgres (CLAUDE.md perf rules). Availability for every wanted
+    combo is read once under lock, every candidate pull's existing claims are read in one query, the
+    allocation is decided in memory oldest-first, and only the rows that actually change are written.
+
     Returns {pull_request_id: units claimed}, for callers and tests to assert on.
     """
     from .receiving import find_pending_replacement_pulls
@@ -396,10 +402,26 @@ def top_up_replacement_reservations(
     if not wanted:
         return {}
 
-    claimed: dict[uuid.UUID, int] = {}
     pulls = sorted(find_pending_replacement_pulls(session, project_id, wanted), key=lambda p: p.created_at)
+    if not pulls:
+        return {}
+
+    # One locked availability read for every combo in play, and one pass over the existing claims of
+    # every candidate pull.
+    pool = get_available_quantities(session, project_id, sorted(wanted), lock=True)
+    held_rows = session.scalars(
+        select(InventoryReservationModel).where(
+            InventoryReservationModel.source == ReservationSource.REPLACEMENT_PULL,
+            InventoryReservationModel.pull_request_id.in_([p.id for p in pulls]),
+        )
+    ).all()
+    held: dict[tuple[uuid.UUID, str, str], InventoryReservationModel] = {
+        (row.pull_request_id, row.hardware_category, row.product_code): row for row in held_rows
+    }
+
+    claimed: dict[uuid.UUID, int] = {}
     for pr in pulls:
-        # What this pull still wants, per combo, net of what it already holds.
+        # What this pull wants of the combos that just became available, net of what it already holds.
         needs: dict[tuple[str, str], int] = {}
         for line in pr.items:
             if not line.hardware_category or not line.product_code or line.requested_quantity <= 0:
@@ -408,23 +430,24 @@ def top_up_replacement_reservations(
             if key not in wanted:
                 continue
             needs[key] = needs.get(key, 0) + line.requested_quantity
-        if not needs:
-            continue
 
-        held = {
-            (row.hardware_category, row.product_code): row.quantity
-            for row in session.scalars(
-                select(InventoryReservationModel).where(
-                    InventoryReservationModel.source == ReservationSource.REPLACEMENT_PULL,
-                    InventoryReservationModel.pull_request_id == pr.id,
-                )
-            ).all()
-        }
         for combo, need in sorted(needs.items()):
-            gap = need - held.get(combo, 0)
-            if gap <= 0:
+            existing = held.get((pr.id, *combo))
+            gap = need - (existing.quantity if existing is not None else 0)
+            take = min(gap, pool.get(combo, 0))
+            if take <= 0:
                 continue
-            got = reserve_for_replacement_pull(session, pr.id, project_id, combo[0], combo[1], gap)
-            if got:
-                claimed[pr.id] = claimed.get(pr.id, 0) + got
+            pool[combo] -= take
+            if existing is not None:
+                # One row per combo per holder, same as `create_reservations` - every availability sum
+                # is an aggregate, and a stack of one-unit rows would only make it add them back up.
+                existing.quantity += take
+            else:
+                row = _new_reservation(project_id, ReservationSource.REPLACEMENT_PULL, pr.id, combo[0], combo[1], take)
+                session.add(row)
+                held[(pr.id, *combo)] = row
+            claimed[pr.id] = claimed.get(pr.id, 0) + take
+
+    if claimed:
+        session.flush()
     return claimed

--- a/backend/app/repositories/warehouse/reservations.py
+++ b/backend/app/repositories/warehouse/reservations.py
@@ -24,10 +24,12 @@ from app.models.enums import ReservationSource
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.inventory_reservation import InventoryReservation as InventoryReservationModel
 
-# The FK column each source discriminator writes to / filters on.
+# The FK column each source discriminator writes to / filters on. A REPLACEMENT_PULL claim is held
+# by the PR-REPL pull itself, because a deficiency has no request behind it (#342 follow-up).
 _SOURCE_COLUMN = {
     ReservationSource.SHOP_ASSEMBLY_REQUEST: InventoryReservationModel.shop_assembly_request_id,
     ReservationSource.SHIPPING_OUT_REQUEST: InventoryReservationModel.shipping_out_request_id,
+    ReservationSource.REPLACEMENT_PULL: InventoryReservationModel.pull_request_id,
 }
 
 
@@ -176,6 +178,43 @@ def get_project_availability(session: Session, project_id: uuid.UUID) -> list[di
     return result
 
 
+def get_available_quantities(
+    session: Session,
+    project_id: uuid.UUID,
+    combos: Iterable[tuple[str, str]],
+    *,
+    lock: bool = False,
+) -> dict[tuple[str, str], int]:
+    """Free stock per combo: `on-hand - deficient - every active reservation`, floored at 0.
+
+    The same arithmetic `check_inventory_sufficiency` applies, exposed as a number rather than a
+    pass/fail, because the replacement-reservation paths do not ask "does all of it fit" - they ask
+    "how much of it can I claim right now" and take whatever that is. **No self-exclusion**: a
+    reservation the caller already holds is stock it has already claimed, so counting it here is what
+    stops a top-up from claiming the same units twice.
+
+    `lock=True` takes `SELECT ... FOR UPDATE` on the inventory rows, so a mint that reads this number
+    and writes a claim against it serialises with any concurrent one.
+    """
+    pairs = list(combos)
+    if not pairs:
+        return {}
+
+    inv_stmt = select(InventoryLocationModel).where(
+        InventoryLocationModel.project_id == project_id,
+        _combo_filter(pairs, InventoryLocationModel.hardware_category, InventoryLocationModel.product_code),
+    )
+    if lock:
+        inv_stmt = inv_stmt.order_by(InventoryLocationModel.id).with_for_update()
+    on_hand: dict[tuple[str, str], int] = {}
+    for il in session.scalars(inv_stmt).all():
+        key = (il.hardware_category, il.product_code)
+        on_hand[key] = on_hand.get(key, 0) + il.quantity - (il.deficient_quantity or 0)
+
+    reserved = get_reserved_quantities(session, project_id, pairs)
+    return {key: max(0, on_hand.get(key, 0) - reserved.get(key, 0)) for key in pairs}
+
+
 def create_reservations(
     session: Session,
     project_id: uuid.UUID,
@@ -201,21 +240,39 @@ def create_reservations(
 
     created: list[InventoryReservationModel] = []
     for (cat, code), qty in sorted(totals.items()):
-        row = InventoryReservationModel(
-            id=uuid.uuid4(),
-            project_id=project_id,
-            hardware_category=cat,
-            product_code=code,
-            quantity=qty,
-            source=source,
-            shop_assembly_request_id=(request_id if source is ReservationSource.SHOP_ASSEMBLY_REQUEST else None),
-            shipping_out_request_id=(request_id if source is ReservationSource.SHIPPING_OUT_REQUEST else None),
-        )
+        row = _new_reservation(project_id, source, request_id, cat, code, qty)
         session.add(row)
         created.append(row)
     if created:
         session.flush()
     return created
+
+
+def _new_reservation(
+    project_id: uuid.UUID,
+    source: ReservationSource,
+    holder_id: uuid.UUID,
+    hardware_category: str,
+    product_code: str,
+    quantity: int,
+) -> InventoryReservationModel:
+    """One reservation row, with the holder written to the single FK its `source` requires.
+
+    The check constraint (`ck_inventory_reservations_source_matches_request`) refuses any other
+    combination, so this is the only place that has to know which column goes with which
+    discriminator.
+    """
+    return InventoryReservationModel(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        hardware_category=hardware_category,
+        product_code=product_code,
+        quantity=quantity,
+        source=source,
+        shop_assembly_request_id=(holder_id if source is ReservationSource.SHOP_ASSEMBLY_REQUEST else None),
+        shipping_out_request_id=(holder_id if source is ReservationSource.SHIPPING_OUT_REQUEST else None),
+        pull_request_id=(holder_id if source is ReservationSource.REPLACEMENT_PULL else None),
+    )
 
 
 def release_reservations(session: Session, source: ReservationSource, request_id: uuid.UUID) -> int:
@@ -233,6 +290,7 @@ def release_reservations(session: Session, source: ReservationSource, request_id
     | Pull approval that comes up short        | **no release** - the pull stays blocked, holding  |
     | Re-upload drops the request's openings    | release, by rebuilding from what survived         |
     | Re-upload leaves the request empty       | auto-reject, which releases                       |
+    | Discard a PENDING replacement pull       | release - the pull is hard-deleted, so is its claim |
 
     **Reopen deliberately does not release.** A reopen undoes the *accept*, not the *creation*: the
     request goes back to PENDING and is still a live claim on stock, exactly as it was between
@@ -253,3 +311,120 @@ def release_reservations(session: Session, source: ReservationSource, request_id
     )
     session.flush()
     return int(result.rowcount or 0)
+
+
+def reserve_for_replacement_pull(
+    session: Session,
+    pull_request_id: uuid.UUID,
+    project_id: uuid.UUID,
+    hardware_category: str,
+    product_code: str,
+    wanted: int,
+) -> int:
+    """Claim up to `wanted` more units of one combo for a PR-REPL pull. Returns what it claimed.
+
+    Called the moment a unit is flagged deficient at the bench. Before this existed, the replacement
+    pull was the only pull holding nothing: any request created *after* the defect was found could
+    take the very stock the replacement was waiting on, so the pull sat blocked while the hardware
+    walked. Reserving at the flag puts the replacement into the queue at the moment its demand
+    becomes real, which is the only defensible position for it.
+
+    **Claiming less than was condemned is the normal case, not a failure.** The whole reason a
+    replacement is needed is often that there is no spare on the shelf; the pull holds whatever it
+    could get and `top_up_replacement_reservations` closes the gap as stock arrives or is repaired.
+
+    It only ever claims *free* stock - `get_available_quantities` is already net of everyone else's
+    claims - so a replacement can never take hardware another request has reserved. And because every
+    term in the chain is keyed by `project_id`, a claim on another project's stock is not expressible.
+    """
+    if wanted <= 0:
+        return 0
+    combo = (hardware_category, product_code)
+    available = get_available_quantities(session, project_id, [combo], lock=True).get(combo, 0)
+    claim = min(available, wanted)
+    if claim <= 0:
+        return 0
+
+    existing = session.scalars(
+        select(InventoryReservationModel).where(
+            InventoryReservationModel.source == ReservationSource.REPLACEMENT_PULL,
+            InventoryReservationModel.pull_request_id == pull_request_id,
+            InventoryReservationModel.hardware_category == hardware_category,
+            InventoryReservationModel.product_code == product_code,
+        )
+    ).first()
+    if existing is not None:
+        # One row per combo per holder, same as `create_reservations` - every availability sum is an
+        # aggregate, and a stack of one-unit rows would only make it add them back up.
+        existing.quantity += claim
+    else:
+        session.add(
+            _new_reservation(
+                project_id,
+                ReservationSource.REPLACEMENT_PULL,
+                pull_request_id,
+                hardware_category,
+                product_code,
+                claim,
+            )
+        )
+    session.flush()
+    return claim
+
+
+def top_up_replacement_reservations(
+    session: Session,
+    project_id: uuid.UUID,
+    combos: Iterable[tuple[str, str]],
+) -> dict[uuid.UUID, int]:
+    """Raise every PENDING replacement pull's claim towards what it actually needs, oldest first.
+
+    A replacement reserves what it can at flag time, which is often less than it was owed. This is
+    the other half: whenever availability *rises* - stock is received, a condemned unit is repaired
+    back into service - the replacements already waiting get first refusal on it, in the order the
+    defects were found. Without it a receive intended to unblock a replacement could be claimed by
+    a request created in between, and the replacement would go round the blocked/backfill loop again.
+
+    Oldest pull first is the queue the warehouse already works, and it is what makes the outcome
+    deterministic when two replacements want the same scarce combo.
+
+    Returns {pull_request_id: units claimed}, for callers and tests to assert on.
+    """
+    from .receiving import find_pending_replacement_pulls
+
+    wanted = set(combos)
+    if not wanted:
+        return {}
+
+    claimed: dict[uuid.UUID, int] = {}
+    pulls = sorted(find_pending_replacement_pulls(session, project_id, wanted), key=lambda p: p.created_at)
+    for pr in pulls:
+        # What this pull still wants, per combo, net of what it already holds.
+        needs: dict[tuple[str, str], int] = {}
+        for line in pr.items:
+            if not line.hardware_category or not line.product_code or line.requested_quantity <= 0:
+                continue
+            key = (line.hardware_category, line.product_code)
+            if key not in wanted:
+                continue
+            needs[key] = needs.get(key, 0) + line.requested_quantity
+        if not needs:
+            continue
+
+        held = {
+            (row.hardware_category, row.product_code): row.quantity
+            for row in session.scalars(
+                select(InventoryReservationModel).where(
+                    InventoryReservationModel.source == ReservationSource.REPLACEMENT_PULL,
+                    InventoryReservationModel.pull_request_id == pr.id,
+                )
+            ).all()
+        }
+        for combo, need in sorted(needs.items()):
+            gap = need - held.get(combo, 0)
+            if gap <= 0:
+                continue
+            got = reserve_for_replacement_pull(session, pr.id, project_id, combo[0], combo[1], gap)
+            if got:
+                claimed[pr.id] = claimed.get(pr.id, 0) + got
+    return claimed

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -473,6 +473,7 @@ def shop_assembly_opening_item_to_type(item) -> ShopAssemblyOpeningItem:
         hardware_category=item.hardware_category,
         product_code=item.product_code,
         quantity=item.quantity,
+        allocated_quantity=item.allocated_quantity,
         # Plain columns on the row the caller already loaded (#340) - reading them triggers no load.
         installed_quantity=item.installed_quantity,
         deficient_quantity=item.deficient_quantity,
@@ -561,11 +562,14 @@ def assembly_pipeline_summary_to_type(row) -> AssemblyPipelineSummary:
         completed_opening_count=row.completed_opening_count,
         shipped_opening_count=row.shipped_opening_count,
         planned_unit_count=row.planned_unit_count,
+        allocated_unit_count=row.allocated_unit_count,
+        short_unit_count=row.short_unit_count,
         installed_unit_count=row.installed_unit_count,
         deficient_unit_count=row.deficient_unit_count,
         replacement_pending_unit_count=row.replacement_pending_unit_count,
         awaiting_replacement_opening_count=row.awaiting_replacement_opening_count,
         replacement_after_ship_opening_count=row.replacement_after_ship_opening_count,
+        short_opening_count=row.short_opening_count,
         stage=PipelineStage(row.stage),
     )
 
@@ -590,6 +594,8 @@ def pipeline_opening_to_type(row) -> PipelineOpening:
         assembly_status=row.assembly_status,
         completed_at=row.completed_at,
         planned_unit_count=row.planned_unit_count,
+        allocated_unit_count=row.allocated_unit_count,
+        short_unit_count=row.short_unit_count,
         installed_unit_count=row.installed_unit_count,
         deficient_unit_count=row.deficient_unit_count,
         replacement_pending_unit_count=row.replacement_pending_unit_count,

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -438,7 +438,11 @@ def opening_item_hardware_to_type(oih) -> OpeningItemHardware:
 
 
 def opening_item_to_type(
-    oi, *, leaf_count: int | None = None, awaiting_replacement_quantity: int | None = None
+    oi,
+    *,
+    leaf_count: int | None = None,
+    awaiting_replacement_quantity: int | None = None,
+    never_pulled_quantity: int | None = None,
 ) -> OpeningItem:
     return OpeningItem(
         id=strawberry.ID(str(oi.id)),
@@ -463,6 +467,7 @@ def opening_item_to_type(
         # Computed by the caller from one grouped aggregate over the whole list (#341), never
         # per-row here - this converter runs once per assembled leaf in a project.
         awaiting_replacement_quantity=awaiting_replacement_quantity,
+        never_pulled_quantity=never_pulled_quantity,
     )
 
 

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -216,6 +216,9 @@ class ImportMutations:
                             "hardware_category": item.hardware_category,
                             "product_code": item.product_code,
                             "quantity": item.quantity,
+                            # None is forwarded as-is; the repository resolves it to `quantity`
+                            # (fully allocated), which is the pre-allocator behaviour.
+                            "allocated_quantity": item.allocated_quantity,
                         }
                         for item in sa.items
                     ],

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -141,7 +141,13 @@ class ShippingOutPRDraftInput:
 class SAROpeningItemInput:
     hardware_category: str
     product_code: str
+    # What the schedule says this leaf is owed. Never reduced by scarcity.
     quantity: int
+    # What the requester could actually claim out of available inventory, 0..quantity. The allocator
+    # step always sends it explicitly. **None means "fully allocated" (= quantity)**, which is what
+    # keeps every non-wizard caller - tests, scripts, a stale tab - on the pre-allocation behaviour:
+    # ask for the whole line, and fail the availability gate if it does not fit.
+    allocated_quantity: int | None = None
 
 
 @strawberry.input

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -293,8 +293,12 @@ class ShopAssemblyMutations:
             )
             session.commit()
             refreshed = warehouse_repository.get_opening_item_details(session, result.id)
-            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [refreshed.id])
-            return opening_item_to_type(refreshed, awaiting_replacement_quantity=awaiting.get(refreshed.id, 0))
+            shortfall = shop_assembly_repository.get_leaf_shortfalls(session, [refreshed.id]).get(refreshed.id)
+            return opening_item_to_type(
+                refreshed,
+                awaiting_replacement_quantity=shortfall.awaiting_replacement if shortfall else 0,
+                never_pulled_quantity=shortfall.never_pulled if shortfall else 0,
+            )
 
     @strawberry.mutation
     def complete_opening(self, info: strawberry.Info, input: CompleteOpeningInput) -> OpeningItem:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -576,11 +576,19 @@ class ShopAssemblyOpeningItem:
     shop_assembly_opening_id: strawberry.ID
     hardware_category: str
     product_code: str
+    # Owed: what the hardware schedule says this door leaf takes.
     quantity: int
+    # What the requester actually claimed out of available inventory when the request was sent, and
+    # therefore what physically arrives on the cart. Short is `quantity - allocatedQuantity`, derived
+    # on the client exactly as it is on the server - it is never stored, because the authority on
+    # what a leaf is still missing is the current schedule against what is on the leaf, not this
+    # request's record of what it managed to send.
+    allocated_quantity: int = 0
     # Persisted assembly progress (#340). installed_quantity is what the assembler has recorded
     # fitting to the leaf; deficient_quantity is what has already been condemned and replaced.
-    # Remaining is quantity - installed - deficient, derived on the client - completion is refused
-    # while any line still has remaining > 0.
+    # Remaining is allocated - installed - deficient, derived on the client - completion is refused
+    # while any line still has remaining > 0. Short units are outside that sum: they were never
+    # pulled, so there is nothing on the bench to disposition.
     installed_quantity: int = 0
     deficient_quantity: int = 0
     # Units whose replacement has arrived but is not on the leaf yet (#341). Non-zero only on a
@@ -668,7 +676,11 @@ class PipelineOpening:
     assigned_to: str | None
     assembly_status: AssemblyStatus
     completed_at: datetime | None
+    # Owed by the schedule vs what the request could claim. The progress counters below partition
+    # `allocated_unit_count`; `short_unit_count` is the rest and was never pulled.
     planned_unit_count: int
+    allocated_unit_count: int
+    short_unit_count: int
     installed_unit_count: int
     deficient_unit_count: int
     replacement_pending_unit_count: int
@@ -728,11 +740,16 @@ class AssemblyPipelineSummary:
     completed_opening_count: int
     shipped_opening_count: int
     planned_unit_count: int
+    # Sent short: a request can be legitimately complete and still not have delivered its full bill
+    # of hardware, and nothing else on this row would say so.
+    allocated_unit_count: int
+    short_unit_count: int
     installed_unit_count: int
     deficient_unit_count: int
     replacement_pending_unit_count: int
     awaiting_replacement_opening_count: int
     replacement_after_ship_opening_count: int
+    short_opening_count: int
     # The stage of the least-advanced opening: what the request is waiting on, not its best news.
     stage: PipelineStage
 

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -521,6 +521,12 @@ class OpeningItem:
     # acknowledgment. Only populated by the resolvers that ask for it (the openingItems list and the
     # detail view); null everywhere else, which reads as "not evaluated", not as "nothing owed".
     awaiting_replacement_quantity: int | None = None
+    # Units this leaf was owed by the schedule that its request never pulled - they were not
+    # available to claim when it was sent, so nothing arrived and nothing is in flight. The other
+    # half of the same shipping decision as the field above, and deliberately separate: waiting fixes
+    # an awaiting-replacement unit and does nothing at all for one of these. Same null-means-not-
+    # evaluated convention.
+    never_pulled_quantity: int | None = None
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -253,12 +253,15 @@ class WarehouseQueries:
             # assembled leaf in the project.
             from app.repositories import shop_assembly_repository
 
-            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [oi.id for oi in ois])
+            shortfalls = shop_assembly_repository.get_leaf_shortfalls(session, [oi.id for oi in ois])
             return [
                 opening_item_to_type(
                     oi,
                     leaf_count=leaf_counts.get(oi.opening_number),
-                    awaiting_replacement_quantity=awaiting.get(oi.id, 0),
+                    awaiting_replacement_quantity=(
+                        shortfalls[oi.id].awaiting_replacement if oi.id in shortfalls else 0
+                    ),
+                    never_pulled_quantity=(shortfalls[oi.id].never_pulled if oi.id in shortfalls else 0),
                 )
                 for oi in ois
             ]
@@ -287,8 +290,13 @@ class WarehouseQueries:
             from app.repositories import shop_assembly_repository
 
             oi = warehouse_repository.get_opening_item_details(session, uuid.UUID(str(id)))
-            awaiting = shop_assembly_repository.get_awaiting_replacement_quantities(session, [oi.id])
-            opening_item = opening_item_to_type(oi, awaiting_replacement_quantity=awaiting.get(oi.id, 0))
+            shortfalls = shop_assembly_repository.get_leaf_shortfalls(session, [oi.id])
+            shortfall = shortfalls.get(oi.id)
+            opening_item = opening_item_to_type(
+                oi,
+                awaiting_replacement_quantity=shortfall.awaiting_replacement if shortfall else 0,
+                never_pulled_quantity=shortfall.never_pulled if shortfall else 0,
+            )
             return OpeningItemDetail(
                 opening_item=opening_item,
                 installed_hardware=[opening_item_hardware_to_type(h) for h in oi.installed_hardware],

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -99,11 +99,26 @@ def notify_po_shortfall(
     project_id: uuid.UUID,
     request_number: str | None,
     shortfalls,
+    sent_short: bool = False,
 ) -> Notification:
-    """PO "couldn't be fulfilled - backfill needed" signal (#224), carrying the shortfall detail.
-    Raised by both gates: import "Start a Task" (no PR yet) and warehouse approve_pull_request."""
+    """PO backfill signal (#224), carrying the shortfall detail.
+
+    Raised from three places, and the wording distinguishes the one that is not a failure:
+
+    - the creation gate refusing a request outright, and `approve_pull_request` finding a pull it
+      cannot fill - both are "couldn't be fulfilled";
+    - a shop-assembly request that **was** created and deliberately sent short of what the schedule
+      calls for (`sent_short=True`). Nothing failed there and nothing is blocked; purchasing is being
+      told what the project is missing. Calling that "couldn't be fulfilled" would send somebody
+      hunting for a stuck request that does not exist.
+    """
     label = f"Pull Request {request_number}" if request_number else "A shop-assembly task"
-    message = f"{label} couldn't be fulfilled - backfill needed. {format_shortfall_lines(shortfalls)}"
+    headline = (
+        f"{label} was sent short of what the schedule calls for - backfill needed."
+        if sent_short
+        else f"{label} couldn't be fulfilled - backfill needed."
+    )
+    message = f"{headline} {format_shortfall_lines(shortfalls)}"
     return create_notification(
         session,
         project_id=project_id,

--- a/backend/tests/test_accept_requests.py
+++ b/backend/tests/test_accept_requests.py
@@ -221,6 +221,63 @@ def test_accept_shop_assembly_mints_pr_and_repoints_openings(db_session):
     assert pr_items[0].requested_quantity == 2
 
 
+def test_accept_mints_lines_only_for_what_was_allocated(db_session):
+    """The pull asks for the ALLOCATED quantity, and a line with nothing allocated mints no pull line
+    at all. That is what keeps the pull equal to the reservation, so `approve_pull_request` stays
+    all-or-nothing with no warehouse-side change - asking for the owed quantity instead would send
+    the warehouse after stock nobody claimed and leave the pull blocked."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, quantity=2)
+    _seed_inventory(db_session, project.id, category="CLOSER", code="CL-1", quantity=0)
+    result = import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [{"opening_number": "A01", "building": "B1", "floor": "F2", "location": "Lobby"}],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": f"SA-{uuid.uuid4().hex[:6]}",
+            "shop_assembly_openings": [
+                {
+                    "opening_number": "A01",
+                    "leaf": 1,
+                    "items": [
+                        {
+                            "hardware_category": "HINGE",
+                            "product_code": "HG-100",
+                            "quantity": 4,
+                            "allocated_quantity": 2,
+                        },
+                        {
+                            "hardware_category": "CLOSER",
+                            "product_code": "CL-1",
+                            "quantity": 1,
+                            "allocated_quantity": 0,
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+    sar = result["shop_assembly_request"]
+    db_session.flush()
+
+    shop_assembly_repository.accept_shop_assembly_request(db_session, sar.id, "acceptor")
+    db_session.flush()
+
+    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number))
+    pr_items = db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all()
+    assert len(pr_items) == 1  # the fully-short closer line is not on the sheet
+    assert pr_items[0].product_code == "HG-100"
+    assert pr_items[0].requested_quantity == 2  # allocated, not the 4 owed
+
+    # The pull asks for exactly what is reserved, which is the invariant approval relies on.
+    reservations = db_session.scalars(
+        select(InventoryReservation).where(InventoryReservation.shop_assembly_request_id == sar.id)
+    ).all()
+    assert [(r.product_code, r.quantity) for r in reservations] == [("HG-100", 2)]
+
+
 def test_creating_a_shop_assembly_request_blocks_on_shortfall(db_session):
     """#342 moved this gate from accept to creation: a selection that does not fit available
     inventory is refused before anything exists, so there is no request for anyone to accept."""

--- a/backend/tests/test_assembly_progress.py
+++ b/backend/tests/test_assembly_progress.py
@@ -115,13 +115,18 @@ def _make_pulled_opening(
     session.flush()
 
     sao_items = {}
-    for category, code, qty in items:
+    # `items` entries are (category, code, owed) or (category, code, owed, allocated). Omitting the
+    # fourth means fully allocated - the ordinary case, and the only one that existed before partial
+    # allocation. A test that wants a short line says so explicitly.
+    for category, code, qty, *rest in items:
+        allocated = rest[0] if rest else qty
         sao_item = ShopAssemblyOpeningItem(
             id=uuid.uuid4(),
             shop_assembly_opening_id=opening.id,
             hardware_category=category,
             product_code=code,
             quantity=qty,
+            allocated_quantity=allocated,
         )
         session.add(sao_item)
         sao_items[code] = sao_item
@@ -234,6 +239,42 @@ def test_installed_plus_deficient_cannot_exceed_the_pulled_quantity(db_session):
     with pytest.raises(ValidationError):
         shop_assembly_repository.record_assembly_progress(
             db_session, opening.id, [Update(item_id, installed_quantity=3)]
+        )
+
+
+def test_progress_is_capped_at_what_was_pulled_not_at_what_was_owed(db_session):
+    """A short unit never left inventory, so there is nothing on the cart to install or condemn.
+    Letting progress run to the owed quantity would mean recording hardware onto a leaf that never
+    arrived."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    # Owed 4, only 2 pulled.
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-ALLOC1", items=[(*HINGE, 4, 2)])
+    item_id = sao[HINGE[1]].id
+
+    shop_assembly_repository.record_assembly_progress(db_session, opening.id, [Update(item_id, installed_quantity=2)])
+    db_session.flush()
+    assert sao[HINGE[1]].installed_quantity == 2
+
+    with pytest.raises(ValidationError) as excinfo:
+        shop_assembly_repository.record_assembly_progress(
+            db_session, opening.id, [Update(item_id, installed_quantity=3)]
+        )
+    # The message names the pulled quantity and says why the other two are not coming.
+    assert "2 unit(s) pulled" in str(excinfo.value)
+    assert "never pulled" in str(excinfo.value)
+
+
+def test_a_short_line_cannot_be_flagged_deficient_beyond_what_arrived(db_session):
+    """Deficiency is a statement about a unit somebody held. A short unit was never held."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1])
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-ALLOC2", items=[(*HINGE, 4, 1)])
+    with pytest.raises(ValidationError):
+        shop_assembly_repository.record_assembly_progress(
+            db_session,
+            opening.id,
+            [Update(sao[HINGE[1]].id, flag_deficient_quantity=2, deficient_reason="bent")],
         )
 
 

--- a/backend/tests/test_completion_deficiency_checklist.py
+++ b/backend/tests/test_completion_deficiency_checklist.py
@@ -114,7 +114,8 @@ def _make_pulled_opening(session, project_id, *, request_number, items):
     session.flush()
 
     sao_items = {}
-    for category, code, qty in items:
+    for category, code, qty, *rest in items:
+        allocated = rest[0] if rest else qty
         session.add(
             PullRequestItem(
                 id=uuid.uuid4(),
@@ -123,7 +124,7 @@ def _make_pulled_opening(session, project_id, *, request_number, items):
                 opening_number="A01",
                 hardware_category=category,
                 product_code=code,
-                requested_quantity=qty,
+                requested_quantity=allocated,
             )
         )
         sao_item = ShopAssemblyOpeningItem(
@@ -132,6 +133,7 @@ def _make_pulled_opening(session, project_id, *, request_number, items):
             hardware_category=category,
             product_code=code,
             quantity=qty,
+            allocated_quantity=allocated,
         )
         session.add(sao_item)
         sao_items[code] = sao_item

--- a/backend/tests/test_replacement_loop.py
+++ b/backend/tests/test_replacement_loop.py
@@ -32,8 +32,10 @@ from app.models.enums import (
     PullRequestSource,
     PullRequestStatus,
     PullStatus,
+    ReservationSource,
 )
 from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
 from app.models.notification import Notification
 from app.models.opening_item import OpeningItemHardware
 from app.models.project import Project
@@ -115,13 +117,18 @@ def _make_pulled_opening(session, project_id, *, request_number, items, leaf=1, 
     session.flush()
 
     sao_items = {}
-    for category, code, qty in items:
+    # `items` entries are (category, code, owed) or (category, code, owed, allocated). Omitting the
+    # fourth means fully allocated - the ordinary case, and the only one that existed before partial
+    # allocation. A test that wants a short line says so explicitly.
+    for category, code, qty, *rest in items:
+        allocated = rest[0] if rest else qty
         sao_item = ShopAssemblyOpeningItem(
             id=uuid.uuid4(),
             shop_assembly_opening_id=opening.id,
             hardware_category=category,
             product_code=code,
             quantity=qty,
+            allocated_quantity=allocated,
         )
         session.add(sao_item)
         sao_items[code] = sao_item
@@ -164,7 +171,9 @@ def _complete(session, opening, sao_items):
     updates = [
         shop_assembly_repository.AssemblyProgressUpdate(
             shop_assembly_opening_item_id=item.id,
-            installed_quantity=item.quantity - item.deficient_quantity,
+            # What arrived, minus what was condemned. Short units were never pulled, so there is
+            # nothing on the cart for them and completion excuses them.
+            installed_quantity=item.allocated_quantity - item.deficient_quantity,
         )
         for item in sao_items.values()
     ]
@@ -866,3 +875,260 @@ def test_awaiting_replacement_reads_only_the_latest_assembly_of_a_leaf(db_sessio
     )
     assert awaiting.get(fresh_leaf.id, 0) == 0
     assert awaiting.get(shipped_leaf.id, 0) == 1
+
+
+# --- 8. the replacement holds a claim of its own (#342 follow-up) --------------------------------
+#
+# A PR-REPL pull used to be the one pull holding nothing. Nobody can reserve for a deficiency that
+# has not happened yet - true when the source request was created, and irrelevant from the moment the
+# assembler finds the defect. From then on the replacement is a known, dated demand competing with
+# requests created *after* it, and it lost every time: it sat PENDING while the stock it was waiting
+# on was claimed by somebody else. So the claim is minted where it becomes real - at the flag.
+
+
+def _replacement_reservations(session, pr_id):
+    return list(
+        session.scalars(
+            select(InventoryReservation).where(
+                InventoryReservation.source == ReservationSource.REPLACEMENT_PULL,
+                InventoryReservation.pull_request_id == pr_id,
+            )
+        ).all()
+    )
+
+
+def test_flagging_reserves_free_stock_for_the_replacement(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES1", items=[(*HINGE, 4)])
+
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+
+    rows = _replacement_reservations(db_session, repl.id)
+    assert [(r.hardware_category, r.product_code, r.quantity) for r in rows] == [(*HINGE, 2)]
+    # It is the pull that holds it - there is no request behind a deficiency.
+    assert rows[0].shop_assembly_request_id is None
+    assert rows[0].shipping_out_request_id is None
+
+
+def test_reserving_less_than_was_condemned_is_normal_not_a_failure(db_session):
+    """The usual reason a replacement is needed is that there is no spare on the shelf. The pull
+    takes whatever it can get and the top-up hooks close the gap later."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES2", items=[(*HINGE, 4)])
+
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    assert _replacement_reservations(db_session, repl.id) == []
+
+
+def test_repeated_flags_merge_into_one_reservation_row(db_session):
+    """One row per combo per holder, the same rule create_reservations follows: every availability
+    sum is an aggregate, and a stack of one-unit rows would only make it add them back up."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES3", items=[(*HINGE, 4)])
+
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+
+    rows = _replacement_reservations(db_session, repl.id)
+    assert len(rows) == 1
+    assert rows[0].quantity == 2
+
+
+def test_the_claim_makes_the_stock_unavailable_to_everyone_else(db_session):
+    """Which is the whole point: a request created after the defect can no longer take the units the
+    replacement is waiting on."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=3)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES4", items=[(*HINGE, 4)])
+
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    db_session.flush()
+
+    check = warehouse_repository.check_inventory_sufficiency(
+        db_session, project.id, [(*HINGE, 3)], reservation_aware=True
+    )
+    assert not check.sufficient
+    assert check.shortfalls[0].reserved == 2
+
+
+def test_the_replacement_pull_is_its_own_reservation_holder(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES5", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 1)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+
+    assert warehouse_repository.find_reservation_holder(db_session, repl) == (
+        ReservationSource.REPLACEMENT_PULL,
+        repl.id,
+    )
+
+
+def test_approving_a_covered_replacement_spends_its_claim(db_session):
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES6", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    db_session.flush()
+
+    _pr, outcome, _notif, shortfalls = warehouse_repository.approve_pull_request(db_session, repl.id, "warehouse")
+    db_session.flush()
+
+    assert (outcome, shortfalls) == ("APPROVED", [])
+    # The claim became the deduction: the two condemned units returned to the row, and two good ones
+    # left it, so the row is back where it started with the condemned pair still flagged.
+    assert (il.quantity, il.deficient_quantity) == (5, 2)
+    assert _replacement_reservations(db_session, repl.id) == []
+
+
+def test_a_partly_reserved_replacement_stays_blocked_and_asks_the_po_to_backfill(db_session):
+    """Holding a claim is not the same as being covered. The PO loop is unchanged."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES7", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    db_session.flush()
+
+    pr, outcome, notif, shortfalls = warehouse_repository.approve_pull_request(db_session, repl.id, "warehouse")
+    db_session.flush()
+
+    assert outcome == "INSUFFICIENT"
+    assert pr.status == PullRequestStatus.PENDING
+    assert notif is not None
+    assert shortfalls[0].short == 2
+    # A partly-covered replacement is the EXPECTED shortfall population, so it must not be recorded
+    # as an inventory integrity error - flagging every one of them is how a real one gets missed.
+    integrity = [
+        row
+        for row in db_session.scalars(
+            select(InventoryAuditLog).where(InventoryAuditLog.action == AuditAction.PULL_DEDUCTION)
+        ).all()
+        if (row.detail or {}).get("integrityError")
+    ]
+    assert integrity == []
+
+
+def test_a_receive_claims_the_arriving_stock_for_the_waiting_replacement(db_session):
+    """Top up FIRST, then announce. Announcing without claiming would leave the units free until
+    somebody got round to approving, and a request created in between could take them - the pull
+    would be announced as coverable and then come up short, which is the loop this ends."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES8", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    assert _replacement_reservations(db_session, repl.id) == []
+
+    il.quantity += 2  # the backfill lands
+    db_session.flush()
+    raised = warehouse_repository.notify_unblocked_replacement_pulls(db_session, project.id, {HINGE})
+    db_session.flush()
+
+    assert [r.quantity for r in _replacement_reservations(db_session, repl.id)] == [2]
+    # And the announcement still fires - the pull own fresh claim is excluded from the coverability
+    # check, without which it would read as insufficient forever.
+    assert len(raised) == 1
+    assert raised[0].type == NotificationType.PULL_UNBLOCKED
+
+
+def test_a_receive_that_only_narrows_the_gap_claims_it_but_says_nothing(db_session):
+    """Claiming is unconditional - every unit that lands is one the replacement should hold - but the
+    announcement is reserved for a pull the warehouse can actually act on."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES9", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 3)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+
+    il.quantity += 1
+    db_session.flush()
+    raised = warehouse_repository.notify_unblocked_replacement_pulls(db_session, project.id, {HINGE})
+    db_session.flush()
+
+    assert [r.quantity for r in _replacement_reservations(db_session, repl.id)] == [1]
+    assert raised == []
+
+
+def test_repairing_a_condemned_unit_claims_it_for_the_replacement(db_session):
+    """The other moment project availability rises. A repaired unit is exactly what the replacement
+    was condemned for, so it goes to the replacement rather than to whoever asks next."""
+    from app.models.enums import DeficiencyResolution
+    from app.repositories import stock as stock_repository
+
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES10", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    assert _replacement_reservations(db_session, repl.id) == []
+
+    stock_repository.resolve_deficiency(
+        db_session,
+        inventory_location_id=il.id,
+        stock_item_id=None,
+        resolution=DeficiencyResolution.REPAIR,
+        quantity=2,
+        reason_text="straightened",
+        rma_reference=None,
+        destock_source=None,
+        reviewed_by="reviewer",
+    )
+    db_session.flush()
+
+    assert [r.quantity for r in _replacement_reservations(db_session, repl.id)] == [2]
+
+
+def test_discarding_a_pending_replacement_pull_releases_its_claim(db_session):
+    """The pull IS the holder, so hard-deleting it without releasing would strand a claim with
+    nothing left that could ever spend or release it."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-RES11", items=[(*HINGE, 4)])
+    _flag_deficient(db_session, opening, sao[HINGE[1]], 2)
+    repl = _repl_pull_for(db_session, sao[HINGE[1]])
+    repl_id = repl.id
+    db_session.flush()
+
+    warehouse_repository.discard_pending_pull_request(db_session, repl_id)
+    db_session.flush()
+
+    assert _replacement_reservations(db_session, repl_id) == []
+    check = warehouse_repository.check_inventory_sufficiency(
+        db_session, project.id, [(*HINGE, 5)], reservation_aware=True
+    )
+    assert check.sufficient
+
+
+def test_two_replacements_are_topped_up_oldest_first(db_session):
+    """Deterministic when two of them want the same scarce combo, and it is the queue the warehouse
+    already works: the order the defects were found."""
+    project = _make_project(db_session)
+    il = _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=0)
+    first_opening, first_sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-RES12", items=[(*HINGE, 4)]
+    )
+    _flag_deficient(db_session, first_opening, first_sao[HINGE[1]], 2)
+    first_repl = _repl_pull_for(db_session, first_sao[HINGE[1]])
+
+    second_opening, second_sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-RES13", items=[(*HINGE, 4)]
+    )
+    _flag_deficient(db_session, second_opening, second_sao[HINGE[1]], 2)
+    second_repl = _repl_pull_for(db_session, second_sao[HINGE[1]])
+    db_session.flush()
+
+    il.quantity += 3  # not enough for both
+    db_session.flush()
+    warehouse_repository.top_up_replacement_reservations(db_session, project.id, [HINGE])
+    db_session.flush()
+
+    assert [r.quantity for r in _replacement_reservations(db_session, first_repl.id)] == [2]
+    assert [r.quantity for r in _replacement_reservations(db_session, second_repl.id)] == [1]

--- a/backend/tests/test_replacement_loop.py
+++ b/backend/tests/test_replacement_loop.py
@@ -1132,3 +1132,59 @@ def test_two_replacements_are_topped_up_oldest_first(db_session):
 
     assert [r.quantity for r in _replacement_reservations(db_session, first_repl.id)] == [2]
     assert [r.quantity for r in _replacement_reservations(db_session, second_repl.id)] == [1]
+
+
+# --- 9. the shipping guard sees both kinds of short ----------------------------------------------
+
+
+def test_leaf_shortfalls_reports_both_halves_of_one_leaf(db_session):
+    """Condemned-and-unreplaced and never-pulled are counted apart because the remedies differ: a
+    replacement is already in flight for one and there is nothing coming for the other."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=20)
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-SHORTFALL1",
+        # 4 hinges owed, 3 pulled; 2 locks owed, both pulled.
+        items=[(*HINGE, 4, 3), (*LOCK, 2, 2)],
+    )
+    _flag_deficient(db_session, opening, sao[LOCK[1]], 1)
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    shortfalls = shop_assembly_repository.get_leaf_shortfalls(db_session, [leaf.id])
+    assert shortfalls[leaf.id].awaiting_replacement == 1
+    assert shortfalls[leaf.id].never_pulled == 1
+    assert shortfalls[leaf.id].total == 2
+
+    # The two named readings are views of the same row.
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {leaf.id: 1}
+    assert shop_assembly_repository.get_never_pulled_quantities(db_session, [leaf.id]) == {leaf.id: 1}
+
+
+def test_a_leaf_that_is_only_short_is_still_flagged(db_session):
+    """Nothing was condemned, so the awaiting-replacement reading is silent - and the leaf is still
+    physically missing hardware its list claims, so shipping it has to be a decision."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=20)
+    opening, sao = _make_pulled_opening(
+        db_session, project.id, request_number="PR-SA-SHORTFALL2", items=[(*HINGE, 4, 2)]
+    )
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    assert shop_assembly_repository.get_awaiting_replacement_quantities(db_session, [leaf.id]) == {}
+    shortfalls = shop_assembly_repository.get_leaf_shortfalls(db_session, [leaf.id])
+    assert shortfalls[leaf.id].never_pulled == 2
+
+
+def test_a_whole_leaf_reports_no_shortfall_at_all(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=20)
+    opening, sao = _make_pulled_opening(db_session, project.id, request_number="PR-SA-SHORTFALL3", items=[(*HINGE, 4)])
+    leaf = _complete(db_session, opening, sao)
+    db_session.flush()
+
+    assert shop_assembly_repository.get_leaf_shortfalls(db_session, [leaf.id]) == {}
+    assert shop_assembly_repository.get_leaf_shortfalls(db_session, []) == {}

--- a/backend/tests/test_sar_allocation.py
+++ b/backend/tests/test_sar_allocation.py
@@ -1,0 +1,416 @@
+"""Partial allocation at shop-assembly request creation.
+
+Shop assembly stops being all-or-nothing. The creation gate used to refuse a request outright when
+its full bill of hardware did not fit available inventory, so one leaf short of one hinge held up
+every leaf behind it. The requester now assigns what is available to leaves, partially-covered leaves
+stay in the request, and the send/don't-send call is theirs.
+
+What that turns into on the server, and what is pinned here:
+
+- `quantity` still means **owed** - the schedule's number, never reduced by scarcity.
+- `allocated_quantity` is what was claimed, reserved and will be pulled.
+- The gate now runs over the ALLOCATION, so it is no longer the shortfall gate; it is the **race**
+  gate, and it still refuses the whole finalize when availability moved under the allocation.
+- Short is `quantity - allocated_quantity`, derived, never stored.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import InventoryShortfallError, ValidationError
+from app.models.enums import NotificationType, ReservationSource, ShopAssemblyRequestStatus
+from app.models.inventory import InventoryLocation
+from app.models.inventory_reservation import InventoryReservation
+from app.models.notification import Notification
+from app.models.project import Project
+from app.models.shop_assembly import ShopAssemblyOpening, ShopAssemblyOpeningItem
+from app.models.stock_item import StockItem
+from app.repositories import import_repository, warehouse_admin_repository
+
+HINGE = ("HINGE", "HG-A1")
+CLOSER = ("CLOSER", "CL-A1")
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _seed_inventory(session, project_id, *, category, code, quantity):
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    si = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(si)
+    session.flush()
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        stock_item_id=si.id,
+        warehouse_id=warehouse_id,
+        hardware_category=category,
+        product_code=code,
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(il)
+    session.flush()
+    return il
+
+
+def _opening_input(number):
+    return {
+        "opening_number": number,
+        "building": "B1",
+        "floor": "F1",
+        "location": "Lobby",
+        "location_to": None,
+        "location_from": None,
+        "hand": None,
+        "width": None,
+        "length": None,
+        "door_thickness": None,
+        "jamb_thickness": None,
+        "door_type": None,
+        "frame_type": None,
+        "interior_exterior": None,
+        "keying": None,
+        "heading_no": None,
+        "single_pair": None,
+        "assignment_multiplier": None,
+        "leaf_count": 1,
+    }
+
+
+def _finalize(session, project, sar_openings, *, request_number=None):
+    """`sar_openings` is [(opening_number, leaf, [(category, code, owed, allocated_or_None), ...])]."""
+    return import_repository.finalize_import_session(
+        session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input(number) for number, _, _ in sar_openings],
+            "hardware_items": [],
+            "include_shop_assembly_request": True,
+            "shop_assembly_request_number": request_number or f"SA-{uuid.uuid4().hex[:6]}",
+            "shop_assembly_openings": [
+                {
+                    "opening_number": number,
+                    "leaf": leaf,
+                    "items": [
+                        {
+                            "hardware_category": cat,
+                            "product_code": code,
+                            "quantity": owed,
+                            "allocated_quantity": allocated,
+                        }
+                        for cat, code, owed, allocated in lines
+                    ],
+                }
+                for number, leaf, lines in sar_openings
+            ],
+        },
+    )
+
+
+def _sao_items(session, sar_id):
+    return list(
+        session.scalars(
+            select(ShopAssemblyOpeningItem)
+            .join(ShopAssemblyOpening, ShopAssemblyOpening.id == ShopAssemblyOpeningItem.shop_assembly_opening_id)
+            .where(ShopAssemblyOpening.shop_assembly_request_id == sar_id)
+        ).all()
+    )
+
+
+def _reservations(session, project_id):
+    return list(
+        session.scalars(select(InventoryReservation).where(InventoryReservation.project_id == project_id)).all()
+    )
+
+
+# --- the default: None means fully allocated -----------------------------------------------------
+
+
+def test_omitted_allocation_means_fully_allocated(db_session):
+    """A caller that predates the allocator - a test, a script, a tab loaded before the deploy - asks
+    for the whole line and is held to the old all-or-nothing behaviour."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=4)
+
+    result = _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, None)])])
+    db_session.flush()
+
+    items = _sao_items(db_session, result["shop_assembly_request"].id)
+    assert [(i.quantity, i.allocated_quantity) for i in items] == [(4, 4)]
+
+
+def test_omitted_allocation_still_bounces_when_it_does_not_fit(db_session):
+    """The default is "ask for everything", so an old caller still gets the old refusal."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=1)
+
+    with pytest.raises(InventoryShortfallError):
+        _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, None)])])
+
+
+# --- partial allocation --------------------------------------------------------------------------
+
+
+def test_partial_allocation_keeps_owed_and_reserves_only_what_it_claimed(db_session):
+    """The checklist keeps the schedule's number; the claim is the allocation. The difference is
+    short, and it is derived from the two columns rather than stored anywhere."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=2)
+
+    result = _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, 2)])])
+    db_session.flush()
+
+    (item,) = _sao_items(db_session, result["shop_assembly_request"].id)
+    assert (item.quantity, item.allocated_quantity) == (4, 2)
+
+    reservations = _reservations(db_session, project.id)
+    assert len(reservations) == 1
+    assert reservations[0].quantity == 2  # not 4 - the request never claimed the other two
+
+
+def test_a_zero_line_is_legal_on_a_leaf_its_other_lines_cover(db_session):
+    """A leaf can be missing one product entirely and still be worth sending: the cart has the rest
+    of its hardware on it and the assembler has real work to do."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=4)
+    _seed_inventory(db_session, project.id, category=CLOSER[0], code=CLOSER[1], quantity=0)
+
+    result = _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, 4), (*CLOSER, 1, 0)])])
+    db_session.flush()
+
+    items = {i.product_code: i for i in _sao_items(db_session, result["shop_assembly_request"].id)}
+    assert (items[HINGE[1]].quantity, items[HINGE[1]].allocated_quantity) == (4, 4)
+    assert (items[CLOSER[1]].quantity, items[CLOSER[1]].allocated_quantity) == (1, 0)
+    # Nothing is reserved for the line that got nothing.
+    assert {(r.product_code, r.quantity) for r in _reservations(db_session, project.id)} == {(HINGE[1], 4)}
+
+
+def test_scarcity_across_leaves_is_the_caller_decision_not_a_refusal(db_session):
+    """Two leaves, four hinges: one whole leaf and one short one, both sent. This is the case the
+    old gate refused outright."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=6)
+
+    result = _finalize(
+        db_session,
+        project,
+        [("A01", 1, [(*HINGE, 4, 4)]), ("A02", 1, [(*HINGE, 4, 2)])],
+    )
+    db_session.flush()
+
+    sar = result["shop_assembly_request"]
+    assert sar.status == ShopAssemblyRequestStatus.PENDING
+    assert sorted(i.allocated_quantity for i in _sao_items(db_session, sar.id)) == [2, 4]
+    # One reservation row per combo across the whole request, for the total allocated.
+    assert [r.quantity for r in _reservations(db_session, project.id)] == [6]
+
+
+# --- validation ----------------------------------------------------------------------------------
+
+
+def test_allocation_above_owed_is_refused(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, 5)])])
+    assert "allocated_quantity" == excinfo.value.field
+
+
+def test_negative_allocation_is_refused(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+
+    with pytest.raises(ValidationError):
+        _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, -1)])])
+
+
+def test_a_leaf_with_nothing_allocated_at_all_is_refused(db_session):
+    """An empty cart: nothing to pull, nothing to stage, nothing to assemble, and `complete_opening`
+    would refuse it at the far end for having zero installed units. The wizard drops such leaves
+    before submitting, so reaching here is a race or a non-UI caller - both better refused than
+    turned into a work unit that can never be finished."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=10)
+
+    with pytest.raises(ValidationError) as excinfo:
+        _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, 0), (*CLOSER, 1, 0)])])
+    assert "nothing to pull" in str(excinfo.value)
+
+    db_session.rollback()
+    assert _reservations(db_session, project.id) == []
+
+
+# --- the gate is now the race gate ----------------------------------------------------------------
+
+
+def test_allocation_beyond_what_is_available_is_still_refused_whole(db_session):
+    """The allocator never asks for more than was free when it built its numbers, so this can only
+    be a race - availability moved between load and send. Writing a claim on hardware that is not
+    there would be worse than bouncing; the wizard refetches and rebuilds."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=2)
+
+    with pytest.raises(InventoryShortfallError) as excinfo:
+        _finalize(db_session, project, [("A01", 1, [(*HINGE, 8, 5)])])
+    # Measured against the allocation, not the owed quantity: 5 asked for, 2 available.
+    assert (excinfo.value.shortfalls[0].requested, excinfo.value.shortfalls[0].available) == (5, 2)
+
+    db_session.rollback()
+    assert _reservations(db_session, project.id) == []
+
+
+# --- purchasing signal ----------------------------------------------------------------------------
+
+
+def test_a_successful_short_send_tells_purchasing_about_the_gap(db_session):
+    """A short combo is out of available stock by construction - the allocator only leaves a line
+    short once that combo's pool is exhausted - so it is always a genuine purchasing signal, not
+    somebody else's claim. It fires on the SUCCESS path; the refusal path stays for races."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=2)
+
+    _finalize(db_session, project, [("A01", 1, [(*HINGE, 6, 2)])], request_number="SA-SHORT-1")
+    db_session.flush()
+
+    notifs = list(
+        db_session.scalars(
+            select(Notification).where(
+                Notification.project_id == project.id,
+                Notification.type == NotificationType.INVENTORY_SHORTFALL,
+            )
+        ).all()
+    )
+    assert len(notifs) == 1
+    assert "SA-SHORT-1" in notifs[0].message
+    assert "short 4" in notifs[0].message
+
+
+def test_a_fully_covered_send_tells_purchasing_nothing(db_session):
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=4)
+
+    _finalize(db_session, project, [("A01", 1, [(*HINGE, 4, 4)])])
+    db_session.flush()
+
+    assert (
+        db_session.scalars(
+            select(Notification).where(
+                Notification.project_id == project.id,
+                Notification.type == NotificationType.INVENTORY_SHORTFALL,
+            )
+        ).all()
+        == []
+    )
+
+
+def test_short_across_two_leaves_is_one_notification_per_combo(db_session):
+    """The signal purchasing acts on is "the project is N hinges short", not "leaf A02 is 2 short and
+    leaf A03 is 4 short" - they order against the combo."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    _seed_inventory(db_session, project.id, category=CLOSER[0], code=CLOSER[1], quantity=1)
+
+    _finalize(
+        db_session,
+        project,
+        [
+            ("A01", 1, [(*HINGE, 4, 4)]),
+            ("A02", 1, [(*HINGE, 4, 1), (*CLOSER, 2, 1)]),
+        ],
+        request_number="SA-SHORT-2",
+    )
+    db_session.flush()
+
+    notifs = list(
+        db_session.scalars(
+            select(Notification).where(
+                Notification.project_id == project.id,
+                Notification.type == NotificationType.INVENTORY_SHORTFALL,
+            )
+        ).all()
+    )
+    assert len(notifs) == 1
+    assert "short 3" in notifs[0].message  # the hinges, summed across both leaves
+    assert "short 1" in notifs[0].message  # the closers
+
+
+# --- re-upload reconciliation ---------------------------------------------------------------------
+
+
+def test_reupload_rebuilds_the_reservation_from_allocated_not_owed(db_session):
+    """A re-upload that drops one of a request's openings rebuilds the claim from what survived.
+    Rebuilding from `quantity` would inflate it into a claim on hardware this request never had."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=6)
+
+    _finalize(
+        db_session,
+        project,
+        [("A01", 1, [(*HINGE, 4, 4)]), ("A02", 1, [(*HINGE, 4, 2)])],
+    )
+    db_session.flush()
+    assert [r.quantity for r in _reservations(db_session, project.id)] == [6]
+
+    # A02 is gone from the new schedule; A01 survives holding its 4.
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01")],
+            "hardware_items": [],
+            "replace_schedule": True,
+            "include_shop_assembly_request": False,
+        },
+    )
+    db_session.flush()
+
+    assert [r.quantity for r in _reservations(db_session, project.id)] == [4]
+
+
+def test_reupload_of_a_fully_short_line_rebuilds_to_nothing_for_it(db_session):
+    """A surviving leaf whose line got nothing holds nothing, and `create_reservations` drops the
+    zero rather than writing a row the `quantity >= 1` constraint would refuse."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+    _seed_inventory(db_session, project.id, category=CLOSER[0], code=CLOSER[1], quantity=0)
+
+    _finalize(
+        db_session,
+        project,
+        [("A01", 1, [(*HINGE, 4, 4), (*CLOSER, 2, 0)]), ("A02", 1, [(*HINGE, 2, 1)])],
+    )
+    db_session.flush()
+
+    import_repository.finalize_import_session(
+        db_session,
+        {
+            "project_id": str(project.id),
+            "openings": [_opening_input("A01")],
+            "hardware_items": [],
+            "replace_schedule": True,
+            "include_shop_assembly_request": False,
+        },
+    )
+    db_session.flush()
+
+    rows = _reservations(db_session, project.id)
+    assert {(r.product_code, r.quantity) for r in rows} == {(HINGE[1], 4)}
+    assert all(r.source is ReservationSource.SHOP_ASSEMBLY_REQUEST for r in rows)

--- a/backend/tests/test_sar_allocation.py
+++ b/backend/tests/test_sar_allocation.py
@@ -301,6 +301,10 @@ def test_a_successful_short_send_tells_purchasing_about_the_gap(db_session):
     assert len(notifs) == 1
     assert "SA-SHORT-1" in notifs[0].message
     assert "short 4" in notifs[0].message
+    # Not "couldn't be fulfilled": the request exists and nothing is blocked. Purchasing is being
+    # told what the project is missing, not sent hunting for a stuck request.
+    assert "was sent short" in notifs[0].message
+    assert "couldn't be fulfilled" not in notifs[0].message
 
 
 def test_a_fully_covered_send_tells_purchasing_nothing(db_session):
@@ -414,3 +418,51 @@ def test_reupload_of_a_fully_short_line_rebuilds_to_nothing_for_it(db_session):
     rows = _reservations(db_session, project.id)
     assert {(r.product_code, r.quantity) for r in rows} == {(HINGE[1], 4)}
     assert all(r.source is ReservationSource.SHOP_ASSEMBLY_REQUEST for r in rows)
+
+
+def test_the_purchasing_signal_totals_a_combo_across_every_line(db_session):
+    """Purchasing orders against the combo, so the numbers have to be what this request wanted of
+    that product against what it got. Counting only the short lines reported a request that took 4
+    hinges on one leaf and missed 3 on another as "need 4, 1 available", which is true of neither."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=5)
+
+    _finalize(
+        db_session,
+        project,
+        [("A01", 1, [(*HINGE, 4, 4)]), ("A02", 1, [(*HINGE, 4, 1)])],
+        request_number="SA-SHORT-3",
+    )
+    db_session.flush()
+
+    (notif,) = db_session.scalars(
+        select(Notification).where(
+            Notification.project_id == project.id,
+            Notification.type == NotificationType.INVENTORY_SHORTFALL,
+        )
+    ).all()
+    # 8 owed across the request, 5 claimed, 3 genuinely missing from the shelf.
+    assert "need 8, 5 available (short 3)" in notif.message
+
+
+def test_a_line_that_omits_the_allocation_is_still_counted_in_the_combo_total(db_session):
+    """The None default means fully allocated, so such a line contributes owed == allocated and must
+    not drag the combo's reported availability down."""
+    project = _make_project(db_session)
+    _seed_inventory(db_session, project.id, category=HINGE[0], code=HINGE[1], quantity=6)
+
+    _finalize(
+        db_session,
+        project,
+        [("A01", 1, [(*HINGE, 4, None)]), ("A02", 1, [(*HINGE, 4, 2)])],
+        request_number="SA-SHORT-4",
+    )
+    db_session.flush()
+
+    (notif,) = db_session.scalars(
+        select(Notification).where(
+            Notification.project_id == project.id,
+            Notification.type == NotificationType.INVENTORY_SHORTFALL,
+        )
+    ).all()
+    assert "need 8, 6 available (short 2)" in notif.message

--- a/backend/tests/test_shop_assembly_completion_guards.py
+++ b/backend/tests/test_shop_assembly_completion_guards.py
@@ -110,14 +110,19 @@ def _make_pulled_opening(session, project_id, *, request_number, items, leaf=Non
     session.flush()
 
     sao_items = {}
-    for category, code, qty in items:
+    # (category, code, owed) or (category, code, owed, allocated); omitting allocated means fully
+    # allocated. `install_all` installs everything that was *pulled* - a short unit never arrived, so
+    # there is nothing to install.
+    for category, code, qty, *rest in items:
+        allocated = rest[0] if rest else qty
         sao_item = ShopAssemblyOpeningItem(
             id=uuid.uuid4(),
             shop_assembly_opening_id=opening.id,
             hardware_category=category,
             product_code=code,
             quantity=qty,
-            installed_quantity=qty if install_all else 0,
+            allocated_quantity=allocated,
+            installed_quantity=allocated if install_all else 0,
         )
         session.add(sao_item)
         sao_items[code] = sao_item
@@ -350,6 +355,58 @@ def test_partially_deficient_completion_still_succeeds(db_session):
         db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == result.id)).all()
     )
     assert {h.product_code: h.quantity for h in hw} == {HINGE[1]: 1}
+
+
+def test_completion_excuses_units_that_were_never_pulled(db_session):
+    """A short unit cannot be dispositioned - nothing arrived for the assembler to install or
+    condemn - so holding the leaf open for it would strand it forever waiting on hardware nobody
+    ever requested. Accounting is against what was pulled; the gap stays recorded as
+    `quantity - allocated_quantity` and belongs to purchasing and reallocation."""
+    project = _make_project(db_session)
+    opening, sao = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-SHORT1",
+        # Owed 4 hinges, 2 pulled and both fitted; the lock line got nothing at all.
+        items=[(*HINGE, 4, 2), (*LOCK, 1, 0)],
+        leaf=1,
+        install_all=True,
+    )
+
+    result = shop_assembly_repository.complete_opening(
+        db_session, opening.id, None, None, None, completed_by="assembler"
+    )
+    db_session.flush()
+
+    assert opening.assembly_status == AssemblyStatus.COMPLETED
+    assert result.state == OpeningItemState.IN_INVENTORY
+    # The leaf carries what actually went on it, not what the schedule said it should.
+    hw = list(
+        db_session.scalars(select(OpeningItemHardware).where(OpeningItemHardware.opening_item_id == result.id)).all()
+    )
+    assert {h.product_code: h.quantity for h in hw} == {HINGE[1]: 2}
+    # And the owed quantity is untouched, so the shortfall is still derivable afterwards.
+    assert (sao[HINGE[1]].quantity, sao[HINGE[1]].allocated_quantity) == (4, 2)
+
+
+def test_completion_still_refuses_a_leaf_that_was_entirely_short(db_session):
+    """The zero-installed guard covers this without knowing about allocation: an "assembled" leaf
+    with nothing on it would read as ship-ready inventory whether the cause was every unit being
+    condemned or every unit never arriving."""
+    project = _make_project(db_session)
+    opening, _ = _make_pulled_opening(
+        db_session,
+        project.id,
+        request_number="PR-SA-SHORT2",
+        items=[(*HINGE, 4, 0), (*LOCK, 1, 0)],
+        leaf=1,
+        install_all=True,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    assert "never pulled" in str(excinfo.value)
+    assert opening.completed_at is None
 
 
 def test_opening_with_no_items_still_completes(db_session):

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -36,6 +36,7 @@ export const GET_ASSEMBLE_LIST = gql`
         hardwareCategory
         productCode
         quantity
+        allocatedQuantity
         installedQuantity
         deficientQuantity
         replacementPendingQuantity
@@ -66,6 +67,7 @@ export const GET_MY_WORK = gql`
         hardwareCategory
         productCode
         quantity
+        allocatedQuantity
         installedQuantity
         deficientQuantity
         replacementPendingQuantity
@@ -155,11 +157,14 @@ const PIPELINE_SUMMARY_FIELDS = `
   completedOpeningCount
   shippedOpeningCount
   plannedUnitCount
+  allocatedUnitCount
+  shortUnitCount
   installedUnitCount
   deficientUnitCount
   replacementPendingUnitCount
   awaitingReplacementOpeningCount
   replacementAfterShipOpeningCount
+  shortOpeningCount
   stage
 `;
 
@@ -196,6 +201,8 @@ export const GET_ASSEMBLY_PIPELINE = gql`
         assemblyStatus
         completedAt
         plannedUnitCount
+        allocatedUnitCount
+        shortUnitCount
         installedUnitCount
         deficientUnitCount
         replacementPendingUnitCount
@@ -292,6 +299,7 @@ export const ASSIGN_OPENINGS = gql`
         hardwareCategory
         productCode
         quantity
+        allocatedQuantity
         installedQuantity
         deficientQuantity
         replacementPendingQuantity
@@ -321,6 +329,7 @@ export const REMOVE_OPENING_FROM_USER = gql`
         hardwareCategory
         productCode
         quantity
+        allocatedQuantity
         installedQuantity
         deficientQuantity
         replacementPendingQuantity
@@ -354,6 +363,7 @@ export const RECORD_ASSEMBLY_PROGRESS = gql`
         hardwareCategory
         productCode
         quantity
+        allocatedQuantity
         installedQuantity
         deficientQuantity
         replacementPendingQuantity

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -245,6 +245,7 @@ export const GET_SHOP_ASSEMBLY_REQUESTS = gql`
           hardwareCategory
           productCode
           quantity
+          allocatedQuantity
         }
       }
     }

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -78,6 +78,7 @@ export const GET_OPENING_ITEMS = gql`
       aisle row bay
       createdAt updatedAt
       awaitingReplacementQuantity
+      neverPulledQuantity
       installedHardware {
         id openingItemId productCode hardwareCategory quantity
       }

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -551,7 +551,7 @@ const PULL_REQUEST_FIELDS = `
 const PULL_STAGING_OPENING_FIELDS = `
   id pullRequestId openingId openingNumber leaf building floor
   pullStatus assemblyStatus assignedToUserId assignedTo stagedAt stagedBy
-  items { id shopAssemblyOpeningId hardwareCategory productCode quantity }
+  items { id shopAssemblyOpeningId hardwareCategory productCode quantity allocatedQuantity }
 `;
 
 export const APPROVE_PULL_REQUEST = gql`

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -25,6 +25,7 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client/react';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { useWizard } from '../../contexts/WizardContext';
 import { useToast } from '../../components/Toast';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -63,6 +64,13 @@ import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
 import PurchaseOrdersStep from './PurchaseOrdersStep';
 import ShopAssemblyStep from './ShopAssemblyStep';
+import {
+  autoAssign,
+  buildAllocatedDrafts,
+  leafCoverage,
+  leafKey,
+  type Allocation,
+} from './allocation';
 import ShippingPRsStep from './ShippingPRsStep';
 
 // ---- Local Types ----
@@ -74,6 +82,17 @@ type StepId = 'upload' | 'purpose' | 'openings' | 'reconciliation'
 interface StepDescriptor {
   id: StepId;
   label: string;
+}
+
+/**
+ * Did the finalize bounce because stock was not available? On a shop-assembly finalize that can only
+ * be a race now - the allocation never asks for more than was free when it was built - so it is the
+ * signal to refetch and rebuild rather than an error to show and leave the user staring at.
+ */
+function isInventoryShortfall(err: unknown): boolean {
+  return (
+    CombinedGraphQLErrors.is(err) && err.errors?.[0]?.extensions?.code === 'INVENTORY_SHORTFALL'
+  );
 }
 
 /** The slice of GET_OPENING_ITEMS the shipping purpose reads (#335). */
@@ -155,6 +174,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   const [siteShopClassifications, setSiteShopClassifications] = useState<Map<string, string>>(new Map());
   const [orderAsValues, setOrderAsValues] = useState<Map<string, string>>(new Map());
   const [sarRequestNumber, setSarRequestNumber] = useState('');
+  // Shop-assembly allocation: how much of each leaf's owed hardware this request actually claims,
+  // and which leaves are being sent. Held here rather than inside the step so stepping back and
+  // forward does not silently re-run auto-assign over the user's manual moves.
+  const [sarAllocation, setSarAllocation] = useState<Allocation>(new Map());
+  const [includedLeafKeys, setIncludedLeafKeys] = useState<Set<string>>(new Set());
+  // The server refused the finalize because availability moved under the allocation (#342 race).
+  // The step says so and shows the rebuilt numbers rather than letting the user resend the stale set.
+  const [allocationStale, setAllocationStale] = useState(false);
   const [shippingPRDrafts, setShippingPRDrafts] = useState<ShippingPRDraft[]>([]);
   // The user has been shown the "incomplete - awaiting replacement" warning on a leaf and chose to
   // ship it anyway (#341). The backend refuses a flagged leaf without this, so the flag is the
@@ -508,6 +535,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     data: availabilityData,
     loading: availabilityLoading,
     error: availabilityError,
+    refetch: refetchAvailability,
   } = useQuery<{ projectInventoryAvailability: InventoryAvailabilityRow[] }>(
     GET_PROJECT_INVENTORY_AVAILABILITY,
     {
@@ -586,16 +614,28 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       });
   }, [purpose, parsed, selectedOpenings, classifications]);
 
-  // What this wizard is about to claim, per combo. Shop assembly claims every checklist line;
-  // shipping claims only its LOOSE lines - an assembled leaf left fungible inventory when it was
-  // built and ships as itself (docs/HARDWARE_IDENTITY_LIFECYCLE.md), so it reserves nothing.
+  // The exact payload the shop-assembly finalize sends: the included, non-empty leaves with both
+  // numbers per line. Derived from the same drafts the allocator step renders, so what the user was
+  // held to is by construction what gets submitted.
+  const allocatedShopAssemblyDrafts = useMemo(
+    () =>
+      purpose === 'assembly'
+        ? buildAllocatedDrafts(shopAssemblyOpeningDrafts, sarAllocation, includedLeafKeys)
+        : [],
+    [purpose, shopAssemblyOpeningDrafts, sarAllocation, includedLeafKeys],
+  );
+
+  // What this wizard is about to claim, per combo. Shop assembly claims the ALLOCATED quantities -
+  // a short line reserves nothing, which is the whole point of the allocator. Shipping claims only
+  // its LOOSE lines: an assembled leaf left fungible inventory when it was built and ships as itself
+  // (docs/HARDWARE_IDENTITY_LIFECYCLE.md), so it reserves nothing.
   const requestedByCombo = useMemo(() => {
     const map = new Map<string, number>();
     if (purpose === 'assembly') {
-      for (const draft of shopAssemblyOpeningDrafts) {
+      for (const draft of allocatedShopAssemblyDrafts) {
         for (const item of draft.items) {
           const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
-          map.set(key, (map.get(key) ?? 0) + item.quantity);
+          map.set(key, (map.get(key) ?? 0) + item.allocatedQuantity);
         }
       }
     } else if (purpose === 'shipping') {
@@ -608,7 +648,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       }
     }
     return map;
-  }, [purpose, shopAssemblyOpeningDrafts, effectiveShippingPRDrafts]);
+  }, [purpose, allocatedShopAssemblyDrafts, effectiveShippingPRDrafts]);
 
   const availabilityShortfalls = useMemo(
     // While the lookup is still in flight an empty map would read as "nothing available" and block
@@ -707,6 +747,9 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     setClassifications(new Map());
     setSiteShopClassifications(new Map());
     setSarRequestNumber('');
+    setSarAllocation(new Map());
+    setIncludedLeafKeys(new Set());
+    setAllocationStale(false);
     setShippingPRDrafts([]);
     setSelectedReconItems(new Set());
     setMutationError(null);
@@ -1017,10 +1060,12 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       replaceSchedule: canStartFromLatest && !hydratedFromPersisted,
       // Only ever true after the user confirmed the warning dialog on a flagged leaf (#341).
       acknowledgeIncompleteLeaves: acknowledgedIncompleteLeaves,
-      // The exact work units the wizard gated on (#342), not a second derivation of them.
-      shopAssemblyOpenings: purpose === 'assembly' ? shopAssemblyOpeningDrafts : null,
+      // The exact work units the wizard gated on (#342), not a second derivation of them - now
+      // carrying the allocated quantity per line, and already minus the excluded and auto-dropped
+      // leaves.
+      shopAssemblyOpenings: purpose === 'assembly' ? allocatedShopAssemblyDrafts : null,
     };
-  }, [parsed, project.id, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, shopAssemblyOpeningDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted, acknowledgedIncompleteLeaves]);
+  }, [parsed, project.id, purpose, vendorGroups, vendorPOInfo, selectedVendors, unitCostOverrides, orderAsValues, classifications, siteShopClassifications, effectiveShippingPRDrafts, allocatedShopAssemblyDrafts, sarRequestNumber, canStartFromLatest, hydratedFromPersisted, acknowledgedIncompleteLeaves]);
 
   const handleFinalize = useCallback(async () => {
     setConfirmOpen(false);
@@ -1035,6 +1080,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       const data = result.data?.finalizeImportSession as FinalizeResultData;
       setFinalizeResult(data);
       setFinalizeLoading(false);
+      setAllocationStale(false);
 
       showToast('Import session finalized successfully!', 'success');
       setPostSuccessOpen(true);
@@ -1042,8 +1088,33 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       const message = err instanceof Error ? err.message : 'An unknown error occurred';
       setMutationError(message);
       setFinalizeLoading(false);
+      // INVENTORY_SHORTFALL on a shop-assembly finalize now means one thing only: availability moved
+      // between building the allocation and sending it, because the allocation itself never asks for
+      // more than was free when it was built. Refetch, rebuild from the current numbers and send the
+      // user back to review - resending the stale allocation would just bounce again.
+      if (purpose === 'assembly' && isInventoryShortfall(err)) {
+        setAllocationStale(true);
+        const refreshed = await refetchAvailability().catch(() => null);
+        const fresh = new Map<string, number>();
+        for (const row of refreshed?.data?.projectInventoryAvailability ?? []) {
+          fresh.set(
+            itemGroupKey({ hardware_category: row.hardwareCategory, product_code: row.productCode }),
+            row.availableQuantity,
+          );
+        }
+        const next = autoAssign(shopAssemblyOpeningDrafts, fresh);
+        setSarAllocation(next);
+        setIncludedLeafKeys(
+          new Set(
+            shopAssemblyOpeningDrafts
+              .filter((draft) => leafCoverage(next, draft) !== 'NONE')
+              .map((draft) => leafKey(draft)),
+          ),
+        );
+        setActiveStepId('shop-assembly');
+      }
     }
-  }, [buildFinalizeInput, finalizeImport, showToast]);
+  }, [buildFinalizeInput, finalizeImport, showToast, purpose, refetchAvailability, shopAssemblyOpeningDrafts]);
 
   const handlePostAction = useCallback(
     (action: 'po' | 'inventory' | 'home') => {
@@ -1422,11 +1493,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               sarRequestNumber={sarRequestNumber}
               onSarNumberChange={setSarRequestNumber}
               openingDrafts={shopAssemblyOpeningDrafts}
-              requestedByCombo={requestedByCombo}
               availabilityByCombo={availabilityByCombo}
-              availabilityShortfalls={availabilityShortfalls}
+              allocation={sarAllocation}
+              onAllocationChange={setSarAllocation}
+              includedLeafKeys={includedLeafKeys}
+              onIncludedLeafKeysChange={setIncludedLeafKeys}
               availabilityLoading={availabilityLoading && availabilityData === undefined}
               availabilityError={availabilityError !== undefined}
+              allocationStale={allocationStale}
               onNext={handleNext}
               onBack={handleBack}
             />

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -67,6 +67,7 @@ import ShopAssemblyStep from './ShopAssemblyStep';
 import {
   autoAssign,
   buildAllocatedDrafts,
+  draftsSignature,
   leafCoverage,
   leafKey,
   type Allocation,
@@ -104,6 +105,8 @@ interface OpeningItemResponse {
   installedHardware: Array<{ productCode: string; quantity: number }>;
   /** Units still awaiting a replacement (#341); null on a server that predates the field. */
   awaitingReplacementQuantity: number | null;
+  /** Units the schedule owed that the request never pulled; null on a server predating the field. */
+  neverPulledQuantity: number | null;
 }
 
 /** The slices used to find leaves already claimed by an open request or pull (#335). */
@@ -179,6 +182,10 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
   // forward does not silently re-run auto-assign over the user's manual moves.
   const [sarAllocation, setSarAllocation] = useState<Allocation>(new Map());
   const [includedLeafKeys, setIncludedLeafKeys] = useState<Set<string>>(new Set());
+  // The draft signature the allocation above was seeded from. Held here, not in the step, because
+  // the step unmounts whenever the user is on another step - a flag inside it would reset on the way
+  // back and auto-assign would overwrite whatever they had moved by hand.
+  const [seededSignature, setSeededSignature] = useState<string | null>(null);
   // The server refused the finalize because availability moved under the allocation (#342 race).
   // The step says so and shows the rebuilt numbers rather than letting the user resend the stale set.
   const [allocationStale, setAllocationStale] = useState(false);
@@ -468,6 +475,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         leaf: oi.leaf,
         installedHardware: oi.installedHardware ?? [],
         awaitingReplacementQuantity: oi.awaitingReplacementQuantity ?? 0,
+        neverPulledQuantity: oi.neverPulledQuantity ?? 0,
       }))
       .sort((a, b) => a.openingNumber.localeCompare(b.openingNumber) || (a.leaf ?? 0) - (b.leaf ?? 0));
   }, [purpose, openingItemsData, selectedOpenings, claimedOpeningItemIds]);
@@ -625,30 +633,26 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     [purpose, shopAssemblyOpeningDrafts, sarAllocation, includedLeafKeys],
   );
 
-  // What this wizard is about to claim, per combo. Shop assembly claims the ALLOCATED quantities -
-  // a short line reserves nothing, which is the whole point of the allocator. Shipping claims only
-  // its LOOSE lines: an assembled leaf left fungible inventory when it was built and ships as itself
+  // What the SHIPPING purpose is about to claim, per combo - only its LOOSE lines, because an
+  // assembled leaf left fungible inventory when it was built and ships as itself
   // (docs/HARDWARE_IDENTITY_LIFECYCLE.md), so it reserves nothing.
+  //
+  // Shop assembly is deliberately not here any more. Its step derives its own per-combo totals from
+  // the allocation (`comboSummary`), and it has to: the numbers on screen have to be the ones being
+  // submitted, and a second derivation living up here would be exactly the drift the allocated-drafts
+  // comment above warns about. Nothing downstream of this map reads it for the assembly purpose.
   const requestedByCombo = useMemo(() => {
     const map = new Map<string, number>();
-    if (purpose === 'assembly') {
-      for (const draft of allocatedShopAssemblyDrafts) {
-        for (const item of draft.items) {
-          const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
-          map.set(key, (map.get(key) ?? 0) + item.allocatedQuantity);
-        }
-      }
-    } else if (purpose === 'shipping') {
-      for (const draft of effectiveShippingPRDrafts) {
-        for (const item of draft.items) {
-          if (item.itemType !== 'LOOSE' || !item.hardwareCategory || !item.productCode) continue;
-          const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
-          map.set(key, (map.get(key) ?? 0) + item.requestedQuantity);
-        }
+    if (purpose !== 'shipping') return map;
+    for (const draft of effectiveShippingPRDrafts) {
+      for (const item of draft.items) {
+        if (item.itemType !== 'LOOSE' || !item.hardwareCategory || !item.productCode) continue;
+        const key = itemGroupKey({ hardware_category: item.hardwareCategory, product_code: item.productCode });
+        map.set(key, (map.get(key) ?? 0) + item.requestedQuantity);
       }
     }
     return map;
-  }, [purpose, allocatedShopAssemblyDrafts, effectiveShippingPRDrafts]);
+  }, [purpose, effectiveShippingPRDrafts]);
 
   const availabilityShortfalls = useMemo(
     // While the lookup is still in flight an empty map would read as "nothing available" and block
@@ -749,6 +753,7 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
     setSarRequestNumber('');
     setSarAllocation(new Map());
     setIncludedLeafKeys(new Set());
+    setSeededSignature(null);
     setAllocationStale(false);
     setShippingPRDrafts([]);
     setSelectedReconItems(new Set());
@@ -1094,9 +1099,16 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       // user back to review - resending the stale allocation would just bounce again.
       if (purpose === 'assembly' && isInventoryShortfall(err)) {
         setAllocationStale(true);
+        setActiveStepId('shop-assembly');
         const refreshed = await refetchAvailability().catch(() => null);
+        const rows = refreshed?.data?.projectInventoryAvailability;
+        // A failed refetch means the numbers are unknown, not zero. Rebuilding from an empty map
+        // would allocate nothing to everything and read as "no stock anywhere", which is a worse lie
+        // than the stale allocation the user already has in front of them. Leave it alone and let
+        // the stale banner stand.
+        if (!rows) return;
         const fresh = new Map<string, number>();
-        for (const row of refreshed?.data?.projectInventoryAvailability ?? []) {
+        for (const row of rows) {
           fresh.set(
             itemGroupKey({ hardware_category: row.hardwareCategory, product_code: row.productCode }),
             row.availableQuantity,
@@ -1104,14 +1116,21 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         }
         const next = autoAssign(shopAssemblyOpeningDrafts, fresh);
         setSarAllocation(next);
-        setIncludedLeafKeys(
-          new Set(
+        // Re-seeding must not silently put back a leaf the user chose to leave out. Only leaves that
+        // were in the request keep their place; the rest of the rebuild is the allocator's.
+        setIncludedLeafKeys((previous) => {
+          const seeded = previous.size === 0;
+          return new Set(
             shopAssemblyOpeningDrafts
-              .filter((draft) => leafCoverage(next, draft) !== 'NONE')
+              .filter(
+                (draft) =>
+                  leafCoverage(next, draft) !== 'NONE' &&
+                  (seeded || previous.has(leafKey(draft))),
+              )
               .map((draft) => leafKey(draft)),
-          ),
-        );
-        setActiveStepId('shop-assembly');
+          );
+        });
+        setSeededSignature(draftsSignature(shopAssemblyOpeningDrafts));
       }
     }
   }, [buildFinalizeInput, finalizeImport, showToast, purpose, refetchAvailability, shopAssemblyOpeningDrafts]);
@@ -1498,6 +1517,8 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
               onAllocationChange={setSarAllocation}
               includedLeafKeys={includedLeafKeys}
               onIncludedLeafKeysChange={setIncludedLeafKeys}
+              seededSignature={seededSignature}
+              onSeeded={setSeededSignature}
               availabilityLoading={availabilityLoading && availabilityData === undefined}
               availabilityError={availabilityError !== undefined}
               allocationStale={allocationStale}

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -25,6 +25,26 @@ import type {
 import { aggregationKey, itemGroupKey, shippingPRItemKey } from './types';
 import { leafSuffix } from '../../utils/leaf';
 
+/** Units of a leaf's own hardware list that are not physically on it, however they went missing. */
+function incompleteUnits(leaf: AssembledLeafCandidate): number {
+  return leaf.awaitingReplacementQuantity + leaf.neverPulledQuantity;
+}
+
+/**
+ * Why a leaf is short, in the shipper's words. Both counts are named when both apply, because the
+ * remedies are different: a replacement is already on its way, and a never-pulled unit is not.
+ */
+function incompleteSummary(leaf: AssembledLeafCandidate): string {
+  const parts: string[] = [];
+  if (leaf.awaitingReplacementQuantity > 0) {
+    parts.push(`awaiting replacement hardware for ${leaf.awaitingReplacementQuantity} unit(s)`);
+  }
+  if (leaf.neverPulledQuantity > 0) {
+    parts.push(`missing ${leaf.neverPulledQuantity} unit(s) that were never pulled`);
+  }
+  return parts.join(', and ');
+}
+
 interface ShippingPRsStepProps {
   shippingPRDrafts: ShippingPRDraft[];
   /** Assembled door leaves (OpeningItems) on the selected openings, still in inventory (#335). */
@@ -104,7 +124,12 @@ export default function ShippingPRsStep({
   const handleToggleLeaf = useCallback(
     (prIndex: number, item: ShippingPRItem, leaf: AssembledLeafCandidate, isSelected: boolean) => {
       // Only adding a flagged leaf needs a decision. Removing one always just removes it.
-      if (!isSelected && leaf.awaitingReplacementQuantity > 0) {
+      //
+      // BOTH kinds of shortfall gate it, because the server refuses on both: a leaf that is merely
+      // short - owed hardware its request could never claim, with nothing condemned and nothing in
+      // flight - would otherwise offer no confirm anywhere, never set the acknowledgment, and be
+      // refused by finalize with no way for the user to say yes.
+      if (!isSelected && incompleteUnits(leaf) > 0) {
         setPendingIncomplete({ prIndex, item, leaf });
         return;
       }
@@ -262,7 +287,7 @@ export default function ShippingPRsStep({
                     const key = shippingPRItemKey(item);
                     const onAnotherDraft = leafKeysByDraft.some((keys, i) => i !== prIdx && keys.has(key));
                     const isSelected = selectedKeys.has(key);
-                    const incomplete = leaf.awaitingReplacementQuantity > 0;
+                    const incomplete = incompleteUnits(leaf) > 0;
                     return (
                       <FormControlLabel
                         key={leaf.id}
@@ -289,7 +314,11 @@ export default function ShippingPRsStep({
                                   size="small"
                                   variant="outlined"
                                   color="warning"
-                                  label="Incomplete - awaiting replacement"
+                                  label={
+                                    leaf.awaitingReplacementQuantity > 0
+                                      ? 'Incomplete - awaiting replacement'
+                                      : 'Incomplete - never pulled'
+                                  }
                                 />
                               )}
                             </Box>
@@ -300,8 +329,7 @@ export default function ShippingPRsStep({
                             </Typography>
                             {incomplete && (
                               <Typography variant="caption" color="warning.main" sx={{ display: 'block' }}>
-                                {leaf.awaitingReplacementQuantity} unit(s) still awaiting replacement
-                                hardware
+                                {incompleteSummary(leaf)}
                               </Typography>
                             )}
                           </Box>
@@ -395,9 +423,9 @@ export default function ShippingPRsStep({
         message={
           pendingIncomplete
             ? `Opening ${pendingIncomplete.leaf.openingNumber}${leafSuffix(pendingIncomplete.leaf.leaf)} is ` +
-              `still awaiting replacement hardware for ${pendingIncomplete.leaf.awaitingReplacementQuantity} ` +
-              `unit(s). Shipping it now sends it short of the hardware its list says it carries. ` +
-              `Reallocation can fill the gap later, but the shortfall goes to site either way.`
+              `${incompleteSummary(pendingIncomplete.leaf)}. Shipping it now sends it short of the ` +
+              `hardware its list says it carries. Reallocation can fill the gap later, but the ` +
+              `shortfall goes to site either way.`
             : ''
         }
         confirmLabel="Ship it short"

--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -1,47 +1,65 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Alert,
   Box,
   Button,
   Chip,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Switch,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import type { AvailabilityShortfall, InventoryAvailabilityRow } from './types';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import type { InventoryAvailabilityRow } from './types';
+import {
+  allocatedFor,
+  autoAssign,
+  clampCeiling,
+  comboKey,
+  comboSummary,
+  leafAllocatedTotal,
+  leafCoverage,
+  leafKey,
+  remainingPool,
+  setLineAllocation,
+  type Allocation,
+  type ShopAssemblyOpeningDraft,
+} from './allocation';
 import { leafSuffix } from '../../utils/leaf';
-
-/** One assembly work unit (a door leaf) the wizard would submit, with its checklist aggregated. */
-interface ShopAssemblyOpeningDraft {
-  openingNumber: string;
-  leaf: number | null;
-  items: Array<{ hardwareCategory: string; productCode: string; quantity: number }>;
-}
 
 interface ShopAssemblyStepProps {
   sarRequestNumber: string;
   onSarNumberChange: (value: string) => void;
   /** The exact work units finalize will send - the same derivation, not a parallel one. */
   openingDrafts: ShopAssemblyOpeningDraft[];
-  /** Total demand per (category|product) across every work unit above. */
-  requestedByCombo: Map<string, number>;
   /** Reservation-aware availability per (category|product) for this project (#342). */
   availabilityByCombo: Map<string, InventoryAvailabilityRow>;
-  /** Combos this selection would over-claim. Non-empty blocks the step. */
-  availabilityShortfalls: AvailabilityShortfall[];
+  /** Allocated quantity per leaf per line. Owned by the wizard so it survives a step change. */
+  allocation: Allocation;
+  onAllocationChange: (next: Allocation) => void;
+  /** Leaves the user has kept in the request. Auto-dropped leaves are never in here. */
+  includedLeafKeys: Set<string>;
+  onIncludedLeafKeysChange: (next: Set<string>) => void;
   /** The availability lookup has not answered yet, so the counts below are not final. */
   availabilityLoading: boolean;
   /** The availability lookup failed; the counts are unknown, not zero. */
   availabilityError: boolean;
+  /**
+   * Availability moved between loading this step and submitting, so the server refused the
+   * finalize and the allocation has been re-derived from fresh numbers (#342 race).
+   */
+  allocationStale: boolean;
   onNext: () => void;
   onBack: () => void;
 }
@@ -50,51 +68,89 @@ export default function ShopAssemblyStep({
   sarRequestNumber,
   onSarNumberChange,
   openingDrafts,
-  requestedByCombo,
   availabilityByCombo,
-  availabilityShortfalls,
+  allocation,
+  onAllocationChange,
+  includedLeafKeys,
+  onIncludedLeafKeysChange,
   availabilityLoading,
   availabilityError,
+  allocationStale,
   onNext,
   onBack,
 }: ShopAssemblyStepProps) {
-  // Creating this request RESERVES the hardware it needs (#342), so the selection has to fit inside
-  // what is actually free right now. Blocking here rather than letting the server refuse the whole
-  // finalize is the point: this is the last screen where refining the selection is cheap.
-  const canProceed = useMemo(
-    () =>
-      sarRequestNumber.trim() !== '' &&
-      openingDrafts.length > 0 &&
-      availabilityShortfalls.length === 0 &&
-      !availabilityLoading &&
-      !availabilityError,
-    [sarRequestNumber, openingDrafts, availabilityShortfalls, availabilityLoading, availabilityError],
+  const availableByCombo = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [key, row] of availabilityByCombo) map.set(key, row.availableQuantity);
+    return map;
+  }, [availabilityByCombo]);
+
+  const runAutoAssign = useCallback(() => {
+    const next = autoAssign(openingDrafts, availableByCombo);
+    onAllocationChange(next);
+    onIncludedLeafKeysChange(
+      new Set(
+        openingDrafts
+          .filter((draft) => leafCoverage(next, draft) !== 'NONE')
+          .map((draft) => leafKey(draft)),
+      ),
+    );
+  }, [openingDrafts, availableByCombo, onAllocationChange, onIncludedLeafKeysChange]);
+
+  // Auto-assign runs **once**, when the step first has real numbers to work with, and never again on
+  // its own. Re-running silently would throw away every manual move the moment an unrelated query
+  // refetched; the user re-runs it deliberately with the button, and a race refusal re-runs it while
+  // saying so. Waiting for the lookup to answer matters too - an empty availability map reads as
+  // "nothing available" and would allocate nothing to everything.
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current || availabilityLoading || availabilityError || openingDrafts.length === 0) return;
+    seeded.current = true;
+    runAutoAssign();
+  }, [availabilityLoading, availabilityError, openingDrafts, runAutoAssign]);
+
+  const pool = useMemo(
+    () => remainingPool(openingDrafts, allocation, availableByCombo, includedLeafKeys),
+    [openingDrafts, allocation, availableByCombo, includedLeafKeys],
   );
 
-  // What this request would claim, next to what is available. Sorted so the same combo is always in
-  // the same place between renders.
-  const demandRows = useMemo(
-    () =>
-      Array.from(requestedByCombo.entries())
-        .map(([key, requested]) => {
-          const [hardwareCategory, productCode] = key.split('|');
-          const row = availabilityByCombo.get(key);
-          return {
-            key,
-            hardwareCategory,
-            productCode,
-            requested,
-            available: row?.availableQuantity ?? 0,
-            reserved: row?.reservedQuantity ?? 0,
-          };
-        })
-        .sort(
-          (a, b) =>
-            a.hardwareCategory.localeCompare(b.hardwareCategory) ||
-            a.productCode.localeCompare(b.productCode),
-        ),
-    [requestedByCombo, availabilityByCombo],
+  const summaryRows = useMemo(
+    () => comboSummary(openingDrafts, allocation, availableByCombo, includedLeafKeys),
+    [openingDrafts, allocation, availableByCombo, includedLeafKeys],
   );
+
+  const totalShort = useMemo(() => summaryRows.reduce((sum, row) => sum + row.short, 0), [summaryRows]);
+  const includedCount = useMemo(
+    () =>
+      openingDrafts.filter(
+        (draft) => includedLeafKeys.has(leafKey(draft)) && leafAllocatedTotal(allocation, draft) > 0,
+      ).length,
+    [openingDrafts, includedLeafKeys, allocation],
+  );
+
+  // A shortfall no longer blocks. What has to be true is that there is a request to make: a number,
+  // at least one leaf carrying something, and availability numbers that are real rather than
+  // unknown. Sending short is now a decision the user is allowed to make, not an error state.
+  const canProceed =
+    sarRequestNumber.trim() !== '' && includedCount > 0 && !availabilityLoading && !availabilityError;
+
+  const handleLineChange = (
+    draft: ShopAssemblyOpeningDraft,
+    item: ShopAssemblyOpeningDraft['items'][number],
+    next: number,
+  ) => {
+    onAllocationChange(
+      setLineAllocation(allocation, draft, item, next, pool.get(comboKey(item)) ?? 0),
+    );
+  };
+
+  const toggleLeaf = (draft: ShopAssemblyOpeningDraft) => {
+    const key = leafKey(draft);
+    const next = new Set(includedLeafKeys);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    onIncludedLeafKeysChange(next);
+  };
 
   return (
     <Box>
@@ -111,13 +167,11 @@ export default function ShopAssemblyStep({
         sx={{ mb: 3, width: 300 }}
       />
 
-      <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-        Shop Assembly Preview
-      </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Openings with items classified as Shop Hardware (in the Classification step) will be
-        included. Creating the request reserves this hardware, so it has to fit what is available
-        now.
+        Openings with items classified as Shop Hardware (in the Classification step) are listed below.
+        Creating the request reserves what you assign here, so a leaf can only claim hardware that is
+        genuinely free. Leaves that come up short still go to the shop - assign what you can and send
+        them, or leave them out.
       </Typography>
 
       {openingDrafts.length === 0 && (
@@ -127,83 +181,63 @@ export default function ShopAssemblyStep({
         </Alert>
       )}
 
-      <List dense>
-        {openingDrafts.map((draft) => (
-          <ListItem key={`${draft.openingNumber}|${draft.leaf ?? 'none'}`}>
-            <ListItemIcon>
-              <CheckCircleIcon color="success" fontSize="small" />
-            </ListItemIcon>
-            <ListItemText
-              primary={draft.openingNumber + leafSuffix(draft.leaf)}
-              secondary={`${draft.items.length} shop hardware items`}
-            />
-          </ListItem>
-        ))}
-      </List>
-
       {availabilityError && (
-        <Alert severity="error" sx={{ mt: 2 }}>
+        <Alert severity="error" sx={{ mb: 2 }}>
           Could not read this project's available inventory, so the counts below are unknown rather
           than zero. Go back and retry before creating the request.
         </Alert>
       )}
 
       {availabilityLoading && !availabilityError && (
-        <Alert severity="info" sx={{ mt: 2 }}>
+        <Alert severity="info" sx={{ mb: 2 }}>
           Checking available inventory...
         </Alert>
       )}
 
-      {availabilityShortfalls.length > 0 && (
-        <Alert severity="error" sx={{ mt: 2 }}>
-          This selection asks for more hardware than is available. Available means on hand, minus
-          units flagged deficient, minus what other open requests have already reserved - so a
-          shortfall can mean the stock is here but spoken for. Reduce the selection, or release
-          another request.
-          <Box component="ul" sx={{ mt: 1, mb: 0, pl: 3 }}>
-            {availabilityShortfalls.map((s) => (
-              <li key={`${s.hardwareCategory}|${s.productCode}`}>
-                {s.hardwareCategory} {s.productCode}: need {s.requested}, {s.available} available
-                {s.reserved > 0 ? ` (${s.reserved} reserved by other requests)` : ''} - short{' '}
-                {s.short}
-              </li>
-            ))}
-          </Box>
+      {allocationStale && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Available inventory changed while this request was being built - another request claimed
+          some of it, or stock was written off. The allocation below has been rebuilt from the
+          current numbers. Review it before sending again.
         </Alert>
       )}
 
-      {demandRows.length > 0 && (
-        <Box sx={{ mt: 3 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-            Hardware this request would reserve
-          </Typography>
+      {summaryRows.length > 0 && (
+        <Box sx={{ mb: 3 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Hardware this request would reserve
+            </Typography>
+            <Button size="small" startIcon={<RestartAltIcon />} onClick={runAutoAssign}>
+              Re-run auto-assign
+            </Button>
+          </Stack>
           <Table size="small">
             <TableHead>
               <TableRow>
                 <TableCell>Product Code</TableCell>
                 <TableCell>Hardware Category</TableCell>
-                <TableCell align="right">Needed</TableCell>
+                <TableCell align="right">Owed</TableCell>
                 <TableCell align="right">Available</TableCell>
-                <TableCell align="right">Reserved elsewhere</TableCell>
-                <TableCell />
+                <TableCell align="right">Allocated</TableCell>
+                <TableCell align="right">Left to assign</TableCell>
+                <TableCell align="right">Short</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {demandRows.map((row) => (
+              {summaryRows.map((row) => (
                 <TableRow key={row.key}>
                   <TableCell>{row.productCode}</TableCell>
                   <TableCell>{row.hardwareCategory}</TableCell>
-                  <TableCell align="right">{row.requested}</TableCell>
+                  <TableCell align="right">{row.owed}</TableCell>
                   <TableCell align="right">{availabilityError ? '?' : row.available}</TableCell>
-                  <TableCell align="right">{availabilityError ? '?' : row.reserved}</TableCell>
-                  <TableCell>
-                    {!availabilityError && row.requested > row.available && (
-                      <Chip
-                        size="small"
-                        variant="outlined"
-                        color="error"
-                        label={`Short ${row.requested - row.available}`}
-                      />
+                  <TableCell align="right">{row.allocated}</TableCell>
+                  <TableCell align="right">{availabilityError ? '?' : row.remaining}</TableCell>
+                  <TableCell align="right">
+                    {row.short > 0 ? (
+                      <Chip size="small" variant="outlined" color="warning" label={row.short} />
+                    ) : (
+                      0
                     )}
                   </TableCell>
                 </TableRow>
@@ -212,6 +246,142 @@ export default function ShopAssemblyStep({
           </Table>
         </Box>
       )}
+
+      {totalShort > 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          This request will be sent {totalShort} unit(s) short of what the schedule calls for.
+          Available means on hand, minus units flagged deficient, minus what other open requests have
+          already reserved - so a shortfall can mean the stock is here but spoken for. The short
+          units are not pulled and not owed to the assembler; purchasing is told about them when the
+          request is sent.
+        </Alert>
+      )}
+
+      <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+        Door leaves ({includedCount} of {openingDrafts.length} being sent)
+      </Typography>
+
+      <Stack spacing={1.5}>
+        {openingDrafts.map((draft) => {
+          const key = leafKey(draft);
+          const coverage = leafCoverage(allocation, draft);
+          const autoDropped = coverage === 'NONE';
+          const included = includedLeafKeys.has(key) && !autoDropped;
+          const owed = draft.items.reduce((sum, item) => sum + item.quantity, 0);
+          const allocated = leafAllocatedTotal(allocation, draft);
+
+          return (
+            <Paper
+              key={key}
+              variant="outlined"
+              sx={{ p: 1.5, opacity: autoDropped ? 0.55 : included ? 1 : 0.75 }}
+            >
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                  {draft.openingNumber}
+                  {leafSuffix(draft.leaf)}
+                </Typography>
+                {coverage === 'FULL' && <Chip size="small" color="success" label="Fully covered" />}
+                {coverage === 'PARTIAL' && <Chip size="small" color="warning" label="Partial" />}
+                {autoDropped && (
+                  <Tooltip title="No hardware could be allocated to this leaf, so there would be nothing to pull, stage or assemble. It is left out of the request.">
+                    <Chip size="small" variant="outlined" label="Not covered - auto-dropped" />
+                  </Tooltip>
+                )}
+                <Box sx={{ flexGrow: 1 }} />
+                <Typography variant="caption" color="text.secondary">
+                  {allocated} of {owed} allocated
+                </Typography>
+                <Tooltip
+                  title={
+                    autoDropped
+                      ? 'Nothing is allocated to this leaf, so there is nothing to send.'
+                      : included
+                        ? 'Leave this leaf out - its hardware goes back to the pool for the other leaves.'
+                        : 'Include this leaf in the request.'
+                  }
+                >
+                  <span>
+                    <Switch
+                      size="small"
+                      checked={included}
+                      disabled={autoDropped}
+                      onChange={() => toggleLeaf(draft)}
+                      // `role` is restated because slotProps.input replaces the default input
+                      // props rather than merging with them, and dropping it would turn the control
+                      // back into a plain checkbox for anyone using a screen reader.
+                      slotProps={{
+                        input: {
+                          role: 'switch',
+                          'aria-label': `Include ${draft.openingNumber}${leafSuffix(draft.leaf)}`,
+                        },
+                      }}
+                    />
+                  </span>
+                </Tooltip>
+              </Stack>
+
+              <Divider sx={{ mb: 1 }} />
+
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Product Code</TableCell>
+                    <TableCell>Hardware Category</TableCell>
+                    <TableCell align="right">Owed</TableCell>
+                    <TableCell align="center">Allocated</TableCell>
+                    <TableCell />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {draft.items.map((item) => {
+                    const current = allocatedFor(allocation, draft, item);
+                    const ceiling = clampCeiling(
+                      item.quantity,
+                      current,
+                      included ? (pool.get(comboKey(item)) ?? 0) : 0,
+                    );
+                    const short = item.quantity - current;
+                    return (
+                      <TableRow key={comboKey(item)}>
+                        <TableCell>{item.productCode}</TableCell>
+                        <TableCell>{item.hardwareCategory}</TableCell>
+                        <TableCell align="right">{item.quantity}</TableCell>
+                        <TableCell align="center">
+                          <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5}>
+                            <IconButton
+                              size="small"
+                              disabled={!included || current <= 0}
+                              onClick={() => handleLineChange(draft, item, current - 1)}
+                              aria-label={`Remove one ${item.productCode}`}
+                            >
+                              <RemoveIcon fontSize="inherit" />
+                            </IconButton>
+                            <Box sx={{ minWidth: 28, textAlign: 'center' }}>{current}</Box>
+                            <IconButton
+                              size="small"
+                              disabled={!included || current >= ceiling}
+                              onClick={() => handleLineChange(draft, item, current + 1)}
+                              aria-label={`Add one ${item.productCode}`}
+                            >
+                              <AddIcon fontSize="inherit" />
+                            </IconButton>
+                          </Stack>
+                        </TableCell>
+                        <TableCell>
+                          {short > 0 && (
+                            <Chip size="small" variant="outlined" color="warning" label={`${short} short`} />
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </Paper>
+          );
+        })}
+      </Stack>
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
         <Button onClick={onBack}>Back</Button>

--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
   Alert,
   Box,
@@ -28,6 +28,7 @@ import {
   clampCeiling,
   comboKey,
   comboSummary,
+  draftsSignature,
   leafAllocatedTotal,
   leafCoverage,
   leafKey,
@@ -51,6 +52,13 @@ interface ShopAssemblyStepProps {
   /** Leaves the user has kept in the request. Auto-dropped leaves are never in here. */
   includedLeafKeys: Set<string>;
   onIncludedLeafKeysChange: (next: Set<string>) => void;
+  /**
+   * The draft signature the current allocation was seeded from, or null if it never has been.
+   * Owned by the wizard because this step unmounts every time the user steps away from it - a flag
+   * held here would reset on the way back and auto-assign would wipe their manual moves.
+   */
+  seededSignature: string | null;
+  onSeeded: (signature: string) => void;
   /** The availability lookup has not answered yet, so the counts below are not final. */
   availabilityLoading: boolean;
   /** The availability lookup failed; the counts are unknown, not zero. */
@@ -73,6 +81,8 @@ export default function ShopAssemblyStep({
   onAllocationChange,
   includedLeafKeys,
   onIncludedLeafKeysChange,
+  seededSignature,
+  onSeeded,
   availabilityLoading,
   availabilityError,
   allocationStale,
@@ -97,17 +107,28 @@ export default function ShopAssemblyStep({
     );
   }, [openingDrafts, availableByCombo, onAllocationChange, onIncludedLeafKeysChange]);
 
-  // Auto-assign runs **once**, when the step first has real numbers to work with, and never again on
-  // its own. Re-running silently would throw away every manual move the moment an unrelated query
-  // refetched; the user re-runs it deliberately with the button, and a race refusal re-runs it while
-  // saying so. Waiting for the lookup to answer matters too - an empty availability map reads as
-  // "nothing available" and would allocate nothing to everything.
-  const seeded = useRef(false);
+  // Auto-assign seeds the allocation **once per set of drafts**, and never re-runs on its own after
+  // that. Re-running silently would throw away every manual move - on a refetch, or simply on the
+  // way back from the next step - so what it keys on is whether the drafts still describe what the
+  // current allocation was built from, not whether this component happens to be freshly mounted. The
+  // user re-runs it deliberately with the button, and a race refusal re-runs it while saying so.
+  // Waiting for the lookup to answer matters too: an empty availability map reads as "nothing
+  // available" and would allocate nothing to everything.
+  const signature = useMemo(() => draftsSignature(openingDrafts), [openingDrafts]);
   useEffect(() => {
-    if (seeded.current || availabilityLoading || availabilityError || openingDrafts.length === 0) return;
-    seeded.current = true;
+    if (availabilityLoading || availabilityError || openingDrafts.length === 0) return;
+    if (seededSignature === signature) return;
     runAutoAssign();
-  }, [availabilityLoading, availabilityError, openingDrafts, runAutoAssign]);
+    onSeeded(signature);
+  }, [
+    availabilityLoading,
+    availabilityError,
+    openingDrafts,
+    runAutoAssign,
+    seededSignature,
+    signature,
+    onSeeded,
+  ]);
 
   const pool = useMemo(
     () => remainingPool(openingDrafts, allocation, availableByCombo, includedLeafKeys),

--- a/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
+++ b/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
@@ -16,6 +16,7 @@ function leaf(overrides: Partial<AssembledLeafCandidate> = {}): AssembledLeafCan
     leaf: 1,
     installedHardware: [{ productCode: 'HG-100', quantity: 3 }],
     awaitingReplacementQuantity: 0,
+    neverPulledQuantity: 0,
     ...overrides,
   };
 }
@@ -56,7 +57,22 @@ function leafCheckbox() {
 it('flags a leaf that is still awaiting replacement hardware', () => {
   renderStep([leaf({ awaitingReplacementQuantity: 2 })]);
   expect(screen.getByText(/Incomplete - awaiting replacement/i)).toBeInTheDocument();
-  expect(screen.getByText(/2 unit\(s\) still awaiting replacement/i)).toBeInTheDocument();
+  expect(screen.getByText(/awaiting replacement hardware for 2 unit\(s\)/i)).toBeInTheDocument();
+});
+
+it('flags a leaf that is merely short, with nothing condemned', () => {
+  // The other half of the same decision, and the one with no replacement coming. The server refuses
+  // it too, so without a confirm here the leaf could never be shipped at all.
+  renderStep([leaf({ neverPulledQuantity: 3 })]);
+  expect(screen.getByText(/Incomplete - never pulled/i)).toBeInTheDocument();
+  expect(screen.getByText(/missing 3 unit\(s\) that were never pulled/i)).toBeInTheDocument();
+});
+
+it('names both counts when a leaf is short in both ways', () => {
+  renderStep([leaf({ awaitingReplacementQuantity: 1, neverPulledQuantity: 2 })]);
+  expect(
+    screen.getByText(/awaiting replacement hardware for 1 unit\(s\), and missing 2 unit\(s\)/i),
+  ).toBeInTheDocument();
 });
 
 it('does not flag a whole leaf', () => {

--- a/frontend/src/modules/import/__tests__/allocation.test.ts
+++ b/frontend/src/modules/import/__tests__/allocation.test.ts
@@ -4,6 +4,7 @@ import {
   buildAllocatedDrafts,
   clampCeiling,
   comboSummary,
+  draftsSignature,
   leafAllocatedTotal,
   leafCoverage,
   leafKey,
@@ -221,5 +222,47 @@ describe('buildAllocatedDrafts', () => {
   it('drops a leaf the user excluded even though it is fully covered', () => {
     const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
     expect(buildAllocatedDrafts(drafts, autoAssign(drafts, pool([['HINGE|HG-100', 4]])), new Set())).toEqual([]);
+  });
+});
+
+describe('comboSummary and buildAllocatedDrafts agree on what is being sent', () => {
+  it('does not count a leaf steppered down to zero as short', () => {
+    // Its toggle is disabled and buildAllocatedDrafts drops it, so the server never learns its owed
+    // quantities. Reporting them as short would show the user a shortfall purchasing is never told
+    // about - the two readings have to describe the same request.
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const available = pool([['HINGE|HG-100', 8]]);
+    let allocation = autoAssign(drafts, available);
+    allocation = setLineAllocation(allocation, drafts[1], drafts[1].items[0], 0, 4);
+
+    const rows = comboSummary(drafts, allocation, available, allKeys(drafts));
+    expect(rows[0]).toMatchObject({ owed: 4, allocated: 4, short: 0 });
+    expect(buildAllocatedDrafts(drafts, allocation, allKeys(drafts))).toHaveLength(1);
+  });
+});
+
+describe('draftsSignature', () => {
+  it('is stable across rebuilt draft objects, so stepping away and back does not re-seed', () => {
+    const first = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const second = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    expect(draftsSignature(first)).toBe(draftsSignature(second));
+  });
+
+  it('changes when a leaf is added, so a new selection does get re-seeded', () => {
+    const before = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const after = [...before, draft('A02', [['HINGE', 'HG-100', 4]])];
+    expect(draftsSignature(before)).not.toBe(draftsSignature(after));
+  });
+
+  it('changes when an owed quantity changes', () => {
+    expect(draftsSignature([draft('A01', [['HINGE', 'HG-100', 4]])])).not.toBe(
+      draftsSignature([draft('A01', [['HINGE', 'HG-100', 5]])]),
+    );
+  });
+
+  it('does not depend on the order leaves arrive in', () => {
+    const a = draft('A01', [['HINGE', 'HG-100', 2]]);
+    const b = draft('A02', [['HINGE', 'HG-100', 2]]);
+    expect(draftsSignature([a, b])).toBe(draftsSignature([b, a]));
   });
 });

--- a/frontend/src/modules/import/__tests__/allocation.test.ts
+++ b/frontend/src/modules/import/__tests__/allocation.test.ts
@@ -1,0 +1,225 @@
+import {
+  allocatedFor,
+  autoAssign,
+  buildAllocatedDrafts,
+  clampCeiling,
+  comboSummary,
+  leafAllocatedTotal,
+  leafCoverage,
+  leafKey,
+  remainingPool,
+  setLineAllocation,
+  type ShopAssemblyOpeningDraft,
+} from '../allocation';
+
+/**
+ * The assignment rules behind the shop-assembly allocator.
+ *
+ * These are the numbers the requester is held to and the numbers the server reserves against, so
+ * they are worth pinning down without rendering anything. The single property everything else hangs
+ * off: a leaf never gets more than it is owed, and the combos never hand out more than is available.
+ */
+
+const draft = (
+  openingNumber: string,
+  items: Array<[string, string, number]>,
+  leaf: number | null = 1,
+): ShopAssemblyOpeningDraft => ({
+  openingNumber,
+  leaf,
+  items: items.map(([hardwareCategory, productCode, quantity]) => ({
+    hardwareCategory,
+    productCode,
+    quantity,
+  })),
+});
+
+const pool = (entries: Array<[string, number]>) => new Map(entries);
+const allKeys = (drafts: ShopAssemblyOpeningDraft[]) => new Set(drafts.map((d) => leafKey(d)));
+
+describe('autoAssign', () => {
+  it('gives every leaf its full owed quantity when the pool covers everything', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 8]]));
+    expect(leafAllocatedTotal(allocation, drafts[0])).toBe(4);
+    expect(leafAllocatedTotal(allocation, drafts[1])).toBe(4);
+    expect(drafts.map((d) => leafCoverage(allocation, d))).toEqual(['FULL', 'FULL']);
+  });
+
+  it('fills whole leaves in schedule order rather than spreading scarcity across all of them', () => {
+    // 6 hinges, 3 leaves wanting 4 each. Spreading gives three unassemblable half-leaves; filling in
+    // order gives one finished leaf, one partial and one that is simply not sent.
+    const drafts = [
+      draft('A01', [['HINGE', 'HG-100', 4]]),
+      draft('A02', [['HINGE', 'HG-100', 4]]),
+      draft('A03', [['HINGE', 'HG-100', 4]]),
+    ];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 6]]));
+    expect(drafts.map((d) => leafAllocatedTotal(allocation, d))).toEqual([4, 2, 0]);
+    expect(drafts.map((d) => leafCoverage(allocation, d))).toEqual(['FULL', 'PARTIAL', 'NONE']);
+  });
+
+  it('allocates nothing when the pool is empty, and reports every leaf as not covered', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 0]]));
+    expect(leafAllocatedTotal(allocation, drafts[0])).toBe(0);
+    expect(leafCoverage(allocation, drafts[0])).toBe('NONE');
+  });
+
+  it('treats a combo with no availability row as zero, not as unlimited', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    expect(leafAllocatedTotal(autoAssign(drafts, pool([])), drafts[0])).toBe(0);
+  });
+
+  it('keeps combos independent - one running out does not starve another', () => {
+    const drafts = [
+      draft('A01', [
+        ['HINGE', 'HG-100', 4],
+        ['CLOSER', 'CL-1', 1],
+      ]),
+      draft('A02', [
+        ['HINGE', 'HG-100', 4],
+        ['CLOSER', 'CL-1', 1],
+      ]),
+    ];
+    const allocation = autoAssign(
+      drafts,
+      pool([
+        ['HINGE|HG-100', 4],
+        ['CLOSER|CL-1', 2],
+      ]),
+    );
+    expect(allocatedFor(allocation, drafts[1], drafts[1].items[0])).toBe(0);
+    expect(allocatedFor(allocation, drafts[1], drafts[1].items[1])).toBe(1);
+    // A leaf with one line covered and one not is PARTIAL, not NONE - it still has a cart to build.
+    expect(leafCoverage(allocation, drafts[1])).toBe('PARTIAL');
+  });
+
+  it('never hands a leaf more than it is owed, even with stock to spare', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 2]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 99]]));
+    expect(leafAllocatedTotal(allocation, drafts[0])).toBe(2);
+  });
+
+  it('is deterministic - the same inputs give the same allocation', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 3]]), draft('A02', [['HINGE', 'HG-100', 3]])];
+    const first = autoAssign(drafts, pool([['HINGE|HG-100', 4]]));
+    const second = autoAssign(drafts, pool([['HINGE|HG-100', 4]]));
+    expect(drafts.map((d) => leafAllocatedTotal(first, d))).toEqual(
+      drafts.map((d) => leafAllocatedTotal(second, d)),
+    );
+  });
+
+  it('distinguishes the two leaves of a pair', () => {
+    // Same opening number, different leaves: two work units, two carts, two allocations.
+    const drafts = [
+      draft('A01', [['HINGE', 'HG-100', 2]], 1),
+      draft('A01', [['HINGE', 'HG-100', 2]], 2),
+    ];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 3]]));
+    expect(drafts.map((d) => leafAllocatedTotal(allocation, d))).toEqual([2, 1]);
+  });
+});
+
+describe('remainingPool', () => {
+  it('counts only the included leaves, so an excluded one hands its hardware back', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const available = pool([['HINGE|HG-100', 6]]);
+    const allocation = autoAssign(drafts, available);
+    expect(remainingPool(drafts, allocation, available, allKeys(drafts)).get('HINGE|HG-100')).toBe(0);
+    // Drop A01 and its 4 units are assignable again.
+    const withoutFirst = new Set([leafKey(drafts[1])]);
+    expect(remainingPool(drafts, allocation, available, withoutFirst).get('HINGE|HG-100')).toBe(4);
+  });
+});
+
+describe('clampCeiling', () => {
+  it('never exceeds what the line is owed', () => {
+    expect(clampCeiling(4, 2, 99)).toBe(4);
+  });
+
+  it('never exceeds what the line holds plus what is left in the pool', () => {
+    expect(clampCeiling(10, 2, 3)).toBe(5);
+  });
+
+  it('holds at the current value when the pool is empty', () => {
+    expect(clampCeiling(10, 2, 0)).toBe(2);
+  });
+
+  it('does not go negative on an over-drawn pool', () => {
+    expect(clampCeiling(10, 0, -5)).toBe(0);
+  });
+});
+
+describe('setLineAllocation', () => {
+  it('clamps a raise to what is actually assignable', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 2]]));
+    const next = setLineAllocation(allocation, drafts[0], drafts[0].items[0], 4, 0);
+    expect(allocatedFor(next, drafts[0], drafts[0].items[0])).toBe(2);
+  });
+
+  it('allows lowering freely, and floors at zero', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 4]]));
+    const next = setLineAllocation(allocation, drafts[0], drafts[0].items[0], -3, 0);
+    expect(allocatedFor(next, drafts[0], drafts[0].items[0])).toBe(0);
+  });
+
+  it('does not mutate the allocation it was given', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    const allocation = autoAssign(drafts, pool([['HINGE|HG-100', 4]]));
+    setLineAllocation(allocation, drafts[0], drafts[0].items[0], 1, 0);
+    expect(allocatedFor(allocation, drafts[0], drafts[0].items[0])).toBe(4);
+  });
+});
+
+describe('comboSummary', () => {
+  it('totals owed, allocated, what is left and what is short across the included leaves', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const available = pool([['HINGE|HG-100', 6]]);
+    const rows = comboSummary(drafts, autoAssign(drafts, available), available, allKeys(drafts));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ owed: 8, available: 6, allocated: 6, remaining: 0, short: 2 });
+  });
+
+  it('does not count an excluded leaf as short - it is not in the request at all', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const available = pool([['HINGE|HG-100', 6]]);
+    const allocation = autoAssign(drafts, available);
+    const rows = comboSummary(drafts, allocation, available, new Set([leafKey(drafts[0])]));
+    expect(rows[0]).toMatchObject({ owed: 4, allocated: 4, short: 0, remaining: 2 });
+  });
+});
+
+describe('buildAllocatedDrafts', () => {
+  it('sends owed and allocated per line, and drops leaves with nothing on them', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]]), draft('A02', [['HINGE', 'HG-100', 4]])];
+    const payload = buildAllocatedDrafts(drafts, autoAssign(drafts, pool([['HINGE|HG-100', 4]])), allKeys(drafts));
+    expect(payload).toHaveLength(1);
+    expect(payload[0].openingNumber).toBe('A01');
+    expect(payload[0].items[0]).toMatchObject({ quantity: 4, allocatedQuantity: 4 });
+  });
+
+  it('keeps a zero line on a leaf that other lines cover, so the checklist stays whole', () => {
+    // Owed is the schedule's number and the leaf still takes that closer; it just did not get one.
+    const drafts = [
+      draft('A01', [
+        ['HINGE', 'HG-100', 2],
+        ['CLOSER', 'CL-1', 1],
+      ]),
+    ];
+    const payload = buildAllocatedDrafts(
+      drafts,
+      autoAssign(drafts, pool([['HINGE|HG-100', 2]])),
+      allKeys(drafts),
+    );
+    expect(payload[0].items).toHaveLength(2);
+    expect(payload[0].items[1]).toMatchObject({ productCode: 'CL-1', quantity: 1, allocatedQuantity: 0 });
+  });
+
+  it('drops a leaf the user excluded even though it is fully covered', () => {
+    const drafts = [draft('A01', [['HINGE', 'HG-100', 4]])];
+    expect(buildAllocatedDrafts(drafts, autoAssign(drafts, pool([['HINGE|HG-100', 4]])), new Set())).toEqual([]);
+  });
+});

--- a/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
+++ b/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
@@ -88,6 +88,8 @@ const SA_DRAFTS = [
 function Harness({ drafts, ...props }: { drafts: typeof SA_DRAFTS } & Record<string, unknown>) {
   const [allocation, setAllocation] = useState<Allocation>(new Map());
   const [included, setIncluded] = useState<Set<string>>(new Set());
+  // The wizard owns this so the step can remount without re-seeding over the user's manual moves.
+  const [seededSignature, setSeededSignature] = useState<string | null>(null);
   return (
     <ShopAssemblyStep
       sarRequestNumber="SA-1"
@@ -98,6 +100,8 @@ function Harness({ drafts, ...props }: { drafts: typeof SA_DRAFTS } & Record<str
       onAllocationChange={setAllocation}
       includedLeafKeys={included}
       onIncludedLeafKeysChange={setIncluded}
+      seededSignature={seededSignature}
+      onSeeded={setSeededSignature}
       availabilityLoading={false}
       availabilityError={false}
       allocationStale={false}

--- a/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
+++ b/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import ShopAssemblyStep from '../ShopAssemblyStep';
 import ShippingPRsStep from '../ShippingPRsStep';
 import type {
@@ -7,15 +8,16 @@ import type {
   ShippingPRDraft,
 } from '../types';
 import { computeAvailabilityShortfalls } from '../types';
+import type { Allocation } from '../allocation';
 
 /**
- * Reservation-aware availability gating in Start a Task (#342).
+ * Reservation-aware availability gating in Start a Task (#342), and the allocator that replaced the
+ * all-or-nothing half of it.
  *
- * Creating a shop-assembly or shipping-out request RESERVES the hardware it needs, so the server
- * refuses a selection that does not fit `on-hand - deficient - other requests' reservations`. The
- * wizard applies the same numbers and blocks before submission - this is the last screen where
- * refining the selection is cheap, and a bounced finalize tells the user nothing they can act on
- * without starting over.
+ * Creating a shipping-out request still RESERVES what it needs and is still refused whole if it does
+ * not fit. Shop assembly is not: the requester assigns what is available to leaves, partially covered
+ * leaves stay in the request, and the send/don't-send call is theirs. Both wizards apply the same
+ * numbers the server does, because this is the last screen where refining is cheap.
  */
 
 function availability(rows: Partial<InventoryAvailabilityRow>[]): Map<string, InventoryAvailabilityRow> {
@@ -63,7 +65,7 @@ describe('computeAvailabilityShortfalls', () => {
   });
 });
 
-// ---- shop assembly step ----
+// ---- shop assembly step (the allocator) ----
 
 const SA_DRAFTS = [
   {
@@ -71,65 +73,123 @@ const SA_DRAFTS = [
     leaf: 1,
     items: [{ hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 4 }],
   },
+  {
+    openingNumber: 'A02',
+    leaf: 1,
+    items: [{ hardwareCategory: 'HINGE', productCode: 'HG-100', quantity: 4 }],
+  },
 ];
 
-function renderShopAssembly(overrides: Record<string, unknown> = {}) {
-  const onNext = vi.fn();
-  render(
+/**
+ * The step is controlled - the wizard owns the allocation so it survives a step change - so the
+ * harness has to own it too. Rendering it with a frozen allocation would make every assertion about
+ * moving hardware between leaves a no-op that still passed.
+ */
+function Harness({ drafts, ...props }: { drafts: typeof SA_DRAFTS } & Record<string, unknown>) {
+  const [allocation, setAllocation] = useState<Allocation>(new Map());
+  const [included, setIncluded] = useState<Set<string>>(new Set());
+  return (
     <ShopAssemblyStep
       sarRequestNumber="SA-1"
       onSarNumberChange={vi.fn()}
-      openingDrafts={SA_DRAFTS}
-      requestedByCombo={new Map([['HINGE|HG-100', 4]])}
+      openingDrafts={drafts}
       availabilityByCombo={availability([{ onHandQuantity: 10, availableQuantity: 10 }])}
-      availabilityShortfalls={[]}
+      allocation={allocation}
+      onAllocationChange={setAllocation}
+      includedLeafKeys={included}
+      onIncludedLeafKeysChange={setIncluded}
       availabilityLoading={false}
       availabilityError={false}
-      onNext={onNext}
+      allocationStale={false}
+      onNext={vi.fn()}
       onBack={vi.fn()}
-      {...overrides}
-    />,
+      {...props}
+    />
   );
-  return { onNext };
+}
+
+function renderShopAssembly(overrides: Record<string, unknown> = {}) {
+  render(<Harness drafts={SA_DRAFTS} {...overrides} />);
 }
 
 const nextButton = () => screen.getByRole('button', { name: 'Next' });
+const leafCard = (opening: string) =>
+  screen.getByText(opening, { exact: false }).closest('.MuiPaper-root')!;
 
-describe('ShopAssemblyStep availability gating', () => {
-  it('shows what the request would reserve against what is available', () => {
+describe('ShopAssemblyStep allocator', () => {
+  it('fills leaves in schedule order until the pool runs out', () => {
+    // 6 hinges, two leaves wanting 4 each: the first leaf is whole, the second gets the remainder.
+    // Whole leaves first is the point - half a leaf's hardware assembles nothing, and the leaf still
+    // occupies a cart and a bench either way.
+    renderShopAssembly({
+      availabilityByCombo: availability([{ onHandQuantity: 6, availableQuantity: 6 }]),
+    });
+    expect(leafCard('A01')).toHaveTextContent('4 of 4 allocated');
+    expect(leafCard('A01')).toHaveTextContent('Fully covered');
+    expect(leafCard('A02')).toHaveTextContent('2 of 4 allocated');
+    expect(leafCard('A02')).toHaveTextContent('Partial');
+    expect(leafCard('A02')).toHaveTextContent('2 short');
+  });
+
+  it('does NOT block on a shortfall - sending short is the requester decision', () => {
+    // The whole point of the slice: the old gate refused the request outright, so one leaf short of
+    // one hinge held up every leaf behind it.
+    renderShopAssembly({
+      availabilityByCombo: availability([{ onHandQuantity: 6, availableQuantity: 6 }]),
+    });
+    expect(nextButton()).toBeEnabled();
+    expect(screen.getByText(/2 unit\(s\) short of what the schedule calls for/)).toBeInTheDocument();
+  });
+
+  it('auto-drops a leaf nothing could be allocated to and leaves it out of the request', () => {
+    // An empty cart has nothing to pull, stage or assemble, and the server refuses one too.
+    renderShopAssembly({
+      availabilityByCombo: availability([{ onHandQuantity: 4, availableQuantity: 4 }]),
+    });
+    expect(leafCard('A02')).toHaveTextContent('auto-dropped');
+    expect(screen.getByText(/1 of 2 being sent/)).toBeInTheDocument();
+    // Still sendable: the covered leaf goes on its own.
+    expect(nextButton()).toBeEnabled();
+  });
+
+  it('frees units for a later leaf when an earlier one gives them back', () => {
+    renderShopAssembly({
+      availabilityByCombo: availability([{ onHandQuantity: 6, availableQuantity: 6 }]),
+    });
+    const minus = within(leafCard('A01')).getByRole('button', { name: 'Remove one HG-100' });
+    fireEvent.click(minus);
+    fireEvent.click(minus);
+    expect(leafCard('A01')).toHaveTextContent('2 of 4 allocated');
+    // The two freed hinges are now assignable on A02, which was capped at 2 a moment ago.
+    const plus = within(leafCard('A02')).getByRole('button', { name: 'Add one HG-100' });
+    fireEvent.click(plus);
+    fireEvent.click(plus);
+    expect(leafCard('A02')).toHaveTextContent('4 of 4 allocated');
+  });
+
+  it('returns an excluded leaf allocation to the pool', () => {
+    renderShopAssembly({
+      availabilityByCombo: availability([{ onHandQuantity: 6, availableQuantity: 6 }]),
+    });
+    fireEvent.click(within(leafCard('A01')).getByRole('switch', { name: /Include A01/ }));
+    // A01 is out, so the summary is A02 alone and the 4 hinges it was holding are assignable again.
+    expect(screen.getByText(/1 of 2 being sent/)).toBeInTheDocument();
+    const plus = within(leafCard('A02')).getByRole('button', { name: 'Add one HG-100' });
+    fireEvent.click(plus);
+    fireEvent.click(plus);
+    expect(leafCard('A02')).toHaveTextContent('4 of 4 allocated');
+  });
+
+  it('shows owed against available per combo', () => {
     renderShopAssembly({
       availabilityByCombo: availability([
         { onHandQuantity: 10, reservedQuantity: 3, availableQuantity: 7 },
       ]),
     });
     expect(screen.getByText('Hardware this request would reserve')).toBeInTheDocument();
-    const row = screen.getByText('HG-100').closest('tr')!;
-    expect(row).toHaveTextContent('4'); // needed
+    const row = screen.getAllByText('HG-100')[0].closest('tr')!;
+    expect(row).toHaveTextContent('8'); // owed across both leaves
     expect(row).toHaveTextContent('7'); // available
-    expect(row).toHaveTextContent('3'); // reserved elsewhere
-    expect(nextButton()).toBeEnabled();
-  });
-
-  it('blocks the step and names the short combo when the selection does not fit', () => {
-    renderShopAssembly({
-      availabilityByCombo: availability([
-        { onHandQuantity: 10, reservedQuantity: 8, availableQuantity: 2 },
-      ]),
-      availabilityShortfalls: [
-        {
-          hardwareCategory: 'HINGE',
-          productCode: 'HG-100',
-          requested: 4,
-          available: 2,
-          reserved: 8,
-          short: 2,
-        },
-      ],
-    });
-    expect(nextButton()).toBeDisabled();
-    expect(screen.getByText(/HINGE HG-100: need 4, 2 available/)).toBeInTheDocument();
-    // The distinction that matters: the stock is here, another request has it.
-    expect(screen.getByText(/8 reserved by other requests/)).toBeInTheDocument();
   });
 
   it('blocks while the availability lookup is still in flight', () => {
@@ -147,9 +207,20 @@ describe('ShopAssemblyStep availability gating', () => {
 
   it('blocks a request with no work units at all', () => {
     // A zero-opening request is refused server-side too (#342); catching it here saves the round trip.
-    renderShopAssembly({ openingDrafts: [], requestedByCombo: new Map() });
+    renderShopAssembly({ drafts: [] });
     expect(nextButton()).toBeDisabled();
     expect(screen.getByText(/nothing to send to shop assembly/i)).toBeInTheDocument();
+  });
+
+  it('blocks when every leaf was auto-dropped - there is no request to make', () => {
+    renderShopAssembly({ availabilityByCombo: availability([{ availableQuantity: 0 }]) });
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/0 of 2 being sent/)).toBeInTheDocument();
+  });
+
+  it('says the allocation was rebuilt after a race, rather than silently changing the numbers', () => {
+    renderShopAssembly({ allocationStale: true });
+    expect(screen.getByText(/Available inventory changed/)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/modules/import/allocation.ts
+++ b/frontend/src/modules/import/allocation.ts
@@ -1,0 +1,248 @@
+/**
+ * Assigning available inventory to door leaves, as pure functions.
+ *
+ * Shop assembly is deliberately not all-or-nothing. The old creation gate refused the whole request
+ * when the selection did not fit available stock, which meant one leaf short of one hinge held up
+ * every leaf behind it. The requester now decides: each checklist line gets an *allocated* quantity
+ * out of what is genuinely free, a partially-covered leaf still goes to the bench, and the
+ * send/don't-send call is theirs to make with the numbers in front of them.
+ *
+ * Nothing here touches React or Apollo on purpose - the assignment rules are the part that has to be
+ * exactly right, and they are worth testing without rendering anything.
+ */
+
+/** One assembly work unit (a door leaf) the wizard would submit, with its checklist aggregated. */
+export interface ShopAssemblyOpeningDraft {
+  openingNumber: string;
+  leaf: number | null;
+  items: Array<{ hardwareCategory: string; productCode: string; quantity: number }>;
+}
+
+/** Allocated quantity per checklist line, keyed by leaf then by combo. */
+export type Allocation = Map<string, Map<string, number>>;
+
+/** How much of a leaf's owed hardware it actually got. */
+export type LeafCoverage = 'FULL' | 'PARTIAL' | 'NONE';
+
+export const comboKey = (item: { hardwareCategory: string; productCode: string }) =>
+  `${item.hardwareCategory}|${item.productCode}`;
+
+/** Identity of a work unit. Opening number alone is not unique - a pair has two leaves. */
+export const leafKey = (draft: { openingNumber: string; leaf: number | null }) =>
+  `${draft.openingNumber}|${draft.leaf ?? 'none'}`;
+
+/**
+ * Fill leaves from the available pool, in schedule order, until each combo's pool runs out.
+ *
+ * First-leaf-first rather than spreading thinly across every leaf. Half a leaf's hardware assembles
+ * nothing: the leaf still occupies a cart, a bench and an assembler, and it still cannot ship. Whole
+ * leaves are what the shop can actually finish, so scarcity is pushed to the *end* of the schedule
+ * where it lands on the fewest leaves. Schedule order is also the order the site expects openings in.
+ *
+ * Deterministic by construction - same drafts and same pool in, same allocation out - which is what
+ * lets the step re-run it after a race without the numbers moving under the user for no reason.
+ */
+export function autoAssign(
+  drafts: ShopAssemblyOpeningDraft[],
+  availableByCombo: Map<string, number>,
+): Allocation {
+  const pool = new Map<string, number>();
+  const allocation: Allocation = new Map();
+
+  for (const draft of drafts) {
+    const lines = new Map<string, number>();
+    for (const item of draft.items) {
+      const key = comboKey(item);
+      if (!pool.has(key)) pool.set(key, Math.max(0, availableByCombo.get(key) ?? 0));
+      const remaining = pool.get(key)!;
+      const take = Math.min(item.quantity, remaining);
+      pool.set(key, remaining - take);
+      lines.set(key, take);
+    }
+    allocation.set(leafKey(draft), lines);
+  }
+  return allocation;
+}
+
+/** What one line was allocated. A line the allocation has never seen counts as zero, not as owed. */
+export function allocatedFor(
+  allocation: Allocation,
+  draft: ShopAssemblyOpeningDraft,
+  item: { hardwareCategory: string; productCode: string },
+): number {
+  return allocation.get(leafKey(draft))?.get(comboKey(item)) ?? 0;
+}
+
+/** Total allocated across a leaf's lines. Zero means an empty cart. */
+export function leafAllocatedTotal(allocation: Allocation, draft: ShopAssemblyOpeningDraft): number {
+  return draft.items.reduce((sum, item) => sum + allocatedFor(allocation, draft, item), 0);
+}
+
+/**
+ * How well a leaf is covered. NONE means nothing at all was allocated to it: an empty cart, with
+ * nothing to pull, stage or assemble, so the step drops it from the request rather than sending a
+ * work unit that could never be completed.
+ */
+export function leafCoverage(allocation: Allocation, draft: ShopAssemblyOpeningDraft): LeafCoverage {
+  let allocated = 0;
+  let owed = 0;
+  for (const item of draft.items) {
+    owed += item.quantity;
+    allocated += allocatedFor(allocation, draft, item);
+  }
+  if (allocated <= 0) return 'NONE';
+  return allocated >= owed ? 'FULL' : 'PARTIAL';
+}
+
+/**
+ * What is left of each combo's pool once the *included* leaves have taken their share.
+ *
+ * Excluded and auto-dropped leaves hand their allocation back, which is what makes the exclude
+ * toggle mean something: the freed units become assignable on a leaf the user would rather send.
+ */
+export function remainingPool(
+  drafts: ShopAssemblyOpeningDraft[],
+  allocation: Allocation,
+  availableByCombo: Map<string, number>,
+  includedLeafKeys: ReadonlySet<string>,
+): Map<string, number> {
+  const pool = new Map<string, number>();
+  for (const draft of drafts) {
+    for (const item of draft.items) {
+      const key = comboKey(item);
+      if (!pool.has(key)) pool.set(key, Math.max(0, availableByCombo.get(key) ?? 0));
+    }
+  }
+  for (const draft of drafts) {
+    if (!includedLeafKeys.has(leafKey(draft))) continue;
+    for (const item of draft.items) {
+      const key = comboKey(item);
+      pool.set(key, (pool.get(key) ?? 0) - allocatedFor(allocation, draft, item));
+    }
+  }
+  return pool;
+}
+
+/**
+ * The most this line could be raised to right now: never above what the leaf is owed, and never
+ * above what this line already holds plus what is left in the pool.
+ *
+ * Written as a ceiling rather than a "can I add N" predicate because it is what the stepper's max
+ * has to be, and deriving the two separately is how they drift apart.
+ */
+export function clampCeiling(owed: number, allocatedNow: number, poolRemaining: number): number {
+  return Math.max(0, Math.min(owed, allocatedNow + Math.max(0, poolRemaining)));
+}
+
+/** Set one line's allocation, clamped to what is actually assignable. Returns a new Allocation. */
+export function setLineAllocation(
+  allocation: Allocation,
+  draft: ShopAssemblyOpeningDraft,
+  item: { hardwareCategory: string; productCode: string; quantity: number },
+  requested: number,
+  poolRemaining: number,
+): Allocation {
+  const ceiling = clampCeiling(item.quantity, allocatedFor(allocation, draft, item), poolRemaining);
+  const next = new Map(allocation);
+  const lines = new Map(next.get(leafKey(draft)) ?? []);
+  lines.set(comboKey(item), Math.max(0, Math.min(requested, ceiling)));
+  next.set(leafKey(draft), lines);
+  return next;
+}
+
+/** One row of the combo summary: the whole request's claim on one product, at a glance. */
+export interface ComboSummaryRow {
+  key: string;
+  hardwareCategory: string;
+  productCode: string;
+  owed: number;
+  available: number;
+  allocated: number;
+  remaining: number;
+  short: number;
+}
+
+/**
+ * Per-combo totals over the included leaves only.
+ *
+ * `short` is owed minus allocated across *included* leaves - what this request is knowingly sending
+ * without. A leaf the user excluded is not short, it is simply not in the request.
+ */
+export function comboSummary(
+  drafts: ShopAssemblyOpeningDraft[],
+  allocation: Allocation,
+  availableByCombo: Map<string, number>,
+  includedLeafKeys: ReadonlySet<string>,
+): ComboSummaryRow[] {
+  const rows = new Map<string, ComboSummaryRow>();
+  for (const draft of drafts) {
+    if (!includedLeafKeys.has(leafKey(draft))) continue;
+    for (const item of draft.items) {
+      const key = comboKey(item);
+      let row = rows.get(key);
+      if (!row) {
+        row = {
+          key,
+          hardwareCategory: item.hardwareCategory,
+          productCode: item.productCode,
+          owed: 0,
+          available: Math.max(0, availableByCombo.get(key) ?? 0),
+          allocated: 0,
+          remaining: 0,
+          short: 0,
+        };
+        rows.set(key, row);
+      }
+      row.owed += item.quantity;
+      row.allocated += allocatedFor(allocation, draft, item);
+    }
+  }
+  const result = Array.from(rows.values());
+  for (const row of result) {
+    row.remaining = Math.max(0, row.available - row.allocated);
+    row.short = Math.max(0, row.owed - row.allocated);
+  }
+  result.sort(
+    (a, b) =>
+      a.hardwareCategory.localeCompare(b.hardwareCategory) || a.productCode.localeCompare(b.productCode),
+  );
+  return result;
+}
+
+/** A draft plus the allocated quantity per line, exactly as the finalize mutation takes it. */
+export interface AllocatedOpeningDraft {
+  openingNumber: string;
+  leaf: number | null;
+  items: Array<{
+    hardwareCategory: string;
+    productCode: string;
+    quantity: number;
+    allocatedQuantity: number;
+  }>;
+}
+
+/**
+ * The payload: the included leaves that have something allocated, carrying both numbers per line.
+ *
+ * Owed is sent unchanged even on a line that got nothing - the checklist is what the leaf takes, and
+ * the schedule is the authority on that. Leaves with nothing at all are dropped, because an empty
+ * cart is not a work unit; the server refuses one too, as a backstop for a race.
+ */
+export function buildAllocatedDrafts(
+  drafts: ShopAssemblyOpeningDraft[],
+  allocation: Allocation,
+  includedLeafKeys: ReadonlySet<string>,
+): AllocatedOpeningDraft[] {
+  return drafts
+    .filter((draft) => includedLeafKeys.has(leafKey(draft)) && leafAllocatedTotal(allocation, draft) > 0)
+    .map((draft) => ({
+      openingNumber: draft.openingNumber,
+      leaf: draft.leaf,
+      items: draft.items.map((item) => ({
+        hardwareCategory: item.hardwareCategory,
+        productCode: item.productCode,
+        quantity: item.quantity,
+        allocatedQuantity: allocatedFor(allocation, draft, item),
+      })),
+    }));
+}

--- a/frontend/src/modules/import/allocation.ts
+++ b/frontend/src/modules/import/allocation.ts
@@ -32,6 +32,29 @@ export const leafKey = (draft: { openingNumber: string; leaf: number | null }) =
   `${draft.openingNumber}|${draft.leaf ?? 'none'}`;
 
 /**
+ * What the drafts *are*, as a comparable string: which leaves, and what each owes.
+ *
+ * The allocator seeds itself once and must not re-seed afterwards, or it would silently discard the
+ * user's manual moves. "Once" cannot be a flag inside the step, because the wizard mounts the step
+ * only while it is the active one - stepping Back and Next again remounts it and resets the flag.
+ * The wizard holds this signature instead: unchanged drafts mean the existing allocation still
+ * describes them and is left alone; changed drafts (different openings picked, different
+ * classification) mean it no longer does, and re-seeding is the correct answer rather than a loss.
+ */
+export function draftsSignature(drafts: ShopAssemblyOpeningDraft[]): string {
+  return drafts
+    .map(
+      (draft) =>
+        `${leafKey(draft)}:${draft.items
+          .map((item) => `${comboKey(item)}=${item.quantity}`)
+          .sort()
+          .join(',')}`,
+    )
+    .sort()
+    .join(';');
+}
+
+/**
  * Fill leaves from the available pool, in schedule order, until each combo's pool runs out.
  *
  * First-leaf-first rather than spreading thinly across every leaf. Half a leaf's hardware assembles
@@ -92,6 +115,27 @@ export function leafCoverage(allocation: Allocation, draft: ShopAssemblyOpeningD
   }
   if (allocated <= 0) return 'NONE';
   return allocated >= owed ? 'FULL' : 'PARTIAL';
+}
+
+/**
+ * The leaves actually going on the request: included by the user AND carrying something.
+ *
+ * A leaf the user steppered down to zero is greyed out and its toggle disabled, but its key is still
+ * in `includedLeafKeys` - so "included" alone over-counts. Every reading that has to agree with the
+ * payload uses this, because `buildAllocatedDrafts` drops those leaves and the server therefore
+ * never sees their owed quantities: counting them as short would report a shortfall to the user that
+ * purchasing is never told about.
+ */
+export function effectivelyIncluded(
+  drafts: ShopAssemblyOpeningDraft[],
+  allocation: Allocation,
+  includedLeafKeys: ReadonlySet<string>,
+): Set<string> {
+  return new Set(
+    drafts
+      .filter((draft) => includedLeafKeys.has(leafKey(draft)) && leafAllocatedTotal(allocation, draft) > 0)
+      .map((draft) => leafKey(draft)),
+  );
 }
 
 /**
@@ -175,8 +219,9 @@ export function comboSummary(
   includedLeafKeys: ReadonlySet<string>,
 ): ComboSummaryRow[] {
   const rows = new Map<string, ComboSummaryRow>();
+  const effective = effectivelyIncluded(drafts, allocation, includedLeafKeys);
   for (const draft of drafts) {
-    if (!includedLeafKeys.has(leafKey(draft))) continue;
+    if (!effective.has(leafKey(draft))) continue;
     for (const item of draft.items) {
       const key = comboKey(item);
       let row = rows.get(key);
@@ -233,8 +278,9 @@ export function buildAllocatedDrafts(
   allocation: Allocation,
   includedLeafKeys: ReadonlySet<string>,
 ): AllocatedOpeningDraft[] {
+  const effective = effectivelyIncluded(drafts, allocation, includedLeafKeys);
   return drafts
-    .filter((draft) => includedLeafKeys.has(leafKey(draft)) && leafAllocatedTotal(allocation, draft) > 0)
+    .filter((draft) => effective.has(leafKey(draft)))
     .map((draft) => ({
       openingNumber: draft.openingNumber,
       leaf: draft.leaf,

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -52,6 +52,13 @@ export interface AssembledLeafCandidate {
    * hardware list it would ship under, so it is flagged and takes an explicit confirm.
    */
   awaitingReplacementQuantity: number;
+  /**
+   * Units the schedule owed this leaf that its shop-assembly request never pulled - they were not
+   * available to claim when it was sent. The other half of the same "this leaf is short" decision,
+   * and counted apart because the remedies differ: an awaiting-replacement unit has a pull in
+   * flight and waiting fixes it, while one of these needs purchasing and then reallocation.
+   */
+  neverPulledQuantity: number;
 }
 
 /**

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -24,7 +24,7 @@ import OpeningLeafStatusPanel from '../../components/OpeningLeafStatusPanel';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import AssemblyDetailModal from './AssemblyDetailModal';
-import { assemblyProgress, assemblyStatusLabel } from './openingFilters';
+import { assemblyProgress, assemblyStatusLabel, unitProgressLabel } from './openingFilters';
 
 // --- Types ---
 
@@ -274,8 +274,18 @@ export default function AssembleListPage() {
                             variant="outlined"
                           />
                           <Typography variant="body2" color="text.secondary">
-                            {progress.planned - progress.remaining}/{progress.planned} units
+                            {unitProgressLabel(opening.items ?? [])}
                           </Typography>
+                          {/* Owed but never pulled. Its own chip rather than part of the progress
+                              count: it is not outstanding work, and the leaf finishes without it. */}
+                          {progress.short > 0 && (
+                            <Chip
+                              label={`${progress.short} never pulled`}
+                              color="warning"
+                              size="small"
+                              variant="outlined"
+                            />
+                          )}
                         </Stack>
                       </AccordionSummary>
                       <AccordionDetails>

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -33,7 +33,10 @@ interface AssembleOpeningItem {
   shopAssemblyOpeningId: string;
   hardwareCategory: string;
   productCode: string;
+  // Owed by the schedule vs pulled for the bench. The three progress buckets partition
+  // `allocatedQuantity`; `quantity - allocatedQuantity` was never pulled and is not outstanding work.
   quantity: number;
+  allocatedQuantity: number;
   installedQuantity: number;
   deficientQuantity: number;
   // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned
@@ -283,6 +286,7 @@ export default function AssembleListPage() {
                               <TableRow>
                                 <TableCell>Product Code</TableCell>
                                 <TableCell>Hardware Category</TableCell>
+                                <TableCell align="right">Owed</TableCell>
                                 <TableCell align="right">Pulled</TableCell>
                                 <TableCell align="right">Installed</TableCell>
                                 <TableCell align="right">Deficient</TableCell>
@@ -294,6 +298,18 @@ export default function AssembleListPage() {
                                   <TableCell>{item.productCode}</TableCell>
                                   <TableCell>{item.hardwareCategory}</TableCell>
                                   <TableCell align="right">{item.quantity}</TableCell>
+                                  <TableCell align="right">
+                                    {item.allocatedQuantity}
+                                    {item.quantity > item.allocatedQuantity && (
+                                      <Chip
+                                        size="small"
+                                        variant="outlined"
+                                        color="warning"
+                                        label={`${item.quantity - item.allocatedQuantity} never pulled`}
+                                        sx={{ ml: 0.5 }}
+                                      />
+                                    )}
+                                  </TableCell>
                                   <TableCell align="right">{item.installedQuantity}</TableCell>
                                   <TableCell align="right">{item.deficientQuantity}</TableCell>
                                 </TableRow>

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -347,7 +347,7 @@ export default function AssemblyDetailModal({
             <Chip
               size="small"
               variant="outlined"
-              label={`${draftProgress.planned - draftProgress.remaining}/${draftProgress.planned} units accounted for`}
+              label={`${draftProgress.dispositioned}/${draftProgress.allocated} units accounted for`}
             />
           </Stack>
 

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -35,7 +35,12 @@ interface OpeningItem {
   shopAssemblyOpeningId: string;
   hardwareCategory: string;
   productCode: string;
+  // Owed: what the schedule says this leaf takes.
   quantity: number;
+  // Pulled: what the request could claim out of inventory and what physically arrived on the cart.
+  // The bench works against this number, never against `quantity` - the difference was never pulled,
+  // so no amount of work here can account for it.
+  allocatedQuantity: number;
   installedQuantity: number;
   deficientQuantity: number;
   // Units whose replacement has arrived but has not been fitted yet (#341). Zero while the leaf is
@@ -137,9 +142,9 @@ export default function AssemblyDetailModal({
     return value.length >= 1 && value.length <= 20;
   };
 
-  // The most a line can be marked installed: everything not already condemned.
+  // The most a line can be marked installed: everything pulled that is not already condemned.
   const maxInstalled = (item: OpeningItem): number =>
-    item.quantity - item.deficientQuantity - item.replacementPendingQuantity;
+    item.allocatedQuantity - item.deficientQuantity - item.replacementPendingQuantity;
 
   const draftFor = (item: OpeningItem): string =>
     draftInstalled[item.id] ?? String(item.installedQuantity);
@@ -164,6 +169,7 @@ export default function AssemblyDetailModal({
       assemblyProgress(
         opening.items.map((item) => ({
           quantity: item.quantity,
+          allocatedQuantity: item.allocatedQuantity,
           installedQuantity: parsedDraft(item) ?? item.installedQuantity,
           deficientQuantity: item.deficientQuantity,
           replacementPendingQuantity: item.replacementPendingQuantity,
@@ -255,7 +261,7 @@ export default function AssemblyDetailModal({
   // so allowing a flag that the unsaved draft has already spoken for would leave the draft above its
   // own maximum the moment the flag lands - the field turns red and Save Progress refuses it.
   const flagRemaining = flagging
-    ? flagging.quantity -
+    ? flagging.allocatedQuantity -
       (parsedDraft(flagging) ?? flagging.installedQuantity) -
       flagging.deficientQuantity -
       flagging.replacementPendingQuantity
@@ -360,6 +366,7 @@ export default function AssemblyDetailModal({
                 <TableRow>
                   <TableCell>Product Code</TableCell>
                   <TableCell>Hardware Category</TableCell>
+                  <TableCell align="right">Owed</TableCell>
                   <TableCell align="right">Pulled</TableCell>
                   <TableCell align="right">Installed</TableCell>
                   <TableCell align="right">Deficient</TableCell>
@@ -371,22 +378,38 @@ export default function AssemblyDetailModal({
                 {opening.items.map((item) => {
                   const parsed = parsedDraft(item);
                   const storedRemaining =
-                    item.quantity -
+                    item.allocatedQuantity -
                     item.installedQuantity -
                     item.deficientQuantity -
                     item.replacementPendingQuantity;
                   const remaining =
                     parsed === null
                       ? storedRemaining
-                      : item.quantity -
+                      : item.allocatedQuantity -
                         parsed -
                         item.deficientQuantity -
                         item.replacementPendingQuantity;
+                  // Owed but never pulled. Shown so the leaf does not read as a full bill of hardware
+                  // it is not carrying, and labelled rather than folded into Remaining - it is not
+                  // this assembler's outstanding work, and the leaf completes without it.
+                  const short = item.quantity - item.allocatedQuantity;
                   return (
                     <TableRow key={item.id}>
                       <TableCell>{item.productCode}</TableCell>
                       <TableCell>{item.hardwareCategory}</TableCell>
                       <TableCell align="right">{item.quantity}</TableCell>
+                      <TableCell align="right">
+                        {item.allocatedQuantity}
+                        {short > 0 && (
+                          <Chip
+                            size="small"
+                            variant="outlined"
+                            color="warning"
+                            label={`${short} never pulled`}
+                            sx={{ ml: 0.5 }}
+                          />
+                        )}
+                      </TableCell>
                       <TableCell align="right">
                         <TextField
                           size="small"

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -35,7 +35,10 @@ interface OpeningItem {
   shopAssemblyOpeningId: string;
   hardwareCategory: string;
   productCode: string;
+  // Owed by the schedule vs pulled for the bench. The three progress buckets partition
+  // `allocatedQuantity`; `quantity - allocatedQuantity` was never pulled and is not outstanding work.
   quantity: number;
+  allocatedQuantity: number;
   installedQuantity: number;
   deficientQuantity: number;
   // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -6,7 +6,7 @@ import { useIdentity } from '../../hooks/useIdentity';
 import DataTable from '../../components/DataTable';
 import AssemblyDetailModal from './AssemblyDetailModal';
 import ReplacementWorkPanel from './ReplacementWorkPanel';
-import { assemblyProgress, assemblyStatusLabel } from './openingFilters';
+import { assemblyStatusLabel, unitProgressLabel } from './openingFilters';
 import { leafLabel } from '../../utils/leaf';
 import type { GridColDef } from '@mui/x-data-grid';
 
@@ -77,8 +77,7 @@ const columns: GridColDef[] = [
       // Accounted-for is planned minus remaining, so the three buckets a line is partitioned into
       // (installed, condemned, replacement arrived but not yet fitted) all count - a finished leaf
       // never reads as 3/4 because its replacement turned up.
-      const { planned, remaining } = assemblyProgress(row.items ?? []);
-      return `${planned - remaining}/${planned} units`;
+      return unitProgressLabel(row.items ?? []);
     },
   },
   {

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -15,7 +15,10 @@ interface OpeningItem {
   shopAssemblyOpeningId: string;
   hardwareCategory: string;
   productCode: string;
+  // Owed by the schedule vs pulled for the bench. The three progress buckets partition
+  // `allocatedQuantity`; `quantity - allocatedQuantity` was never pulled and is not outstanding work.
   quantity: number;
+  allocatedQuantity: number;
   installedQuantity: number;
   deficientQuantity: number;
   // Arrived-but-not-yet-fitted replacement units (#341): the third bucket a line is partitioned

--- a/frontend/src/modules/shop-assembly/PipelinePage.tsx
+++ b/frontend/src/modules/shop-assembly/PipelinePage.tsx
@@ -52,11 +52,16 @@ export interface PipelineSummary {
   completedOpeningCount: number;
   shippedOpeningCount: number;
   plannedUnitCount: number;
+  /** Claimed out of inventory; the progress counters partition this, not plannedUnitCount. */
+  allocatedUnitCount: number;
+  /** Owed but never pulled - the request was sent short. */
+  shortUnitCount: number;
   installedUnitCount: number;
   deficientUnitCount: number;
   replacementPendingUnitCount: number;
   awaitingReplacementOpeningCount: number;
   replacementAfterShipOpeningCount: number;
+  shortOpeningCount: number;
   stage: string;
 }
 
@@ -76,6 +81,8 @@ export interface PipelineOpeningRow {
   assemblyStatus: string;
   completedAt: string | null;
   plannedUnitCount: number;
+  allocatedUnitCount: number;
+  shortUnitCount: number;
   installedUnitCount: number;
   deficientUnitCount: number;
   replacementPendingUnitCount: number;
@@ -297,6 +304,14 @@ function PipelineDetailModal({ requestId, onClose }: { requestId: string; onClos
                 label={`${summary.awaitingReplacementOpeningCount} awaiting replacement`}
               />
             )}
+            {summary.shortUnitCount > 0 && (
+              <Chip
+                size='small'
+                variant='outlined'
+                color='warning'
+                label={`${summary.shortUnitCount} unit(s) never pulled across ${summary.shortOpeningCount} leaf/leaves`}
+              />
+            )}
           </Stack>
           {progress !== null && (
             <LinearProgress variant='determinate' value={progress * 100} sx={{ mb: 2 }} />
@@ -359,20 +374,29 @@ function PipelineDetailModal({ requestId, onClose }: { requestId: string; onClos
                       <TableCell>{unitProgressLabel(row)}</TableCell>
                       <TableCell>{row.assembledLocation ?? '-'}</TableCell>
                       <TableCell>
-                        {row.awaitingReplacementUnitCount > 0 ? (
-                          <Chip
-                            size='small'
-                            variant='outlined'
-                            color={row.replacementArrivedAfterShip ? 'error' : 'warning'}
-                            label={
-                              row.replacementArrivedAfterShip
-                                ? `${row.awaitingReplacementUnitCount} arrived after shipping`
-                                : `${row.awaitingReplacementUnitCount} awaiting replacement`
-                            }
-                          />
-                        ) : (
-                          '-'
-                        )}
+                        <Stack direction='row' spacing={0.5} sx={{ flexWrap: 'wrap' }}>
+                          {row.awaitingReplacementUnitCount > 0 && (
+                            <Chip
+                              size='small'
+                              variant='outlined'
+                              color={row.replacementArrivedAfterShip ? 'error' : 'warning'}
+                              label={
+                                row.replacementArrivedAfterShip
+                                  ? `${row.awaitingReplacementUnitCount} arrived after shipping`
+                                  : `${row.awaitingReplacementUnitCount} awaiting replacement`
+                              }
+                            />
+                          )}
+                          {row.shortUnitCount > 0 && (
+                            <Chip
+                              size='small'
+                              variant='outlined'
+                              color='warning'
+                              label={`${row.shortUnitCount} never pulled`}
+                            />
+                          )}
+                          {row.awaitingReplacementUnitCount === 0 && row.shortUnitCount === 0 && '-'}
+                        </Stack>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
+++ b/frontend/src/modules/shop-assembly/ShopAssemblyRequestsPage.tsx
@@ -26,7 +26,10 @@ interface RequestOpeningItem {
   id: string;
   hardwareCategory: string;
   productCode: string;
+  /** Owed by the schedule. */
   quantity: number;
+  /** Claimed out of inventory when the request was sent - what the pull will actually ask for. */
+  allocatedQuantity: number;
 }
 
 interface RequestOpening {
@@ -88,9 +91,28 @@ export default function ShopAssemblyRequestsPage() {
         reopenMutation={REOPEN_SHOP_ASSEMBLY_REQUEST}
         mode={view === 'APPROVED' ? 'approved' : 'pending'}
         onChanged={refetch}
-        renderSummary={(req) => (
-          <Chip label={`${req.openings.length} opening(s)`} size="small" variant="outlined" />
-        )}
+        renderSummary={(req) => {
+          // The acceptor is approving a pull for the ALLOCATED quantities, so the short count has to
+          // be on the summary line, not buried in the per-leaf tables. Approving a request that is
+          // knowingly short is fine; approving one without knowing it is short is not.
+          const short = req.openings.reduce(
+            (sum, o) => sum + o.items.reduce((n, i) => n + (i.quantity - i.allocatedQuantity), 0),
+            0,
+          );
+          return (
+            <Stack direction="row" spacing={1}>
+              <Chip label={`${req.openings.length} opening(s)`} size="small" variant="outlined" />
+              {short > 0 && (
+                <Chip
+                  label={`${short} unit(s) short`}
+                  size="small"
+                  variant="outlined"
+                  color="warning"
+                />
+              )}
+            </Stack>
+          );
+        }}
         renderDetails={(req) =>
         req.openings.map((opening) => (
           <Box key={opening.id}>
@@ -110,7 +132,8 @@ export default function ShopAssemblyRequestsPage() {
                   <TableRow>
                     <TableCell>Product Code</TableCell>
                     <TableCell>Hardware Category</TableCell>
-                    <TableCell align="right">Quantity</TableCell>
+                    <TableCell align="right">Owed</TableCell>
+                    <TableCell align="right">Allocated</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -119,6 +142,18 @@ export default function ShopAssemblyRequestsPage() {
                       <TableCell>{item.productCode}</TableCell>
                       <TableCell>{item.hardwareCategory}</TableCell>
                       <TableCell align="right">{item.quantity}</TableCell>
+                      <TableCell align="right">
+                        {item.allocatedQuantity}
+                        {item.quantity > item.allocatedQuantity && (
+                          <Chip
+                            size="small"
+                            variant="outlined"
+                            color="warning"
+                            label={`${item.quantity - item.allocatedQuantity} short`}
+                            sx={{ ml: 0.5 }}
+                          />
+                        )}
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
@@ -16,6 +16,9 @@ function item(overrides: Record<string, unknown> = {}) {
     hardwareCategory: 'HINGE',
     productCode: 'HG-100',
     quantity: 4,
+    // Fully allocated unless a test says otherwise: the interesting short cases set it explicitly,
+    // and every other case is about the progress buckets, which partition allocated.
+    allocatedQuantity: 4,
     installedQuantity: 0,
     deficientQuantity: 0,
     replacementPendingQuantity: 0,
@@ -82,7 +85,7 @@ describe('AssemblyDetailModal progress editor', () => {
 
   it('refuses to enable Mark Complete when every unit was flagged deficient', () => {
     // Fully dispositioned but nothing installed - completing would mint an empty assembled leaf.
-    renderModal([item({ quantity: 2, installedQuantity: 0, deficientQuantity: 2 })]);
+    renderModal([item({ quantity: 2, allocatedQuantity: 2, installedQuantity: 0, deficientQuantity: 2 })]);
 
     expect(screen.getByRole('button', { name: /mark complete/i })).toBeDisabled();
     expect(screen.getByText(/nothing assembled to complete/i)).toBeInTheDocument();
@@ -201,7 +204,7 @@ describe('AssemblyDetailModal progress editor', () => {
             floor: '2',
             leaf: 1,
             items: [
-              { __typename: 'ShopAssemblyOpeningItem', ...item({ quantity: 2, installedQuantity: 2 }) },
+              { __typename: 'ShopAssemblyOpeningItem', ...item({ quantity: 2, allocatedQuantity: 2, installedQuantity: 2 }) },
             ],
           },
         },
@@ -246,7 +249,7 @@ describe('AssemblyDetailModal progress editor', () => {
       },
     };
 
-    const { onCompleted } = renderModal([item({ quantity: 2 })], [saveMock, completeMock]);
+    const { onCompleted } = renderModal([item({ quantity: 2, allocatedQuantity: 2 })], [saveMock, completeMock]);
 
     fireEvent.change(installedInput(), { target: { value: '2' } });
     fireEvent.click(screen.getByRole('button', { name: /mark complete/i }));
@@ -257,7 +260,7 @@ describe('AssemblyDetailModal progress editor', () => {
   });
 
   it('requires a reason before a deficiency can be flagged', async () => {
-    renderModal([item({ quantity: 2 })]);
+    renderModal([item({ quantity: 2, allocatedQuantity: 2 })]);
 
     fireEvent.click(screen.getByRole('button', { name: /flag deficient/i }));
     const confirm = await screen.findByRole('button', { name: /^flag deficient$/i });
@@ -270,7 +273,7 @@ describe('AssemblyDetailModal progress editor', () => {
   });
 
   it('will not let more units be flagged deficient than are left unrecorded', async () => {
-    renderModal([item({ quantity: 3, installedQuantity: 2 })]);
+    renderModal([item({ quantity: 3, allocatedQuantity: 3, installedQuantity: 2 })]);
 
     fireEvent.click(screen.getByRole('button', { name: /flag deficient/i }));
     fireEvent.change(await screen.findByLabelText('Deficiency reason'), {

--- a/frontend/src/modules/shop-assembly/openingFilters.ts
+++ b/frontend/src/modules/shop-assembly/openingFilters.ts
@@ -18,32 +18,52 @@ export function isAvailableForAssignment(o: AssignableFields): boolean {
   return o.pullStatus === 'PULLED' && o.assignedToUserId === null && o.assemblyStatus !== 'COMPLETED';
 }
 
-/** Progress rollup for one opening: units installed, condemned, awaiting a replacement install, and
- * still unaccounted for.
+/** Progress rollup for one opening: units installed, condemned, awaiting a replacement install,
+ * never pulled, and still unaccounted for.
  *
  * The whole gating story reduces to `remaining === 0`. Kept here rather than in a component so the
  * modal's Mark Complete gate and the lists' "5/8 units" column cannot drift apart.
  *
  * A line is partitioned three ways, not two (#341): `installed + deficient + replacementPending`
- * always sums to `quantity`. When a replacement arrives for a leaf that is already finished, the
+ * always sums to `allocated`. When a replacement arrives for a leaf that is already finished, the
  * unit moves `deficient -> replacementPending` - the leaf is complete, with a known unit of work
  * outstanding. Leaving that bucket out of `remaining` made a finished 4-unit leaf read as 3/4 the
  * moment its replacement landed, which is the one thing this rollup is on screen to prevent.
+ *
+ * **The partition is over `allocated`, not `planned`.** A short line was never pulled, so no work at
+ * the bench can ever account for it; counting it as remaining would leave the leaf permanently
+ * unfinishable on screen while the backend happily completes it. `short` carries that number
+ * separately, because the assembler still needs to see that the leaf is not carrying its full bill
+ * of hardware - it is just not their outstanding work.
  */
 export function assemblyProgress(items: ProgressFields[]): {
   planned: number;
+  allocated: number;
   installed: number;
   deficient: number;
   replacementPending: number;
+  short: number;
   remaining: number;
   complete: boolean;
 } {
   const planned = items.reduce((sum, i) => sum + i.quantity, 0);
+  // Fall back to the owed quantity on a server that predates allocation, where every line was fully
+  // allocated by construction - the all-or-nothing gate could not create anything else.
+  const allocated = items.reduce((sum, i) => sum + (i.allocatedQuantity ?? i.quantity), 0);
   const installed = items.reduce((sum, i) => sum + i.installedQuantity, 0);
   const deficient = items.reduce((sum, i) => sum + i.deficientQuantity, 0);
   const replacementPending = items.reduce((sum, i) => sum + (i.replacementPendingQuantity ?? 0), 0);
-  const remaining = planned - installed - deficient - replacementPending;
-  return { planned, installed, deficient, replacementPending, remaining, complete: remaining === 0 };
+  const remaining = allocated - installed - deficient - replacementPending;
+  return {
+    planned,
+    allocated,
+    installed,
+    deficient,
+    replacementPending,
+    short: planned - allocated,
+    remaining,
+    complete: remaining === 0,
+  };
 }
 
 interface ProgressFields {
@@ -54,6 +74,7 @@ interface ProgressFields {
   // substitutes its unsaved draft for installedQuantity) need not restate a field it does not touch;
   // every query that feeds this rollup selects it.
   replacementPendingQuantity?: number;
+  allocatedQuantity?: number;
 }
 
 /** Chip label for an opening's assembly status. */

--- a/frontend/src/modules/shop-assembly/openingFilters.ts
+++ b/frontend/src/modules/shop-assembly/openingFilters.ts
@@ -43,6 +43,7 @@ export function assemblyProgress(items: ProgressFields[]): {
   deficient: number;
   replacementPending: number;
   short: number;
+  dispositioned: number;
   remaining: number;
   complete: boolean;
 } {
@@ -61,9 +62,23 @@ export function assemblyProgress(items: ProgressFields[]): {
     deficient,
     replacementPending,
     short: planned - allocated,
+    dispositioned: installed + deficient + replacementPending,
     remaining,
     complete: remaining === 0,
   };
+}
+
+/** "5/8 units" - what the assembler has accounted for, out of what actually turned up.
+ *
+ * Both halves are measured against `allocated`. Rendering `planned - remaining` over `planned`
+ * instead - which is what every view did while the two numbers were the same - reads a leaf owed 4
+ * and allocated 2 with no work done as "2/4 units", and the same leaf fully built as "4/4 units"
+ * while it carries 2. One helper so the three views cannot drift apart again; the short units are
+ * surfaced separately, per line, where they can be labelled as never pulled.
+ */
+export function unitProgressLabel(items: ProgressFields[]): string {
+  const { dispositioned, allocated } = assemblyProgress(items);
+  return `${dispositioned}/${allocated} units`;
 }
 
 interface ProgressFields {

--- a/frontend/src/modules/shop-assembly/pipelineStages.ts
+++ b/frontend/src/modules/shop-assembly/pipelineStages.ts
@@ -68,6 +68,8 @@ export function stageProgress(stage: string): number | null {
 
 export interface PipelineUnitFields {
   plannedUnitCount: number;
+  /** Null on a server that predates allocation, where every line was fully allocated by construction. */
+  allocatedUnitCount?: number | null;
   installedUnitCount: number;
   deficientUnitCount: number;
   replacementPendingUnitCount: number;
@@ -77,16 +79,21 @@ export interface PipelineUnitFields {
  * fitted is most of the job, and a line count would report it as untouched.
  *
  * Dispositioned - installed plus condemned plus awaiting-a-replacement - rather than installed alone,
- * because that is the number completion is gated on (#340). */
+ * because that is the number completion is gated on (#340).
+ *
+ * Measured against ALLOCATED, not owed. A short unit was never pulled, so it can never be
+ * dispositioned; counting it in the denominator would leave a finished request stuck reading "6/8
+ * units" forever, which is the one thing a progress label must not do. */
 export function unitProgressLabel(row: PipelineUnitFields): string {
   const done = row.installedUnitCount + row.deficientUnitCount + row.replacementPendingUnitCount;
-  return `${done}/${row.plannedUnitCount} units`;
+  return `${done}/${row.allocatedUnitCount ?? row.plannedUnitCount} units`;
 }
 
 export interface PipelineFlagFields {
   integrityNote?: string | null;
   awaitingReplacementOpeningCount?: number | null;
   replacementAfterShipOpeningCount?: number | null;
+  shortUnitCount?: number | null;
 }
 
 /** The flags earlier slices introduced, as short chip labels, in the order somebody should read them:
@@ -109,6 +116,12 @@ export function pipelineFlags(row: PipelineFlagFields): { label: string; severit
       label: `${row.replacementAfterShipOpeningCount} arrived after shipping`,
       severity: 'error',
     });
+  }
+  // Sent short: units the schedule owed that were never available to pull. A warning rather than an
+  // error - it was a decision somebody made with the numbers in front of them - but it has to be on
+  // the row, because every other count here can read as complete while it is non-zero.
+  if (row.shortUnitCount) {
+    flags.push({ label: `${row.shortUnitCount} unit(s) never pulled`, severity: 'warning' });
   }
   return flags;
 }

--- a/frontend/src/modules/warehouse/PullStagingPanel.tsx
+++ b/frontend/src/modules/warehouse/PullStagingPanel.tsx
@@ -204,7 +204,18 @@ export default function PullStagingPanel({
                     <Box component="ul" sx={{ m: 0, pl: 2 }}>
                       {opening.items.map((item) => (
                         <li key={item.id}>
-                          {item.quantity} x {item.productCode} ({item.hardwareCategory})
+                          {/* The pick count is the ALLOCATED quantity - that is what the pull line
+                              asks for and what was reserved. Owed is shown only when it differs, so
+                              the puller can see the cart is deliberately short rather than wondering
+                              whether they miscounted. */}
+                          {item.allocatedQuantity} x {item.productCode} ({item.hardwareCategory})
+                          {item.quantity > item.allocatedQuantity && (
+                            <Typography component="span" variant="caption" color="text.secondary">
+                              {' '}
+                              - {item.quantity - item.allocatedQuantity} of {item.quantity} owed
+                              never pulled
+                            </Typography>
+                          )}
                         </li>
                       ))}
                     </Box>

--- a/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
@@ -47,6 +47,7 @@ function opening(overrides: Record<string, unknown> = {}) {
         hardwareCategory: 'HINGE',
         productCode: 'HG-100',
         quantity: 3,
+        allocatedQuantity: 3,
       },
     ],
     ...overrides,

--- a/frontend/src/modules/warehouse/pullStaging.ts
+++ b/frontend/src/modules/warehouse/pullStaging.ts
@@ -31,7 +31,10 @@ export interface PullStagingOpeningItem {
   shopAssemblyOpeningId: string;
   hardwareCategory: string;
   productCode: string;
+  /** Owed by the schedule. Context only - the warehouse does not pick against this number. */
   quantity: number;
+  /** The pick count: what was reserved, what the pull line asks for, what goes on the cart. */
+  allocatedQuantity: number;
 }
 
 export interface PullStagingOpening {

--- a/frontend/src/test/__tests__/apolloDevtoolsTimer.test.ts
+++ b/frontend/src/test/__tests__/apolloDevtoolsTimer.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client/core';
+
+/**
+ * The setup file defuses Apollo's one-shot "install the Apollo DevTools" timer, because a pending
+ * 10-second timer outliving its test file fires with no `window` and fails the whole run as an
+ * unhandled ReferenceError - from an unrelated file, with every test passing.
+ *
+ * That workaround leans on an Apollo heuristic (it only nags a top-level http(s)/file document), so
+ * it can stop working silently on an upgrade and the flake would creep back with nothing pointing at
+ * the cause. This is the alarm: if a fresh client ever schedules a timer again, this fails on the
+ * spot and names the reason.
+ */
+describe('apollo devtools suggestion timer', () => {
+  it('is already spent, so building a client schedules nothing', () => {
+    vi.useFakeTimers();
+    try {
+      void new ApolloClient({ cache: new InMemoryCache(), link: ApolloLink.empty() });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,27 @@
 import '@testing-library/jest-dom';
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client/core';
+
+/**
+ * Defuse Apollo's "install the Apollo DevTools" suggestion timer.
+ *
+ * The first ApolloClient built in a process schedules a **one-shot 10-second** `setTimeout` that
+ * logs a suggestion to install the browser devtools. Vitest tears the jsdom environment down as soon
+ * as a test file finishes, so if that timer is still pending when the file that armed it ends, it
+ * fires into a world with no `window` and vitest reports an unhandled `ReferenceError` - failing the
+ * whole run, and blaming whichever unrelated file happened to be in flight ten seconds later. Every
+ * test passes and the job still goes red, which is the worst kind of failure to read.
+ *
+ * Whether it lands inside a file or after one is pure timing, so it stays latent until a run gets
+ * slightly slower or a test file is added. Rather than leave it to resurface, arm and waste the
+ * one-shot here: Apollo only schedules it when the page looks like a top-level http(s)/file
+ * document, so building a throwaway client while `window.top` is not `window.self` flips its
+ * internal "already suggested" flag without scheduling anything. Every real client built afterwards
+ * - including the ones `MockedProvider` builds internally, which take no devtools option - finds
+ * that flag already set.
+ *
+ * `window.top` is restored immediately, so nothing under test sees the frame-like window.
+ */
+const realTop = window.top;
+Object.defineProperty(window, 'top', { configurable: true, value: null });
+void new ApolloClient({ cache: new InMemoryCache(), link: ApolloLink.empty() });
+Object.defineProperty(window, 'top', { configurable: true, value: realTop });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -19,9 +19,15 @@ import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client/core';
  * - including the ones `MockedProvider` builds internally, which take no devtools option - finds
  * that flag already set.
  *
- * `window.top` is restored immediately, so nothing under test sees the frame-like window.
+ * `window.top` is restored from its own descriptor rather than reassigned, so nothing under test
+ * sees either the frame-like window or a property that has quietly become read-only.
+ *
+ * If Apollo ever changes that heuristic this stops having any effect - so the assertion in
+ * `__tests__/apolloDevtoolsTimer.test.ts` fails loudly instead of the flake creeping back.
  */
-const realTop = window.top;
+const topDescriptor = Object.getOwnPropertyDescriptor(window, 'top');
 Object.defineProperty(window, 'top', { configurable: true, value: null });
 void new ApolloClient({ cache: new InMemoryCache(), link: ApolloLink.empty() });
-Object.defineProperty(window, 'top', { configurable: true, value: realTop });
+if (topDescriptor) {
+  Object.defineProperty(window, 'top', topDescriptor);
+}


### PR DESCRIPTION
closes #377.

shop assembly no longer all-or-nothing at creation. requester assigns available inventory to leaves, partially-covered leaves stay in the request, send/don't-send call is theirs.

workstream A - allocation builder + owed/short bucket

`ShopAssemblyOpeningItem` gains `allocated_quantity`.
`quantity` keeps meaning owed, never reduced by scarcity.
short = `quantity - allocated_quantity`, derived everywhere, stored nowhere - the authority on what a leaf is still missing is the current schedule against what is on the leaf, which is the reallocation module.
three progress buckets partition `allocated_quantity`, not `quantity`.

- migration 070 adds the column, backfills `allocated = quantity` for every existing row (all cleared the all-or-nothing gate, so fully covered by construction), rewrites the progress check constraint.
- `SAROpeningItemInput.allocated_quantity` defaults to None = fully allocated, non-allocator callers unchanged.
- finalize validates 0 <= allocated <= quantity, refuses a leaf with nothing allocated on any line, gates and reserves over the allocation, fires the PO shortfall notification for short combos on the success path.
- creation gate is now the race gate. refusal means availability moved, wizard refetches, re-runs auto-assign, asks the user to review.
- accept mints pull lines only for allocated > 0 at the allocated quantity, so the pull equals the reservation and `approve_pull_request` needs no change.
- `record_assembly_progress` caps at allocated, `complete_opening` accounts against allocated and excuses short units. zero-installed guard unchanged, now covers the all-short leaf.
- re-upload rebuilds surviving reservations from allocated, not owed.
- shipping incomplete-leaf gate counts short units as well as awaiting-replacement ones, names both per leaf - waiting fixes one and not the other.

allocator step - rewritten `ShopAssemblyStep.tsx` + pure `allocation.ts`
- auto-assign fills whole leaves in schedule order until each combo's pool runs out
- per-line steppers clamped to owed and remaining pool
- leaf include/exclude toggle returns allocation to the pool
- zero-coverage leaves greyed out and auto-dropped
- shortfall alert informational, no longer blocks Next

downstream display
- accept UI shows allocated vs owed plus a request-level short chip
- bench modal shows owed / pulled / "N never pulled"
- staging cart picks the allocated count
- pipeline gains short unit and short opening rollups

workstream B - flag-time replacement reservations

PR-REPL pulls now hold a claim from the flag instead of competing for stock at approval.

`ReservationSource.REPLACEMENT_PULL`
`inventory_reservations.pull_request_id` (CASCADE, indexed)
three-way source/FK check constraint
migration 071

- `report_deficiency_at_assembly` reserves `min(free stock, condemned)` at the flag. reserving less is the normal case - the shelf is usually empty, which is why a replacement is needed.
- `find_reservation_holder` detects a replacement structurally (any line with `sa_opening_item_id`) and returns the pull itself as holder. `approve_pull_request` consumes it like any other claim.
- `top_up_replacement_reservations` raises each PENDING replacement toward its need, oldest pull first, on a receive and on a REPAIR resolution.
- `notify_unblocked_replacement_pulls` tops up first, then checks coverability with the pull's own claim excluded - without the exclusion it reads insufficient forever.
- `discard_pending_pull_request` releases. cancel of an approved replacement releases nothing, approval already consumed it.
- partly-reserved replacement that comes up short is excluded from the RESERVED_PULL_SHORT integrity audit - it is the expected population, and flagging every one is how a real discrepancy gets missed.

two deviations from the spec

- spec listed SEND_TO_STOCK as a second availability-raising resolution. it is not - it decrements `quantity` and `deficient_quantity` together, so project available is unchanged. only REPAIR calls the top-up.
- spec said add REPLACEMENT_PULL to both enum files. `ReservationSource` is not in `app/schemas/enums.py` - DB-only enum, no GraphQL surface - so only `app/models/enums.py` changed.

state

- frontend 294 tests pass, lint and build clean
- backend ruff check and format clean
- DB-backed backend tests are skipped locally (no DATABASE_URL, no local postgres), so the new suites run for the first time in CI
- two `test_manufacturer_match` failures on this machine are pre-existing on master and unrelated
- simulated user testing against Railway not yet run
