### PR TITLE
polish(shipping): skeleton loading on the ship-ready leaf ledger

### DIFF
--- a/frontend/src/modules/shipping/ShipReadyBrowser.tsx
+++ b/frontend/src/modules/shipping/ShipReadyBrowser.tsx
@@ -4,9 +4,9 @@ import {
   Box,
   Button,
   Chip,
-  CircularProgress,
   InputAdornment,
   MenuItem,
+  Skeleton,
   Stack,
   Tab,
   Tabs,
@@ -221,9 +221,14 @@ function LeafStatusLedger({ projectId }: { projectId: string | undefined }) {
   }, [visible, grouped]);
 
   if (loading && !data) {
+    // Skeletons shaped like the rows they become, matching OpeningLeafStatusPanel's loading state
+    // (DESIGN.md: skeletons over spinners).
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
-        <CircularProgress size={20} />
+      <Box sx={{ mb: 2 }}>
+        <Skeleton width={110} height={14} sx={{ mb: 1 }} />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} height={26} sx={{ mb: 0.5, maxWidth: 480 }} />
+        ))}
       </Box>
     );
   }


### PR DESCRIPTION
ShipReadyBrowser leaf-status ledger loading state moved to row-shaped skeletons, matching #404's OpeningLeafStatusPanel (DESIGN.md "skeletons over spinners") - the two sibling ledgers now load identically. last CircularProgress on the shipping browse removed.

also the live test for the PR-environment watch-pattern change. backend and frontend service instances now carry two watch patterns:
backend/**
frontend/**
this frontend-only PR's ephemeral environment should deploy BOTH services (previously a one-sided PR only deployed the touched service). relay-only and docs-only changes trigger neither service. production now redeploys both services on any app merge.