### PR TITLE
fix(frontend): parse zone-less server datetimes as UTC

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -14,6 +14,7 @@ import { Bell, BellOff } from 'lucide-react';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_NOTIFICATIONS, MARK_NOTIFICATION_AS_READ } from '../graphql/shared';
 import { microLabelSx } from '../theme';
+import { parseServerDate } from '../utils/serverDate';
 
 interface Notification {
   id: string;
@@ -27,7 +28,7 @@ interface Notification {
 
 function formatTimeAgo(dateString: string): string {
   const now = new Date();
-  const date = new Date(dateString);
+  const date = parseServerDate(dateString);
   const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
 
   if (seconds < 60) return 'just now';

--- a/frontend/src/modules/admin/GpWriteQueuePanel.tsx
+++ b/frontend/src/modules/admin/GpWriteQueuePanel.tsx
@@ -7,6 +7,7 @@ import { RETRY_GP_OUTBOX_ENTRY, CANCEL_GP_OUTBOX_ENTRY } from '../../graphql/adm
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface OutboxEntry {
   id: string;
@@ -23,7 +24,7 @@ interface OutboxEntry {
 }
 
 function fmtDate(v: string | null | undefined): string {
-  return v ? new Date(v).toLocaleString() : '—';
+  return v ? parseServerDate(v).toLocaleString() : '—';
 }
 
 const STATUS_COLOR: Record<string, 'default' | 'warning' | 'success' | 'error'> = {

--- a/frontend/src/modules/admin/RelayInstallsPage.tsx
+++ b/frontend/src/modules/admin/RelayInstallsPage.tsx
@@ -35,6 +35,7 @@ import { useRelayStatus } from '../../relay/useRelayStatus';
 import RelayStatusChip from '../../relay/RelayStatusChip';
 import { FONT_MONO, microLabelSx, monoSx, tabularSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 // The GP companies a relay may be provisioned for. Matches the relay's baked KNOWN_COMPANIES; the relay's
 // own Setup tab must be set to the same company as the token it enrolls with.
@@ -69,11 +70,11 @@ interface AdoptWindow {
 }
 
 function fmtDate(v: string | null | undefined): string {
-  return v ? new Date(v).toLocaleString() : '—';
+  return v ? parseServerDate(v).toLocaleString() : '—';
 }
 
 function fmtCountdown(expiresAt: string): string {
-  const ms = new Date(expiresAt).getTime() - Date.now();
+  const ms = parseServerDate(expiresAt).getTime() - Date.now();
   if (ms <= 0) return 'expired';
   const total = Math.floor(ms / 1000);
   return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;

--- a/frontend/src/modules/home/HomeDashboard.tsx
+++ b/frontend/src/modules/home/HomeDashboard.tsx
@@ -7,6 +7,7 @@ import { GET_HOME_DASHBOARD_STATS } from '../../graphql/home';
 import { GET_AUDIT_LOG } from '../../graphql/shared';
 import { microLabelSx, monoSx } from '../../theme';
 import { FadeIn, StaggerList, StaggerItem } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface HomeStatsData {
   homeDashboardStats: {
@@ -82,7 +83,7 @@ function prettify(value: string, capitalize: boolean): string {
 }
 
 function formatRelativeTime(iso: string): string {
-  const date = new Date(iso);
+  const date = parseServerDate(iso);
   const diffMs = Date.now() - date.getTime();
   const diffMin = Math.floor(diffMs / 60000);
   if (diffMin < 1) return 'just now';

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -41,6 +41,7 @@ import { poVendorName } from './poVendorName';
 import { formatPoStatus, poStatusChipColor } from './poStatus';
 import { monoSx, tabularSx, microLabelSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 const ICON = { size: 18, strokeWidth: 1.75 } as const;
 
@@ -59,13 +60,13 @@ function formatDate(dateStr: string | null | undefined): string {
   // Parse a date-only string (YYYY-MM-DD) as LOCAL midnight, not UTC, so it displays as entered
   // (same #238 fix as the PO-document code - `new Date('2026-08-01')` renders 7/31 behind UTC).
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : new Date(dateStr);
+  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : parseServerDate(dateStr);
   return isNaN(d.getTime()) ? EMPTY : d.toLocaleDateString();
 }
 
 function formatDateTime(dateStr: string | null | undefined): string {
   if (!dateStr) return EMPTY;
-  return new Date(dateStr).toLocaleString();
+  return parseServerDate(dateStr).toLocaleString();
 }
 
 function formatFileSize(bytes: number): string {

--- a/frontend/src/modules/po/POGenerateDialog.tsx
+++ b/frontend/src/modules/po/POGenerateDialog.tsx
@@ -12,6 +12,7 @@ import { poVendorName } from './poVendorName';
 import PurchaseOrderDocument, { type PurchaseOrderDocumentProps } from './PurchaseOrderDocument';
 import type { PurchaseOrder } from './index';
 import { monoSx, microLabelSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 /** Section separator for this form: a 2px ink rule under a micro-label. */
 function SectionHeading({ children }: { children: ReactNode }) {
@@ -59,7 +60,7 @@ function formatDocDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '';
   // Parse a date-only string (YYYY-MM-DD) as LOCAL midnight, not UTC, so it prints as entered.
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : new Date(dateStr);
+  const d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : parseServerDate(dateStr);
   return isNaN(d.getTime()) ? '' : d.toLocaleDateString();
 }
 

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -50,6 +50,7 @@ import { useIdentity } from '../../hooks/useIdentity';
 import PODocumentSettingsPage from './PODocumentSettingsPage';
 import { monoSx, tabularSx, microLabelSx } from '../../theme';
 import { AnimatedNumber, FadeIn, StaggerItem, StaggerList, springs } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 const ICON = { size: 18, strokeWidth: 1.75 } as const;
 
@@ -672,7 +673,7 @@ function POTableRow({
         </TableCell>
         <TableCell>{poVendorName(po) || '-'}</TableCell>
         <TableCell sx={hugSx}>
-          {po.orderedAt ? new Date(po.orderedAt).toLocaleDateString() : '-'}
+          {po.orderedAt ? parseServerDate(po.orderedAt).toLocaleDateString() : '-'}
         </TableCell>
         <TableCell sx={{ ...hugSx, ...tabularSx }} align="right">
           {po.lineItems?.length ?? 0}

--- a/frontend/src/modules/shipping/PackingSlipForm.tsx
+++ b/frontend/src/modules/shipping/PackingSlipForm.tsx
@@ -16,6 +16,7 @@ import { extractGpError } from '../../graphql/gpError';
 import PackingSlipDocument from './PackingSlipDocument';
 import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import { StaggerItem, StaggerList } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface PackingSlipFormProps {
   open: boolean;
@@ -204,7 +205,7 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
           packingSlipNumber={result.packingSlipNumber}
           projectName={projectName}
           shippedBy={result.shippedBy}
-          shippedAt={new Date(result.shippedAt).toLocaleString()}
+          shippedAt={parseServerDate(result.shippedAt).toLocaleString()}
           openingItems={openingItems}
           looseItems={looseItems}
         />

--- a/frontend/src/modules/shipping/ShipmentsList.tsx
+++ b/frontend/src/modules/shipping/ShipmentsList.tsx
@@ -19,6 +19,7 @@ import { GET_PACKING_SLIPS } from '../../graphql/shipping';
 import ReturnShipmentDialog, { type ReturnSlip } from './ReturnShipmentDialog';
 import { monoSx, tabularSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface PackingSlipItem {
   id: string;
@@ -128,7 +129,7 @@ export default function ShipmentsList({ projectId, heading }: Props) {
         headerName: 'Shipped',
         width: 120,
         cellClassName: 'tabular-cell',
-        renderCell: ({ row }) => new Date(row.shippedAt).toLocaleDateString(),
+        renderCell: ({ row }) => parseServerDate(row.shippedAt).toLocaleDateString(),
       },
       { field: 'looseUnits', headerName: 'Loose units', width: 110, type: 'number' },
       {

--- a/frontend/src/modules/shop-assembly/PipelinePage.tsx
+++ b/frontend/src/modules/shop-assembly/PipelinePage.tsx
@@ -24,6 +24,7 @@ import { leafSuffix } from '../../utils/leaf';
 import { pipelineFlags, stageColor, stageLabel, stageProgress, unitProgressLabel } from './pipelineStages';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { FadeIn, springs } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 export interface PipelineSummary {
   requestId: string;
@@ -212,7 +213,7 @@ const columns: GridColDef[] = [
 
 function formatWhen(value: string | null): string {
   if (!value) return '-';
-  const date = new Date(value);
+  const date = parseServerDate(value);
   return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
 }
 

--- a/frontend/src/modules/warehouse/AuditHistoryDrawer.tsx
+++ b/frontend/src/modules/warehouse/AuditHistoryDrawer.tsx
@@ -13,6 +13,7 @@ import { X } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 import { GET_AUDIT_LOG } from '../../graphql/shared';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface AuditLogEntry {
   id: string;
@@ -54,7 +55,7 @@ const ACTION_LABELS: Record<string, string> = {
 };
 
 function formatDateTime(dateStr: string): string {
-  return new Date(dateStr).toLocaleString();
+  return parseServerDate(dateStr).toLocaleString();
 }
 
 function formatLocation(loc: Record<string, unknown> | null | undefined): string {

--- a/frontend/src/modules/warehouse/FetchListPanel.tsx
+++ b/frontend/src/modules/warehouse/FetchListPanel.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../../components/Toast';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { leafIdentity } from '../../utils/leaf';
 import { locationLabel, type PickSheetFetchItem } from './pick';
+import { parseServerDate } from '../../utils/serverDate';
 
 const STATE_TAG: Record<string, { label: string; color: 'default' | 'success' | 'info' | 'error' }> = {
   IN_INVENTORY: { label: 'In inventory', color: 'default' },
@@ -16,7 +17,7 @@ const STATE_TAG: Record<string, { label: string; color: 'default' | 'success' | 
 
 function formatDateTime(value: string | null): string {
   if (!value) return '';
-  return new Date(value).toLocaleString();
+  return parseServerDate(value).toLocaleString();
 }
 
 interface FetchListPanelProps {

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -29,6 +29,7 @@ import SpotCheckModal from './SpotCheckModal';
 import DestockInventoryModal from './stock/DestockInventoryModal';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { AnimatedNumber } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface InventoryItem {
   id: string;
@@ -92,7 +93,7 @@ function formatLocation(aisle: string | null, row: string | null, bay: string | 
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—';
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 function formatCurrency(value: number | null | undefined): string {

--- a/frontend/src/modules/warehouse/LocationAuditStrip.tsx
+++ b/frontend/src/modules/warehouse/LocationAuditStrip.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client/react';
 import { Box, Typography, List, ListItem, ListItemText, Skeleton, Alert, Chip } from '@mui/material';
 import { GET_LOCATION_AUDIT_HISTORY } from '../../graphql/warehouse';
 import { microLabelSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface AuditDetail {
   fromLocation?: { aisle?: string | null; row?: string | null; bay?: string | null };
@@ -123,7 +124,7 @@ export default function LocationAuditStrip({ aisle, row, bay }: Props) {
                   <Typography variant="body2">{summarize(e)}</Typography>
                 </Box>
               }
-              secondary={`${new Date(e.createdAt).toLocaleString()} — ${e.performedBy}`}
+              secondary={`${parseServerDate(e.createdAt).toLocaleString()} — ${e.performedBy}`}
               slotProps={{ secondary: { sx: tabularSx } }}
             />
           </ListItem>

--- a/frontend/src/modules/warehouse/OpeningItemsTab.tsx
+++ b/frontend/src/modules/warehouse/OpeningItemsTab.tsx
@@ -25,6 +25,7 @@ import FindInStockButton from './stock/FindInStockButton';
 import { leafLabel } from '../../utils/leaf';
 import OpeningLeafStatusPanel from '../../components/OpeningLeafStatusPanel';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface InstalledHardware {
   id: string;
@@ -66,7 +67,7 @@ interface OpeningItemsTabProps {
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—';
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 function formatLocation(aisle: string | null, row: string | null, bay: string | null): string {

--- a/frontend/src/modules/warehouse/PickPage.tsx
+++ b/frontend/src/modules/warehouse/PickPage.tsx
@@ -24,6 +24,7 @@ import PickSection from './PickSection';
 import FetchListPanel from './FetchListPanel';
 import PickSheetDocument from './PickSheetDocument';
 import { entriesFromDraft, pickTotals, toPickLines, type PickEntries, type PickSheet } from './pick';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface ProjectRow {
   id: string;
@@ -287,7 +288,7 @@ export default function PickPage() {
 
       {isPicked && (
         <Alert severity="success" sx={{ mb: 2 }}>
-          This pull was picked by {pr.pickedBy} on {new Date(pr.pickedAt as string).toLocaleString()}.
+          This pull was picked by {pr.pickedBy} on {parseServerDate(pr.pickedAt as string).toLocaleString()}.
           Its hardware is off the shelf; go back to the queue to stage the carts.
         </Alert>
       )}

--- a/frontend/src/modules/warehouse/PickSection.tsx
+++ b/frontend/src/modules/warehouse/PickSection.tsx
@@ -1,6 +1,7 @@
 import { Box, Chip, Stack, TextField, Typography } from '@mui/material';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { leafIdentity } from '../../utils/leaf';
+import { parseServerDate } from '../../utils/serverDate';
 import {
   entryKey,
   locationLabel,
@@ -12,7 +13,7 @@ import {
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return '-';
-  return new Date(value).toLocaleDateString();
+  return parseServerDate(value).toLocaleDateString();
 }
 
 /** One figure of the section's arithmetic. Required / Entered / Remaining, in that order, always. */

--- a/frontend/src/modules/warehouse/PickSheetDocument.tsx
+++ b/frontend/src/modules/warehouse/PickSheetDocument.tsx
@@ -1,6 +1,7 @@
 import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
 import { leafIdentity } from '../../utils/leaf';
 import { locationLabel, type PickSheetFetchItem, type PickSheetSection } from './pick';
+import { parseServerDate } from '../../utils/serverDate';
 
 const styles = StyleSheet.create({
   page: { fontFamily: 'Helvetica', fontSize: 11, padding: 36, color: '#333' },
@@ -140,7 +141,7 @@ export default function PickSheetDocument({
                       {locationLabel(loc) ?? 'Unlocated'}
                     </Text>
                     <Text style={[styles.td, { width: '22%' }]}>
-                      {new Date(loc.receivedAt).toLocaleDateString()}
+                      {parseServerDate(loc.receivedAt).toLocaleDateString()}
                     </Text>
                     <Text style={[styles.td, { width: '18%' }]}>{loc.available}</Text>
                     <View style={{ width: '22%' }}>

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -35,6 +35,7 @@ import { isCancellable, pullPhase } from './pullStaging';
 import type { PullRequest } from './PullRequestQueue';
 import { leafIdentity } from '../../utils/leaf';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 // --- Status config ---
 
@@ -59,12 +60,12 @@ function formatStatus(status: string): string {
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 function formatDateTime(dateStr: string | null | undefined): string {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleString();
+  return parseServerDate(dateStr).toLocaleString();
 }
 
 // --- Props ---

--- a/frontend/src/modules/warehouse/PullRequestQueue.tsx
+++ b/frontend/src/modules/warehouse/PullRequestQueue.tsx
@@ -9,6 +9,7 @@ import Tabs from '../../components/Tabs';
 import PullRequestDetailModal from './PullRequestDetailModal';
 import { pullPhase } from './pullStaging';
 import { monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 // --- Types ---
 
@@ -75,7 +76,7 @@ function formatStatus(status: string): string {
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 // --- Columns ---

--- a/frontend/src/modules/warehouse/PullStagingPanel.tsx
+++ b/frontend/src/modules/warehouse/PullStagingPanel.tsx
@@ -13,6 +13,7 @@ import { isStageable, type PullStagingOpening } from './pullStaging';
 import { leafIdentity } from '../../utils/leaf';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 function openingLabel(opening: PullStagingOpening): string {
   return leafIdentity(opening.openingNumber, opening.leaf);
@@ -20,7 +21,7 @@ function openingLabel(opening: PullStagingOpening): string {
 
 function formatDateTime(value: string | null): string {
   if (!value) return '';
-  return new Date(value).toLocaleString();
+  return parseServerDate(value).toLocaleString();
 }
 
 /** "1 leaf" / "3 leaves". A raw "leaf(s)" is a machine string, not something you say to a person. */

--- a/frontend/src/modules/warehouse/PutAwayTab.tsx
+++ b/frontend/src/modules/warehouse/PutAwayTab.tsx
@@ -28,6 +28,7 @@ import { GET_PROJECTS, ASSIGN_INVENTORY_LOCATION } from '../../graphql/shared';
 import { GET_UNLOCATED_INVENTORY, GET_LOCATION_DISTINCT_VALUES } from '../../graphql/warehouse';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { StaggerItem, StaggerList } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 // ---- Types ----
 
@@ -73,7 +74,7 @@ const ACCORDION_SX = {
 } as const;
 
 function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 function groupByCategory(items: UnlocatedItem[]): Map<string, UnlocatedItem[]> {

--- a/frontend/src/modules/warehouse/ReceivingPage.tsx
+++ b/frontend/src/modules/warehouse/ReceivingPage.tsx
@@ -24,6 +24,7 @@ import { GET_OPEN_POS, GET_RECENT_RECEIVE_RECORDS } from '../../graphql/warehous
 import { poVendorName } from '../po/poVendorName';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import { parseServerDate } from '../../utils/serverDate';
 
 // ---- Types ----
 
@@ -66,11 +67,11 @@ interface RecentReceiveRecord {
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '\u2014';
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 function formatDateTime(dateStr: string): string {
-  return new Date(dateStr).toLocaleString();
+  return parseServerDate(dateStr).toLocaleString();
 }
 
 function isOverdue(expectedDeliveryDate: string | null): boolean {

--- a/frontend/src/utils/__tests__/serverDate.test.ts
+++ b/frontend/src/utils/__tests__/serverDate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseServerDate } from '../serverDate';
+
+describe('parseServerDate', () => {
+  it('parses a zone-less server datetime as UTC', () => {
+    const d = parseServerDate('2026-07-29T06:00:00.123456');
+    expect(d.getTime()).toBe(Date.UTC(2026, 6, 29, 6, 0, 0, 123));
+  });
+
+  it('leaves an explicit-zone datetime alone', () => {
+    const d = parseServerDate('2026-07-29T06:00:00Z');
+    expect(d.getTime()).toBe(Date.UTC(2026, 6, 29, 6, 0, 0));
+    const offset = parseServerDate('2026-07-29T06:00:00+02:00');
+    expect(offset.getTime()).toBe(Date.UTC(2026, 6, 29, 4, 0, 0));
+  });
+
+  it('leaves date-only strings on unchanged platform semantics', () => {
+    // Calendar dates are not instants; the #238 call sites parse them into local components
+    // themselves. This pins that parseServerDate appends nothing to them.
+    const d = parseServerDate('2026-08-15');
+    expect(d.getTime()).toBe(new Date('2026-08-15').getTime());
+  });
+});

--- a/frontend/src/utils/serverDate.ts
+++ b/frontend/src/utils/serverDate.ts
@@ -1,0 +1,14 @@
+/**
+ * Backend datetimes are naive UTC (`datetime.utcnow()`) serialized without a zone suffix
+ * ("2026-07-29T06:00:00.123456"). `new Date()` on such a string parses it as LOCAL time, which
+ * pushes every server timestamp into the future by the viewer's UTC offset - relative times read
+ * "just now" for hours, and absolute times are simply wrong.
+ *
+ * Date-ONLY strings ("2026-07-29") must keep local parsing (#238): they are calendar dates, and
+ * UTC-parsing them prints the previous day in any behind-UTC timezone. This helper therefore only
+ * appends "Z" to zone-less date-TIME strings and leaves everything else to the platform.
+ */
+export function parseServerDate(value: string): Date {
+  const zoneless = /T\d{2}:\d{2}/.test(value) && !/(Z|[+-]\d{2}:?\d{2})$/.test(value);
+  return new Date(zoneless ? `${value}Z` : value);
+}


### PR DESCRIPTION
backend datetimes are naive UTC (datetime.utcnow) serialized without a zone suffix ("2026-07-29T06:00:00.123456"). new Date() parses that as local time, pushing every server timestamp into the future by the viewer's UTC offset.

the skew was observed live on Railway:
- home page Recent Activity rows read "just now" for actions 40+ minutes old
- notification bell shares the relative-time code
- relay adopt-window countdown (expiresAt minus now) runs on the same skew
- every toLocaleString/toLocaleDateString call on a server timestamp rendered the wrong wall time

new util parseServerDate appends "Z" only to zone-less date-time strings. explicit-zone strings pass through. date-only strings unchanged - calendar dates are not instants; the #238 call sites (PODetailModal, POGenerateDialog) parse those into local date components themselves, and delivery-date fields were deliberately left alone.

swapped 24 call sites across 23 files to parseServerDate.

three unit tests pin the parser:
- zone-less datetime becomes UTC
- explicit-zone strings unchanged
- date-only strings unchanged