### PR TITLE
fix(po): cancelling a PO strands its schedule rows in IN_PO

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import InvalidStateTransitionError, NotFoundError, ValidationError
-from app.models.enums import Classification, PODocumentType, POStatus
+from app.models.enums import Classification, HardwareItemState, PODocumentType, POStatus
 from app.models.purchase_order import PODocument, PODocumentData, POLineItem, PurchaseOrder
 from app.models.receiving import ReceiveRecord
 
@@ -390,13 +390,17 @@ def register_po_in_gp(
             )
 
     # Remove lines the user dropped. A DRAFT PO has no receiving/inventory yet, so the only rows that can
-    # reference these lines are imported HardwareItem rows (FK is RESTRICT) - orphan them (po_line_item_id
-    # -> NULL) before deleting, which the user accepted as the cost of editing the imported line set.
+    # reference these lines are imported HardwareItem rows (FK is RESTRICT) - release them back to
+    # AVAILABLE before deleting, which the user accepted as the cost of editing the imported line set.
+    # State must come back too: an orphaned row left IN_PO counts as ordered nowhere yet blocks the
+    # item from being recreated as AVAILABLE by a later import.
     removed = [poli for lid, poli in existing.items() if lid not in seen_ids]
     if removed:
         removed_ids = [poli.id for poli in removed]
         session.execute(
-            update(HardwareItem).where(HardwareItem.po_line_item_id.in_(removed_ids)).values(po_line_item_id=None)
+            update(HardwareItem)
+            .where(HardwareItem.po_line_item_id.in_(removed_ids))
+            .values(po_line_item_id=None, state=HardwareItemState.AVAILABLE)
         )
         for poli in removed:
             session.delete(poli)
@@ -702,8 +706,11 @@ def cancel_po(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     - Validate exists + not soft-deleted (NotFoundError)
     - Validate status in (Draft, GP_Registered, Vendor_Confirmed) (InvalidStateTransitionError)
     - Set status=Cancelled, deleted_at=datetime.utcnow()
+    - Release the PO's hardware-schedule rows back to AVAILABLE
     - Return updated PO
     """
+    from app.models.hardware import HardwareItem
+
     po = get_purchase_order(session, po_id)
     if po is None:
         raise NotFoundError(f"Purchase order {po_id} not found")
@@ -713,6 +720,19 @@ def cancel_po(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
 
     po.status = POStatus.CANCELLED
     po.deleted_at = datetime.utcnow()
+
+    # These statuses precede receiving, so nothing from this PO is in inventory yet. Without this,
+    # the schedule rows the wizard stamped stay IN_PO against a dead PO: reconciliation reads the
+    # combo as needing ordering again (it excludes cancelled POs), but the re-order mints brand-new
+    # IN_PO rows next to the stranded ones - required_quantity rollups double-count, and the
+    # stranded key blocks the item from ever being recreated as AVAILABLE by a later import.
+    line_ids = [li.id for li in po.line_items]
+    if line_ids:
+        session.execute(
+            update(HardwareItem)
+            .where(HardwareItem.po_line_item_id.in_(line_ids))
+            .values(po_line_item_id=None, state=HardwareItemState.AVAILABLE)
+        )
 
     return po
 

--- a/backend/tests/test_po_cancel_release.py
+++ b/backend/tests/test_po_cancel_release.py
@@ -1,0 +1,102 @@
+"""Cancelling a PO must release its hardware-schedule rows.
+
+The wizard stamps HardwareItem rows IN_PO with po_line_item_id when it drafts a PO. Cancelling the
+PO used to leave them that way: reconciliation (which excludes cancelled POs) told the user the
+combo still needed ordering, but the re-order minted brand-new IN_PO rows next to the stranded
+ones - double-counting required_quantity - and the stranded key blocked the item from ever being
+recreated as AVAILABLE by a later import.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from app.errors import InvalidStateTransitionError
+from app.models.enums import HardwareItemState, POStatus
+from app.models.hardware import HardwareItem
+from app.models.project import Opening, Project
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.repositories import po_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:6]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _po_with_schedule_item(session, project, *, status=POStatus.DRAFT):
+    po = PurchaseOrder(
+        id=uuid.uuid4(),
+        request_number=f"PO-REQ-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        status=status,
+    )
+    session.add(po)
+    session.flush()
+    line = POLineItem(
+        id=uuid.uuid4(),
+        po_id=po.id,
+        hardware_category="HINGE",
+        product_code="HG-100",
+        ordered_quantity=2,
+        received_quantity=0,
+        unit_cost=Decimal("10.00"),
+    )
+    session.add(line)
+    opening = Opening(id=uuid.uuid4(), project_id=project.id, opening_number=f"OP-{uuid.uuid4().hex[:4]}")
+    session.add(opening)
+    session.flush()
+    hi = HardwareItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=opening.id,
+        hardware_category="HINGE",
+        product_code="HG-100",
+        item_quantity=2,
+        state=HardwareItemState.IN_PO,
+        po_line_item_id=line.id,
+    )
+    session.add(hi)
+    session.flush()
+    return po, line, hi
+
+
+def test_cancel_po_releases_schedule_items(db_session):
+    project = _make_project(db_session)
+    po, _line, hi = _po_with_schedule_item(db_session, project)
+
+    cancelled = po_repository.cancel_po(db_session, po.id)
+    db_session.flush()
+    db_session.refresh(hi)
+
+    assert cancelled.status == POStatus.CANCELLED
+    assert hi.state == HardwareItemState.AVAILABLE
+    assert hi.po_line_item_id is None
+
+
+def test_cancel_po_leaves_other_pos_items_alone(db_session):
+    project = _make_project(db_session)
+    po_a, _line_a, hi_a = _po_with_schedule_item(db_session, project)
+    _po_b, _line_b, hi_b = _po_with_schedule_item(db_session, project)
+
+    po_repository.cancel_po(db_session, po_a.id)
+    db_session.flush()
+    db_session.refresh(hi_a)
+    db_session.refresh(hi_b)
+
+    assert hi_a.state == HardwareItemState.AVAILABLE
+    assert hi_b.state == HardwareItemState.IN_PO
+    assert hi_b.po_line_item_id is not None
+
+
+def test_cancel_po_refused_after_receiving_started(db_session):
+    project = _make_project(db_session)
+    po, _line, hi = _po_with_schedule_item(db_session, project, status=POStatus.PARTIALLY_RECEIVED)
+
+    with pytest.raises(InvalidStateTransitionError):
+        po_repository.cancel_po(db_session, po.id)
+    db_session.refresh(hi)
+    assert hi.state == HardwareItemState.IN_PO


### PR DESCRIPTION
cancel_po flipped the PO status to CANCELLED and stopped there. HardwareItem rows the import wizard stamped stayed IN_PO, po_line_item_id pointing at the dead PO's lines:
- re-ordering through the wizard minted new IN_PO rows next to the stranded ones, double-counting required_quantity in project purchasing progress rollups
- the stranded (opening, product, category, leaf) key sits in finalize's existing_in_po_keys, blocking recreation as AVAILABLE by a later import session
- the admin Hardware Items stat counts the zombies forever

cancel_po now releases the PO's schedule rows -> AVAILABLE, po_line_item_id nulled. cancel accepts:
DRAFT
GP_REGISTERED
VENDOR_CONFIRMED
all three precede receiving, so nothing from the PO is in inventory yet and the release is safe.

register-time line-edit path had the same half-release, nulled po_line_item_id on dropped lines' items but left them IN_PO; now resets state too.

three CI tests added:
- cancel releases the items
- cancel leaves another PO's items alone
- cancel still refused once receiving has started, items untouched