### PR TITLE
fix(warehouse): Deficient Items card counted back-ordered PO units, not deficient stock

### DIFF
--- a/backend/app/repositories/warehouse/progress.py
+++ b/backend/app/repositories/warehouse/progress.py
@@ -15,6 +15,7 @@ from app.models.purchase_order import PurchaseOrder as POModel
 from app.models.receiving import ReceiveLineItem as ReceiveLineItemModel
 from app.models.shipping import PackingSlip as PackingSlipModel
 from app.models.shipping import PackingSlipItem as PackingSlipItemModel
+from app.models.stock_item import StockItem as StockItemModel
 
 
 def get_warehouse_dashboard(session: Session) -> dict:
@@ -98,6 +99,25 @@ def get_warehouse_dashboard(session: Session) -> dict:
         or 0
     )
 
+    # Deficient units held for review: the same rows the Deficient Items screen lists
+    # (project inventory + stock pool), summed by quantity.
+    deficient_project = (
+        session.scalar(
+            select(func.coalesce(func.sum(InventoryLocationModel.deficient_quantity), 0)).where(
+                InventoryLocationModel.deficient_quantity > 0
+            )
+        )
+        or 0
+    )
+    deficient_stock = (
+        session.scalar(
+            select(func.coalesce(func.sum(StockItemModel.deficient_quantity), 0)).where(
+                StockItemModel.deficient_quantity > 0
+            )
+        )
+        or 0
+    )
+
     return {
         "total_item_count": int(inv_stats[0]),
         "total_value": float(inv_stats[1]),
@@ -106,6 +126,7 @@ def get_warehouse_dashboard(session: Session) -> dict:
         "pending_pull_shipping": int(pending_shipping),
         "received_last_7_days": int(received_recent),
         "back_ordered_count": int(back_ordered),
+        "deficient_count": int(deficient_project) + int(deficient_stock),
     }
 
 

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1349,6 +1349,7 @@ class WarehouseDashboard:
     pending_pull_shipping: int
     received_last_7_days: int
     back_ordered_count: int
+    deficient_count: int
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -446,6 +446,7 @@ class WarehouseQueries:
                 pending_pull_shipping=d["pending_pull_shipping"],
                 received_last_7_days=d["received_last_7_days"],
                 back_ordered_count=d["back_ordered_count"],
+                deficient_count=d["deficient_count"],
             )
 
     @strawberry.field

--- a/backend/tests/test_warehouse_dashboard.py
+++ b/backend/tests/test_warehouse_dashboard.py
@@ -54,11 +54,24 @@ def test_deficient_count_sums_project_inventory_and_stock_pool(db_session):
             received_at=now,
         )
     )
-    # Project inventory row with 3 deficient units.
+    # Project inventory row with 3 deficient units. Rows need an origin
+    # (ck_inventory_locations_has_origin), so back it with a stock item the way allocation does.
+    origin = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category="LOCK",
+        product_code="LK-DEF",
+        quantity=4,
+        deficient_quantity=0,
+        received_at=now,
+    )
+    session.add(origin)
+    session.flush()
     session.add(
         InventoryLocation(
             id=uuid.uuid4(),
             project_id=project.id,
+            stock_item_id=origin.id,
             warehouse_id=warehouse_id,
             hardware_category="LOCK",
             product_code="LK-DEF",

--- a/backend/tests/test_warehouse_dashboard.py
+++ b/backend/tests/test_warehouse_dashboard.py
@@ -1,0 +1,76 @@
+"""The warehouseDashboard rollup feeds the Warehouse landing cards.
+
+The Deficient Items card showed `back_ordered_count` (undelivered PO-line units, a deliveries
+concept) while linking to the review screen for damaged/short-shipped units. `deficient_count`
+counts what that screen actually lists: deficient units across project inventory and the stock
+pool.
+"""
+
+import uuid
+from datetime import datetime
+
+from app.models.inventory import InventoryLocation
+from app.models.project import Project
+from app.models.stock_item import StockItem
+from app.repositories import warehouse_admin_repository
+from app.repositories.warehouse import progress
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def test_deficient_count_sums_project_inventory_and_stock_pool(db_session):
+    session = db_session
+    baseline = progress.get_warehouse_dashboard(session)["deficient_count"]
+
+    project = _make_project(session)
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    now = datetime.utcnow()
+
+    # Stock-pool item with 2 deficient units, plus a clean one that must not count.
+    session.add(
+        StockItem(
+            id=uuid.uuid4(),
+            warehouse_id=warehouse_id,
+            hardware_category="HINGE",
+            product_code="HG-DEF",
+            quantity=5,
+            deficient_quantity=2,
+            received_at=now,
+        )
+    )
+    session.add(
+        StockItem(
+            id=uuid.uuid4(),
+            warehouse_id=warehouse_id,
+            hardware_category="HINGE",
+            product_code="HG-OK",
+            quantity=5,
+            deficient_quantity=0,
+            received_at=now,
+        )
+    )
+    # Project inventory row with 3 deficient units.
+    session.add(
+        InventoryLocation(
+            id=uuid.uuid4(),
+            project_id=project.id,
+            warehouse_id=warehouse_id,
+            hardware_category="LOCK",
+            product_code="LK-DEF",
+            quantity=4,
+            deficient_quantity=3,
+            aisle="A",
+            row="1",
+            bay="1",
+            received_at=now,
+        )
+    )
+    session.flush()
+
+    dashboard = progress.get_warehouse_dashboard(session)
+    assert dashboard["deficient_count"] == baseline + 5

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -390,6 +390,7 @@ export const GET_WAREHOUSE_DASHBOARD = gql`
       pendingPullShipping
       receivedLast7Days
       backOrderedCount
+      deficientCount
     }
   }
 `;

--- a/frontend/src/modules/warehouse/DashboardCards.tsx
+++ b/frontend/src/modules/warehouse/DashboardCards.tsx
@@ -16,6 +16,7 @@ export interface WarehouseDashboard {
   pendingPullShipping: number;
   receivedLast7Days: number;
   backOrderedCount: number;
+  deficientCount: number;
 }
 
 function formatCurrency(value: number): string {

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -50,6 +50,7 @@ function buildDestinations(d: WarehouseDashboard | undefined): Destination[] {
       path: '/app/warehouse/deliveries',
       icon: <Truck size={18} strokeWidth={1.75} />,
       caption: 'Upcoming POs and outstanding lines',
+      metric: d ? { value: d.backOrderedCount, noun: 'back-ordered', attention: false } : undefined,
     },
     {
       label: 'Receiving',
@@ -84,7 +85,7 @@ function buildDestinations(d: WarehouseDashboard | undefined): Destination[] {
       icon: <TriangleAlert size={18} strokeWidth={1.75} />,
       caption: 'Resolve damaged and short-shipped units',
       metric: d
-        ? { value: d.backOrderedCount, noun: 'back-ordered', attention: d.backOrderedCount > 0 }
+        ? { value: d.deficientCount, noun: 'deficient', attention: d.deficientCount > 0 }
         : undefined,
     },
     {


### PR DESCRIPTION
warehouse landing's deficient items card showed `backOrderedCount` (undelivered units on active POs); its caption and link point at the deficient-items review screen. on railway the card read 3, the review screen listed 1 unit.

`deficientCount` added to the `warehouseDashboard` rollup, sums `deficient_quantity` over project inventory rows + stock-pool items - the same rows the review screen lists. deficient items card now shows it, amber attention edge when non-zero. back-ordered figure moved to the deliveries card, no attention edge - undelivered lines on open POs are the normal state.

CI test seeds
deficient stock-pool item
clean stock-pool item
deficient project-inventory row
and asserts the dashboard count sums the two deficient sources against the baseline.