### PR TITLE
feat(admin): pick GP buyer identity from GP's buyer master, register new ones from Nexus (#409)

### DIFF
--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -93,3 +93,19 @@ class RelayOpUnsupportedError(AppError):
         super().__init__(message, "RELAY_OP_UNSUPPORTED")
         self.op = op
         self.detail = detail or {}
+
+
+def validation_error_from_relay(e: RelayCallError) -> ValidationError:
+    """Turn a relay refusal into a ValidationError that still carries the relay's error body.
+
+    main.py's ErrorHandlerExtension publishes `extensions.relayError` from whatever `.detail` the
+    raised error has, and ValidationError has no such field - so converting the error plainly would
+    strip the GP proc, the error state and the taErrorCode description on the way to the browser, and
+    the dialog's GpErrorAlert would render an empty detail table. That table is the whole point of
+    #187: error screenshots are how these get reported.
+
+    Lives here rather than in one schema module because every GP write that surfaces a refusal to a
+    dialog needs exactly this conversion (createGpJob #380, createGpBuyer #409)."""
+    error = ValidationError(str(e.message))
+    error.detail = e.detail
+    return error

--- a/backend/app/graphql/user.graphql
+++ b/backend/app/graphql/user.graphql
@@ -19,7 +19,9 @@ type ClerkUser {
   # (app/auth.SHOP_ASSEMBLY_MANAGER_ROLE). Free-form in Clerk, so this is not an enum.
   roles: [String!]!
   # The GP BUYERID this account acts as (#216). Null until an admin links it; createPo and
-  # registerPoInGp enforce that the caller has one.
+  # registerPoInGp enforce that the caller has one. Since #409 the admin picks it from GP's live
+  # buyer master (Query.gpBuyersDetailed) rather than typing it, so an id that was never registered
+  # in GP can no longer be saved here - taPoHdr would have rejected it at PO time anyway (error 269).
   gp_buyer_id: String
   image_url: String!
 }

--- a/backend/app/graphql/user.graphql
+++ b/backend/app/graphql/user.graphql
@@ -20,8 +20,10 @@ type ClerkUser {
   roles: [String!]!
   # The GP BUYERID this account acts as (#216). Null until an admin links it; createPo and
   # registerPoInGp enforce that the caller has one. Since #409 the admin picks it from GP's live
-  # buyer master (Query.gpBuyersDetailed) rather than typing it, so an id that was never registered
-  # in GP can no longer be saved here - taPoHdr would have rejected it at PO time anyway (error 269).
+  # buyer master (Query.gpBuyersDetailed) rather than typing it, so the UI no longer offers an id GP
+  # never registered - taPoHdr would reject that one at PO time anyway (error 269). Note the guard is
+  # the picker, not this mutation: updateUserGpBuyerId still accepts any string, and rows written as
+  # free text before #409 are unmigrated, which is why the Buyers grid flags unregistered ids.
   gp_buyer_id: String
   image_url: String!
 }

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -17,6 +17,7 @@ from .types import (
     ClerkUser,
     DeficiencyReview,
     DeficientItemRow,
+    GpBuyer,
     GpCostCode,
     GpCustomer,
     GpCustomerAddress,
@@ -179,6 +180,10 @@ def gp_vendor_to_type(v: dict) -> GpVendor:
         # relay doesn't break the vendor dropdown.
         currency=v.get("currency") or "CAD",
     )
+
+
+def gp_buyer_to_type(b: dict) -> GpBuyer:
+    return GpBuyer(buyer_id=b["buyer_id"], description=b.get("description"))
 
 
 def gp_cost_code_to_type(c: dict) -> GpCostCode:

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -8,7 +8,13 @@ import strawberry
 
 from app.auth import require_admin
 from app.database import SessionLocal
-from app.errors import ConflictError, NotFoundError, RelayCallError, RelayUnavailableError, ValidationError
+from app.errors import (
+    ConflictError,
+    NotFoundError,
+    RelayCallError,
+    RelayUnavailableError,
+    validation_error_from_relay,
+)
 from app.repositories import project_repository
 from app.services import gp_job_sync
 from app.services.relay_gateway import gateway as relay_gateway
@@ -18,19 +24,6 @@ from .inputs import CreateGpJobInput, UpdateProjectInput
 from .types import CreateGpJobResult, GpJobSyncResult, Project, ProjectShipTo
 
 logger = logging.getLogger(__name__)
-
-
-def _validation_error_from(e: RelayCallError) -> ValidationError:
-    """Turn a relay refusal into a ValidationError that still carries the relay's error body.
-
-    main.py's ErrorHandlerExtension publishes `extensions.relayError` from whatever `.detail` the
-    raised error has, and ValidationError has no such field - so converting the error plainly would
-    strip the GP proc, the error state and the taErrorCode description on the way to the browser, and
-    the dialog's GpErrorAlert would render an empty detail table. That table is the whole point of
-    #187: error screenshots are how these get reported."""
-    error = ValidationError(str(e.message))
-    error.detail = e.detail
-    return error
 
 
 def _load_project(job_number: str) -> Project:
@@ -158,7 +151,7 @@ class ProjectMutations:
             # GP said no - a closed fiscal period, an address code that isn't on the customer, a
             # division without accounts. The proc words those better than we could, so the message is
             # passed through to the dialog rather than replaced with a generic failure.
-            raise _validation_error_from(e) from e
+            raise validation_error_from_relay(e) from e
 
         # GP's own record of what it created, read back from JC00102 by the relay - not the input
         # echoed back (see ops.create_job_op).

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -7,7 +7,14 @@ import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.errors import ConflictError, NotFoundError, RelayCallError, RelayUnavailableError, ValidationError
+from app.errors import (
+    ConflictError,
+    NotFoundError,
+    RelayCallError,
+    RelayUnavailableError,
+    ValidationError,
+    validation_error_from_relay,
+)
 from app.models.relay_install import RelayInstall
 from app.repositories import relay_repository
 from app.services import relay_adopt
@@ -297,10 +304,8 @@ class RelayMutations:
         except RelayCallError as e:
             # GP said no, or the id is already registered. Either way the relay words it better than a
             # generic failure would, and the detail body carries the proc + error state the dialog's
-            # error alert renders.
-            error = ValidationError(str(e.message))
-            error.detail = e.detail
-            raise error from e
+            # error alert renders - which is what validation_error_from_relay preserves.
+            raise validation_error_from_relay(e) from e
 
         # GP's stored row, read back from POP00101 by the relay rather than the request echoed back.
         # That row is what gpBuyersDetailed will serve on its next refetch, so answering with anything

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -7,13 +7,14 @@ import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.errors import ConflictError, NotFoundError
+from app.errors import ConflictError, NotFoundError, RelayCallError, RelayUnavailableError, ValidationError
 from app.models.relay_install import RelayInstall
 from app.repositories import relay_repository
 from app.services import relay_adopt
 from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
+    gp_buyer_to_type,
     gp_cost_code_to_type,
     gp_customer_address_to_type,
     gp_customer_to_type,
@@ -26,6 +27,7 @@ from .converters import (
 )
 from .inputs import EnrollRelayInstallInput
 from .types import (
+    GpBuyer,
     GpCostCode,
     GpCustomer,
     GpCustomerAddress,
@@ -104,6 +106,19 @@ class RelayQueries:
         require_user(info)
         result = await relay_gateway.relay_call(company, "list_buyers")
         return result["buyers"]
+
+    @strawberry.field
+    async def gp_buyers_detailed(self, info: strawberry.Info, company: str) -> list[GpBuyer]:
+        """Registered GP buyers (POP00101) WITH their descriptions, via the connected relay, for the
+        admin screens that link a Nexus account to a GP buyer identity (#409).
+
+        Admin-gated where gp_buyers above is not, on the same reasoning as gp_employees: the bare id
+        list is ordinary working data every PO creator needs, but the descriptions are a staff roster
+        by another name ('Don Roberton', and in the production company every buyer's email), and the
+        only consumers are admin-only screens."""
+        require_admin(info)
+        result = await relay_gateway.relay_call(company, "list_buyers_detailed")
+        return [gp_buyer_to_type(b) for b in result["buyers"]]
 
     @strawberry.field
     async def gp_cost_codes(self, info: strawberry.Info, company: str, job: str) -> list[GpCostCode]:
@@ -238,6 +253,65 @@ class RelayQueries:
 
 @strawberry.type
 class RelayMutations:
+    @strawberry.mutation
+    async def create_gp_buyer(
+        self, info: strawberry.Info, buyer_id: str, description: str = "", company: str | None = None
+    ) -> GpBuyer:
+        """Register a buyer in GP's buyer master through the relay's taCreateBuyer op (#409).
+
+        A Nexus account can only create POs once an admin links it to a GP BUYERID (#216), and until
+        now that id had to already exist - so onboarding a new buyer meant opening GP locally to add
+        one. This is the same registration GP's Buyer Maintenance window performs.
+
+        `company` defaults to whatever the connected relay is enrolled for, which is the only company
+        it could be written to anyway; passing it explicitly is for symmetry with the gp_* reads.
+
+        Admin-only, and writing to the accounting system of record - the same bar create_gp_job sets.
+        Note there is no delete counterpart: eConnect exposes no proc for it, and removing a buyer
+        rows-deep in POP00101 by hand would bypass the business logic that rule exists to protect."""
+        require_admin(info)
+
+        target = company or relay_gateway.company
+        if not target:
+            raise RelayUnavailableError(
+                "The GP relay is not connected, so this buyer cannot be registered in GP. "
+                "Start the relay and try again."
+            )
+
+        # Bounded here as well as in the relay's CreateBuyerRequest: an over-length id would otherwise
+        # travel a full round-trip to come back as a generic invalid_payload, and GP's char widths are
+        # the honest thing to report against (BUYERID char(15), taCreateBuyer's DSCRIPTN char(30)).
+        cleaned_id = (buyer_id or "").strip()
+        if not cleaned_id:
+            raise ValidationError("A GP buyer ID is required.", field="buyer_id")
+        if len(cleaned_id) > 15:
+            raise ValidationError("A GP buyer ID is at most 15 characters.", field="buyer_id")
+        cleaned_description = (description or "").strip()
+        if len(cleaned_description) > 30:
+            raise ValidationError("A GP buyer description is at most 30 characters.", field="description")
+
+        try:
+            result = await relay_gateway.relay_call(
+                target, "create_buyer", {"buyer_id": cleaned_id, "description": cleaned_description}
+            )
+        except RelayCallError as e:
+            # GP said no, or the id is already registered. Either way the relay words it better than a
+            # generic failure would, and the detail body carries the proc + error state the dialog's
+            # error alert renders.
+            error = ValidationError(str(e.message))
+            error.detail = e.detail
+            raise error from e
+
+        # GP's stored row, read back from POP00101 by the relay rather than the request echoed back.
+        # That row is what gpBuyersDetailed will serve on its next refetch, so answering with anything
+        # else could hand the dialog a buyer that differs from the one everything else is about to see.
+        return gp_buyer_to_type(
+            {
+                "buyer_id": str((result or {}).get("buyer_id") or cleaned_id),
+                "description": (result or {}).get("description") or None,
+            }
+        )
+
     @strawberry.mutation
     def provision_relay_install(self, info: strawberry.Info, label: str, company: str) -> RelayInstallProvision:
         """Admin: create a relay install + a one-time enrollment token shown ONCE. The relay uses the

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -184,6 +184,19 @@ class GpVendor:
 
 
 @strawberry.type
+class GpBuyer:
+    """A registered GP buyer (POP00101) read live via the relay, for the admin screens that link a
+    Nexus account to a GP buyer identity (#409).
+
+    The description is the whole reason this exists alongside `gpBuyers`, which returns bare ids for
+    the Create PO dropdown: an id like 'donr' or 'mira' says nothing about who it is, and an admin
+    picking the wrong one silently mis-attributes every PO that account goes on to create."""
+
+    buyer_id: str
+    description: str | None
+
+
+@strawberry.type
 class GpCostCode:
     cost_code: str  # two-segment number 'cc1-cc2' e.g. '310-000'
     description: str | None

--- a/backend/tests/test_create_gp_buyer.py
+++ b/backend/tests/test_create_gp_buyer.py
@@ -142,9 +142,11 @@ def test_over_length_description_is_rejected(monkeypatch):
 
 def test_an_already_registered_buyer_surfaces_the_relays_own_message(monkeypatch):
     _as_admin(monkeypatch)
+    # Shaped as relay/errors.py error_body() builds it: {error, message, context}, always all three.
     detail = {
         "error": "buyer_already_exists",
         "message": "buyer 'donr' is already registered in GP company TUBC (POP00101)",
+        "context": {},
     }
     _relay(monkeypatch, raises=RelayCallError(detail["message"], detail=detail))
 
@@ -159,10 +161,22 @@ def test_an_already_registered_buyer_surfaces_the_relays_own_message(monkeypatch
 
 def test_a_gp_refusal_surfaces_with_its_detail_intact(monkeypatch):
     _as_admin(monkeypatch)
-    detail = {"error": "econnect_error", "message": "taCreateBuyer failed", "proc": "taCreateBuyer", "error_state": 1}
-    _relay(monkeypatch, raises=RelayCallError("taCreateBuyer failed", detail=detail))
+    # relay/errors.py econnect_error_body() nests the proc, the numeric state and its taErrorCode
+    # description under `context` - that is the shape GpErrorAlert reads (error.relay.context.proc),
+    # so asserting against a flattened one would prove nothing about what the alert renders.
+    detail = {
+        "error": "econnect_error",
+        "message": "Unable to insert into the Buyer Master Table - POP00101",
+        "context": {
+            "proc": "taCreateBuyer",
+            "error_state": 2683,
+            "error_description": "Unable to insert into the Buyer Master Table - POP00101",
+        },
+    }
+    _relay(monkeypatch, raises=RelayCallError(detail["message"], detail=detail))
 
     with pytest.raises(ValidationError) as exc:
         _create()
 
-    assert exc.value.detail["proc"] == "taCreateBuyer"
+    assert exc.value.detail["context"]["proc"] == "taCreateBuyer"
+    assert exc.value.detail["context"]["error_state"] == 2683

--- a/backend/tests/test_create_gp_buyer.py
+++ b/backend/tests/test_create_gp_buyer.py
@@ -1,0 +1,168 @@
+"""createGpBuyer: admin gate, relay gating, input bounds, and GP error surfacing (#409).
+
+The mutation writes to GP's buyer master and persists nothing locally, so what these pin is the
+guard order: a non-admin and a missing relay must both stop the call before GP is touched, an
+over-length id must be rejected against GP's own char widths rather than after a round-trip, and a
+refusal (an id already registered) must reach the dialog in the relay's words with its detail body
+intact - that body is what the error alert renders.
+"""
+
+import asyncio
+
+import pytest
+
+from app.auth import AuthError
+from app.errors import RelayCallError, RelayUnavailableError, ValidationError
+from app.schemas import relay as relay_module
+from app.schemas.relay import RelayMutations
+
+
+class _FakeInfo:
+    context = {"request": None}
+
+
+def _as_admin(monkeypatch):
+    monkeypatch.setattr(relay_module, "require_admin", lambda info: {"user_id": "user_1", "roles": ["Admin"]})
+
+
+def _relay(monkeypatch, *, company="TUBC", result=None, raises=None):
+    calls: list[tuple] = []
+
+    async def _call(_company, op, payload=None, timeout=None):
+        calls.append((_company, op, payload))
+        if raises is not None:
+            raise raises
+        return result if result is not None else {"buyer_id": "newbuyer", "description": "New Buyer"}
+
+    monkeypatch.setattr(type(relay_module.relay_gateway), "company", property(lambda self: company))
+    monkeypatch.setattr(relay_module.relay_gateway, "relay_call", _call)
+    return calls
+
+
+def _create(**kwargs):
+    fields = {"buyer_id": "newbuyer", "description": "New Buyer"}
+    fields.update(kwargs)
+    return asyncio.run(RelayMutations().create_gp_buyer(_FakeInfo(), **fields))
+
+
+def test_requires_an_admin(monkeypatch):
+    # Registering a buyer writes to the accounting system of record.
+    def _deny(info):
+        raise AuthError("Admin role required")
+
+    monkeypatch.setattr(relay_module, "require_admin", _deny)
+
+    async def _never(*a, **k):
+        raise AssertionError("the relay must not be called for a non-admin")
+
+    monkeypatch.setattr(relay_module.relay_gateway, "relay_call", _never)
+
+    with pytest.raises(AuthError):
+        _create()
+
+
+def test_no_relay_stops_before_gp(monkeypatch):
+    _as_admin(monkeypatch)
+
+    async def _never(*a, **k):
+        raise AssertionError("the relay must not be called when none is connected")
+
+    monkeypatch.setattr(type(relay_module.relay_gateway), "company", property(lambda self: None))
+    monkeypatch.setattr(relay_module.relay_gateway, "relay_call", _never)
+
+    with pytest.raises(RelayUnavailableError):
+        _create()
+
+
+def test_sends_the_trimmed_buyer_to_the_relay(monkeypatch):
+    _as_admin(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    _create(buyer_id="  newbuyer  ", description="  New Buyer  ")
+
+    assert calls == [("TUBC", "create_buyer", {"buyer_id": "newbuyer", "description": "New Buyer"})]
+
+
+def test_company_defaults_to_the_connected_relays(monkeypatch):
+    # The connected relay is enrolled for exactly one company, which is the only one it could write to.
+    _as_admin(monkeypatch)
+    calls = _relay(monkeypatch, company="TUCSH")
+
+    _create(company=None)
+
+    assert calls[0][0] == "TUCSH"
+
+
+def test_answers_with_gps_stored_row_not_the_request(monkeypatch):
+    # The relay reads POP00101 back after the write, and that row is what the dropdown will show on
+    # its next refetch - so answering with the request echoed back could hand the dialog a buyer that
+    # differs from the one everything else is about to see.
+    _as_admin(monkeypatch)
+    _relay(monkeypatch, result={"buyer_id": "newbuyer", "description": "What GP Actually Kept"})
+
+    buyer = _create(description="What Was Asked For")
+
+    assert buyer.buyer_id == "newbuyer"
+    assert buyer.description == "What GP Actually Kept"
+
+
+def test_blank_buyer_id_is_rejected_before_the_relay(monkeypatch):
+    _as_admin(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        _create(buyer_id="   ")
+
+    assert exc.value.field == "buyer_id"
+    assert calls == []
+
+
+def test_over_length_buyer_id_is_rejected_against_gps_own_width(monkeypatch):
+    # BUYERID is char(15). Caught here rather than after a full round-trip returning invalid_payload.
+    _as_admin(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        _create(buyer_id="x" * 16)
+
+    assert exc.value.field == "buyer_id"
+    assert calls == []
+
+
+def test_over_length_description_is_rejected(monkeypatch):
+    _as_admin(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        _create(description="x" * 31)
+
+    assert exc.value.field == "description"
+    assert calls == []
+
+
+def test_an_already_registered_buyer_surfaces_the_relays_own_message(monkeypatch):
+    _as_admin(monkeypatch)
+    detail = {
+        "error": "buyer_already_exists",
+        "message": "buyer 'donr' is already registered in GP company TUBC (POP00101)",
+    }
+    _relay(monkeypatch, raises=RelayCallError(detail["message"], detail=detail))
+
+    with pytest.raises(ValidationError) as exc:
+        _create(buyer_id="donr")
+
+    assert "already registered" in str(exc.value)
+    # The detail body rides along: ErrorHandlerExtension publishes it as extensions.relayError, which
+    # is what the dialog's error alert renders.
+    assert exc.value.detail == detail
+
+
+def test_a_gp_refusal_surfaces_with_its_detail_intact(monkeypatch):
+    _as_admin(monkeypatch)
+    detail = {"error": "econnect_error", "message": "taCreateBuyer failed", "proc": "taCreateBuyer", "error_state": 1}
+    _relay(monkeypatch, raises=RelayCallError("taCreateBuyer failed", detail=detail))
+
+    with pytest.raises(ValidationError) as exc:
+        _create()
+
+    assert exc.value.detail["proc"] == "taCreateBuyer"

--- a/backend/tests/test_gp_relay_reads.py
+++ b/backend/tests/test_gp_relay_reads.py
@@ -119,6 +119,42 @@ def test_gp_buyers_returns_relay_result_directly(monkeypatch):
     assert fake.calls == [("TUBC", "list_buyers", None)]
 
 
+def test_gp_buyers_detailed_maps_relay_result_to_type(monkeypatch):
+    fake = _install_fake_gateway(
+        monkeypatch,
+        {"buyers": [{"buyer_id": "donr", "description": "Don Roberton"}, {"buyer_id": "mira"}]},
+    )
+
+    async def run():
+        return await Query().gp_buyers_detailed(FakeInfo(), company="TUBC")
+
+    buyers = asyncio.run(run())
+    assert [(b.buyer_id, b.description) for b in buyers] == [("donr", "Don Roberton"), ("mira", None)]
+    # list_buyers_detailed, not list_buyers - the bare-id op still backs the Create PO dropdown
+    assert fake.calls == [("TUBC", "list_buyers_detailed", None)]
+
+
+def test_gp_buyers_detailed_requires_an_admin(monkeypatch):
+    # gp_buyers (bare ids) stays require_user; the descriptions are a staff roster by another name.
+    from app.auth import AuthError
+
+    def _deny(info):
+        raise AuthError("Admin role required")
+
+    monkeypatch.setattr(relay_module, "require_admin", _deny)
+
+    async def _never(*a, **k):
+        raise AssertionError("the relay must not be called for a non-admin")
+
+    monkeypatch.setattr(relay_module, "relay_gateway", type("G", (), {"relay_call": staticmethod(_never)})())
+
+    async def run():
+        return await Query().gp_buyers_detailed(FakeInfo(), company="TUBC")
+
+    with pytest.raises(AuthError):
+        asyncio.run(run())
+
+
 def test_gp_cost_codes_maps_relay_result_to_type(monkeypatch):
     fake = _install_fake_gateway(
         monkeypatch,

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -362,6 +362,28 @@ export const UPDATE_USER_GP_BUYER_ID = gql`
   }
 `;
 
+// Issue #409: GP's own buyer master, read live through the relay, so an admin picks a buyer identity
+// instead of typing one - and registers a missing one here rather than opening GP. Admin-gated on the
+// backend (the descriptions are a staff roster); gpBuyers, the bare-id read behind the Create PO
+// dropdown, is unchanged and still any-user.
+export const GET_GP_BUYERS_DETAILED = gql`
+  query GetGpBuyersDetailed($company: String!) {
+    gpBuyersDetailed(company: $company) {
+      buyerId
+      description
+    }
+  }
+`;
+
+export const CREATE_GP_BUYER = gql`
+  mutation CreateGpBuyer($buyerId: String!, $description: String!) {
+    createGpBuyer(buyerId: $buyerId, description: $description) {
+      buyerId
+      description
+    }
+  }
+`;
+
 export const SAVE_BUYER_ASSIGNMENT = gql`
   mutation SaveBuyerAssignment($buyerId: String!, $projectIds: [ID!]!, $costCodes: [String!]!) {
     saveBuyerAssignment(buyerId: $buyerId, projectIds: $projectIds, costCodes: $costCodes) {

--- a/frontend/src/modules/admin/BuyersPage.tsx
+++ b/frontend/src/modules/admin/BuyersPage.tsx
@@ -10,10 +10,13 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  Paper,
+  Stack,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
-import { Plus, Trash2 } from 'lucide-react';
+import { AlertTriangle, Plus, Trash2 } from 'lucide-react';
 import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
 import { useMutation, useQuery } from '@apollo/client/react';
 import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/shared';
@@ -23,6 +26,9 @@ import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
 import { FONT_MONO, microLabelSx, monoSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import GpBuyerSelect from './GpBuyerSelect';
+import RegisterGpBuyerDialog from './RegisterGpBuyerDialog';
+import { useGpBuyers } from './useGpBuyers';
 import type { Project } from '../../types/project';
 
 interface AssignmentProject {
@@ -60,6 +66,14 @@ export default function BuyersPage() {
   const [selectedProjects, setSelectedProjects] = useState<Project[]>([]);
   const [costCodesText, setCostCodesText] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [registerOpen, setRegisterOpen] = useState(false);
+
+  // Issue #409: GP's live buyer master. Polled for the whole page, not just the dialog - the panel
+  // below renders it, and the grid uses it to flag assignments for ids GP never registered.
+  const gpBuyers = useGpBuyers({ skip: !isAdmin });
+  const registeredIds = useMemo(() => new Set(gpBuyers.buyers.map((b) => b.buyerId)), [gpBuyers.buyers]);
+  // Only meaningful once the list actually loaded: an unavailable read would otherwise flag every row.
+  const canFlagUnregistered = !gpBuyers.unavailable && !gpBuyers.loading && gpBuyers.buyers.length > 0;
 
   const [saveAssignment, { loading: saving }] = useMutation(SAVE_BUYER_ASSIGNMENT, {
     refetchQueries: [{ query: GET_BUYER_ASSIGNMENTS }],
@@ -120,12 +134,26 @@ export default function BuyersPage() {
       {
         field: 'buyerId',
         headerName: 'GP Buyer',
-        width: 160,
-        renderCell: (params) => (
-          <Box component="span" sx={{ ...monoSx, fontWeight: 600 }}>
-            {params.row.buyerId}
-          </Box>
-        ),
+        width: 190,
+        renderCell: (params) => {
+          // #409: an assignment for an id GP never registered can never produce a PO - taPoHdr rejects
+          // the BUYERID (error 269). Free text made these easy to create and invisible afterwards.
+          const unregistered = canFlagUnregistered && !registeredIds.has(params.row.buyerId);
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Box component="span" sx={{ ...monoSx, fontWeight: 600 }}>
+                {params.row.buyerId}
+              </Box>
+              {unregistered && (
+                <Tooltip title="Not registered in GP (POP00101). POs for this buyer will be rejected.">
+                  <Box component="span" sx={{ display: 'flex', color: 'warning.main' }}>
+                    <AlertTriangle size={15} strokeWidth={2} aria-label="Not registered in GP" />
+                  </Box>
+                </Tooltip>
+              )}
+            </Box>
+          );
+        },
       },
       {
         field: 'projects',
@@ -179,7 +207,7 @@ export default function BuyersPage() {
         ),
       },
     ],
-    [],
+    [canFlagUnregistered, registeredIds],
   );
 
   if (!isAdmin) {
@@ -229,19 +257,80 @@ export default function BuyersPage() {
         sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
       />
 
+      {/* Issue #409: GP's own buyer master, so an admin can see what exists and add to it without
+          opening GP. Separate from the grid above because the two are different things: this is who
+          GP knows as a buyer, that is what each buyer is allowed to do here. */}
+      <Paper variant="outlined" sx={{ mt: 3, p: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1.5 }}>
+          <Box sx={{ flex: 1 }}>
+            <Typography component="div" sx={microLabelSx}>
+              Registered in GP
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              GP&apos;s buyer master (POP00101) for {gpBuyers.company || 'the connected company'}. A buyer must
+              be registered here before an account can be linked to it. Removing one is still a GP task.
+            </Typography>
+          </Box>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Plus size={18} strokeWidth={1.75} />}
+            onClick={() => setRegisterOpen(true)}
+            disabled={gpBuyers.unavailable}
+            sx={{ flexShrink: 0 }}
+          >
+            Register GP Buyer
+          </Button>
+        </Box>
+
+        {gpBuyers.unavailable ? (
+          <Alert severity="warning" sx={{ mt: 1 }}>
+            {gpBuyers.unsupported
+              ? 'The connected relay is too old to list GP buyers. Update the relay on that workstation, then reload this page.'
+              : gpBuyers.relayConnected
+                ? `Could not read the buyer master from GP. ${gpBuyers.error?.message ?? ''}`
+                : 'The GP relay is not connected, so the buyer master cannot be read or added to.'}
+          </Alert>
+        ) : gpBuyers.buyers.length === 0 && !gpBuyers.loading ? (
+          <Typography variant="body2" color="text.secondary">
+            No buyers are registered in this GP company yet.
+          </Typography>
+        ) : (
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+            {gpBuyers.buyers.map((b) => (
+              <Chip
+                key={b.buyerId}
+                size="small"
+                variant="outlined"
+                label={b.description ? `${b.buyerId} · ${b.description}` : b.buyerId}
+                sx={{ '& .MuiChip-label': { fontFamily: FONT_MONO } }}
+              />
+            ))}
+          </Stack>
+        )}
+      </Paper>
+
+      <RegisterGpBuyerDialog
+        open={registerOpen}
+        company={gpBuyers.company}
+        onClose={() => setRegisterOpen(false)}
+      />
+
       <Dialog open={editOpen} onClose={() => setEditOpen(false)} maxWidth="sm" fullWidth>
         <DialogTitle>{isNew ? 'Add Buyer Assignment' : `Edit Buyer: ${buyerId}`}</DialogTitle>
         <DialogContent>
-          <TextField
-            label="GP Buyer ID"
-            value={buyerId}
-            onChange={(e) => setBuyerId(e.target.value)}
-            size="small"
-            fullWidth
-            disabled={!isNew}
-            sx={{ mt: 1, mb: 2, '& .MuiInputBase-input': { fontFamily: FONT_MONO } }}
-            helperText={isNew ? 'The GP BUYERID exactly as it appears in GP (POP00101)' : ''}
-          />
+          {/* #409: picked from GP's buyer master rather than typed. Still locked on an existing
+              assignment - the buyer id is the row key, so changing it would be a different row. */}
+          <Box sx={{ mt: 1, mb: 2 }}>
+            <GpBuyerSelect
+              value={buyerId || null}
+              onChange={(next) => setBuyerId(next ?? '')}
+              state={gpBuyers}
+              disabled={!isNew}
+              fullWidth
+              helperText={isNew ? 'Only buyers registered in GP (POP00101) can be assigned' : ''}
+            />
+          </Box>
           <Typography component="div" sx={{ ...microLabelSx, mb: 1 }}>
             Scope
           </Typography>

--- a/frontend/src/modules/admin/BuyersPage.tsx
+++ b/frontend/src/modules/admin/BuyersPage.tsx
@@ -284,13 +284,34 @@ export default function BuyersPage() {
         </Box>
 
         {gpBuyers.unavailable ? (
-          <Alert severity="warning" sx={{ mt: 1 }}>
-            {gpBuyers.unsupported
-              ? 'The connected relay is too old to list GP buyers. Update the relay on that workstation, then reload this page.'
-              : gpBuyers.relayConnected
-                ? `Could not read the buyer master from GP. ${gpBuyers.error?.message ?? ''}`
-                : 'The GP relay is not connected, so the buyer master cannot be read or added to.'}
-          </Alert>
+          // Same three-way state GpBuyerSelect words, in the same order. The null relay status is its
+          // own case: it is the first poll still in flight, and reporting that as "not connected" puts
+          // a warning on every load of this page during the second it takes to find out.
+          gpBuyers.relayStatus === null ? (
+            <Typography variant="body2" color="text.secondary">
+              Checking the GP relay&hellip;
+            </Typography>
+          ) : (
+            <Alert
+              severity="warning"
+              sx={{ mt: 1 }}
+              // A failed read is sticky - nothing re-runs the buyer query on its own, so without this
+              // one GP timeout locks the panel and both buyer pickers until the page is remounted.
+              action={
+                gpBuyers.relayConnected && !gpBuyers.unsupported ? (
+                  <Button color="inherit" size="small" onClick={gpBuyers.refetch}>
+                    Retry
+                  </Button>
+                ) : undefined
+              }
+            >
+              {gpBuyers.unsupported
+                ? 'The connected relay is too old to list GP buyers. Update the relay on that workstation, then reload this page.'
+                : gpBuyers.relayConnected
+                  ? `Could not read the buyer master from GP. ${gpBuyers.error?.message ?? ''}`
+                  : 'The GP relay is not connected, so the buyer master cannot be read or added to.'}
+            </Alert>
+          )
         ) : gpBuyers.buyers.length === 0 && !gpBuyers.loading ? (
           <Typography variant="body2" color="text.secondary">
             No buyers are registered in this GP company yet.

--- a/frontend/src/modules/admin/GpBuyerSelect.tsx
+++ b/frontend/src/modules/admin/GpBuyerSelect.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Autocomplete, Box, TextField } from '@mui/material';
 import RegisterGpBuyerDialog from './RegisterGpBuyerDialog';
 import type { GpBuyerOption, GpBuyersState } from './useGpBuyers';
-import { monoSx } from '../../theme';
+import { FONT_MONO, monoSx } from '../../theme';
 
 const REGISTER_NEW_ID = '__register_new__';
 
@@ -49,17 +49,20 @@ export default function GpBuyerSelect({
   const [registerOpen, setRegisterOpen] = useState(false);
   const { buyers, loading, company, relayConnected, relayStatus, unsupported, unavailable } = state;
 
-  const options: (GpBuyerOption | { buyerId: typeof REGISTER_NEW_ID; description: null })[] = useMemo(
-    () => [...buyers, { buyerId: REGISTER_NEW_ID, description: null }],
-    [buyers],
-  );
-
   // A value set before this dropdown existed (or by an older relay's list) still has to show. Without
   // this the field would render empty over a link that is really there, which reads as "not set".
   const selected = useMemo(
     () => buyers.find((b) => b.buyerId === value) ?? (value ? { buyerId: value, description: null } : null),
     [buyers, value],
   );
+
+  // The held value joins the option list when the live list doesn't carry it - the relay-down case
+  // above. MUI matches `value` against `options` and warns "None of the options match" otherwise, on
+  // every render of exactly the path this component exists to support.
+  const options: (GpBuyerOption | { buyerId: typeof REGISTER_NEW_ID; description: null })[] = useMemo(() => {
+    const held = selected && !buyers.some((b) => b.buyerId === selected.buyerId) ? [selected] : [];
+    return [...held, ...buyers, { buyerId: REGISTER_NEW_ID, description: null }];
+  }, [buyers, selected]);
 
   const handleChange = useCallback(
     (_: unknown, option: GpBuyerOption | { buyerId: string } | null) => {
@@ -121,6 +124,9 @@ export default function GpBuyerSelect({
             label={label}
             size="small"
             helperText={unavailable ? unavailableText : helperText}
+            // The id reads mono in the option list, in the Buyers grid and in the User Management
+            // grid; the selected value has to match or the same BUYERID renders in two faces.
+            sx={{ '& .MuiInputBase-input': { fontFamily: FONT_MONO } }}
           />
         )}
         sx={sx}

--- a/frontend/src/modules/admin/GpBuyerSelect.tsx
+++ b/frontend/src/modules/admin/GpBuyerSelect.tsx
@@ -47,7 +47,7 @@ export default function GpBuyerSelect({
   helperText,
 }: GpBuyerSelectProps) {
   const [registerOpen, setRegisterOpen] = useState(false);
-  const { buyers, loading, company, relayStatus, unsupported, unavailable } = state;
+  const { buyers, loading, company, relayConnected, relayStatus, unsupported, unavailable } = state;
 
   const options: (GpBuyerOption | { buyerId: typeof REGISTER_NEW_ID; description: null })[] = useMemo(
     () => [...buyers, { buyerId: REGISTER_NEW_ID, description: null }],
@@ -72,13 +72,17 @@ export default function GpBuyerSelect({
     [onChange],
   );
 
-  const unavailableText = !company && relayStatus === null
-    ? 'Checking the GP relay…'
-    : unsupported
-      ? 'The connected relay is too old to list GP buyers. Update the relay, then reopen this.'
-      : state.relayConnected
-        ? 'Could not read the buyer list from GP, so this cannot be changed right now.'
-        : 'The GP relay is not connected, so this cannot be changed right now.';
+  // Ordered most-specific first. The null status is its own case rather than folded into the
+  // disconnected one: the first poll is still in flight, and reporting that as "not connected" would
+  // tell the user something is wrong during the second it takes to find out.
+  const unavailableText =
+    relayStatus === null
+      ? 'Checking the GP relay…'
+      : unsupported
+        ? 'The connected relay is too old to list GP buyers. Update the relay, then reopen this.'
+        : relayConnected
+          ? 'Could not read the buyer list from GP, so this cannot be changed right now.'
+          : 'The GP relay is not connected, so this cannot be changed right now.';
 
   return (
     <>

--- a/frontend/src/modules/admin/GpBuyerSelect.tsx
+++ b/frontend/src/modules/admin/GpBuyerSelect.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Autocomplete, Box, TextField } from '@mui/material';
+import RegisterGpBuyerDialog from './RegisterGpBuyerDialog';
+import type { GpBuyerOption, GpBuyersState } from './useGpBuyers';
+import { monoSx } from '../../theme';
+
+const REGISTER_NEW_ID = '__register_new__';
+
+interface GpBuyerSelectProps {
+  value: string | null;
+  onChange: (buyerId: string | null) => void;
+  /** The shared list state, so a page that also renders the buyer master isn't querying it twice. */
+  state: GpBuyersState;
+  label?: string;
+  /** Extra reason to lock the field beyond the relay's own state (e.g. an id that is a row key). */
+  disabled?: boolean;
+  fullWidth?: boolean;
+  sx?: object;
+  /** Shown under the field when the list IS available; the unavailable cases word themselves. */
+  helperText?: string;
+}
+
+function buyerLabel(b: GpBuyerOption): string {
+  return b.description ? `${b.buyerId} - ${b.description}` : b.buyerId;
+}
+
+/**
+ * Pick a GP buyer identity from GP's live buyer master, with an inline way to register a missing one
+ * (#409). Replaces the free-text BUYERID fields that made an admin open GP to find out what was
+ * registered - and let a typo through, which surfaces much later as a rejected PO (taPoHdr rejects an
+ * unregistered BUYERID with error 269).
+ *
+ * When the list can't be read the field is DISABLED rather than falling back to free text, unlike the
+ * create-job dialog's employee pickers. The difference is what a wrong value costs: an estimator id is
+ * rejected by the proc during the same submit, but a buyer id is written to Clerk and sits there
+ * looking correct until someone tries to raise a PO. A held value is still displayed while disabled,
+ * so a relay outage doesn't make an existing link look empty.
+ */
+export default function GpBuyerSelect({
+  value,
+  onChange,
+  state,
+  label = 'GP Buyer ID',
+  disabled,
+  fullWidth,
+  sx,
+  helperText,
+}: GpBuyerSelectProps) {
+  const [registerOpen, setRegisterOpen] = useState(false);
+  const { buyers, loading, company, relayStatus, unsupported, unavailable } = state;
+
+  const options: (GpBuyerOption | { buyerId: typeof REGISTER_NEW_ID; description: null })[] = useMemo(
+    () => [...buyers, { buyerId: REGISTER_NEW_ID, description: null }],
+    [buyers],
+  );
+
+  // A value set before this dropdown existed (or by an older relay's list) still has to show. Without
+  // this the field would render empty over a link that is really there, which reads as "not set".
+  const selected = useMemo(
+    () => buyers.find((b) => b.buyerId === value) ?? (value ? { buyerId: value, description: null } : null),
+    [buyers, value],
+  );
+
+  const handleChange = useCallback(
+    (_: unknown, option: GpBuyerOption | { buyerId: string } | null) => {
+      if (option && option.buyerId === REGISTER_NEW_ID) {
+        setRegisterOpen(true);
+        return;
+      }
+      onChange(option?.buyerId ?? null);
+    },
+    [onChange],
+  );
+
+  const unavailableText = !company && relayStatus === null
+    ? 'Checking the GP relay…'
+    : unsupported
+      ? 'The connected relay is too old to list GP buyers. Update the relay, then reopen this.'
+      : state.relayConnected
+        ? 'Could not read the buyer list from GP, so this cannot be changed right now.'
+        : 'The GP relay is not connected, so this cannot be changed right now.';
+
+  return (
+    <>
+      <Autocomplete
+        value={selected}
+        options={options}
+        loading={loading}
+        disabled={disabled || unavailable}
+        fullWidth={fullWidth}
+        onChange={handleChange}
+        getOptionLabel={(o) => (o.buyerId === REGISTER_NEW_ID ? '+ Register new GP buyer…' : buyerLabel(o))}
+        isOptionEqualToValue={(o, v) => o.buyerId === v.buyerId}
+        // The register entry is an action sitting in a list of data; it gets a rule above it so it
+        // never reads as just another buyer.
+        renderOption={(props, option) => {
+          const { key, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & { key: string };
+          const isRegister = option.buyerId === REGISTER_NEW_ID;
+          return (
+            <Box
+              component="li"
+              key={key}
+              {...liProps}
+              sx={
+                isRegister
+                  ? { fontWeight: 600, borderTop: 1, borderColor: 'divider', color: 'text.primary' }
+                  : monoSx
+              }
+            >
+              {isRegister ? '+ Register new GP buyer…' : buyerLabel(option)}
+            </Box>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            size="small"
+            helperText={unavailable ? unavailableText : helperText}
+          />
+        )}
+        sx={sx}
+      />
+      <RegisterGpBuyerDialog
+        open={registerOpen}
+        company={company}
+        onClose={() => setRegisterOpen(false)}
+        onRegistered={(buyerId) => onChange(buyerId)}
+      />
+    </>
+  );
+}

--- a/frontend/src/modules/admin/RegisterGpBuyerDialog.tsx
+++ b/frontend/src/modules/admin/RegisterGpBuyerDialog.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import { CREATE_GP_BUYER, GET_GP_BUYERS_DETAILED } from '../../graphql/admin';
+import GpErrorAlert from '../../components/GpErrorAlert';
+import { extractGpError, type GpError } from '../../graphql/gpError';
+import { useToast } from '../../components/Toast';
+import { monoSx } from '../../theme';
+
+/** GP column widths, so an over-length value is caught in the field rather than by the proc. */
+const MAX = { buyerId: 15, description: 30 };
+
+interface RegisterGpBuyerDialogProps {
+  open: boolean;
+  company: string;
+  onClose: () => void;
+  /** The registered buyer, so a caller can select it straight away instead of hunting for it. */
+  onRegistered?: (buyerId: string) => void;
+}
+
+/**
+ * Register a buyer in GP's buyer master through the relay (#409).
+ *
+ * A Nexus account can only create POs once it is linked to a GP BUYERID, and that id has to already
+ * exist in GP - so onboarding a new buyer used to mean opening GP locally. This is the same thing
+ * GP's Buyer Maintenance window does.
+ *
+ * The buyer id is free text on purpose. BUYERID is not a GP user id or an email: the production
+ * companies hold values like 'donr' next to 'Anna Wyzynski', so there is no master to pick from - this
+ * IS the master, and the point of the dialog is adding to it.
+ *
+ * There is no edit or delete counterpart. eConnect exposes only taCreateBuyer, and removing a row from
+ * POP00101 by hand would bypass the business logic the eConnect-only rule exists to protect.
+ */
+export default function RegisterGpBuyerDialog({
+  open,
+  company,
+  onClose,
+  onRegistered,
+}: RegisterGpBuyerDialogProps) {
+  const { showToast } = useToast();
+  const [buyerId, setBuyerId] = useState('');
+  const [description, setDescription] = useState('');
+  const [gpError, setGpError] = useState<GpError | null>(null);
+
+  const reset = useCallback(() => {
+    setBuyerId('');
+    setDescription('');
+    setGpError(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [reset, onClose]);
+
+  const [createGpBuyer, { loading }] = useMutation<{ createGpBuyer: { buyerId: string } }>(CREATE_GP_BUYER, {
+    // The dropdowns this feeds read gpBuyersDetailed, so they have to see the new row before the
+    // caller's onRegistered tries to select it.
+    refetchQueries: [{ query: GET_GP_BUYERS_DETAILED, variables: { company } }],
+    awaitRefetchQueries: true,
+    onCompleted: (data) => {
+      showToast(`Buyer '${data.createGpBuyer.buyerId}' registered in GP`, 'success');
+      onRegistered?.(data.createGpBuyer.buyerId);
+      handleClose();
+    },
+    onError: (err) => setGpError(extractGpError(err) ?? { message: err.message }),
+  });
+
+  const handleSubmit = useCallback(() => {
+    setGpError(null);
+    void createGpBuyer({ variables: { buyerId: buyerId.trim(), description: description.trim() } });
+  }, [createGpBuyer, buyerId, description]);
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Register a GP Buyer</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info">
+            This writes to GP&apos;s buyer master for {company || 'the connected company'}. A registered buyer
+            cannot be removed from Nexus afterwards.
+          </Alert>
+
+          {gpError && <GpErrorAlert error={gpError} onClose={() => setGpError(null)} title="Could not register the buyer" />}
+
+          <TextField
+            label="Buyer ID"
+            value={buyerId}
+            onChange={(e) => setBuyerId(e.target.value)}
+            required
+            autoFocus
+            disabled={loading}
+            size="small"
+            slotProps={{ input: { sx: monoSx }, htmlInput: { maxLength: MAX.buyerId } }}
+            helperText="As it should appear in GP (POP00101). Up to 15 characters."
+          />
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={loading}
+            size="small"
+            slotProps={{ htmlInput: { maxLength: MAX.description } }}
+            helperText="Who or what this buyer is, e.g. a name or department. Up to 30 characters."
+          />
+          <Typography variant="caption" color="text.secondary">
+            Registering a buyer does not by itself let anyone create POs - link an account to it in User
+            Management, and give it project scope on this page.
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={loading || !buyerId.trim()}>
+          {loading ? 'Registering…' : 'Register'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/modules/admin/RegisterGpBuyerDialog.tsx
+++ b/frontend/src/modules/admin/RegisterGpBuyerDialog.tsx
@@ -10,7 +10,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { useMutation } from '@apollo/client/react';
+import { useApolloClient, useMutation } from '@apollo/client/react';
 import { CREATE_GP_BUYER, GET_GP_BUYERS_DETAILED } from '../../graphql/admin';
 import GpErrorAlert from '../../components/GpErrorAlert';
 import { extractGpError, type GpError } from '../../graphql/gpError';
@@ -64,17 +64,35 @@ export default function RegisterGpBuyerDialog({
     onClose();
   }, [reset, onClose]);
 
+  const client = useApolloClient();
+  const refetchBuyers = useCallback(
+    () => client.refetchQueries({ include: [GET_GP_BUYERS_DETAILED] }),
+    [client],
+  );
+
   const [createGpBuyer, { loading }] = useMutation<{ createGpBuyer: { buyerId: string } }>(CREATE_GP_BUYER, {
-    // The dropdowns this feeds read gpBuyersDetailed, so they have to see the new row before the
-    // caller's onRegistered tries to select it.
+    // The dropdowns this feeds read gpBuyersDetailed, so the new row is pulled in behind the write.
+    // NOT awaited: awaitRefetchQueries folds a refetch failure into the mutation's, which would report
+    // a buyer GP really did register as a failed registration if the relay dropped in the window right
+    // after taCreateBuyer committed. Nothing depends on the refetch having landed either - GpBuyerSelect
+    // renders an id that isn't in the list yet from its own held-value fallback.
     refetchQueries: [{ query: GET_GP_BUYERS_DETAILED, variables: { company } }],
-    awaitRefetchQueries: true,
     onCompleted: (data) => {
       showToast(`Buyer '${data.createGpBuyer.buyerId}' registered in GP`, 'success');
       onRegistered?.(data.createGpBuyer.buyerId);
       handleClose();
     },
-    onError: (err) => setGpError(extractGpError(err) ?? { message: err.message }),
+    onError: (err) => {
+      const gp = extractGpError(err) ?? { message: err.message };
+      setGpError(gp);
+      // 'Already registered' is the answer to a retry after an ambiguous failure: the first attempt
+      // committed and its reply was lost. GP holds the buyer, but the list this dialog feeds was read
+      // before the write, so without a refetch here the admin is shown an error for a buyer that
+      // exists AND still can't pick it - a dead end only a page reload clears.
+      if (gp.relay?.error === 'buyer_already_exists') {
+        void refetchBuyers();
+      }
+    },
   });
 
   const handleSubmit = useCallback(() => {

--- a/frontend/src/modules/admin/UserManagementPage.tsx
+++ b/frontend/src/modules/admin/UserManagementPage.tsx
@@ -21,8 +21,10 @@ import { useQuery, useMutation } from '@apollo/client/react';
 import { GET_USERS, UPDATE_USER_GP_BUYER_ID, UPDATE_USER_NAME, UPDATE_USER_ROLES } from '../../graphql/admin';
 import { useToast } from '../../components/Toast';
 import { useIdentity } from '../../hooks/useIdentity';
-import { FONT_MONO, microLabelSx, monoSx } from '../../theme';
+import { microLabelSx, monoSx } from '../../theme';
 import { FadeIn } from '../../motion';
+import GpBuyerSelect from './GpBuyerSelect';
+import { useGpBuyers } from './useGpBuyers';
 
 const ALL_ROLES = [
   'Hardware Schedule Import',
@@ -121,7 +123,7 @@ export default function UserManagementPage() {
   const { showToast } = useToast();
   const [selectedUser, setSelectedUser] = useState<ClerkUser | null>(null);
   const [editRoles, setEditRoles] = useState<string[]>([]);
-  const [editGpBuyerId, setEditGpBuyerId] = useState('');
+  const [editGpBuyerId, setEditGpBuyerId] = useState<string | null>(null);
   // Issue #240: admin-editable display name (Clerk first/last name).
   const [editFirstName, setEditFirstName] = useState('');
   const [editLastName, setEditLastName] = useState('');
@@ -129,6 +131,10 @@ export default function UserManagementPage() {
 
   const { data, loading } = useQuery<{ users: ClerkUser[] }>(GET_USERS);
   const users = useMemo(() => data?.users ?? [], [data]);
+
+  // Issue #409: GP's live buyer master backs the buyer field below. Only polled while the edit dialog
+  // is open - the grid shows whatever id is already stored and needs no GP round-trip for that.
+  const gpBuyers = useGpBuyers({ skip: !selectedUser });
 
   const [updateRoles] = useMutation(UPDATE_USER_ROLES);
   const [updateName] = useMutation(UPDATE_USER_NAME);
@@ -139,7 +145,7 @@ export default function UserManagementPage() {
   const handleRowClick = useCallback((params: GridRowParams<ClerkUser>) => {
     setSelectedUser(params.row);
     setEditRoles(params.row.roles);
-    setEditGpBuyerId(params.row.gpBuyerId ?? '');
+    setEditGpBuyerId(params.row.gpBuyerId);
     setEditFirstName(params.row.firstName ?? '');
     setEditLastName(params.row.lastName ?? '');
   }, []);
@@ -164,7 +170,12 @@ export default function UserManagementPage() {
           variables: { userId: selectedUser.id, firstName: editFirstName.trim(), lastName: editLastName.trim() },
         });
       }
-      await updateGpBuyerId({ variables: { userId: selectedUser.id, gpBuyerId: editGpBuyerId.trim() || null } });
+      // Same only-when-changed rule as the name above, which #409 makes load-bearing rather than
+      // merely tidy: while the relay is down the buyer field is disabled and holds the stored id, and
+      // an unconditional write would re-PATCH Clerk on every unrelated save.
+      if (editGpBuyerId !== (selectedUser.gpBuyerId ?? null)) {
+        await updateGpBuyerId({ variables: { userId: selectedUser.id, gpBuyerId: editGpBuyerId } });
+      }
       showToast('User updated successfully', 'success');
       setSelectedUser(null);
     } catch (err: unknown) {
@@ -282,13 +293,14 @@ export default function UserManagementPage() {
           <Typography component="div" sx={{ ...microLabelSx, mt: 2, mb: 1 }}>
             GP identity
           </Typography>
-          <TextField
-            label="GP Buyer ID"
+          {/* Issue #409: picked from GP's live buyer master rather than typed, with an inline way to
+              register a missing one - a typo here only surfaces later as a rejected PO. */}
+          <GpBuyerSelect
             value={editGpBuyerId}
-            onChange={(e) => setEditGpBuyerId(e.target.value)}
-            size="small"
-            sx={{ width: 240, '& .MuiInputBase-input': { fontFamily: FONT_MONO } }}
-            helperText="The GP BUYERID this account creates POs as (issue #216). Blank = cannot create POs."
+            onChange={setEditGpBuyerId}
+            state={gpBuyers}
+            sx={{ width: 320 }}
+            helperText="The GP buyer this account creates POs as (issue #216). Blank = cannot create POs."
           />
         </DialogContent>
         <DialogActions>

--- a/frontend/src/modules/admin/__tests__/BuyersPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/BuyersPage.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import BuyersPage from '../BuyersPage';
+import { GET_GP_BUYERS_DETAILED } from '../../../graphql/admin';
+import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS, GET_RELAY_STATUS } from '../../../graphql/shared';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const INFINITE = Number.POSITIVE_INFINITY;
+const COMPANY = 'TUBC';
+const GRID_TIMEOUT = { timeout: 15_000 };
+
+// jsdom reports every element as 0x0 and MUI's DataGrid sizes itself from a measured container, so at
+// zero width the row cells never reach the accessibility tree (see RelayInstallsPage.test.tsx).
+beforeAll(() => {
+  for (const [prop, value] of [
+    ['clientWidth', 1200],
+    ['clientHeight', 800],
+    ['offsetWidth', 1200],
+    ['offsetHeight', 800],
+  ] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, { configurable: true, value });
+  }
+});
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Admin',
+    userId: 'user_admin',
+    roles: ['Admin/Manager'],
+    hasRole: () => true,
+    isAdmin: true,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+function relayStatusMock(connected: boolean): MockedResponse {
+  return {
+    request: { query: GET_RELAY_STATUS },
+    maxUsageCount: INFINITE,
+    result: {
+      data: {
+        relayStatus: {
+          connected,
+          company: connected ? COMPANY : null,
+          build: connected ? 'relay-v0.1.0-build.40' : null,
+          installId: connected ? 'install-1' : null,
+          __typename: 'RelayStatus',
+        },
+      },
+    },
+  };
+}
+
+function assignmentsMock(buyerIds: string[]): MockedResponse {
+  return {
+    request: { query: GET_BUYER_ASSIGNMENTS },
+    maxUsageCount: INFINITE,
+    result: {
+      data: {
+        buyerAssignments: buyerIds.map((buyerId) => ({
+          buyerId,
+          costCodes: ['310-000'],
+          projects: [],
+          __typename: 'BuyerAssignment',
+        })),
+      },
+    },
+  };
+}
+
+const projectsMock: MockedResponse = {
+  request: { query: GET_PROJECTS },
+  maxUsageCount: INFINITE,
+  result: { data: { projects: [] } },
+};
+
+const buyersMock: MockedResponse = {
+  request: { query: GET_GP_BUYERS_DETAILED, variables: { company: COMPANY } },
+  maxUsageCount: INFINITE,
+  result: {
+    data: {
+      gpBuyersDetailed: [
+        { buyerId: 'donr', description: 'Don Roberton', __typename: 'GpBuyer' },
+        { buyerId: 'mira', description: 'Accounting', __typename: 'GpBuyer' },
+      ],
+    },
+  },
+};
+
+function renderPage(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <BuyersPage />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+test('the registered-in-GP panel lists GPs own buyer master', async () => {
+  renderPage([relayStatusMock(true), assignmentsMock([]), projectsMock, buyersMock]);
+
+  expect(await screen.findByText('Registered in GP')).toBeInTheDocument();
+  expect(await screen.findByText(/donr · Don Roberton/)).toBeInTheDocument();
+  expect(screen.getByText(/mira · Accounting/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Register GP Buyer/i })).toBeEnabled();
+});
+
+test('the panel explains itself and blocks registering when the relay is down', async () => {
+  renderPage([relayStatusMock(false), assignmentsMock([]), projectsMock]);
+
+  expect(await screen.findByText(/relay is not connected, so the buyer master/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Register GP Buyer/i })).toBeDisabled();
+});
+
+test('an assignment for a buyer GP never registered is flagged', async () => {
+  // Free text made these easy to create and invisible afterwards - the PO only fails much later,
+  // when taPoHdr rejects the unregistered BUYERID.
+  renderPage([relayStatusMock(true), assignmentsMock(['donr', 'typoo']), projectsMock, buyersMock]);
+
+  await screen.findByText('typoo', {}, GRID_TIMEOUT);
+  await waitFor(() => expect(screen.getByLabelText('Not registered in GP')).toBeInTheDocument());
+  // The registered one must not be flagged, or the marker means nothing.
+  expect(screen.getAllByLabelText('Not registered in GP')).toHaveLength(1);
+});
+
+test('the add-assignment dialog picks a buyer from GP rather than free text', async () => {
+  renderPage([relayStatusMock(true), assignmentsMock([]), projectsMock, buyersMock]);
+
+  fireEvent.click(await screen.findByRole('button', { name: /Add Buyer/i }));
+
+  const field = await screen.findByRole('combobox', { name: /GP Buyer ID/i });
+  await waitFor(() => expect(field).not.toBeDisabled());
+  fireEvent.mouseDown(field);
+  fireEvent.click(field);
+
+  expect(await screen.findByText(/donr - Don Roberton/)).toBeInTheDocument();
+});

--- a/frontend/src/modules/admin/__tests__/UserManagementPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/UserManagementPage.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { GraphQLError } from 'graphql';
+import { ToastProvider } from '../../../components/Toast';
+import UserManagementPage from '../UserManagementPage';
+import {
+  CREATE_GP_BUYER,
+  GET_GP_BUYERS_DETAILED,
+  GET_USERS,
+  UPDATE_USER_GP_BUYER_ID,
+  UPDATE_USER_ROLES,
+} from '../../../graphql/admin';
+import { GET_RELAY_STATUS } from '../../../graphql/shared';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const INFINITE = Number.POSITIVE_INFINITY;
+const COMPANY = 'TUBC';
+const GRID_TIMEOUT = { timeout: 15_000 };
+
+// jsdom reports every element as 0x0 and MUI's DataGrid sizes itself from a measured container, so at
+// zero width the row cells never reach the accessibility tree (see RelayInstallsPage.test.tsx).
+beforeAll(() => {
+  for (const [prop, value] of [
+    ['clientWidth', 1200],
+    ['clientHeight', 800],
+    ['offsetWidth', 1200],
+    ['offsetHeight', 800],
+  ] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, { configurable: true, value });
+  }
+});
+
+vi.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Admin',
+    userId: 'user_admin',
+    roles: ['Admin/Manager'],
+    hasRole: () => true,
+    isAdmin: true,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+const USER = {
+  id: 'user_1',
+  firstName: 'Jay',
+  lastName: 'Puzon',
+  email: 'jay@example.com',
+  roles: ['PO User'],
+  gpBuyerId: null as string | null,
+  imageUrl: '',
+  __typename: 'ClerkUser',
+};
+
+function usersMock(user = USER): MockedResponse {
+  return {
+    request: { query: GET_USERS },
+    maxUsageCount: INFINITE,
+    result: { data: { users: [user] } },
+  };
+}
+
+function relayStatusMock(connected: boolean): MockedResponse {
+  return {
+    request: { query: GET_RELAY_STATUS },
+    maxUsageCount: INFINITE,
+    result: {
+      data: {
+        relayStatus: {
+          connected,
+          company: connected ? COMPANY : null,
+          build: connected ? 'relay-v0.1.0-build.40' : null,
+          installId: connected ? 'install-1' : null,
+          __typename: 'RelayStatus',
+        },
+      },
+    },
+  };
+}
+
+const buyersMock: MockedResponse = {
+  request: { query: GET_GP_BUYERS_DETAILED, variables: { company: COMPANY } },
+  maxUsageCount: INFINITE,
+  result: {
+    data: {
+      gpBuyersDetailed: [
+        { buyerId: 'donr', description: 'Don Roberton', __typename: 'GpBuyer' },
+        { buyerId: 'mira', description: 'Accounting', __typename: 'GpBuyer' },
+      ],
+    },
+  },
+};
+
+const buyersUnsupportedMock: MockedResponse = {
+  request: { query: GET_GP_BUYERS_DETAILED, variables: { company: COMPANY } },
+  maxUsageCount: INFINITE,
+  result: {
+    errors: [
+      new GraphQLError('The connected relay does not support list_buyers_detailed', {
+        extensions: { code: 'RELAY_OP_UNSUPPORTED' },
+      }),
+    ],
+  },
+};
+
+function renderPage(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <UserManagementPage />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+/** Open the edit dialog by clicking the user's row. */
+async function openEditDialog() {
+  const cell = await screen.findByText('jay@example.com', {}, GRID_TIMEOUT);
+  fireEvent.click(cell);
+  return screen.findByRole('combobox', { name: /GP Buyer ID/i });
+}
+
+test('the GP buyer field is a dropdown of the buyers registered in GP', async () => {
+  // #409: free text meant an admin had to open GP to see what was registered, and a typo only
+  // surfaced later as a rejected PO.
+  renderPage([relayStatusMock(true), usersMock(), buyersMock]);
+
+  const field = await openEditDialog();
+  await waitFor(() => expect(field).not.toBeDisabled());
+  fireEvent.mouseDown(field);
+  fireEvent.click(field);
+
+  expect(await screen.findByText(/donr - Don Roberton/)).toBeInTheDocument();
+  expect(screen.getByText(/mira - Accounting/)).toBeInTheDocument();
+});
+
+test('the buyer field is disabled when the relay is not connected', async () => {
+  // Blocking beats a free-text fallback here: a wrong buyer id is written to Clerk and looks correct
+  // until someone tries to raise a PO.
+  renderPage([relayStatusMock(false), usersMock()]);
+
+  const field = await openEditDialog();
+  await waitFor(() => expect(field).toBeDisabled());
+  expect(screen.getByText(/relay is not connected/i)).toBeInTheDocument();
+});
+
+test('a relay too old for the buyer read says so instead of showing an empty dropdown', async () => {
+  renderPage([relayStatusMock(true), usersMock(), buyersUnsupportedMock]);
+
+  const field = await openEditDialog();
+  await waitFor(() => expect(field).toBeDisabled());
+  expect(await screen.findByText(/too old to list GP buyers/i)).toBeInTheDocument();
+});
+
+test('an already-linked buyer still shows while the relay is down', async () => {
+  // Rendering the field empty over a link that is really there would read as "not set".
+  renderPage([relayStatusMock(false), usersMock({ ...USER, gpBuyerId: 'donr' })]);
+
+  const field = (await openEditDialog()) as HTMLInputElement;
+  await waitFor(() => expect(field).toBeDisabled());
+  expect(field.value).toBe('donr');
+});
+
+test('registering a new buyer selects it without a second trip through the dropdown', async () => {
+  const createMock: MockedResponse = {
+    request: { query: CREATE_GP_BUYER, variables: { buyerId: 'newbuyer', description: 'New Buyer' } },
+    result: { data: { createGpBuyer: { buyerId: 'newbuyer', description: 'New Buyer', __typename: 'GpBuyer' } } },
+  };
+  const buyersAfterMock: MockedResponse = {
+    request: { query: GET_GP_BUYERS_DETAILED, variables: { company: COMPANY } },
+    maxUsageCount: INFINITE,
+    result: {
+      data: {
+        gpBuyersDetailed: [
+          { buyerId: 'donr', description: 'Don Roberton', __typename: 'GpBuyer' },
+          { buyerId: 'newbuyer', description: 'New Buyer', __typename: 'GpBuyer' },
+        ],
+      },
+    },
+  };
+  renderPage([relayStatusMock(true), usersMock(), buyersMock, createMock, buyersAfterMock]);
+
+  const field = (await openEditDialog()) as HTMLInputElement;
+  await waitFor(() => expect(field).not.toBeDisabled());
+  fireEvent.mouseDown(field);
+  fireEvent.click(field);
+  fireEvent.click(await screen.findByText(/Register new GP buyer/i));
+
+  fireEvent.change(await screen.findByRole('textbox', { name: /Buyer ID/i }), {
+    target: { value: 'newbuyer' },
+  });
+  fireEvent.change(screen.getByRole('textbox', { name: /Description/i }), {
+    target: { value: 'New Buyer' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /^Register$/i }));
+
+  await waitFor(() => expect(field.value).toMatch(/newbuyer/));
+});
+
+test('saving an unchanged buyer does not re-write it to Clerk', async () => {
+  // The buyer mutation is a Clerk PATCH, and while the relay is down the disabled field still holds
+  // the stored id - an unconditional write would fire on every unrelated save.
+  const rolesMock: MockedResponse = {
+    request: { query: UPDATE_USER_ROLES, variables: { userId: 'user_1', roles: ['PO User', 'Warehouse Staff'] } },
+    result: { data: { updateUserRoles: { ...USER, gpBuyerId: 'donr', roles: ['PO User', 'Warehouse Staff'] } } },
+  };
+  let buyerWrites = 0;
+  const buyerWriteMock: MockedResponse = {
+    request: { query: UPDATE_USER_GP_BUYER_ID, variables: { userId: 'user_1', gpBuyerId: 'donr' } },
+    maxUsageCount: INFINITE,
+    result: () => {
+      buyerWrites += 1;
+      return { data: { updateUserGpBuyerId: { ...USER, gpBuyerId: 'donr' } } };
+    },
+  };
+  renderPage([
+    relayStatusMock(true),
+    usersMock({ ...USER, gpBuyerId: 'donr' }),
+    buyersMock,
+    rolesMock,
+    buyerWriteMock,
+  ]);
+
+  await openEditDialog();
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Warehouse Staff' }));
+  fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+  await waitFor(() => expect(screen.getByText(/User updated successfully/i)).toBeInTheDocument());
+  expect(buyerWrites).toBe(0);
+});

--- a/frontend/src/modules/admin/useGpBuyers.ts
+++ b/frontend/src/modules/admin/useGpBuyers.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { useQuery } from '@apollo/client/react';
+import { GET_GP_BUYERS_DETAILED } from '../../graphql/admin';
+import { isRelayOpUnsupported } from '../../graphql/gpError';
+import { useRelayStatus } from '../../relay/useRelayStatus';
+
+export interface GpBuyerOption {
+  buyerId: string;
+  description: string | null;
+}
+
+export interface GpBuyersState {
+  buyers: GpBuyerOption[];
+  loading: boolean;
+  /** The connected relay is enrolled for exactly one GP company; '' while disconnected. */
+  company: string;
+  relayConnected: boolean;
+  /** null while the first relay-status check is in flight, so "not yet known" isn't shown as "down". */
+  relayStatus: boolean | null;
+  /** The installed relay predates list_buyers_detailed (#315 gating). */
+  unsupported: boolean;
+  /** Any reason the live list can't be trusted: relay down, op unsupported, or the read failed. */
+  unavailable: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+/**
+ * GP's buyer master (POP00101) read live through the relay, for the admin screens that assign or
+ * register a buyer identity (#409).
+ *
+ * Shared rather than queried per page because both consumers need the same three-way state - list,
+ * relay down, relay too old - and a page that got any of them wrong would put an id into Clerk that
+ * GP never registered, which surfaces much later as a rejected PO (taPoHdr error 269).
+ *
+ * `unavailable` deliberately folds a failed read in with a missing one: an empty list from a query
+ * that errored must not read as "this company has no buyers", which is the state that would let a
+ * blank dropdown look like an answer.
+ */
+export function useGpBuyers(options?: { skip?: boolean }): GpBuyersState {
+  const skip = options?.skip ?? false;
+  const relay = useRelayStatus({ skip });
+  const company = relay.company ?? '';
+  const relayConnected = relay.connected === true;
+
+  const { data, loading, error, refetch } = useQuery<{ gpBuyersDetailed: GpBuyerOption[] }>(
+    GET_GP_BUYERS_DETAILED,
+    {
+      variables: { company },
+      skip: skip || !relayConnected || !company,
+      fetchPolicy: 'cache-and-network',
+    },
+  );
+
+  const buyers = useMemo(() => data?.gpBuyersDetailed ?? [], [data]);
+  const unsupported = isRelayOpUnsupported(error);
+
+  return {
+    buyers,
+    loading,
+    company,
+    relayConnected,
+    relayStatus: relay.connected,
+    unsupported,
+    unavailable: !relayConnected || Boolean(error),
+    error: error ?? null,
+    refetch: () => {
+      void refetch();
+    },
+  };
+}

--- a/relay/README.md
+++ b/relay/README.md
@@ -91,10 +91,15 @@ shared_secret` on the connect handshake. the backend's `relay_call(company, op, 
 down that socket as `{id, op, company, payload}`; the relay answers `{id, ok, result|error}` by
 running the same eConnect logic the HTTP routes use (`ops.py` holds the shared `create_po`/
 `create_receipt` orchestration). set `[channel] backend_url` in `config.toml` to enable it; leave it
-blank to run HTTP-only, as before. op dispatch: `list_vendors`, `list_buyers`, `list_cost_codes`,
-`list_jobs`, `create_po`, `create_receipt`. reconnects with exponential backoff on drop; the
-`websockets` client's default 20s ping/pong keeps the channel alive through a corporate proxy's idle
-timeout.
+blank to run HTTP-only, as before. op dispatch (`_OPS` in `channel.py`, which is also what the relay
+advertises to the backend on connect so an out-of-date relay is caught before the round-trip):
+- reads: `list_vendors`, `list_buyers`, `list_buyers_detailed`, `list_tax_details`, `list_cost_codes`,
+  `list_jobs`, `list_customers`, `list_customer_addresses`, `list_tax_schedules`, `list_divisions`,
+  `list_employees`, `read_po_totals`
+- writes: `create_po`, `create_receipt`, `create_job`, `create_buyer`
 
-this is a foundation slice - nothing calls through `relay_call` yet (no GraphQL fields, no frontend
-change). every other relay-through-backend slice builds on this channel.
+reconnects with exponential backoff on drop; the `websockets` client's default 20s ping/pong keeps the
+channel alive through a corporate proxy's idle timeout.
+
+the ops newer than `create_po` / `create_receipt` are channel-only - they have no HTTP route, because
+the browser hop is no longer the live path.

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -119,6 +119,26 @@ def _run_list_buyers(company: str, payload: dict) -> dict:
     return {"company": company, "buyers": ids}
 
 
+def _run_list_buyers_detailed(company: str, payload: dict) -> dict:
+    ops.check_company_allowed(company)
+    with db.get_read_connection(company) as conn:
+        rows = econnect.list_buyers_detailed(conn)
+    return models.BuyersDetailedResponse(company=company, buyers=rows).model_dump(mode="json")
+
+
+def _run_create_buyer(company: str, payload: dict) -> dict:
+    ops.check_company_allowed(company)
+    request = models.CreateBuyerRequest(company=company, **payload)
+    with db.get_connection(company) as conn:
+        try:
+            response = ops.create_buyer_op(conn, company=company, request=request)
+            conn.commit()
+            return response.model_dump(mode="json")
+        except Exception:
+            conn.rollback()
+            raise
+
+
 def _run_list_tax_details(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     with db.get_read_connection(company) as conn:
@@ -253,6 +273,10 @@ _OPS = {
     # issue #392 - estimator / WS manager are validated against the payroll master, so they need a
     # picker rather than free text.
     "list_employees": _run_list_employees,
+    # issue #409 - the admin buyer screens: the buyer master with descriptions, and registering a new
+    # buyer so linking a Nexus account to a GP buyer identity never needs GP opened.
+    "list_buyers_detailed": _run_list_buyers_detailed,
+    "create_buyer": _run_create_buyer,
 }
 
 

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -610,6 +610,26 @@ def buyer_exists(conn, buyer_id: str) -> bool:
     return row.n > 0
 
 
+def get_buyer(conn, buyer_id: str) -> dict | None:
+    """Read-only: one buyer's stored row from POP00101, or None. Used as the read-back after a create
+    (#409) so the response carries GP's OWN id and description rather than the request echoed back -
+    DSCRIPTN is char(31) on the table and char(30) on the proc, so a longer description is truncated
+    on write and the request no longer describes the row. Doubles as proof the row actually landed.
+
+    Matched the same way buyer_exists matches (RTRIM'd column, stripped argument, SQL comparison) so
+    the pre-check and the read-back agree about what counts as the same buyer - a Python `==` against
+    list_buyers_detailed would disagree with the pre-check on case, and would roll back a create that
+    actually succeeded."""
+    row = conn.cursor().execute(
+        "SELECT RTRIM(BUYERID) AS buyer_id, RTRIM(DSCRIPTN) AS description "
+        "FROM dbo.POP00101 WHERE RTRIM(BUYERID) = ?",
+        buyer_id.strip(),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"buyer_id": row.buyer_id, "description": row.description or None}
+
+
 def create_buyer(conn, *, buyer_id: str, description: str = "") -> None:
     """Register a GP buyer through eConnect's taCreateBuyer (#409) - the same thing GP's Buyer
     Maintenance window does, so an admin no longer has to open GP just to add one.

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -585,6 +585,61 @@ def list_buyers(conn) -> list[str]:
     return [r.b for r in rows]
 
 
+def list_buyers_detailed(conn) -> list[dict]:
+    """The same POP00101 buyer master as list_buyers, with each buyer's description (#409).
+
+    list_buyers returns bare ids because that is all the Create PO dropdown needs. The admin screens
+    that assign a buyer identity to a Nexus account need the description too: an id like 'donr' or
+    'mira' says nothing on its own about who or what it is, and picking the wrong one silently
+    mis-attributes every PO that account creates. Kept separate rather than widening list_buyers so
+    the PO path's payload doesn't grow a field it never reads."""
+    rows = conn.cursor().execute(
+        "SELECT RTRIM(BUYERID) AS buyer_id, RTRIM(DSCRIPTN) AS description "
+        "FROM dbo.POP00101 WHERE BUYERID <> '' ORDER BY BUYERID"
+    ).fetchall()
+    return [{"buyer_id": r.buyer_id, "description": r.description or None} for r in rows]
+
+
+def buyer_exists(conn, buyer_id: str) -> bool:
+    """Read-only: is buyer_id already in the buyer master POP00101? BUYERID is char(15), so the column
+    is RTRIM'd and the argument stripped - the same normalization list_buyers/list_buyers_detailed
+    apply, so an id read out of either dropdown compares equal here."""
+    row = conn.cursor().execute(
+        "SELECT COUNT(*) AS n FROM dbo.POP00101 WHERE RTRIM(BUYERID) = ?", buyer_id.strip()
+    ).fetchone()
+    return row.n > 0
+
+
+def create_buyer(conn, *, buyer_id: str, description: str = "") -> None:
+    """Register a GP buyer through eConnect's taCreateBuyer (#409) - the same thing GP's Buyer
+    Maintenance window does, so an admin no longer has to open GP just to add one.
+
+    taCreateBuyer's body is encrypted (as every taXxx proc's is), so what it does with a BUYERID that
+    already exists cannot be read off it. create_buyer_op pre-checks POP00101 rather than find out.
+
+    Only BUYERID and DSCRIPTN are sent. The proc's other inputs (RequesterTrx, USRDEFND1-5) are
+    defaulted, matching create_job's rule: an unset optional is absent from the EXEC, not an explicit
+    NULL."""
+    sql = """
+    DECLARE @err int = 0;
+    DECLARE @err_str varchar(255) = '';
+    EXEC dbo.taCreateBuyer
+        @I_vBUYERID    = ?,
+        @I_vDSCRIPTN   = ?,
+        @O_iErrorState = @err OUTPUT,
+        @oErrString    = @err_str OUTPUT;
+    SELECT @err AS error_state, @err_str AS err_string;
+    """
+    row = conn.cursor().execute(sql, buyer_id, description).fetchone()
+    if row.error_state != 0:
+        message = (row.err_string or "").strip()
+        raise EConnectError(
+            f"taCreateBuyer failed for buyer {buyer_id}: {message}",
+            proc="taCreateBuyer",
+            error_state=row.error_state,
+        )
+
+
 def list_jobs(conn) -> list[dict]:
     """Read-only: the job master JC00102 (WennSoft Job Cost). Feeds the outbound-channel list_jobs
     op - there's no existing HTTP route for this (nothing reads it via the browser hop today)."""

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -614,12 +614,13 @@ def create_buyer(conn, *, buyer_id: str, description: str = "") -> None:
     """Register a GP buyer through eConnect's taCreateBuyer (#409) - the same thing GP's Buyer
     Maintenance window does, so an admin no longer has to open GP just to add one.
 
-    taCreateBuyer's body is encrypted (as every taXxx proc's is), so what it does with a BUYERID that
-    already exists cannot be read off it. create_buyer_op pre-checks POP00101 rather than find out.
-
     Only BUYERID and DSCRIPTN are sent. The proc's other inputs (RequesterTrx, USRDEFND1-5) are
-    defaulted, matching create_job's rule: an unset optional is absent from the EXEC, not an explicit
-    NULL."""
+    defaulted, matching what _exec_tapohdr does with taPoHdr's ~100: an unset optional is absent from
+    the EXEC, not an explicit NULL.
+
+    Error states worth recognizing, from DYNAMICS.taErrorCode: 2681 (BUYERID empty), 2684 (duplicate
+    in POP00101), 2683 (insert failed), 2679 (a null input). create_buyer_op pre-empts 2684 with its
+    own check so the dialog gets a sentence rather than a code."""
     sql = """
     DECLARE @err int = 0;
     DECLARE @err_str varchar(255) = '';

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -175,17 +175,26 @@ class CreateBuyerRequest(BaseModel):
     therefore the binding one."""
 
     company: str
-    buyer_id: str = Field(..., max_length=15)
-    description: str = Field(default="", max_length=30)
+    buyer_id: str
+    description: str = ""
 
     @model_validator(mode="after")
     def normalize(self):
-        """Trim both, then reject a blank id. A whitespace-only BUYERID would land in POP00101 as the
-        blank buyer that list_buyers explicitly filters out - registered, invisible, unusable."""
+        """Trim both, reject a blank id, then bound the trimmed values. A whitespace-only BUYERID would
+        land in POP00101 as the blank buyer that list_buyers explicitly filters out - registered,
+        invisible, unusable.
+
+        The widths are checked here rather than through Field(max_length=...) because a Field
+        constraint runs BEFORE this validator, so it would measure the padding too and reject a padded
+        value that trims to a perfectly legal id."""
         self.buyer_id = (self.buyer_id or "").strip()
         if not self.buyer_id:
             raise ValueError("buyer_id is required")
+        if len(self.buyer_id) > 15:
+            raise ValueError("buyer_id is at most 15 characters (BUYERID is char(15))")
         self.description = (self.description or "").strip()
+        if len(self.description) > 30:
+            raise ValueError("description is at most 30 characters (taCreateBuyer's DSCRIPTN is char(30))")
         return self
 
 

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -153,6 +153,48 @@ class BuyersResponse(BaseModel):
     buyers: list[str]  # registered GP buyer IDs (POP00101) for the Create PO buyer dropdown
 
 
+# --- register a GP buyer (issue #409) ---
+# The admin screens that link a Nexus account to a GP buyer identity need the buyer master with
+# descriptions, and a way to add to it - otherwise an admin has to open GP to do either.
+
+class BuyerOut(BaseModel):
+    buyer_id: str                   # GP BUYERID (POP00101), char(15)
+    description: str | None = None  # GP DSCRIPTN
+
+
+class BuyersDetailedResponse(BaseModel):
+    company: str
+    buyers: list[BuyerOut]
+
+
+class CreateBuyerRequest(BaseModel):
+    """Max lengths are taCreateBuyer's own parameter widths - char(15) BUYERID, char(30) DSCRIPTN -
+    so an over-length value is rejected here rather than silently truncated on the way into GP.
+
+    Note DSCRIPTN is char(31) on POP00101 but char(30) on the proc; the proc is the narrower gate and
+    therefore the binding one."""
+
+    company: str
+    buyer_id: str = Field(..., max_length=15)
+    description: str = Field(default="", max_length=30)
+
+    @model_validator(mode="after")
+    def normalize(self):
+        """Trim both, then reject a blank id. A whitespace-only BUYERID would land in POP00101 as the
+        blank buyer that list_buyers explicitly filters out - registered, invisible, unusable."""
+        self.buyer_id = (self.buyer_id or "").strip()
+        if not self.buyer_id:
+            raise ValueError("buyer_id is required")
+        self.description = (self.description or "").strip()
+        return self
+
+
+class CreateBuyerResponse(BaseModel):
+    company: str
+    buyer_id: str
+    description: str | None = None
+
+
 # --- cost codes (per-job, feeds the Create PO cost-code dropdown) ---
 
 class CostCodeOut(BaseModel):

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -263,14 +263,14 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
 def create_buyer_op(conn, *, company: str, request: models.CreateBuyerRequest) -> models.CreateBuyerResponse:
     """Register a GP buyer (issue #409): pre-check, create, read back. The caller commits.
 
-    Same three-beat shape as create_job_op, for the same reasons. The pre-check matters more here
-    because taCreateBuyer's body is encrypted: whether it errors on a duplicate or quietly overwrites
-    the existing description is not knowable from the proc, and overwriting one would rename a buyer
-    that live POs are already attributed to. Checking POP00101 first makes the answer ours.
+    Same three-beat shape as create_job_op, for the same reasons. taCreateBuyer does reject a
+    duplicate on its own (error state 2684), but it does so from inside the proc, and this turns that
+    into a clean buyer_already_exists the dialog can show. It also makes a retry after an ambiguous
+    failure safe: if the first attempt committed and the reply was lost, the retry says "already
+    registered" instead of surfacing a raw eConnect state for something that already worked.
 
-    The read-back guards the err=0-but-nothing-landed case and returns GP's stored description - the
-    column is char(30) on the proc, so a longer one is truncated on write and the request no longer
-    describes the row."""
+    The read-back guards the err=0-but-nothing-landed case and answers with GP's stored row, which is
+    what the buyer dropdowns will show on their next refetch."""
     if econnect.buyer_exists(conn, request.buyer_id):
         raise RelayOpError(
             "buyer_already_exists",

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -270,7 +270,9 @@ def create_buyer_op(conn, *, company: str, request: models.CreateBuyerRequest) -
     registered" instead of surfacing a raw eConnect state for something that already worked.
 
     The read-back guards the err=0-but-nothing-landed case and answers with GP's stored row, which is
-    what the buyer dropdowns will show on their next refetch."""
+    what the buyer dropdowns will show on their next refetch. It goes through econnect.get_buyer, so
+    it normalizes the id exactly as the buyer_exists pre-check does - a Python match against the whole
+    buyer master would disagree with the pre-check on case and roll back a create that worked."""
     if econnect.buyer_exists(conn, request.buyer_id):
         raise RelayOpError(
             "buyer_already_exists",
@@ -279,10 +281,7 @@ def create_buyer_op(conn, *, company: str, request: models.CreateBuyerRequest) -
 
     econnect.create_buyer(conn, buyer_id=request.buyer_id, description=request.description)
 
-    created = next(
-        (b for b in econnect.list_buyers_detailed(conn) if b["buyer_id"] == request.buyer_id),
-        None,
-    )
+    created = econnect.get_buyer(conn, request.buyer_id)
     if created is None:
         raise econnect.EConnectError(
             f"taCreateBuyer reported success but buyer {request.buyer_id} is not in POP00101",

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -260,6 +260,42 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
     )
 
 
+def create_buyer_op(conn, *, company: str, request: models.CreateBuyerRequest) -> models.CreateBuyerResponse:
+    """Register a GP buyer (issue #409): pre-check, create, read back. The caller commits.
+
+    Same three-beat shape as create_job_op, for the same reasons. The pre-check matters more here
+    because taCreateBuyer's body is encrypted: whether it errors on a duplicate or quietly overwrites
+    the existing description is not knowable from the proc, and overwriting one would rename a buyer
+    that live POs are already attributed to. Checking POP00101 first makes the answer ours.
+
+    The read-back guards the err=0-but-nothing-landed case and returns GP's stored description - the
+    column is char(30) on the proc, so a longer one is truncated on write and the request no longer
+    describes the row."""
+    if econnect.buyer_exists(conn, request.buyer_id):
+        raise RelayOpError(
+            "buyer_already_exists",
+            f"buyer '{request.buyer_id}' is already registered in GP company {company} (POP00101)",
+        )
+
+    econnect.create_buyer(conn, buyer_id=request.buyer_id, description=request.description)
+
+    created = next(
+        (b for b in econnect.list_buyers_detailed(conn) if b["buyer_id"] == request.buyer_id),
+        None,
+    )
+    if created is None:
+        raise econnect.EConnectError(
+            f"taCreateBuyer reported success but buyer {request.buyer_id} is not in POP00101",
+            proc="taCreateBuyer",
+        )
+
+    return models.CreateBuyerResponse(
+        company=company,
+        buyer_id=created["buyer_id"],
+        description=created["description"],
+    )
+
+
 def create_receipt_op(conn, *, company: str, request: models.ReceiptRequest) -> models.ReceiptResponse:
     """Receive against a PO. Reads the PO's lines from POP10110, then: taGetPurchReceiptNextNumber ->
     taPopRcptLineInsert x N -> taPopRcptHdrInsert, and (for companies with a paired custom DB) inserts

--- a/relay/tests/test_channel.py
+++ b/relay/tests/test_channel.py
@@ -287,6 +287,50 @@ def test_create_job_invalid_payload_translates_cleanly():
     assert reply["error"]["error"] == "invalid_payload"
 
 
+# --- buyer ops (issue #409) ---
+
+
+def test_list_buyers_detailed_routes_to_econnect(monkeypatch):
+    monkeypatch.setattr(
+        econnect,
+        "list_buyers_detailed",
+        lambda conn: [{"buyer_id": "donr", "description": "Don Roberton"}],
+    )
+    reply = channel._dispatch("list_buyers_detailed", "TUBC", {})
+    assert reply == {
+        "ok": True,
+        "result": {"company": "TUBC", "buyers": [{"buyer_id": "donr", "description": "Don Roberton"}]},
+    }
+
+
+def test_create_buyer_success_returns_the_response_body(monkeypatch):
+    from ucnexus_relay.models import CreateBuyerResponse
+
+    def _fake(conn, *, company, request):
+        return CreateBuyerResponse(company=company, buyer_id=request.buyer_id, description=request.description)
+
+    monkeypatch.setattr(ops, "create_buyer_op", _fake)
+    reply = channel._dispatch("create_buyer", "TUBC", {"buyer_id": "newbuyer", "description": "New Buyer"})
+    assert reply["ok"] is True
+    assert reply["result"] == {"company": "TUBC", "buyer_id": "newbuyer", "description": "New Buyer"}
+
+
+def test_create_buyer_already_exists_translates_cleanly(monkeypatch):
+    def _raise(conn, *, company, request):
+        raise ops.RelayOpError("buyer_already_exists", "buyer 'donr' is already registered in GP company TUBC")
+
+    monkeypatch.setattr(ops, "create_buyer_op", _raise)
+    reply = channel._dispatch("create_buyer", "TUBC", {"buyer_id": "donr"})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "buyer_already_exists"
+
+
+def test_create_buyer_invalid_payload_translates_cleanly():
+    reply = channel._dispatch("create_buyer", "TUBC", {"buyer_id": "   "})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "invalid_payload"
+
+
 def test_hello_frame_advertises_build_and_the_full_op_set():
     # Issue #315: the relay's connect frame carries its build tag and exact op-set so the backend can gate
     # a call for an op this build lacks. The op list must mirror channel._OPS - a new op added there is

--- a/relay/tests/test_create_buyer.py
+++ b/relay/tests/test_create_buyer.py
@@ -1,0 +1,199 @@
+"""create_buyer / create_buyer_op (issue #409). No real GP: a fake cursor records each EXEC's SQL +
+params and answers with a settable (error_state, err_string).
+
+taCreateBuyer's body is encrypted, so nothing here can assert what GP does with a duplicate - which is
+precisely why the op pre-checks POP00101 itself, and why that pre-check is pinned below."""
+
+from collections import namedtuple
+
+import pytest
+
+from ucnexus_relay import econnect, models, ops
+from ucnexus_relay.econnect import EConnectError, create_buyer
+
+_ExecRow = namedtuple("_ExecRow", "error_state err_string")
+_CountRow = namedtuple("_CountRow", "n")
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self._sql = ""
+
+    def execute(self, sql, *params):
+        self._sql = sql
+        self._conn.calls.append((sql, params))
+        return self
+
+    def fetchone(self):
+        if "taCreateBuyer" in self._sql:
+            return _ExecRow(self._conn.error_state, self._conn.err_string)
+        return _CountRow(self._conn.buyer_count)  # the buyer_exists pre-check
+
+
+class _FakeConn:
+    def __init__(self, *, error_state=0, err_string="", buyer_count=0):
+        self.error_state = error_state
+        self.err_string = err_string
+        self.buyer_count = buyer_count
+        self.calls: list[tuple[str, tuple]] = []
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def proc_calls(self):
+        return [c for c in self.calls if "taCreateBuyer" in c[0]]
+
+
+# --- econnect.create_buyer ---
+
+
+def test_only_buyerid_and_description_reach_the_exec():
+    # The proc's other inputs (RequesterTrx, USRDEFND1-5) carry defaults; sending them as explicit
+    # NULLs is not the same as leaving them defaulted.
+    conn = _FakeConn()
+    create_buyer(conn, buyer_id="donr", description="Don Roberton")
+    sql, params = conn.proc_calls()[0]
+
+    assert "@I_vBUYERID" in sql
+    assert "@I_vDSCRIPTN" in sql
+    for param in ("@I_vRequesterTrx", "@I_vUSRDEFND1", "@I_vUSRDEFND2"):
+        assert param not in sql
+    assert params == ("donr", "Don Roberton")
+
+
+def test_blank_description_is_still_sent():
+    # DSCRIPTN has no meaningful GP default to preserve, so a buyer registered without one is created
+    # with a blank description rather than being rejected.
+    conn = _FakeConn()
+    create_buyer(conn, buyer_id="donr")
+    _, params = conn.proc_calls()[0]
+    assert params == ("donr", "")
+
+
+def test_proc_error_raises_carrying_the_error_state():
+    # No proc_message here, unlike wsiJCJobMaster: taCreateBuyer IS a taXxx proc, so its error states
+    # are taErrorCode entries and errors.econnect_error_body resolves a real GP description for them.
+    conn = _FakeConn(error_state=1234, err_string="")
+    with pytest.raises(EConnectError) as exc:
+        create_buyer(conn, buyer_id="donr", description="Don")
+    assert exc.value.proc == "taCreateBuyer"
+    assert exc.value.error_state == 1234
+    assert exc.value.proc_message is None
+
+
+# --- econnect.buyer_exists / list_buyers_detailed ---
+
+
+def test_buyer_exists_strips_the_argument():
+    # BUYERID is char(15); the column is RTRIM'd, so the argument must be too or a padded id read out
+    # of a dropdown fails a pre-check against the row it came from.
+    conn = _FakeConn(buyer_count=1)
+    assert econnect.buyer_exists(conn, "  donr  ") is True
+    _, params = conn.calls[0]
+    assert params == ("donr",)
+
+
+def test_buyer_exists_is_false_when_absent():
+    conn = _FakeConn(buyer_count=0)
+    assert econnect.buyer_exists(conn, "nobody") is False
+
+
+# --- ops.create_buyer_op: pre-check, create, read back ---
+
+
+def _request(**overrides):
+    return models.CreateBuyerRequest(
+        company="TUBC", **{"buyer_id": "newbuyer", "description": "New Buyer", **overrides}
+    )
+
+
+def _stub_read_back(monkeypatch, buyer_id="newbuyer", description="New Buyer"):
+    monkeypatch.setattr(
+        econnect, "list_buyers_detailed", lambda c: [{"buyer_id": buyer_id, "description": description}]
+    )
+
+
+def test_op_creates_then_reads_back(monkeypatch):
+    conn = _FakeConn()
+    seen: list[tuple[str, str]] = []
+    monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: False)
+    monkeypatch.setattr(econnect, "create_buyer", lambda c, *, buyer_id, description: seen.append((buyer_id, description)))
+    _stub_read_back(monkeypatch)
+
+    response = ops.create_buyer_op(conn, company="TUBC", request=_request())
+
+    assert seen == [("newbuyer", "New Buyer")]
+    assert response.buyer_id == "newbuyer"
+    assert response.company == "TUBC"
+
+
+def test_op_answers_with_gps_stored_description_not_the_request(monkeypatch):
+    # DSCRIPTN is char(30) on the proc, so a longer description is truncated on write and the request
+    # no longer describes the row.
+    conn = _FakeConn()
+    monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: False)
+    monkeypatch.setattr(econnect, "create_buyer", lambda c, **k: None)
+    _stub_read_back(monkeypatch, description="What GP Actually Kept")
+
+    response = ops.create_buyer_op(conn, company="TUBC", request=_request())
+
+    assert response.description == "What GP Actually Kept"
+
+
+def test_op_refuses_a_duplicate_without_calling_the_proc(monkeypatch):
+    # Overwriting an existing registration would rename a buyer that live POs are already attributed
+    # to, so this must stop before taCreateBuyer runs.
+    conn = _FakeConn()
+    called = []
+    monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: True)
+    monkeypatch.setattr(econnect, "create_buyer", lambda c, **k: called.append(k))
+
+    with pytest.raises(ops.RelayOpError) as exc:
+        ops.create_buyer_op(conn, company="TUBC", request=_request(buyer_id="donr"))
+
+    assert exc.value.code == "buyer_already_exists"
+    assert called == []
+
+
+def test_op_raises_when_the_row_never_landed(monkeypatch):
+    # err=0 with no row: the silent-failure class create_po_line and create_job_op guard against.
+    conn = _FakeConn()
+    monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: False)
+    monkeypatch.setattr(econnect, "create_buyer", lambda c, **k: None)
+    monkeypatch.setattr(econnect, "list_buyers_detailed", lambda c: [])
+
+    with pytest.raises(EConnectError, match="not in POP00101"):
+        ops.create_buyer_op(conn, company="TUBC", request=_request())
+
+
+# --- CreateBuyerRequest normalization ---
+
+
+def test_request_trims_both_fields():
+    request = _request(buyer_id="  donr  ", description="  Don Roberton  ")
+    assert request.buyer_id == "donr"
+    assert request.description == "Don Roberton"
+
+
+def test_request_rejects_a_whitespace_only_buyer_id():
+    # It would land in POP00101 as the blank buyer list_buyers filters out: registered, invisible,
+    # unusable.
+    with pytest.raises(ValueError, match="buyer_id is required"):
+        _request(buyer_id="   ")
+
+
+def test_request_rejects_an_over_length_buyer_id():
+    with pytest.raises(ValueError):
+        _request(buyer_id="x" * 16)
+
+
+def test_request_rejects_an_over_length_description():
+    with pytest.raises(ValueError):
+        _request(description="x" * 31)

--- a/relay/tests/test_create_buyer.py
+++ b/relay/tests/test_create_buyer.py
@@ -1,8 +1,10 @@
 """create_buyer / create_buyer_op (issue #409). No real GP: a fake cursor records each EXEC's SQL +
 params and answers with a settable (error_state, err_string).
 
-taCreateBuyer's body is encrypted, so nothing here can assert what GP does with a duplicate - which is
-precisely why the op pre-checks POP00101 itself, and why that pre-check is pinned below."""
+What matters here is that the EXEC carries ONLY BUYERID and DSCRIPTN - taCreateBuyer's other inputs
+are defaulted, and sending them as explicit NULLs is not the same thing - and that the op's own
+duplicate pre-check runs before the proc, so a re-register reads as a sentence rather than as GP's
+error state 2684."""
 
 from collections import namedtuple
 
@@ -80,11 +82,12 @@ def test_blank_description_is_still_sent():
 def test_proc_error_raises_carrying_the_error_state():
     # No proc_message here, unlike wsiJCJobMaster: taCreateBuyer IS a taXxx proc, so its error states
     # are taErrorCode entries and errors.econnect_error_body resolves a real GP description for them.
-    conn = _FakeConn(error_state=1234, err_string="")
+    # 2683 is that table's "Unable to insert into the Buyer Master Table - POP00101".
+    conn = _FakeConn(error_state=2683, err_string="")
     with pytest.raises(EConnectError) as exc:
         create_buyer(conn, buyer_id="donr", description="Don")
     assert exc.value.proc == "taCreateBuyer"
-    assert exc.value.error_state == 1234
+    assert exc.value.error_state == 2683
     assert exc.value.proc_message is None
 
 
@@ -148,8 +151,9 @@ def test_op_answers_with_gps_stored_description_not_the_request(monkeypatch):
 
 
 def test_op_refuses_a_duplicate_without_calling_the_proc(monkeypatch):
-    # Overwriting an existing registration would rename a buyer that live POs are already attributed
-    # to, so this must stop before taCreateBuyer runs.
+    # The proc would reject it too (error state 2684), but from inside itself. Pre-empting it is what
+    # turns a re-register into a sentence the dialog can show, and what makes a retry after an
+    # ambiguous failure read as "already registered" rather than as a raw eConnect state.
     conn = _FakeConn()
     called = []
     monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: True)

--- a/relay/tests/test_create_buyer.py
+++ b/relay/tests/test_create_buyer.py
@@ -15,6 +15,7 @@ from ucnexus_relay.econnect import EConnectError, create_buyer
 
 _ExecRow = namedtuple("_ExecRow", "error_state err_string")
 _CountRow = namedtuple("_CountRow", "n")
+_BuyerRow = namedtuple("_BuyerRow", "buyer_id description")
 
 
 class _FakeCursor:
@@ -30,14 +31,18 @@ class _FakeCursor:
     def fetchone(self):
         if "taCreateBuyer" in self._sql:
             return _ExecRow(self._conn.error_state, self._conn.err_string)
-        return _CountRow(self._conn.buyer_count)  # the buyer_exists pre-check
+        if "COUNT(*)" in self._sql:
+            return _CountRow(self._conn.buyer_count)  # the buyer_exists pre-check
+        # the get_buyer read-back
+        return None if self._conn.buyer_row is None else _BuyerRow(*self._conn.buyer_row)
 
 
 class _FakeConn:
-    def __init__(self, *, error_state=0, err_string="", buyer_count=0):
+    def __init__(self, *, error_state=0, err_string="", buyer_count=0, buyer_row=None):
         self.error_state = error_state
         self.err_string = err_string
         self.buyer_count = buyer_count
+        self.buyer_row = buyer_row
         self.calls: list[tuple[str, tuple]] = []
 
     def cursor(self):
@@ -91,7 +96,7 @@ def test_proc_error_raises_carrying_the_error_state():
     assert exc.value.proc_message is None
 
 
-# --- econnect.buyer_exists / list_buyers_detailed ---
+# --- econnect.buyer_exists / get_buyer ---
 
 
 def test_buyer_exists_strips_the_argument():
@@ -108,6 +113,22 @@ def test_buyer_exists_is_false_when_absent():
     assert econnect.buyer_exists(conn, "nobody") is False
 
 
+def test_get_buyer_matches_the_id_in_sql_like_the_pre_check_does():
+    # The read-back has to normalize the id the SAME way buyer_exists does - RTRIM'd column, stripped
+    # argument, comparison left to SQL - or the two gates disagree about what is the same buyer and a
+    # create that worked gets rolled back as "reported success but not in POP00101".
+    conn = _FakeConn(buyer_row=("donr", "Don Roberton"))
+    assert econnect.get_buyer(conn, "  donr  ") == {"buyer_id": "donr", "description": "Don Roberton"}
+    sql, params = conn.calls[0]
+    assert "RTRIM(BUYERID) = ?" in sql
+    assert params == ("donr",)
+
+
+def test_get_buyer_is_none_when_the_row_never_landed():
+    conn = _FakeConn(buyer_row=None)
+    assert econnect.get_buyer(conn, "nobody") is None
+
+
 # --- ops.create_buyer_op: pre-check, create, read back ---
 
 
@@ -118,9 +139,7 @@ def _request(**overrides):
 
 
 def _stub_read_back(monkeypatch, buyer_id="newbuyer", description="New Buyer"):
-    monkeypatch.setattr(
-        econnect, "list_buyers_detailed", lambda c: [{"buyer_id": buyer_id, "description": description}]
-    )
+    monkeypatch.setattr(econnect, "get_buyer", lambda c, b: {"buyer_id": buyer_id, "description": description})
 
 
 def test_op_creates_then_reads_back(monkeypatch):
@@ -171,7 +190,7 @@ def test_op_raises_when_the_row_never_landed(monkeypatch):
     conn = _FakeConn()
     monkeypatch.setattr(econnect, "buyer_exists", lambda c, b: False)
     monkeypatch.setattr(econnect, "create_buyer", lambda c, **k: None)
-    monkeypatch.setattr(econnect, "list_buyers_detailed", lambda c: [])
+    monkeypatch.setattr(econnect, "get_buyer", lambda c, b: None)
 
     with pytest.raises(EConnectError, match="not in POP00101"):
         ops.create_buyer_op(conn, company="TUBC", request=_request())

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -19,6 +19,28 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
   - Tokens are one-time use; fetch a fresh one each session. Works on any runtime with the same Clerk dev instance.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
 
+### A PR environment is always relay-disconnected, and that is useful
+
+The relay dials ONE backend - the `[channel] backend_url` in its `config.toml`, which is production.
+A PR environment therefore always reports `relayStatus.connected: false`, and no amount of waiting
+changes it. Pointing the relay at a PR backend is not a shortcut either: relay installs live in
+Postgres, and a PR environment boots a fresh empty one, so the relay would have to be re-provisioned
+and re-enrolled there and then put back afterwards.
+
+Read that as a free test fixture rather than a limitation. The relay-down half of any GP-gated
+feature - disabled controls, "not connected" copy, held values still displaying, buttons that must
+not be clickable - is exactly what a PR environment exercises by construction, and it is the half
+that is otherwise awkward to reach on production without stopping the relay for everyone.
+
+What a PR environment cannot show is any populated GP dropdown or any GP write. Those need
+production, after merge and after the installed relay is rebuilt to a build whose `_OPS` includes the
+new op (an older build answers `unknown_op` -> `RELAY_OP_UNSUPPORTED`, which is its own distinct UI
+state and worth checking on purpose during the deploy-before-rebuild window).
+
+Verified on PR #412 (issue #409's buyer dropdown): the field rendered `role="combobox"`, disabled,
+still showing the stored `mira`, with "The GP relay is not connected, so this cannot be changed right
+now." - all four assertions met without touching production.
+
 ### Inventory can only be seeded through the relay - check this first
 
 **Nothing puts new hardware into inventory except `createReceive`, and `createReceive` is


### PR DESCRIPTION
Closes #409.

Admin -> User Management GP Buyer ID goes free text -> dropdown fed live from GP's buyer master, with inline registration for a buyer that isn't there yet. a typo was previously invisible until much later, when taPoHdr rejected the unregistered BUYERID with error 269.

read-only GP discovery against TUBC found:
- `taCreateBuyer` exists, our login has EXECUTE. params `@I_vBUYERID char(15)`, `@I_vDSCRIPTN char(30)`, RequesterTrx, USRDEFND1-5, plus the two OUTPUT error params.
- no `taDeleteBuyer`, no update proc. taCreateBuyer plus its Pre/Post hooks only.
- POP00101 = `BUYERID char(15)`, `DSCRIPTN char(31)`, NOTEINDX, DEX_ROW_ID.
- DYNAMICS.taErrorCode states for it: 2681 BUYERID empty, 2684 duplicate in POP00101, 2683 insert failed, 2679 null input.
- TUBC has `mira` (Accounting), `donr` (Don Roberton). TUCSH ~100, including ids with spaces (`Anna Wyzynski`, `Nazanin T.`). BUYERID is not a GP user id, so the register form is free text.

relay adds two channel ops to `_OPS` in channel.py, advertised in the hello frame:
- `list_buyers_detailed` - POP00101 with descriptions, separate from the existing `list_buyers`.
- `create_buyer` - `create_buyer_op` pre-checks POP00101 -> EXECs taCreateBuyer -> reads the row back. the proc rejects a duplicate itself (2684) but from inside itself, so pre-empting it is what turns a re-register into a sentence the dialog can show, and what makes a retry after an ambiguous failure safe. same reasoning as create_job_op's job_exists check.

backend adds two admin-gated resolvers:
`Query.gpBuyersDetailed(company)`
`Mutation.createGpBuyer(buyerId, description)`

admin-gated because the descriptions are a staff roster by another name (in production, every buyer's email) - same reasoning that made gpEmployees admin-only.
buyerId/description bounded against GP's char widths before the call.
existing `gpBuyers` (bare ids, require_user) untouched, still backs the Create PO dropdown.

frontend adds `useGpBuyers` + `GpBuyerSelect`, shared by both admin screens, covering three states:
list
relay down
relay too old

- User Management free-text field -> dropdown with a pinned "+ Register new GP buyer..." entry (VendorSelect pattern). an already-linked id still displays while the relay is down.
- Buyers page gains a "Registered in GP" panel over the buyer master with a Register button, add-assignment dialog buyer field -> same dropdown, assignments for ids GP never registered carry a warning marker.
- relay down or too old -> field DISABLED, no free-text fallback. deliberately the opposite of the create-job dialog's employee pickers: an estimator id is rejected by the proc during the same submit, but a buyer id is written to Clerk and looks correct until someone tries to raise a PO.

no removal path, stays a GP-side task: eConnect exposes no proc, and a direct DELETE on POP00101 would bypass the business logic the eConnect-only rule exists to protect.
no edit path for an existing registration's description.

no DB migration.
installed relay needs a rebuild -> update through the relay app before the new ops go live.
until then the admin UI shows its disabled / "update the relay" state, existing #315 gating.

relay 304 pass, ruff clean.
backend ruff/format clean, new tests pass.
frontend 358 pass, lint 0 errors, tsc and build clean.