### PR TITLE
polish(frontend): surface query errors, fix empty states and copy

### DIFF
--- a/frontend/src/components/OpeningLeafStatusPanel.tsx
+++ b/frontend/src/components/OpeningLeafStatusPanel.tsx
@@ -1,8 +1,19 @@
 import { useMemo, useState } from 'react';
-import { Box, Typography, Chip, Stack, CircularProgress, Alert, TextField, Button } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Chip,
+  Stack,
+  Skeleton,
+  Alert,
+  TextField,
+  Button,
+  InputAdornment,
+} from '@mui/material';
+import { Search } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 import { GET_OPENING_LEAF_STATUS } from '../graphql/shared';
-import { microLabelSx, tabularSx } from '../theme';
+import { microLabelSx, monoSx, tabularSx } from '../theme';
 
 // Per-opening door-leaf rollup (#313). Shared between the shipping (project-scoped) and shop-assembly
 // (global, grouped by project) views; `mode` reframes the N-of-M summary, `grouped` toggles the
@@ -75,7 +86,10 @@ function OpeningRow({ row, mode }: { row: OpeningLeafStatusRow; mode: 'assembly'
       <Chip
         size="small"
         color={summaryColor(done, row.leafCount)}
-        label={`Opening ${row.openingNumber}: ${done} of ${row.leafCount} leaves ${verb}`}
+        // Single-leaf doors are the common case; "1 of 1 leaves" reads as a machine talking.
+        label={`Opening ${row.openingNumber}: ${done} of ${row.leafCount} ${
+          row.leafCount === 1 ? 'leaf' : 'leaves'
+        } ${verb}`}
       />
       {[...row.leaves]
         .sort((a, b) => a.leaf - b.leaf)
@@ -141,9 +155,13 @@ export default function OpeningLeafStatusPanel({
   }, [filtered, grouped]);
 
   if (loading && !data) {
+    // Skeletons shaped like the rows they become (DESIGN.md: skeletons over spinners).
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
-        <CircularProgress size={20} />
+      <Box sx={{ mb: 2 }}>
+        <Skeleton width={110} height={14} sx={{ mb: 1 }} />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} height={26} sx={{ mb: 0.5, maxWidth: 480 }} />
+        ))}
       </Box>
     );
   }
@@ -168,8 +186,19 @@ export default function OpeningLeafStatusPanel({
             placeholder="Search opening #"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            inputProps={{ 'aria-label': 'Search opening number' }}
-            sx={{ width: 200 }}
+            // Same affordance as the shipping browse: search glyph in, mono for the identifier.
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search size={16} strokeWidth={1.75} />
+                  </InputAdornment>
+                ),
+                sx: monoSx,
+              },
+              htmlInput: { 'aria-label': 'Search opening number' },
+            }}
+            sx={{ width: { xs: '100%', sm: 200 } }}
           />
         )}
       </Stack>
@@ -195,7 +224,7 @@ export default function OpeningLeafStatusPanel({
                       {group.projectName}
                     </Typography>
                     <Typography variant="caption" color="text.secondary" sx={tabularSx}>
-                      {leafDone} of {leafTotal} leaves {verb}
+                      {leafDone} of {leafTotal} {leafTotal === 1 ? 'leaf' : 'leaves'} {verb}
                     </Typography>
                   </Stack>
                 )}

--- a/frontend/src/components/__tests__/OpeningLeafStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/OpeningLeafStatusPanel.test.tsx
@@ -150,8 +150,9 @@ describe('OpeningLeafStatusPanel', () => {
       </MockedProvider>,
     );
 
-    // Once the empty result resolves the spinner clears and the panel collapses to null (no chips).
-    await waitFor(() => expect(container.querySelector('.MuiCircularProgress-root')).toBeNull(), SLOW);
+    // Once the empty result resolves the loading skeletons clear and the panel collapses to null
+    // (no chips).
+    await waitFor(() => expect(container.querySelector('.MuiSkeleton-root')).toBeNull(), SLOW);
     expect(container.querySelector('.MuiChip-root')).toBeNull();
   });
 });

--- a/frontend/src/modules/home/HomeDashboard.tsx
+++ b/frontend/src/modules/home/HomeDashboard.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Card, Skeleton } from '@mui/material';
+import { Alert, Box, Typography, Card, Skeleton } from '@mui/material';
 import { ReceiptText, ClipboardList, PackageCheck, FolderOpen } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 import { useIdentity } from '../../hooks/useIdentity';
@@ -103,15 +103,14 @@ function formatActionLabel(action: string, entityType: string): string {
   return `${a} ${e}`;
 }
 
-
 export default function HomeDashboard() {
   const { displayName } = useIdentity();
 
-  const { data: statsData, loading: statsLoading } = useQuery<HomeStatsData>(
+  const { data: statsData, loading: statsLoading, error: statsError } = useQuery<HomeStatsData>(
     GET_HOME_DASHBOARD_STATS,
     { fetchPolicy: 'cache-and-network' },
   );
-  const { data: activityData, loading: activityLoading } = useQuery<AuditLogData>(
+  const { data: activityData, loading: activityLoading, error: activityError } = useQuery<AuditLogData>(
     GET_AUDIT_LOG,
     { variables: { limit: 10 }, fetchPolicy: 'cache-and-network' },
   );
@@ -133,56 +132,67 @@ export default function HomeDashboard() {
         </Typography>
       </FadeIn>
 
-      <StaggerList count={4} style={{ display: 'flex', gap: 12, marginBottom: 32, flexWrap: 'wrap' }}>
-        {statsLoading && !s
-          ? Array.from({ length: 4 }).map((_, i) => (
-              <StaggerItem key={i} style={{ flex: '1 1 0', minWidth: 150 }}>
-                <StatCardSkeleton />
-              </StaggerItem>
-            ))
-          : s
-            ? [
-                {
-                  key: 'po',
-                  icon: <ReceiptText size={18} strokeWidth={1.75} />,
-                  label: 'Open POs',
-                  value: s.openPoCount,
-                  color: 'text.secondary',
-                },
-                {
-                  key: 'pulls',
-                  icon: <ClipboardList size={18} strokeWidth={1.75} />,
-                  label: 'Pending Pull Requests',
-                  value: s.pendingPullRequestCount,
-                  // Colour is an attention signal, not decoration: a zero count is nothing to act on.
-                  color: s.pendingPullRequestCount > 0 ? 'info.main' : 'text.secondary',
-                },
-                {
-                  key: 'receiving',
-                  icon: <PackageCheck size={18} strokeWidth={1.75} />,
-                  label: 'Items Pending Receiving',
-                  value: s.itemsPendingReceiving,
-                  color: s.itemsPendingReceiving > 0 ? 'warning.main' : 'text.secondary',
-                },
-                {
-                  key: 'projects',
-                  icon: <FolderOpen size={18} strokeWidth={1.75} />,
-                  label: 'Projects',
-                  value: s.projectCount,
-                  color: 'text.secondary',
-                },
-              ].map((tile) => (
-                <StaggerItem key={tile.key} style={{ flex: '1 1 0', minWidth: 150 }}>
-                  <StatCard
-                    icon={tile.icon}
-                    label={tile.label}
-                    value={tile.value}
-                    color={tile.color}
-                  />
+      {/* An errored rollup renders as an error, never as a silently missing gauge row - the
+          operator must not read "no gauges" as "nothing to do". */}
+      {statsError && !s ? (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Error loading dashboard stats: {statsError.message}
+        </Alert>
+      ) : (
+        <StaggerList
+          count={4}
+          style={{ display: 'flex', gap: 12, marginBottom: 24, flexWrap: 'wrap' }}
+        >
+          {statsLoading && !s
+            ? Array.from({ length: 4 }).map((_, i) => (
+                <StaggerItem key={i} style={{ flex: '1 1 0', minWidth: 150 }}>
+                  <StatCardSkeleton />
                 </StaggerItem>
               ))
-            : null}
-      </StaggerList>
+            : s
+              ? [
+                  {
+                    key: 'po',
+                    icon: <ReceiptText size={18} strokeWidth={1.75} />,
+                    label: 'Open POs',
+                    value: s.openPoCount,
+                    color: 'text.secondary',
+                  },
+                  {
+                    key: 'pulls',
+                    icon: <ClipboardList size={18} strokeWidth={1.75} />,
+                    label: 'Pending Pull Requests',
+                    value: s.pendingPullRequestCount,
+                    // Colour is an attention signal, not decoration: a zero count is nothing to act on.
+                    color: s.pendingPullRequestCount > 0 ? 'info.main' : 'text.secondary',
+                  },
+                  {
+                    key: 'receiving',
+                    icon: <PackageCheck size={18} strokeWidth={1.75} />,
+                    label: 'Items Pending Receiving',
+                    value: s.itemsPendingReceiving,
+                    color: s.itemsPendingReceiving > 0 ? 'warning.main' : 'text.secondary',
+                  },
+                  {
+                    key: 'projects',
+                    icon: <FolderOpen size={18} strokeWidth={1.75} />,
+                    label: 'Projects',
+                    value: s.projectCount,
+                    color: 'text.secondary',
+                  },
+                ].map((tile) => (
+                  <StaggerItem key={tile.key} style={{ flex: '1 1 0', minWidth: 150 }}>
+                    <StatCard
+                      icon={tile.icon}
+                      label={tile.label}
+                      value={tile.value}
+                      color={tile.color}
+                    />
+                  </StaggerItem>
+                ))
+              : null}
+        </StaggerList>
+      )}
 
       {/* Bounded: a full-bleed feed strands every timestamp a screen away from the line it belongs
           to. At this width the "when" sits next to the "what". */}
@@ -191,7 +201,9 @@ export default function HomeDashboard() {
           <Typography component="div" sx={{ ...microLabelSx, mb: 1.5 }}>
             Recent Activity
           </Typography>
-          {activityLoading && activity.length === 0 ? (
+          {activityError && activity.length === 0 ? (
+            <Alert severity="error">Error loading recent activity: {activityError.message}</Alert>
+          ) : activityLoading && activity.length === 0 ? (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {Array.from({ length: 5 }).map((_, i) => (
                 <Skeleton key={i} variant="text" width="80%" height={28} />
@@ -242,6 +254,8 @@ export default function HomeDashboard() {
                         variant="caption"
                         color="text.secondary"
                         sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                        // Relative time reads fast; the exact moment is one hover away.
+                        title={parseServerDate(entry.createdAt).toLocaleString()}
                       >
                         {formatRelativeTime(entry.createdAt)}
                       </Typography>

--- a/frontend/src/modules/warehouse/PullRequestQueue.tsx
+++ b/frontend/src/modules/warehouse/PullRequestQueue.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Box, Typography, Chip, Stack } from '@mui/material';
+import { Alert, Box, Typography, Chip, Stack } from '@mui/material';
 import { ChevronRight } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 import type { GridColDef, GridRowParams } from '@mui/x-data-grid';
@@ -108,7 +108,7 @@ const columns: GridColDef[] = [
   },
   {
     field: 'itemsCount',
-    headerName: 'Items Count',
+    headerName: 'Items',
     flex: 0.8,
     minWidth: 120,
     type: 'number',
@@ -162,7 +162,7 @@ const columns: GridColDef[] = [
     filterable: false,
     align: 'center',
     renderCell: () => (
-      <Box data-row-open sx={{ display: 'flex', color: 'text.secondary' }}>
+      <Box data-row-open aria-hidden sx={{ display: 'flex', color: 'text.secondary' }}>
         <ChevronRight size={18} strokeWidth={1.75} />
       </Box>
     ),
@@ -181,7 +181,7 @@ function PullRequestTab({ source }: PullRequestTabProps) {
   // snapshot - the same trap #340 fixed in the assembly views.
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const { data, loading } = useQuery<{ pullRequests: PullRequest[] }>(GET_PULL_REQUESTS, {
+  const { data, loading, error } = useQuery<{ pullRequests: PullRequest[] }>(GET_PULL_REQUESTS, {
     variables: { source },
   });
 
@@ -194,6 +194,13 @@ function PullRequestTab({ source }: PullRequestTabProps) {
 
   return (
     <>
+      {/* Without this, a failed load reads as an empty queue - the one thing this screen must
+          never claim wrongly. */}
+      {error && (
+        <Alert severity="error" sx={{ mb: 1.5 }}>
+          Error loading pull requests: {error.message}
+        </Alert>
+      )}
       <DataTable
         columns={columns}
         rows={requests}
@@ -202,6 +209,7 @@ function PullRequestTab({ source }: PullRequestTabProps) {
         // The phase cell is a tag over a line of detail (#367); the default 52px row clips it.
         rowHeight={64}
         height={520}
+        localeText={{ noRowsLabel: 'No pull requests' }}
         sx={{
           cursor: 'pointer',
           '& .MuiDataGrid-row:hover [data-row-open]': { color: 'text.primary' },

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Box, Typography, Card, CardActionArea, Grid, Skeleton } from '@mui/material';
+import { Alert, Box, Typography, Card, CardActionArea, Grid, Skeleton } from '@mui/material';
 import {
   Boxes,
   ClipboardList,
@@ -149,7 +149,7 @@ function DestinationCard({ dest, onClick }: { dest: Destination; onClick: () => 
 export default function WarehouseLanding() {
   const navigate = useNavigate();
   // One dashboard query for the whole page: the two gauges below and every card count come from it.
-  const { data, loading: queryLoading } = useQuery<{ warehouseDashboard: WarehouseDashboard }>(
+  const { data, loading: queryLoading, error } = useQuery<{ warehouseDashboard: WarehouseDashboard }>(
     GET_WAREHOUSE_DASHBOARD,
     { fetchPolicy: 'cache-and-network' },
   );
@@ -165,6 +165,14 @@ export default function WarehouseLanding() {
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         What is in the building, what is waiting to be worked, and where to go next.
       </Typography>
+
+      {/* A failed rollup must say so; the destination cards below stay navigable without their
+          counts, so the floor can still get where it is going. */}
+      {error && !dashboard && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Error loading warehouse dashboard: {error.message}
+        </Alert>
+      )}
 
       <DashboardCards dashboard={dashboard} loading={loading} />
 


### PR DESCRIPTION
impeccable refinement pass, within DESIGN.md identity, no redesign, no DESIGN.md/sidecar changes. the theme is honest state: a failed query must never render as an empty screen.

home
- stats query error renders error Alert
- activity query error renders Alert inside card
- relative timestamps get title tooltip with exact local datetime
- gauge row margin 32 -> 24

warehouse landing
- dashboard rollup failure shows Alert, destination cards degrade to captions and stay navigable

pull queue
- query error renders Alert above table (a failed load previously read as an empty queue)
- DataGrid noRowsLabel "No pull requests"
- "Items Count" header renamed "Items"
- row-open chevron aria-hidden

leaf status panel
- loading spinner replaced with row-shaped skeletons
- search field matches ShipReadyBrowser (search glyph, mono input, responsive width)
- deprecated inputProps migrated to slotProps.htmlInput, accessible name preserved
- "1 of 1 leaves" pluralization fixed

lint 0 errors, 348/348 tests, build clean.