### PR TITLE
feat(home): identify activity rows by opening, product and request numbers

### DIFF
--- a/frontend/src/modules/home/HomeDashboard.tsx
+++ b/frontend/src/modules/home/HomeDashboard.tsx
@@ -7,6 +7,7 @@ import { GET_HOME_DASHBOARD_STATS } from '../../graphql/home';
 import { GET_AUDIT_LOG } from '../../graphql/shared';
 import { microLabelSx, monoSx } from '../../theme';
 import { FadeIn, StaggerList, StaggerItem } from '../../motion';
+import { describeEntity } from './activityIdentity';
 
 interface HomeStatsData {
   homeDashboardStats: {
@@ -22,6 +23,7 @@ interface AuditLogEntry {
   entityType: string;
   entityId: string;
   action: string;
+  detail: Record<string, unknown> | null;
   performedBy: string;
   createdAt: string;
 }
@@ -100,17 +102,6 @@ function formatActionLabel(action: string, entityType: string): string {
   return `${a} ${e}`;
 }
 
-/**
- * The record's own id, shortened. Two "Staged door leaf" rows in a row are indistinguishable
- * otherwise; a UUID stem is enough to tell them apart and to search the audit log with. Ids that are
- * already short (a request number, say) are shown whole.
- */
-function shortEntityId(entityId: string | null | undefined): string | null {
-  if (!entityId) return null;
-  const trimmed = entityId.trim();
-  if (!trimmed) return null;
-  return trimmed.length > 12 ? trimmed.slice(0, 8) : trimmed;
-}
 
 export default function HomeDashboard() {
   const { displayName } = useIdentity();
@@ -212,7 +203,7 @@ export default function HomeDashboard() {
           ) : (
             <StaggerList count={activity.length} style={{ display: 'block' }}>
               {activity.map((entry, i) => {
-                const shortId = shortEntityId(entry.entityId);
+                const identity = describeEntity(entry);
                 return (
                   <StaggerItem key={entry.id}>
                     <Box
@@ -230,13 +221,16 @@ export default function HomeDashboard() {
                       <Box sx={{ minWidth: 0 }}>
                         <Typography variant="body2">
                           {formatActionLabel(entry.action, entry.entityType)}
-                          {shortId && (
-                            <Box
-                              component="span"
-                              sx={{ ...monoSx, ml: 0.75, color: 'text.secondary' }}
-                            >
-                              {shortId}
-                            </Box>
+                          {identity && (
+                            <>
+                              {' '}
+                              <Box
+                                component="span"
+                                sx={{ ...monoSx, ml: 0.25, color: 'text.secondary' }}
+                              >
+                                {identity}
+                              </Box>
+                            </>
                           )}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">

--- a/frontend/src/modules/home/__tests__/describeEntity.test.ts
+++ b/frontend/src/modules/home/__tests__/describeEntity.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { describeEntity } from '../activityIdentity';
+
+describe('describeEntity', () => {
+  it('reads a door leaf by its opening identity', () => {
+    expect(
+      describeEntity({
+        entityType: 'SHOP_ASSEMBLY_OPENING',
+        entityId: 'fbca2ebc-1234-5678-9abc-def012345678',
+        detail: { openingNumber: '0501-EX', leaf: 2 },
+      }),
+    ).toBe('0501-EX · L2');
+  });
+
+  it('omits the leaf suffix when the detail has none', () => {
+    expect(
+      describeEntity({
+        entityType: 'SHOP_ASSEMBLY_OPENING',
+        entityId: 'fbca2ebc-1234-5678-9abc-def012345678',
+        detail: { openingNumber: '015.2' },
+      }),
+    ).toBe('015.2');
+  });
+
+  it('reads a pull deduction as quantity x product code plus the pull number', () => {
+    expect(
+      describeEntity({
+        entityType: 'INVENTORY_LOCATION',
+        entityId: 'a07e095f-1234-5678-9abc-def012345678',
+        detail: { deducted: 2, productCode: 'HG-100', pullRequestNumber: 'PR-ALLOC-378' },
+      }),
+    ).toBe('2× HG-100 · PR-ALLOC-378');
+  });
+
+  it('reads a receive as quantity x product code plus the PO number', () => {
+    expect(
+      describeEntity({
+        entityType: 'INVENTORY_LOCATION',
+        entityId: '9d4ac8c0-1234-5678-9abc-def012345678',
+        detail: { quantity: 4, productCode: 'E90600IC 626', poNumber: 'PO0000066' },
+      }),
+    ).toBe('4× E90600IC 626 · PO0000066');
+  });
+
+  it('shows a bare product code when no quantity was recorded', () => {
+    expect(
+      describeEntity({
+        entityType: 'STOCK_ITEM',
+        entityId: '9b0c963a-1234-5678-9abc-def012345678',
+        detail: { productCode: 'GSH250 C32D' },
+      }),
+    ).toBe('GSH250 C32D');
+  });
+
+  it('reads a pull request row by its request number alone', () => {
+    expect(
+      describeEntity({
+        entityType: 'PULL_REQUEST',
+        entityId: 'e17be581-1234-5678-9abc-def012345678',
+        detail: { pullRequestNumber: 'PR-REPL-PR-ALLOC-378' },
+      }),
+    ).toBe('PR-REPL-PR-ALLOC-378');
+  });
+
+  it('falls back to the shortened UUID when the detail has no identity', () => {
+    expect(
+      describeEntity({
+        entityType: 'INVENTORY_LOCATION',
+        entityId: 'e17be581-1234-5678-9abc-def012345678',
+        detail: { oldQuantity: 1, newQuantity: 2 },
+      }),
+    ).toBe('e17be581');
+  });
+
+  it('handles a null detail payload', () => {
+    expect(
+      describeEntity({
+        entityType: 'INVENTORY_LOCATION',
+        entityId: 'e17be581-1234-5678-9abc-def012345678',
+        detail: null,
+      }),
+    ).toBe('e17be581');
+  });
+});

--- a/frontend/src/modules/home/activityIdentity.ts
+++ b/frontend/src/modules/home/activityIdentity.ts
@@ -1,0 +1,61 @@
+/**
+ * The identity a person would use for an audit feed row, mined from the detail payload the audit
+ * writers already record: a door leaf by its opening number, stock by quantity x product code, a
+ * pull or PO by its request number. The UUID stem is the last resort, not the plan - nobody on the
+ * floor knows hardware by a hex prefix.
+ */
+
+/**
+ * The record's own id, shortened. Two "Staged door leaf" rows in a row are indistinguishable
+ * otherwise; a UUID stem is enough to tell them apart and to search the audit log with. Ids that
+ * are already short (a request number, say) are shown whole.
+ */
+export function shortEntityId(entityId: string | null | undefined): string | null {
+  if (!entityId) return null;
+  const trimmed = entityId.trim();
+  if (!trimmed) return null;
+  return trimmed.length > 12 ? trimmed.slice(0, 8) : trimmed;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+export function describeEntity(entry: {
+  entityType: string;
+  entityId: string;
+  detail?: Record<string, unknown> | null;
+}): string | null {
+  const d = entry.detail ?? {};
+
+  // A door leaf reads by its opening identity ("0501-EX · L2"), same format the pull screens use.
+  const openingNumber = str(d.openingNumber);
+  if (openingNumber) {
+    const leaf = num(d.leaf);
+    return leaf ? `${openingNumber} · L${leaf}` : openingNumber;
+  }
+
+  const parts: string[] = [];
+  const productCode = str(d.productCode);
+  if (productCode) {
+    // The quantity the action moved, under whichever name its writer records.
+    const qty =
+      num(d.deducted) ??
+      num(d.restockedQuantity) ??
+      num(d.installedQuantity) ??
+      num(d.quantityReceived) ??
+      num(d.quantity);
+    parts.push(qty ? `${qty}× ${productCode}` : productCode);
+  }
+
+  // The document behind the movement, when the writer recorded one.
+  const reference = str(d.pullRequestNumber) ?? str(d.poNumber) ?? str(d.packingSlipNumber);
+  if (reference) parts.push(reference);
+
+  if (parts.length > 0) return parts.join(' · ');
+  return shortEntityId(entry.entityId);
+}


### PR DESCRIPTION
the feed labelled every row with a shortened UUID ("Staged door leaf fbca2ebc"). recent activity feed rows now read identities off the audit row's `detail` JSON.

- door leaf reads by opening identity, "0501-EX · L2"
- stock movement reads as "2× HG-100 · PR-ALLOC-378", quantity then pull/PO/packing-slip number. quantity comes from whichever key the writer records:
  deducted
  restockedQuantity
  installedQuantity
  quantityReceived
  quantity
- pull request row reads by its request number alone
- shortened UUID remains only as last-resort fallback when payload has no identity keys

helper lives in new `activityIdentity.ts` (react-refresh forbids non-component exports from a component file), 8 unit tests cover each identity source and the fallbacks.