### PR TITLE
fix(relay): stop a self-update from gutting the folder its own helper runs from (#376)

### DIFF
--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -489,6 +489,11 @@ export default function PODetailModal({
               </span>
             </Tooltip>
           )}
+          {/* Stays gated on the relay, unlike the receive modal (#376). Registering needs LIVE GP reads
+              to compose at all - the company comes from the connected relay, and the vendor list, tax
+              details and cost codes are all skipped while it is down - so an offline dialog could not be
+              filled in even if it opened. registerPoInGp's outbox path still gets exercised: the relay
+              only has to drop between opening this and submitting. */}
           {canRegisterInGp && (
             <Tooltip
               title={relayConnected ? '' : 'GP relay not detected on this machine - it must be running to register a PO'}

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -690,15 +690,17 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   ) : (
     <>
       <Button onClick={handleClose}>Cancel</Button>
+      {/* An offline relay is NOT a submit blocker (#376). #353 PR E made createReceive enqueue onto the
+          durable outbox instead of failing, and this modal already handles that answer - the `queued`
+          branch and its amber panel below. But this button was disabled on exactly the condition that
+          produces a queued receipt, so that whole path was unreachable from the running app: the only
+          thing that ever reached it was a unit test mocking createReceive past the gate. The relay state
+          is now advisory (the alert above says what will happen), and the warehouse user who has already
+          counted the hardware can record it either way. */}
       <Button
         variant="contained"
         disabled={
-          !hasAnyReceiveQuantity ||
-          hasQuantityErrors ||
-          !putAwayValid ||
-          !relayConnected ||
-          blockedPos.length > 0 ||
-          submitting
+          !hasAnyReceiveQuantity || hasQuantityErrors || !putAwayValid || blockedPos.length > 0 || submitting
         }
         onClick={() => setConfirmOpen(true)}
       >
@@ -749,7 +751,8 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
             />
           </Box>
         )}
-        {/* A receive posts a GP receipt via the on-prem relay, so the relay must be up. */}
+        {/* A receive posts a GP receipt via the on-prem relay. An offline relay no longer blocks the
+            receive (#353 PR E queues it), so this says what will happen rather than refusing. */}
         {!poDetailsLoading && !poDetailsError && !succeeded && (
           <Box sx={{ mb: 2 }}>
             {relayStatus === null ? (
@@ -757,9 +760,9 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
             ) : relayConnected ? (
               <Chip size="small" color="success" label="GP relay connected" />
             ) : (
-              <Alert severity="error">
-                GP relay not detected on this machine - it must be running to receive (a receive posts the
-                GP receipt).
+              <Alert severity="warning">
+                GP relay offline - this receipt will be queued and post itself when the relay reconnects.
+                Nothing appears in inventory until it does.
               </Alert>
             )}
           </Box>

--- a/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
@@ -152,10 +152,32 @@ function createReceiveData(quantityReceived: number) {
   };
 }
 
-function renderModal(extraMocks: MockedResponse[] = []) {
+// The relay reported as DOWN. Used to drive the real offline path rather than mocking past it: the
+// queued outcome only ever happens when the relay is unreachable, so a test that reports it connected
+// and just stubs a queued mutation result never touches the gate that decides whether a user can get
+// there at all (#376).
+function offlineRelayMock(): MockedResponse {
+  return {
+    request: { query: GET_RELAY_STATUS },
+    result: {
+      data: {
+        relayStatus: {
+          __typename: 'RelayStatus',
+          connected: false,
+          company: null,
+          build: null,
+          installId: null,
+        },
+      },
+    },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+  };
+}
+
+function renderModal(extraMocks: MockedResponse[] = [], relay: MockedResponse = relayMock()) {
   const onClose = vi.fn();
   render(
-    <MockedProvider mocks={[relayMock(), warehousesMock(), ...extraMocks]}>
+    <MockedProvider mocks={[relay, warehousesMock(), ...extraMocks]}>
       <MemoryRouter>
         <ToastProvider>
           <ReceiveModal open onClose={onClose} poIds={['po-1']} />
@@ -171,11 +193,19 @@ function renderModal(extraMocks: MockedResponse[] = []) {
 // queries until the transition finishes
 const SLOW = { timeout: 5000 };
 
-// render + wait for the PO grid and the relay-connected chip (submit is gated on the relay)
+// render + wait for the PO grid and the relay-connected chip
 async function openModal(extraMocks: MockedResponse[] = []) {
   const result = renderModal(extraMocks);
   await screen.findByText('HG-100', undefined, SLOW);
   await screen.findByText('GP relay connected', undefined, SLOW);
+  return result;
+}
+
+// render + wait for the PO grid and the offline-relay warning
+async function openModalRelayOffline(extraMocks: MockedResponse[] = []) {
+  const result = renderModal(extraMocks, offlineRelayMock());
+  await screen.findByText('HG-100', undefined, SLOW);
+  await screen.findByText(/GP relay offline/, undefined, SLOW);
   return result;
 }
 
@@ -397,6 +427,45 @@ describe('ReceiveModal', () => {
     expect(screen.queryByText(/items added to inventory/)).toBeNull();
     expect(keys).toHaveLength(1);
     expect(keys[0]).toMatch(UUID_RE);
+  });
+
+  it('lets a receive be submitted while the GP relay is offline, and queues it', async () => {
+    // #376: the queued outcome above was unreachable in the running app. Complete Receive was disabled
+    // on !relayConnected - exactly the condition that produces a queued receipt - so the outbox path,
+    // its amber panel and this behaviour existed only under a mock. The relay state is advisory now:
+    // a warehouse user who has counted the hardware can record it, and it posts itself later.
+    const queuedMock: MockedResponse<Record<string, unknown>, CreateReceiveVars> = {
+      request: { query: CREATE_RECEIVE, variables: () => true },
+      result: {
+        data: {
+          createReceive: {
+            __typename: 'CreateReceiveResult',
+            queued: true,
+            outboxEntryId: 'outbox-9',
+            receiveRecord: null,
+          },
+        },
+      },
+    };
+    await openModalRelayOffline([poDetailsMock(), queuedMock]);
+
+    setReceiveQty('3');
+    fillLocation(0, 'A1', 'B2', 'C3');
+    expect(completeButton()).toBeEnabled(); // the gate that used to make this unreachable
+
+    await submitViaConfirm();
+
+    await screen.findByText(/Queued — the GP relay is offline/, undefined, SLOW);
+    expect(screen.queryByText(/items added to inventory/)).toBeNull();
+  });
+
+  it('still blocks a receive on the things that are genuinely invalid while the relay is offline', async () => {
+    // the relay going advisory must not weaken the real validation - an empty receive is still refused.
+    await openModalRelayOffline([poDetailsMock()]);
+
+    expect(completeButton()).toBeDisabled(); // nothing entered yet
+    setReceiveQty('3');
+    expect(completeButton()).toBeDisabled(); // put-away location still missing
   });
 
   it('blocks receiving a PO that is not GP-registered', async () => {

--- a/relay/src/ucnexus_relay/app.py
+++ b/relay/src/ucnexus_relay/app.py
@@ -44,6 +44,7 @@ class RelayApp:
         self._mutex = None  # single_instance.MutexResult while we own the app slot
         self._control = None  # single_instance.ControlServer answering ping / show / quit_for_upgrade
         self._update_poller_stop = None  # threading.Event stopping the background update poll
+        self._hard_exit_timer = None  # threading.Timer arming the exit-anyway fallback (see _arm_hard_exit)
 
     # --- serve child supervision ----------------------------------------------------------------------
 
@@ -151,11 +152,8 @@ class RelayApp:
             self.shutdown()
             # Guarantee the process exits so the helper's swap can proceed promptly. shutdown() stopped
             # serve + tray and asked the window to close, but destroy() runs off the GUI thread and does
-            # not always tear down webview.start(); this daemon timer is the fallback (it dies with the
-            # process if we exit cleanly first, so it only ever fires when the GUI loop is stuck).
-            timer = threading.Timer(2.0, lambda: os._exit(0))
-            timer.daemon = True
-            timer.start()
+            # not always tear down webview.start(); this is the fallback.
+            self._arm_hard_exit()
         return result
 
     def _reconcile_update_ledger(self) -> None:
@@ -237,25 +235,55 @@ class RelayApp:
         self._show_window()
         single_instance.bring_to_front()
 
+    def _arm_hard_exit(self, delay: float = 2.0) -> None:
+        """Exit the process anyway if a graceful teardown leaves the GUI loop stuck. A daemon timer, so it
+        dies with us and only ever fires when we failed to exit on our own.
+
+        The handle is kept so it can be cancelled. It has to be: the timer outlives whatever armed it, and
+        it resolves os._exit at FIRE time. A test that neutralises os._exit with monkeypatch gets that
+        patch undone at test teardown while this timer is still pending, so two seconds later the real
+        os._exit(0) fired inside the test runner - killing pytest mid-suite with exit code 0, no summary,
+        and a green CI that had silently run about a third of its tests."""
+        timer = threading.Timer(delay, lambda: os._exit(0))
+        timer.daemon = True
+        self._hard_exit_timer = timer
+        timer.start()
+
+    def cancel_hard_exit(self) -> None:
+        """Disarm the exit-anyway fallback (see _arm_hard_exit)."""
+        if self._hard_exit_timer is not None:
+            self._hard_exit_timer.cancel()
+            self._hard_exit_timer = None
+
     def _ipc_quit(self) -> None:
         """A newer instance is taking over: tear down WITHOUT the shutdown-confirm dialog, then guarantee we
         exit so our exe lock frees for the swap (mirrors the updater's hard-exit fallback)."""
         logger.info("relay app evicted by a newer instance; shutting down for handoff")
         self.shutdown()
-        timer = threading.Timer(2.0, lambda: os._exit(0))
-        timer.daemon = True
-        timer.start()
+        self._arm_hard_exit()
 
     def _cleanup_old_versions(self) -> None:
-        """Delete stale app-<build>/ version folders a past update left behind, keeping the one we run
-        from. Best-effort - a folder still held by an exiting update helper is skipped and cleaned on a
-        later start (see layout.cleanup_old_versions)."""
-        from . import layout
+        """Discard stale app-<build>/ version folders a past update left behind, keeping the one we run
+        from, the one `current` points at, and the previous build as a rollback target.
+
+        Skipped outright while an update is still in flight. This runs in the app the update helper just
+        relaunched, and that helper is executing from the PREVIOUS version folder while it health-gates
+        us - so the folder this was most likely to destroy was the one still in use (#376). Removal is
+        all-or-nothing now (see layout.cleanup_old_versions) and would leave it intact anyway, but not
+        touching it at all while it is being used is the honest rule. An abandoned ledger (a helper that
+        died without recording a result, #369) does not count as in-flight, or cleanup would never run
+        again on that machine."""
+        from . import layout, updater
 
         try:
+            install_dir = self._install_dir()
+            ledger = updater.read_ledger(install_dir)
+            if ledger.get("status") in ("staging", "applying") and not updater.ledger_is_abandoned(ledger):
+                logger.info("skipping stale version cleanup: an update is still in flight")
+                return
             running = layout.running_version_dir()
-            keep = {running.name} if running is not None else set()
-            layout.cleanup_old_versions(self._install_dir(), keep)
+            keep = layout.versions_to_keep(install_dir, extra=(running, layout.current_target(install_dir)))
+            layout.cleanup_old_versions(install_dir, keep)
         except Exception:
             logger.exception("error cleaning up old relay versions")
 

--- a/relay/src/ucnexus_relay/layout.py
+++ b/relay/src/ucnexus_relay/layout.py
@@ -24,6 +24,12 @@ from pathlib import Path
 ASSET_NAME = "ucnexus-relay.exe"  # the exe name inside a version folder
 CURRENT_LINK = "current"
 VERSION_PREFIX = "app-"
+# A version folder that has been moved aside for deletion. Deliberately NOT app-*, so a half-deleted
+# leftover can never be mistaken for an installable version by the app-*/ globs.
+TRASH_PREFIX = "trash-"
+# How many version folders cleanup keeps: the running one plus one previous, so a failed update always
+# has an intact bundle to roll back to (#376).
+KEEP_RECENT_VERSIONS = 2
 _NO_WINDOW = 0x08000000  # CREATE_NO_WINDOW
 _SAFE = re.compile(r"[^A-Za-z0-9._-]")
 
@@ -46,12 +52,37 @@ def _build_number(name: str) -> int:
     return int(m.group(1)) if m else -1
 
 
+def version_dirs(data_dir) -> list[Path]:
+    """Every app-*/ version folder that actually contains the exe, highest build number first."""
+    candidates = [p for p in Path(data_dir).glob(VERSION_PREFIX + "*") if (p / ASSET_NAME).exists()]
+    return sorted(candidates, key=lambda p: _build_number(p.name), reverse=True)
+
+
 def newest_version_dir(data_dir) -> Path | None:
     """The app-*/ version folder with the highest build number that actually contains the exe, or None."""
-    candidates = [p for p in Path(data_dir).glob(VERSION_PREFIX + "*") if (p / ASSET_NAME).exists()]
-    if not candidates:
-        return None
-    return max(candidates, key=lambda p: _build_number(p.name))
+    dirs = version_dirs(data_dir)
+    return dirs[0] if dirs else None
+
+
+def current_target(data_dir) -> Path | None:
+    """The real folder the `current` junction points at, or None if it doesn't resolve."""
+    link = current_link(data_dir)
+    try:
+        if link.exists():
+            return link.resolve()
+    except OSError:
+        pass
+    return None
+
+
+def versions_to_keep(data_dir, extra=()) -> set[str]:
+    """The version-folder NAMES cleanup must preserve: the newest KEEP_RECENT_VERSIONS builds, plus
+    anything named in `extra` (the folder we run from, the one `current` points at). Keeping a previous
+    build is the point - it is what a failed update rolls back to, and the run that motivated this deleted
+    it, leaving nothing bootable to fall back to (#376)."""
+    keep = {Path(k).name for k in extra if k}
+    keep |= {p.name for p in version_dirs(data_dir)[:KEEP_RECENT_VERSIONS]}
+    return keep
 
 
 def installed_exe(data_dir) -> Path:
@@ -117,10 +148,39 @@ def extract_zip(zip_path, dest_dir) -> Path:
     return dest
 
 
+def _sweep_trash(data_dir) -> None:
+    """Re-try deleting anything a previous pass moved aside. Partial progress is fine here: a trash- folder
+    is already unreachable by every app-*/ lookup, so whatever survives is dead weight, not a half-install."""
+    for p in Path(data_dir).glob(TRASH_PREFIX + "*"):
+        shutil.rmtree(p, ignore_errors=True)
+
+
 def cleanup_old_versions(data_dir, keep) -> None:
-    """Delete every app-*/ version folder except the ones named in `keep` (folder names). Best-effort: a
-    folder still held open by an exiting helper is skipped and cleaned on a later pass."""
+    """Discard every app-*/ version folder except the ones named in `keep` (folder names).
+
+    Removal is ALL-OR-NOTHING: each folder is renamed aside to trash-<name> first, and only then deleted.
+    On Windows a rename fails while any file inside is open, so a folder still in use is left completely
+    INTACT and retried on a later pass.
+
+    That ordering is the whole fix for #376. This used to be a bare shutil.rmtree(ignore_errors=True),
+    which does not skip a folder that is in use - it deletes every file it CAN and leaves the locked ones.
+    A self-update runs its helper from the PREVIOUS version folder while it health-gates the new one, so
+    the newly launched app's startup cleanup hollowed out that folder underneath the live helper: gone were
+    unicodedata.pyd, webview/, pyodbc; left behind were only the files the helper already held open. The
+    helper's next /health probe needed the lazily-imported idna codec (encodings.idna -> stringprep ->
+    unicodedata), got `LookupError: unknown encoding: idna`, read a perfectly healthy relay as dead, and
+    rolled back to the folder it had just gutted - which then could not start at all."""
+    data_dir = Path(data_dir)
+    _sweep_trash(data_dir)
     keep_names = {Path(k).name for k in keep}
-    for p in Path(data_dir).glob(VERSION_PREFIX + "*"):
-        if p.is_dir() and p.name not in keep_names:
-            shutil.rmtree(p, ignore_errors=True)
+    for p in sorted(data_dir.glob(VERSION_PREFIX + "*")):
+        if not p.is_dir() or p.name in keep_names:
+            continue
+        trash = data_dir / (TRASH_PREFIX + p.name)
+        if trash.exists():
+            continue  # last pass's leftovers still hold the name; the sweep above will get them eventually
+        try:
+            p.rename(trash)
+        except OSError:
+            continue  # in use (an update helper is running from it) - leave it whole and try again later
+        shutil.rmtree(trash, ignore_errors=True)

--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -21,9 +21,11 @@ import json
 import logging
 import os
 import re
+import socket
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 import zipfile
 from datetime import datetime, timezone
@@ -374,13 +376,51 @@ def _health_url(install_dir: Path) -> str:
         return "http://127.0.0.1:7321/health"
 
 
+def _probe_health(url: str, timeout: float = 2.0) -> bool:
+    """One GET of the loopback /health, spoken over a RAW socket instead of through urllib.
+
+    urllib resolves the host with socket.getaddrinfo(<str>), and CPython encodes a str host through the
+    `idna` text codec - a LAZY import that reaches encodings.idna -> stringprep -> unicodedata. Miss any of
+    those in the frozen bundle and the codec registry raises `LookupError: unknown encoding: idna` on EVERY
+    probe, so a perfectly healthy relay reads as dead and gets rolled back. That is #318's codec, and it is
+    what turned #376's damaged bundle into a total outage. Handing getaddrinfo a BYTES host skips the codec
+    path entirely, which keeps the probe truthful in the one situation where its verdict decides whether
+    the machine keeps a working relay: when something is wrong with the install.
+
+    Deliberately minimal HTTP - one request, `Connection: close`, read to EOF. The body is located by its
+    first `{` so chunked framing needs no decoding."""
+    parts = urllib.parse.urlsplit(url)
+    host = parts.hostname or "127.0.0.1"
+    port = parts.port or 80
+    request = (
+        f"GET {parts.path or '/'} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+    ).encode("ascii")
+    chunks: list[bytes] = []
+    with socket.create_connection((host.encode("ascii"), port), timeout=timeout) as conn:
+        conn.settimeout(timeout)
+        conn.sendall(request)
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    head, _, body = b"".join(chunks).partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0].split()
+    if len(status_line) < 2 or status_line[1] != b"200":
+        return False
+    start = body.find(b"{")
+    if start < 0:
+        return False
+    payload, _ = json.JSONDecoder().raw_decode(body[start:].decode("utf-8", "replace"))
+    return isinstance(payload, dict) and payload.get("status") == "ok"
+
+
 def _wait_for_health(url: str, deadline: float, log: logging.Logger | None = None) -> bool:
     last_err: Exception | None = None
     while _monotonic() < deadline:
         try:
-            with urllib.request.urlopen(url, timeout=2) as r:  # noqa: S310 (localhost health URL)
-                if json.loads(r.read().decode()).get("status") == "ok":
-                    return True
+            if _probe_health(url):
+                return True
         except Exception as e:  # noqa: BLE001 - the probe's ONLY job is "is it up yet?"; ANY failure
             # (connection refused, a partial body, or a missing text codec like #318's
             # `LookupError: unknown encoding: idna`) means not-up-yet. Swallow it and retry within the
@@ -417,13 +457,7 @@ def _relaunch_and_wait_healthy(install_dir: Path, deadline: float, log: logging.
 
 def _current_target(install_dir: Path) -> Path | None:
     """The real folder the `current` junction points at now (for rollback on a failed update)."""
-    link = layout.current_link(install_dir)
-    try:
-        if link.exists():
-            return link.resolve()
-    except OSError:
-        pass
-    return None
+    return layout.current_target(install_dir)
 
 
 # --- staging + applying -------------------------------------------------------------------------------
@@ -546,7 +580,9 @@ def apply_staged_update(app_pid, install_dir: str | Path) -> dict:
 
     if _relaunch_and_wait_healthy(install_dir, deadline, log):
         _finish_ledger(install_dir, "success", None)
-        layout.cleanup_old_versions(install_dir, keep={new_dir.name})
+        # Keep the version we just left as well as the new one. WE are still running from it, and it is
+        # what the next update rolls back to if that one fails (#376). Anything older goes now.
+        layout.cleanup_old_versions(install_dir, layout.versions_to_keep(install_dir, extra=(new_dir, old_target)))
         log.info("update applied: now on %s", target)
         return {"ok": True}
 
@@ -578,7 +614,7 @@ def apply_update(url: str, install_dir: str | Path) -> dict:
     except Exception:  # noqa: BLE001
         pass
     if ok:
-        layout.cleanup_old_versions(install_dir, keep={ver.name})
+        layout.cleanup_old_versions(install_dir, layout.versions_to_keep(install_dir, extra=(ver, old_target)))
         return {"ok": True, "restarted": True, "note": "reopen the window to load the updated UI"}
     if old_target is not None:
         layout.repoint_current(install_dir, old_target)

--- a/relay/tests/conftest.py
+++ b/relay/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Suite-wide guards.
+
+The relay arms daemon timers that call os._exit(0) as an exit-anyway fallback when a graceful teardown
+leaves the GUI loop stuck (see app.RelayApp._arm_hard_exit). Those timers outlive the test that armed
+them and resolve os._exit at FIRE time, so a per-test monkeypatch of os._exit is undone at teardown while
+the timer is still pending. When it fired it took the pytest process with it: exit code 0, no summary,
+no failures - and a CI run that reported green having actually executed about a third of the suite.
+
+So os._exit is disarmed for the whole session rather than per test. Calls are recorded on the fixture in
+case a test wants to assert one happened; nothing ever exits the runner.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _never_hard_exit_the_test_runner():
+    calls = []
+    real_exit = os._exit
+    os._exit = lambda code=0: calls.append(code)  # noqa: SLF001 - disarming it is the point
+    try:
+        yield calls
+    finally:
+        os._exit = real_exit

--- a/relay/tests/test_app.py
+++ b/relay/tests/test_app.py
@@ -2,10 +2,12 @@
 verified from the frozen exe; here we cover the serve supervision, the shutdown sequence, the X-close
 decision, and the Api methods that reach the app."""
 
+import json
 import threading
+from datetime import datetime, timedelta, timezone
 
 from ucnexus_relay import app as appmod
-from ucnexus_relay import setup, ui
+from ucnexus_relay import setup, ui, updater
 
 
 def test_ensure_serve_noop_when_already_running(monkeypatch):
@@ -81,8 +83,6 @@ def test_api_shutdown_app_errors_when_not_in_app_mode(monkeypatch):
 
 
 def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
-    import os
-
     from ucnexus_relay import updater
 
     a = appmod.RelayApp()
@@ -93,7 +93,6 @@ def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
     # The staging sequence now lives in RelayApp.begin_update (the update poller runs the same one),
     # so the frozen guard is checked there too.
     monkeypatch.setattr(appmod.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(os, "_exit", lambda code: None)  # neutralize the hard-exit fallback timer
     passed = {}
     monkeypatch.setattr(
         updater, "stage_update", lambda url, d, pid, target_build=None: passed.update(build=target_build) or {"ok": True}
@@ -103,6 +102,19 @@ def test_api_apply_update_stages_then_shuts_down_in_app_mode(monkeypatch):
     assert shut == [True]  # the app shut itself down so the helper can swap the unlocked exe
     assert a._updating is True  # marked as the update handoff, so a later teardown isn't a user cancel
     assert passed["build"] == "relay-v0.1.0-build.11"  # target build threaded through to the ledger
+    assert a._hard_exit_timer is not None  # the exit-anyway fallback is armed for a stuck GUI loop
+    a.cancel_hard_exit()  # and disarmed here, so it cannot fire into the rest of the suite
+
+
+def test_cancel_hard_exit_disarms_the_pending_timer():
+    a = appmod.RelayApp()
+    a._arm_hard_exit(delay=30.0)
+    timer = a._hard_exit_timer
+
+    a.cancel_hard_exit()
+
+    assert timer.finished.is_set()  # cancelled, so it can never reach os._exit
+    assert a._hard_exit_timer is None
 
 
 def test_api_apply_update_does_not_shut_down_on_a_failed_stage(monkeypatch):
@@ -243,17 +255,76 @@ def test_acquire_defers_when_it_loses_the_cold_start_race(monkeypatch):
     assert 7 in sent and (9, "z") in sent
 
 
-def test_cleanup_old_versions_keeps_running_drops_others(monkeypatch, tmp_path):
+def _installed_version(root, name: str):
+    d = root / name
+    d.mkdir()
+    (d / "ucnexus-relay.exe").write_bytes(b"exe")
+    return d
+
+
+def test_cleanup_old_versions_keeps_the_running_build_and_one_previous(monkeypatch, tmp_path):
     from ucnexus_relay import layout
 
     a = appmod.RelayApp()
     monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
-    for name in ("app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.27", "app-old"):
-        (tmp_path / name).mkdir()
+    for name in ("app-relay-v0.1.0-build.25", "app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.27"):
+        _installed_version(tmp_path, name)
+    (tmp_path / "app-old").mkdir()
     running = tmp_path / "app-relay-v0.1.0-build.27"
     monkeypatch.setattr(layout, "running_version_dir", lambda: running)
 
     a._cleanup_old_versions()
 
     remaining = sorted(p.name for p in tmp_path.glob("app-*"))
-    assert remaining == ["app-relay-v0.1.0-build.27"]  # kept the running version, dropped the rest
+    # 26 stays as the rollback target a failed update needs; 25 and the unversioned folder go
+    assert remaining == ["app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.27"]
+
+
+def test_cleanup_old_versions_is_skipped_while_an_update_is_in_flight(monkeypatch, tmp_path):
+    # #376: this runs in the app the update helper just relaunched, and that helper is executing FROM the
+    # previous version folder while it health-gates us. Deleting anything mid-update is the bug.
+    from ucnexus_relay import layout
+
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
+    for name in ("app-relay-v0.1.0-build.20", "app-relay-v0.1.0-build.36", "app-relay-v0.1.0-build.37"):
+        _installed_version(tmp_path, name)
+    monkeypatch.setattr(layout, "running_version_dir", lambda: tmp_path / "app-relay-v0.1.0-build.37")
+    (tmp_path / "update-state.json").write_text(
+        json.dumps(
+            {
+                "status": "applying",
+                "target_build": "relay-v0.1.0-build.37",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    a._cleanup_old_versions()
+
+    assert len(sorted(tmp_path.glob("app-*"))) == 3  # nothing touched, not even the genuinely stale build.20
+
+
+def test_cleanup_old_versions_runs_again_once_the_stuck_ledger_is_abandoned(monkeypatch, tmp_path):
+    # the in-flight guard must not become permanent: a helper that died without recording a result (#369)
+    # leaves the ledger pinned at "applying", and honouring that forever would end cleanup on that machine.
+    from ucnexus_relay import layout
+
+    a = appmod.RelayApp()
+    monkeypatch.setattr(a, "_install_dir", lambda: tmp_path)
+    for name in ("app-relay-v0.1.0-build.20", "app-relay-v0.1.0-build.36", "app-relay-v0.1.0-build.37"):
+        _installed_version(tmp_path, name)
+    monkeypatch.setattr(layout, "running_version_dir", lambda: tmp_path / "app-relay-v0.1.0-build.37")
+    stale = datetime.now(timezone.utc) - timedelta(seconds=updater.ABANDONED_AFTER_SECONDS + 60)
+    (tmp_path / "update-state.json").write_text(
+        json.dumps({"status": "applying", "target_build": "relay-v0.1.0-build.37", "updated_at": stale.isoformat()}),
+        encoding="utf-8",
+    )
+
+    a._cleanup_old_versions()
+
+    assert sorted(p.name for p in tmp_path.glob("app-*")) == [
+        "app-relay-v0.1.0-build.36",
+        "app-relay-v0.1.0-build.37",
+    ]

--- a/relay/tests/test_layout.py
+++ b/relay/tests/test_layout.py
@@ -1,9 +1,20 @@
 """Onedir install layout: version-folder naming, installed-exe resolution, old-version cleanup, and the
 junction repoint (mklink mocked). Pure path logic, no real junction."""
 
+import sys
 import zipfile
 
+import pytest
+
 from ucnexus_relay import layout
+
+
+def _version(root, name: str):
+    """An app-<build>/ folder that looks installable (carries the exe)."""
+    d = root / name
+    d.mkdir()
+    (d / "ucnexus-relay.exe").write_bytes(b"exe")
+    return d
 
 
 def test_version_dir_name_sanitizes():
@@ -45,6 +56,79 @@ def test_cleanup_old_versions_keeps_named(tmp_path):
         (tmp_path / b).mkdir()
     layout.cleanup_old_versions(tmp_path, keep={"app-b"})
     assert sorted(p.name for p in tmp_path.glob("app-*")) == ["app-b"]
+    assert list(tmp_path.glob(layout.TRASH_PREFIX + "*")) == []  # moved aside AND deleted, nothing left over
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="the move-aside guard relies on Windows rename semantics")
+def test_cleanup_leaves_a_version_folder_that_is_in_use_completely_intact(tmp_path):
+    """The #376 regression, exactly as it happened.
+
+    A self-update's helper runs from the PREVIOUS version folder while it health-gates the new one, so the
+    newly launched app's startup cleanup targets a folder that is very much in use. The old code called
+    shutil.rmtree(ignore_errors=True), which does NOT skip an in-use folder - it deletes every file it can
+    and leaves the locked ones, hollowing out the live helper's own bundle (unicodedata.pyd, webview/,
+    pyodbc all went; only what the helper already held open survived). Removal must be all-or-nothing."""
+    victim = _version(tmp_path, "app-relay-v0.1.0-build.36")
+    (victim / "_internal").mkdir()
+    (victim / "_internal" / "unicodedata.pyd").write_bytes(b"pyd")  # NOT open: rmtree would have taken it
+    held_open = victim / "_internal" / "python311.dll"
+    held_open.write_bytes(b"dll")
+
+    with held_open.open("rb"):  # stands in for the helper process holding its own bundle open
+        layout.cleanup_old_versions(tmp_path, keep={"app-relay-v0.1.0-build.37"})
+
+    assert victim.exists()
+    assert (victim / "ucnexus-relay.exe").exists()
+    assert (victim / "_internal" / "unicodedata.pyd").exists()  # the file whose loss caused the outage
+    assert (victim / "_internal" / "python311.dll").exists()
+
+
+def test_cleanup_sweeps_trash_a_previous_pass_left_behind(tmp_path):
+    stale = tmp_path / (layout.TRASH_PREFIX + "app-relay-v0.1.0-build.20")
+    stale.mkdir()
+    (stale / "leftover").write_bytes(b"x")
+
+    layout.cleanup_old_versions(tmp_path, keep=set())
+
+    assert not stale.exists()
+
+
+def test_version_dirs_are_newest_build_first(tmp_path):
+    for b in ("app-relay-v0.1.0-build.8", "app-relay-v0.1.0-build.26", "app-relay-v0.1.0-build.9"):
+        _version(tmp_path, b)
+    assert [p.name for p in layout.version_dirs(tmp_path)] == [
+        "app-relay-v0.1.0-build.26",
+        "app-relay-v0.1.0-build.9",
+        "app-relay-v0.1.0-build.8",
+    ]
+
+
+def test_versions_to_keep_holds_the_newest_two_so_a_rollback_target_survives(tmp_path):
+    for b in ("app-relay-v0.1.0-build.36", "app-relay-v0.1.0-build.37", "app-relay-v0.1.0-build.20"):
+        _version(tmp_path, b)
+
+    keep = layout.versions_to_keep(tmp_path)
+
+    # 37 is running, 36 is what a failed update rolls back to; 20 is dead weight
+    assert keep == {"app-relay-v0.1.0-build.37", "app-relay-v0.1.0-build.36"}
+
+
+def test_versions_to_keep_adds_the_extras_it_is_given(tmp_path):
+    for b in ("app-relay-v0.1.0-build.36", "app-relay-v0.1.0-build.37"):
+        _version(tmp_path, b)
+    odd = _version(tmp_path, "app-dev")  # no build number, so never in the newest-N slice
+
+    keep = layout.versions_to_keep(tmp_path, extra=(odd, None))
+
+    assert "app-dev" in keep  # a running / current folder is kept however it is named
+    assert {"app-relay-v0.1.0-build.37", "app-relay-v0.1.0-build.36"} <= keep
+
+
+def test_current_target_resolves_the_link_and_tolerates_its_absence(tmp_path):
+    assert layout.current_target(tmp_path) is None
+    cur = tmp_path / "current"  # a plain dir stands in for the junction
+    cur.mkdir()
+    assert layout.current_target(tmp_path) == cur.resolve()
 
 
 def test_extract_zip_roundtrip(tmp_path):

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -274,7 +274,7 @@ def test_kill_relay_pids_uses_pid_not_image_name(tmp_path, monkeypatch):
 
 
 def test_wait_for_health_returns_true_on_ok(monkeypatch):
-    monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **k: _Resp({"status": "ok"}))
+    monkeypatch.setattr(updater, "_probe_health", lambda url, **k: True)
     # drive _monotonic off a tick list that steps PAST the deadline (and no-op _sleep) so a regression that
     # stops returning True times out to False instead of spinning forever on the real clock/sleep.
     ticks = [0.0, 1.0, 2.0]
@@ -289,7 +289,7 @@ def test_wait_for_health_logs_last_error_on_timeout(monkeypatch):
     def _boom(*a, **k):
         raise OSError("connection refused")
 
-    monkeypatch.setattr(updater.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(updater, "_probe_health", _boom)
     monkeypatch.setattr(updater, "_sleep", lambda s: None)
     ticks = [0.0, 1.0]
     monkeypatch.setattr(updater, "_monotonic", lambda: ticks.pop(0) if ticks else 999.0)
@@ -311,12 +311,101 @@ def test_wait_for_health_swallows_a_probe_error_instead_of_crashing(monkeypatch)
     def _boom(*a, **k):
         raise LookupError("unknown encoding: idna")
 
-    monkeypatch.setattr(updater.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(updater, "_probe_health", _boom)
     monkeypatch.setattr(updater, "_sleep", lambda s: None)
     ticks = [0.0, 1.0, 2.0]  # three probes, then the next monotonic check is past the deadline
     monkeypatch.setattr(updater, "_monotonic", lambda: ticks.pop(0) if ticks else 999.0)
 
     assert updater._wait_for_health("http://127.0.0.1:7321/health", 5.0) is False
+
+
+# --- _probe_health ------------------------------------------------------------------------------------
+
+
+class _FakeSock:
+    """A socket that replays one canned HTTP response and records what was sent."""
+
+    def __init__(self, response: bytes, sent: list):
+        self._response = response
+        self._sent = sent
+        self._done = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def settimeout(self, t):
+        pass
+
+    def sendall(self, data):
+        self._sent.append(data)
+
+    def recv(self, n):
+        if self._done:
+            return b""
+        self._done = True
+        return self._response
+
+
+def _fake_connect(monkeypatch, response: bytes):
+    """Patch socket.create_connection and hand back (addresses, sent-bytes) for assertions."""
+    addresses, sent = [], []
+
+    def _connect(address, timeout=None):
+        addresses.append(address)
+        return _FakeSock(response, sent)
+
+    monkeypatch.setattr(updater.socket, "create_connection", _connect)
+    return addresses, sent
+
+
+_OK_RESPONSE = b'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"status": "ok", "version": "0.1.0"}'
+
+
+def test_probe_health_passes_a_bytes_host_so_the_idna_codec_is_never_reached(monkeypatch):
+    """#376's outage mechanism, guarded at the source.
+
+    getaddrinfo encodes a STR host through the `idna` text codec, which is a lazy import chain
+    (encodings.idna -> stringprep -> unicodedata). When a damaged bundle is missing any link, every probe
+    raises `LookupError: unknown encoding: idna`, a healthy relay reads as dead, and the update rolls back
+    onto the broken install. A bytes host skips that path, so the probe still answers truthfully when the
+    bundle is exactly the thing that is wrong."""
+    addresses, _ = _fake_connect(monkeypatch, _OK_RESPONSE)
+
+    assert updater._probe_health("http://127.0.0.1:7321/health") is True
+
+    host, port = addresses[0]
+    assert isinstance(host, bytes) and host == b"127.0.0.1"
+    assert port == 7321
+
+
+def test_probe_health_sends_a_close_delimited_get_for_the_url_path(monkeypatch):
+    _, sent = _fake_connect(monkeypatch, _OK_RESPONSE)
+
+    updater._probe_health("http://127.0.0.1:7321/health")
+
+    request = b"".join(sent)
+    assert request.startswith(b"GET /health HTTP/1.1\r\n")
+    assert b"Connection: close\r\n" in request
+
+
+def test_probe_health_is_false_on_a_non_200(monkeypatch):
+    _fake_connect(monkeypatch, b'HTTP/1.1 503 Service Unavailable\r\n\r\n{"status": "ok"}')
+    assert updater._probe_health("http://127.0.0.1:7321/health") is False
+
+
+def test_probe_health_is_false_when_the_body_says_anything_but_ok(monkeypatch):
+    _fake_connect(monkeypatch, b'HTTP/1.1 200 OK\r\n\r\n{"status": "starting"}')
+    assert updater._probe_health("http://127.0.0.1:7321/health") is False
+
+
+def test_probe_health_reads_the_body_through_chunked_framing(monkeypatch):
+    # uvicorn sends content-length today, but the probe must not care: it finds the JSON by its first `{`.
+    chunked = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n17\r\n" + b'{"status": "ok"}' + b"\r\n0\r\n\r\n"
+    _fake_connect(monkeypatch, chunked)
+    assert updater._probe_health("http://127.0.0.1:7321/health") is True
 
 
 # --- _relaunch_and_wait_healthy -----------------------------------------------------------------------


### PR DESCRIPTION
fixes relay self-update failure on TAGGING3W10, reported #376.

update helper runs from the previous version folder while health-gating the new one. relaunched app runs `_cleanup_old_versions()` at startup, keeps only the folder it runs from, `shutil.rmtree(ignore_errors=True)` on the rest.

`ignore_errors=True` does not skip an in-use folder. deletes every file it can, leaves locked ones. app(build.37) hollowed out build.36 while the helper was executing from it, `_internal/` 87 entries -> 21.

app(build.37) deleted from build.36:
unicodedata.pyd
webview/
pystray/
pyodbc
every api-ms-win-* DLL

survivors are the files the helper already held open:
python311.dll
base_library.zip
_socket.pyd
_ssl.pyd
its own exe image

helper then probes /health through urllib. getaddrinfo encodes a str host with the idna text codec, lazy import chain encodings.idna -> stringprep -> unicodedata. every probe raises LookupError: unknown encoding: idna.

build.37 was fine, relay.log shows channel connected. probe could never succeed -> helper declared the new version dead -> rolled back to the gutted build.36. both relaunch attempts failed, relay down. traceback on #376 is that rollback, bottle `from unicodedata import normalize`.

fix

- cleanup is all-or-nothing. rename aside to trash-<name> first, delete only after. Windows blocks renaming a directory with an open file inside, so an in-use folder is left intact and retried on a later pass. verified locally, rename raises PermissionError winerror 5 and the folder is untouched.
- keep the newest two version folders. the old code destroyed the rollback target by design.
- skip cleanup entirely while the ledger says staging or applying, unless abandoned (#369).
- probe /health on a raw socket with a bytes host, getaddrinfo never reaches the idna codec, so a damaged bundle cannot fake an unhealthy relay. same codec as #318.

relay test suite was silently truncating

poetry run pytest exited 0 after ~76 of 246 tests, no summary line. CI green while running a third of the suite.

exit-anyway fallback in apply_update arms threading.Timer(2.0, lambda: os._exit(0)). the lambda resolves os._exit at fire time. a test neutralised os._exit with monkeypatch, teardown restored the real one, the still-pending timer hard-exited pytest with code 0. cutoff wandered between runs, 31% vs 58%.

timer handle is now kept and cancellable, the test that arms it cancels it, session fixture disarms os._exit for the whole run. 246 tests pass, up from ~76.

recovery on TAGGING3W10, done by hand, outside this PR

build.38 clean-installed
current repointed to it
gutted build.36 removed
health ok, channel connected true

the guard lives in the app an update launches, so the first auto-update onto a build carrying this fix is already protected by it.
