### PR TITLE
ux(shop-assembly): window the leaf-status wall and put the work first

### DIFF
--- a/frontend/src/components/OpeningLeafStatusPanel.tsx
+++ b/frontend/src/components/OpeningLeafStatusPanel.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
-import { Box, Typography, Chip, Stack, CircularProgress, Alert } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { Box, Typography, Chip, Stack, CircularProgress, Alert, TextField, Button } from '@mui/material';
 import { useQuery } from '@apollo/client/react';
 import { GET_OPENING_LEAF_STATUS } from '../graphql/shared';
-import { microLabelSx } from '../theme';
+import { microLabelSx, tabularSx } from '../theme';
 
 // Per-opening door-leaf rollup (#313). Shared between the shipping (project-scoped) and shop-assembly
 // (global, grouped by project) views; `mode` reframes the N-of-M summary, `grouped` toggles the
@@ -95,6 +95,11 @@ function OpeningRow({ row, mode }: { row: OpeningLeafStatusRow; mode: 'assembly'
   );
 }
 
+/** Rows shown per project group before the "Show N more" tail. Same windowing the shipping browse
+ *  uses: a schedule-sized project renders hundreds of openings, and a wall of them buries whatever
+ *  sits below this panel. Search is the way to a specific opening; the tail is the way to the rest. */
+const WINDOW_SIZE = 30;
+
 export default function OpeningLeafStatusPanel({
   projectId,
   mode,
@@ -106,15 +111,24 @@ export default function OpeningLeafStatusPanel({
     { variables: { projectId: projectId ?? null }, fetchPolicy: 'cache-and-network' },
   );
 
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
   const rows = useMemo(() => data?.openingLeafStatus ?? [], [data]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((r) => r.openingNumber.toLowerCase().includes(q));
+  }, [rows, search]);
 
   // Group by project only when asked (global view). Key on projectId, not projectName - two projects
   // can share a description, and the backend carries project_id precisely so their same-numbered
   // openings don't collide under one subheader. Rows arrive sorted by project name then opening.
   const groups = useMemo(() => {
-    if (!grouped) return [{ projectId: '', projectName: '', rows }];
+    if (!grouped) return [{ projectId: '', projectName: '', rows: filtered }];
     const byProject = new Map<string, { projectName: string; rows: OpeningLeafStatusRow[] }>();
-    for (const r of rows) {
+    for (const r of filtered) {
       const g = byProject.get(r.projectId) ?? { projectName: r.projectName, rows: [] };
       g.rows.push(r);
       byProject.set(r.projectId, g);
@@ -124,7 +138,7 @@ export default function OpeningLeafStatusPanel({
       projectName: g.projectName,
       rows: g.rows,
     }));
-  }, [rows, grouped]);
+  }, [filtered, grouped]);
 
   if (loading && !data) {
     return (
@@ -140,27 +154,70 @@ export default function OpeningLeafStatusPanel({
 
   if (rows.length === 0) return null;
 
+  const verb = mode === 'shipping' ? 'shipped' : 'assembled';
+
   return (
     <Box sx={{ mb: 2 }}>
-      <Typography component="div" sx={{ ...microLabelSx, mb: 1 }}>
-        {title}
-      </Typography>
-      <Stack spacing={grouped ? 1.5 : 0.5}>
-        {groups.map((group) => (
-          <Box key={group.projectId || 'all'}>
-            {grouped && group.projectName && (
-              <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
-                {group.projectName}
-              </Typography>
-            )}
-            <Stack spacing={0.5}>
-              {group.rows.map((r) => (
-                <OpeningRow key={`${r.projectId}-${r.openingNumber}`} row={r} mode={mode} />
-              ))}
-            </Stack>
-          </Box>
-        ))}
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        <Typography component="div" sx={microLabelSx}>
+          {title}
+        </Typography>
+        {rows.length > WINDOW_SIZE && (
+          <TextField
+            size="small"
+            placeholder="Search opening #"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            inputProps={{ 'aria-label': 'Search opening number' }}
+            sx={{ width: 200 }}
+          />
+        )}
       </Stack>
+      {filtered.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No openings match &ldquo;{search.trim()}&rdquo;.
+        </Typography>
+      ) : (
+        <Stack spacing={grouped ? 1.5 : 0.5}>
+          {groups.map((group) => {
+            const key = group.projectId || 'all';
+            const isExpanded = expanded[key] || !!search.trim();
+            const visible = isExpanded ? group.rows : group.rows.slice(0, WINDOW_SIZE);
+            const hidden = group.rows.length - visible.length;
+            // The group's own N-of-M, so a windowed group still tells its whole story on one line.
+            const leafTotal = group.rows.reduce((n, r) => n + r.leafCount, 0);
+            const leafDone = group.rows.reduce((n, r) => n + completedCount(r.leaves, mode), 0);
+            return (
+              <Box key={key}>
+                {grouped && group.projectName && (
+                  <Stack direction="row" spacing={1} alignItems="baseline" sx={{ mb: 0.5 }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {group.projectName}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={tabularSx}>
+                      {leafDone} of {leafTotal} leaves {verb}
+                    </Typography>
+                  </Stack>
+                )}
+                <Stack spacing={0.5}>
+                  {visible.map((r) => (
+                    <OpeningRow key={`${r.projectId}-${r.openingNumber}`} row={r} mode={mode} />
+                  ))}
+                </Stack>
+                {hidden > 0 && (
+                  <Button
+                    size="small"
+                    onClick={() => setExpanded((prev) => ({ ...prev, [key]: true }))}
+                    sx={{ mt: 0.5 }}
+                  >
+                    Show {hidden} more of {group.rows.length}
+                  </Button>
+                )}
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/__tests__/OpeningLeafStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/OpeningLeafStatusPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
 import OpeningLeafStatusPanel from '../OpeningLeafStatusPanel';
 import { GET_OPENING_LEAF_STATUS } from '../../graphql/shared';
@@ -101,6 +101,45 @@ describe('OpeningLeafStatusPanel', () => {
     await screen.findByText('Opening 101: 2 of 2 leaves assembled', undefined, SLOW);
     expect(screen.getByText('Opening 101: 0 of 2 leaves assembled')).toBeInTheDocument();
     expect(screen.getAllByText('Same')).toHaveLength(2);
+  });
+
+  it('windows a long project group and reveals the rest on demand', async () => {
+    const many = Array.from({ length: 35 }, (_, i) =>
+      row('p1', 'Alpha', `${1000 + i}`, [leaf(1, 'NOT_ASSEMBLED'), leaf(2, 'NOT_ASSEMBLED')]),
+    );
+    const mocks = [statusMock(null, many)];
+    render(
+      <MockedProvider mocks={mocks}>
+        <OpeningLeafStatusPanel mode="assembly" grouped />
+      </MockedProvider>,
+    );
+
+    await screen.findByText('Opening 1000: 0 of 2 leaves assembled', undefined, SLOW);
+    // Row 31 sits behind the tail button.
+    expect(screen.queryByText('Opening 1030: 0 of 2 leaves assembled')).toBeNull();
+    // The group header still tells the whole story.
+    expect(screen.getByText('0 of 70 leaves assembled')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 5 more of 35' }));
+    expect(screen.getByText('Opening 1034: 0 of 2 leaves assembled')).toBeInTheDocument();
+  });
+
+  it('search filters across the window', async () => {
+    const many = Array.from({ length: 35 }, (_, i) =>
+      row('p1', 'Alpha', `${1000 + i}`, [leaf(1, 'NOT_ASSEMBLED'), leaf(2, 'NOT_ASSEMBLED')]),
+    );
+    const mocks = [statusMock(null, many)];
+    render(
+      <MockedProvider mocks={mocks}>
+        <OpeningLeafStatusPanel mode="assembly" grouped />
+      </MockedProvider>,
+    );
+
+    await screen.findByText('Opening 1000: 0 of 2 leaves assembled', undefined, SLOW);
+    fireEvent.change(screen.getByLabelText('Search opening number'), { target: { value: '1034' } });
+    // The match renders even though it sat past the window; the rest drop out.
+    expect(screen.getByText('Opening 1034: 0 of 2 leaves assembled')).toBeInTheDocument();
+    expect(screen.queryByText('Opening 1000: 0 of 2 leaves assembled')).toBeNull();
   });
 
   it('renders nothing when there are no pair openings', async () => {

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -220,8 +220,6 @@ export default function AssembleListPage() {
         </Typography>
       </FadeIn>
 
-      <OpeningLeafStatusPanel mode="assembly" grouped title="Door leaves assembled (by project)" />
-
       {loading && !data && (
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           Loading...
@@ -370,6 +368,12 @@ export default function AssembleListPage() {
           );
         })}
       </Stack>
+
+      {/* Reference, not work: the sections above are what this page is for, so the by-project
+          leaf-status rollup reads below them rather than burying them under a schedule-sized wall. */}
+      <Box sx={{ mt: 4 }}>
+        <OpeningLeafStatusPanel mode="assembly" grouped title="Door leaves assembled (by project)" />
+      </Box>
 
       {completing && (
         <AssemblyDetailModal


### PR DESCRIPTION
Assemble List rendered the shared OpeningLeafStatusPanel chip wall above the pull-status sections. observed live on Railway, 442 opening rows before the 5 workable leaves. the shipping browse dropped this chip-wall pattern in the 2026-07-28 revamp; shop assembly kept the old shared panel.

panel changes land in both consumers:
Assemble List global view
warehouse Opening Items in All Projects mode

- each project group windows at 30 rows with a "Show N more of M" tail button
- opening-number search appears above 30 rows, expands across the window
- project group headers add a "N of M leaves assembled/shipped" summary

on Assemble List the panel moves below the Ready/Waiting/Pending sections - it is reference material, not the page's job.

two new tests cover:
- windowing with reveal-on-demand
- search reaching past the window
existing panel tests unchanged, passing.