### PR TITLE
fix(warehouse): short-pick notification rendered gate-frame arithmetic

### DIFF
--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -1090,6 +1090,9 @@ def confirm_pick(
             request_number=pr.request_number,
             shortfalls=shortfalls,
             pull_request_id=pr.id,
+            # These shortfalls carry the pick frame (short = still owed, available = free now), not
+            # the gate frame (short = need - available); the gate template misreads them.
+            pick_frame=True,
         )
 
     # An *integrity* signal, so it must fire only for a pull that genuinely held a claim for

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -94,6 +94,21 @@ def format_shortfall_lines(shortfalls) -> str:
     )
 
 
+def format_pick_shortfall_lines(shortfalls) -> str:
+    """The short-pick frame (#367), which the creation-gate template cannot say truthfully.
+
+    A pick's `short` is what the pull is still owed after the confirm, and its `available` is what
+    the project shows free *now* - deliberately post-deduction (see `_pick_shortfalls`). Pushing
+    those numbers through the gate template rendered "need 3, 6 available (short 2)": arithmetic
+    that holds in the gate frame (short = need - available) and reads as nonsense in this one.
+    """
+    return "; ".join(
+        f"{s.hardware_category} {s.product_code}: {s.requested - s.short} of {s.requested} picked - "
+        f"{s.short} still owed ({s.available} free in the project now)"
+        for s in shortfalls
+    )
+
+
 def notify_po_shortfall(
     session: Session,
     project_id: uuid.UUID,
@@ -101,6 +116,7 @@ def notify_po_shortfall(
     shortfalls,
     sent_short: bool = False,
     pull_request_id: uuid.UUID | None = None,
+    pick_frame: bool = False,
 ) -> Notification:
     """PO backfill signal (#224), carrying the shortfall detail.
 
@@ -123,7 +139,8 @@ def notify_po_shortfall(
         if sent_short
         else f"{label} couldn't be fulfilled - backfill needed."
     )
-    message = f"{headline} {format_shortfall_lines(shortfalls)}"
+    lines = format_pick_shortfall_lines(shortfalls) if pick_frame else format_shortfall_lines(shortfalls)
+    message = f"{headline} {lines}"
     return create_notification(
         session,
         project_id=project_id,

--- a/backend/tests/test_pick_flow.py
+++ b/backend/tests/test_pick_flow.py
@@ -713,6 +713,23 @@ def test_a_short_confirm_deducts_what_was_entered_and_stays_open(db_session):
     assert [(s.product_code, s.requested, s.short) for s in result.shortfalls] == [(HINGE[1], 12, 3)]
 
 
+def test_a_short_confirm_notification_speaks_the_pick_frame(db_session):
+    """A pick shortfall's numbers are (requested, free-now, still-owed). The creation-gate template
+    rendered them as "need 12, N available (short 3)" - arithmetic that only holds in the gate frame
+    where short = need - available - so purchasing read a contradiction."""
+    project = _make_project(db_session)
+    row = _seed_inventory(db_session, project.id, quantity=9)
+    pr = _started_pull(db_session, project.id, needs=[(*HINGE, 12, 1)])
+
+    result = warehouse_repository.confirm_pick(db_session, pr.id, [_line(row, 9)], "picker")
+    db_session.flush()
+
+    assert result.notification is not None
+    assert f"{HINGE[0]} {HINGE[1]}: 9 of 12 picked - 3 still owed (0 free in the project now)" in (
+        result.notification.message
+    )
+
+
 def test_a_short_confirm_notifies_purchasing_once_per_pull(db_session):
     """A picker keying a big sheet in three sittings must not raise three identical backfill signals
     for the same gap."""


### PR DESCRIPTION
observed live on Railway: INVENTORY_SHORTFALL for a short-picked pull read "Architectural H BB1068 ...: need 3, 6 available (short 2)" - 6 available against a need of 3 shouldn't be short at all.

pick shortfall numbers are (requested, free-now, still-owed). message went through format_shortfall_lines, the creation-gate template where short = need - available.

new pick-frame formatter - "N of M picked - S still owed (A free in the project now)" - selected by a pick_frame flag on notify_po_shortfall, set by confirm_pick. the pick page's own on-screen alert already words it this way; the notification now matches.

gate-path and sent-short messages unchanged, sar_allocation wording tests pass untouched.

one new CI test asserts the pick-frame message text.