### PR TITLE
fix(relay): run the update helper from the real folder, not the junction it repoints (#376)

### DIFF
--- a/relay/src/ucnexus_relay/updater.py
+++ b/relay/src/ucnexus_relay/updater.py
@@ -489,8 +489,8 @@ def _download_and_extract(url: str, install_dir: Path, target_build: str | None)
 
 def stage_update(url: str, install_dir: str | Path, app_pid: int, target_build: str | None = None) -> dict:
     """Download + extract the new version alongside the current one, seed the ledger, and spawn the detached
-    windowless helper from the CURRENT (settled) exe. The caller (ui.apply_update) then shuts the app down
-    so the helper can repoint the junction and relaunch."""
+    windowless helper from the CURRENT (settled) exe, by its REAL path. The caller (ui.apply_update) then
+    shuts the app down so the helper can repoint the junction and relaunch."""
     from . import single_instance
 
     install_dir = Path(install_dir)
@@ -500,7 +500,21 @@ def stage_update(url: str, install_dir: str | Path, app_pid: int, target_build: 
 
     _clear_cancel(install_dir)
     _stage_ledger(install_dir, target_build or "", url, str(ver))
+    # Resolve the `current` junction to the real app-<build>/ folder before spawning. The helper is the
+    # thing that REPOINTS that junction, and a onedir process keeps loading out of the _internal/ next to
+    # the exe path it was launched from - so a helper launched as `current\ucnexus-relay.exe` has its
+    # runtime rooted in a path it then moves out from under itself. Every LAZY import after the repoint
+    # (the health probe's `encodings.idna` -> stringprep -> unicodedata is the one that bites) resolves
+    # through the junction into the NEW version, or into nothing during the remove/recreate window. When
+    # that import loses the race the codec registry caches the failure for the life of the process, so
+    # every subsequent probe reports `LookupError: unknown encoding: idna`, a healthy new version reads as
+    # dead, and the update rolls back. Observed doing exactly that on build.38 -> build.39, whose bundle
+    # was fully intact. Launching from the resolved real folder keeps the helper's runtime still.
     helper_exe = single_instance.installed_exe_path(install_dir)  # the current, already-scanned version
+    try:
+        helper_exe = Path(helper_exe).resolve()
+    except OSError:
+        pass  # unresolvable junction: fall back to the link path rather than not updating at all
     _spawn_detached([str(helper_exe), "update-apply", "--pid", str(int(app_pid))], cwd=install_dir)
     return {"ok": True, "note": "the relay will close and reopen on the new version"}
 

--- a/relay/tests/test_updater.py
+++ b/relay/tests/test_updater.py
@@ -132,6 +132,34 @@ def test_stage_update_extracts_version_seeds_ledger_and_spawns_helper(tmp_path, 
     assert args == [str(helper_exe), "update-apply", "--pid", "4242"]  # helper runs from the CURRENT exe
 
 
+def test_stage_update_spawns_the_helper_from_the_resolved_real_folder(tmp_path, monkeypatch):
+    """The helper must not be launched through the `current` junction it is about to repoint.
+
+    A onedir process keeps loading out of the _internal/ beside the exe path it was launched from, so a
+    helper started as `current\\ucnexus-relay.exe` has its runtime rooted in a path it then moves. Lazy
+    imports after the repoint (the health probe's encodings.idna -> stringprep -> unicodedata) resolve
+    through the junction into the new version, or into nothing mid-swap; a lost race is cached by the
+    codec registry, every later probe reports `LookupError: unknown encoding: idna`, and a healthy new
+    version is rolled back. Seen on build.38 -> build.39 with a fully intact bundle.
+
+    The `..` segment here stands in for the junction: it is a path that only collapses if the code
+    resolves it, so dropping the resolve() call fails this test.
+    """
+    monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: _bundle_zip(dest))
+    real = tmp_path / "app-old" / "ucnexus-relay.exe"
+    real.parent.mkdir(parents=True, exist_ok=True)
+    real.write_bytes(b"exe")
+    via_link = tmp_path / "current" / ".." / "app-old" / "ucnexus-relay.exe"
+    monkeypatch.setattr(single_instance, "installed_exe_path", lambda d: via_link)
+    calls = []
+    monkeypatch.setattr(updater, "_spawn_detached", lambda args, cwd: calls.append((args, cwd)))
+
+    updater.stage_update("u", tmp_path, 7, target_build="relay-v0.1.0-build.12")
+
+    assert calls[0][0][0] == str(real.resolve())
+    assert ".." not in calls[0][0][0]
+
+
 def test_stage_update_rejects_a_tiny_download_and_does_not_spawn(tmp_path, monkeypatch):
     monkeypatch.setattr(updater.urllib.request, "urlretrieve", lambda url, dest: Path(dest).write_bytes(b"tiny"))
 


### PR DESCRIPTION
follow-on to #379, found watching that fix run on TAGGING3W10.

helper spawns as current\ucnexus-relay.exe and the helper repoints current. onedir process keeps loading out of the _internal/ beside the exe path it launched from, so the helper's runtime sits in a path it then moves out from under itself.

every lazy import after the repoint resolves through the junction into the new version, or into nothing during the remove/recreate window. health probe's encodings.idna -> stringprep -> unicodedata loses the race -> codec registry caches the failure for the life of the process -> every later probe reports LookupError: unknown encoding: idna -> healthy new version reads as dead -> update rolls back.

build.38 -> build.39 on TAGGING3W10, unattended via the poller.

```
02:10:30  update-apply start: target=relay-v0.1.0-build.39
02:10:33  relaunch attempt 1 of 2
02:10:59  health probe never returned ok; last error: LookupError('unknown encoding: idna')
02:11:00  relaunch attempt 2 of 2
02:11:26  health probe never returned ok; last error: LookupError('unknown encoding: idna')
02:11:26  the updated version did not become healthy; rolling back
```

both bundles fully intact throughout, unicodedata.pyd and webview present in each, 87 _internal entries each. distinct from the gutting fixed in b2ec28c - that rollback landed on an intact build.38 and the relay stayed up serving GP, where before it rolled back onto a hollowed folder and died. the update itself still failed.

resolve the junction to the real app-<build>/ folder before spawning. helper's runtime does not move.

rollout cannot fix a hop already installed, the helper is always the OLD build's code. a box on build.38 still has build.38's helper. needs one manual install onto a fixed build, then self-update carries itself.
