### PR TITLE
polish(frontend): count-noun agreement on single-count labels

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -298,7 +298,7 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth, s
             }
           />
           <Typography variant="body2" color="text.secondary">
-            ({node.rows.length} items)
+            ({node.rows.length} {node.rows.length === 1 ? 'item' : 'items'})
           </Typography>
           {!readOnly && (
             <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -110,7 +110,11 @@ function DraggableCard({
           <Typography variant='body2' sx={{ ...monoSx, fontWeight: 600 }}>
             {(opening.openingNumber || opening.openingId.slice(0, 8)) + leafSuffix(opening.leaf)}
           </Typography>
-          <Chip label={`${opening.items.length} items`} size="small" variant="outlined" />
+          <Chip
+            label={`${opening.items.length} ${opening.items.length === 1 ? 'item' : 'items'}`}
+            size="small"
+            variant="outlined"
+          />
         </Stack>
         {(opening.building || opening.floor) && (
           <Typography variant='caption' color='text.secondary'>

--- a/frontend/src/modules/warehouse/PullStagingPanel.tsx
+++ b/frontend/src/modules/warehouse/PullStagingPanel.tsx
@@ -153,7 +153,7 @@ export default function PullStagingPanel({
         sx={{ mb: 1.5, pb: 0.75, borderBottom: '2px solid', borderColor: 'text.primary' }}
       >
         <Typography component="div" sx={{ ...microLabelSx, flexGrow: 1 }}>
-          Stage carts ({stagedCount} of {openings.length} leaves)
+          Stage carts ({stagedCount} of {openings.length} {openings.length === 1 ? 'leaf' : 'leaves'})
         </Typography>
         {editable && stageable.length > 0 && (
           <Button size="small" variant="text" onClick={toggleAll}>

--- a/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+﻿import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
 import { ToastProvider } from '../../../components/Toast';
 import PullStagingPanel from '../PullStagingPanel';
@@ -196,7 +196,7 @@ it('says the pull is complete when the last opening is staged', async () => {
 
 it('is read-only once the pull is no longer in progress', async () => {
   renderPanel([openingsMock([opening({ pullStatus: 'PULLED', stagedBy: 'Ada' })])], false);
-  expect(await screen.findByText(/Stage carts \(1 of 1 leaves\)/)).toBeInTheDocument();
+  expect(await screen.findByText(/Stage carts \(1 of 1 leaf\)/)).toBeInTheDocument();
   expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   expect(screen.queryByRole('button', { name: /Confirm/ })).not.toBeInTheDocument();
 });


### PR DESCRIPTION
three single-count labels read plural:
"1 items" on assignment board opening chip
"Stage carts (1 of 1 leaves)" on staging panel header - single-leaf doors are the common case
"(1 items)" on classification group headers in import wizard

same miss class as #404 fixed on leaf-status panel.
staging-panel test updated to "1 of 1 leaf".