### PR TITLE
feat(reset): preserve setup tables across reset, release stranded IN_PO hardware

### DIFF
--- a/backend/alembic/versions/073_release_stranded_in_po_hardware.py
+++ b/backend/alembic/versions/073_release_stranded_in_po_hardware.py
@@ -1,0 +1,63 @@
+"""Release hardware stranded IN_PO by a dead purchase order (#402)
+
+Revision ID: 073
+Revises: 072
+Create Date: 2026-07-29
+
+Before #398, cancelling a PO left its hardware rows behind: the PO went to CANCELLED (or was
+soft-deleted via `deleted_at`) but the `hardware_items` rows it had claimed kept `state = 'IN_PO'`
+and kept pointing at the now-dead `po_line_items` row. `cancel_po` releases them properly now -
+back to `state = 'AVAILABLE'` with `po_line_item_id = NULL` - but that only fixes cancels from here
+on. Every environment still carries the rows the old cancels stranded, and nothing in the app can
+reach them: they are attached to a PO no screen will ever open again.
+
+Three symptoms come out of that, all of them from the same stranded rows:
+
+- required_quantity rollups double-count. The stranded row still reads as ordered, and the
+  replacement the user raised afterwards reads as ordered too.
+- the admin Hardware Items stat is inflated by exactly the stranded count.
+- finalize cannot recreate the items as AVAILABLE, because the stranded row already holds the
+  (opening, product, category, leaf) key it needs.
+
+This is a data migration rather than a one-off admin action on purpose. The backend entrypoint runs
+`alembic upgrade head` on every deploy, so it repairs each environment exactly once, needs no UI,
+and no-ops from then on.
+
+Both statements are idempotent and safe on an empty database. `downgrade()` is a no-op: the pre-#398
+state is a bug, and there is no record of which rows were stranded to put back.
+"""
+
+from alembic import op
+
+revision = "073"
+down_revision = "072"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Anything pointing at a line item of a cancelled or soft-deleted PO, whatever state it claims to
+    # be in. No `state` filter here on purpose: a dead PO cannot own hardware, so both fields get
+    # normalized regardless of how the row got there.
+    op.execute(
+        """
+        UPDATE hardware_items SET state = 'AVAILABLE', po_line_item_id = NULL
+        WHERE po_line_item_id IN (
+          SELECT li.id FROM po_line_items li JOIN purchase_orders po ON po.id = li.po_id
+          WHERE po.status = 'CANCELLED' OR po.deleted_at IS NOT NULL)
+        """
+    )
+
+    # Register-edit orphans: the link was cleared but the state was not, so the row is claimed by a
+    # PO that is not named anywhere.
+    op.execute(
+        """
+        UPDATE hardware_items SET state = 'AVAILABLE'
+        WHERE state = 'IN_PO' AND po_line_item_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op. Re-stranding the rows would restore the defect, and which rows were stranded is not
+    recorded anywhere."""

--- a/backend/alembic/versions/073_release_stranded_in_po_hardware.py
+++ b/backend/alembic/versions/073_release_stranded_in_po_hardware.py
@@ -23,9 +23,23 @@ This is a data migration rather than a one-off admin action on purpose. The back
 `alembic upgrade head` on every deploy, so it repairs each environment exactly once, needs no UI,
 and no-ops from then on.
 
-Both statements are idempotent and safe on an empty database. `downgrade()` is a no-op: the pre-#398
-state is a bug, and there is no record of which rows were stranded to put back.
+Both statements are idempotent. `downgrade()` is a no-op: the pre-#398 state is a bug, and there is
+no record of which rows were stranded to put back.
+
+The empty-table guard in `upgrade()` is not an optimization. `AVAILABLE` is added to
+`hardware_item_state` by `ALTER TYPE ... ADD VALUE` back in 026, and PostgreSQL refuses to *use* a
+label added by a transaction that has not committed yet. `alembic/env.py` wraps the entire
+`upgrade head` in one transaction, so on a fresh database 026 and this migration share it and the
+UPDATE cannot even be parsed. 071 hit the same wall and got out of it by comparing `source::text`,
+which works for a read but not here - an UPDATE has to produce a real enum value, and every route to
+one goes through the same check. Skipping is the honest answer rather than a dodge: a database with
+no `hardware_items` rows has nothing stranded in the first place. On a deployed database 026
+committed deploys ago, so the label is long since safe and the repair runs normally.
+
+The reads still cast to text (071's pattern), which keeps them clear of the same trap.
 """
+
+import sqlalchemy as sa
 
 from alembic import op
 
@@ -36,6 +50,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Nothing to repair, and on a fresh database the statements below could not run anyway - see the
+    # module docstring for why the enum label is off limits inside this transaction.
+    if op.get_bind().execute(sa.text("SELECT 1 FROM hardware_items LIMIT 1")).first() is None:
+        return
+
     # Anything pointing at a line item of a cancelled or soft-deleted PO, whatever state it claims to
     # be in. No `state` filter here on purpose: a dead PO cannot own hardware, so both fields get
     # normalized regardless of how the row got there.
@@ -44,7 +63,7 @@ def upgrade() -> None:
         UPDATE hardware_items SET state = 'AVAILABLE', po_line_item_id = NULL
         WHERE po_line_item_id IN (
           SELECT li.id FROM po_line_items li JOIN purchase_orders po ON po.id = li.po_id
-          WHERE po.status = 'CANCELLED' OR po.deleted_at IS NOT NULL)
+          WHERE po.status::text = 'CANCELLED' OR po.deleted_at IS NOT NULL)
         """
     )
 
@@ -53,7 +72,7 @@ def upgrade() -> None:
     op.execute(
         """
         UPDATE hardware_items SET state = 'AVAILABLE'
-        WHERE state = 'IN_PO' AND po_line_item_id IS NULL
+        WHERE state::text = 'IN_PO' AND po_line_item_id IS NULL
         """
     )
 

--- a/backend/app/crypto.py
+++ b/backend/app/crypto.py
@@ -18,13 +18,14 @@ path and `_fernet` / `encrypt_secret` / `decrypt_secret` are reachable only from
 the `encryption_key_present` log field.
 
 No new legacy row can appear. `set_install_secret` NULLs `secret_encrypted` on every enroll and adopt,
-and the only other statement naming the column is `/admin/reset-data` (main.py), which round-trips
-existing values across a schema rebuild - it can preserve a legacy row, never create one.
+and the only other path that carries the column is `/admin/reset-data`, which round-trips existing
+values across a schema rebuild - it can preserve a legacy row, never create one.
 
 Restoring one from an old backup would not help. Fernet needs the exact original key and no copy of it
 survives anywhere, so a recovered pre-067 row is simply unreadable; an orphaned relay is recovered
 through the admin-armed adopt window (066, #353 PR B) instead. Deleting these functions and dropping
-the column is a separate job, and it has to touch that reset-data SQL too."""
+the column is a separate job, but it is now purely a migration: the reset derives its columns from
+`RelayInstall.__table__`, so nothing over there names this one by hand any more (#411)."""
 
 import hashlib
 import os

--- a/backend/app/services/gp_job_sync.py
+++ b/backend/app/services/gp_job_sync.py
@@ -33,7 +33,19 @@ logger = logging.getLogger(__name__)
 # covers "I just made one and want it now".
 POLL_SECONDS = 300.0
 
+# How long /admin/reset-data waits for its one forced sync pass. Generous next to relay_call's own 30s
+# because this pass also writes a project row per GP job, and the reset is a deliberate manual action
+# that nobody is timing - overshooting costs a few seconds, giving up early costs every buyer link.
+RESET_SYNC_TIMEOUT_SECONDS = 90.0
+
 _wake_event: asyncio.Event | None = None
+
+# The loop `run_forever` was scheduled on, which is the loop the relay websocket lives on. Captured so
+# a *synchronous* caller in the threadpool can still run a sync pass: `/admin/reset-data` is a sync def
+# and must re-adopt every GP job right after it rebuilds the schema, but `run_once` talks to the relay
+# over that socket and may only be awaited on its own loop (#410). None until the lifespan task starts,
+# and it never starts when `enabled()` is False - callers treat that as "no sync available" and skip.
+_loop: "asyncio.AbstractEventLoop | None" = None
 
 
 def enabled() -> bool:
@@ -102,11 +114,39 @@ async def run_once() -> tuple[int, int]:
     return await asyncio.to_thread(_persist_missing, jobs)
 
 
+def run_once_blocking(timeout: float = RESET_SYNC_TIMEOUT_SECONDS) -> tuple[int, int] | None:
+    """One sync pass driven from a worker thread instead of the event loop (#410).
+
+    `/admin/reset-data` is a sync def, so FastAPI runs it in the threadpool - but it has to re-adopt
+    every GP job the moment it has rebuilt the schema. Waiting out POLL_SECONDS is not an option there:
+    the buyer/project links the reset restores are matched by job number, so until the projects are
+    back there is nothing to match and every link drops. `run_once` awaits the relay socket and may
+    only be awaited on the loop that owns it, hence the hand-off.
+
+    Returns (total, adopted), or None when no pass could run - sync disabled, no relay connected, the
+    relay went away mid-pass, or it did not answer in time. Every one of those is a skip rather than a
+    failure: a reset must not fail because GP happened to be unreachable."""
+    loop = _loop
+    if loop is None or not relay_gateway.connected:
+        return None
+    try:
+        return asyncio.run_coroutine_threadsafe(run_once(), loop).result(timeout=timeout)
+    except (RelayUnavailableError, RelayTimeoutError) as e:
+        logger.info("gp job sync: relay unavailable during reset (%s); projects not re-adopted", e.message)
+    except TimeoutError:
+        # The pass is still running on the loop; it will finish or fail on its own. Only this wait ends.
+        logger.warning("gp job sync: pass did not finish within %ss during reset", timeout)
+    except Exception:  # noqa: BLE001 - a reset must not 500 on a bad sync
+        logger.exception("gp job sync: pass failed during reset")
+    return None
+
+
 async def run_forever() -> None:
     """The lifespan task. Every iteration is wrapped so no error can kill it - a dead sync is silently
     missing projects, which surfaces much later as "why isn't this job in Nexus"."""
-    global _wake_event
+    global _wake_event, _loop
     _wake_event = asyncio.Event()
+    _loop = asyncio.get_running_loop()
     logger.info("gp job sync started")
     while True:
         try:

--- a/backend/app/services/gp_job_sync.py
+++ b/backend/app/services/gp_job_sync.py
@@ -44,8 +44,9 @@ _wake_event: asyncio.Event | None = None
 # a *synchronous* caller in the threadpool can still run a sync pass: `/admin/reset-data` is a sync def
 # and must re-adopt every GP job right after it rebuilds the schema, but `run_once` talks to the relay
 # over that socket and may only be awaited on its own loop (#410). None until the lifespan task starts,
-# and it never starts when `enabled()` is False - callers treat that as "no sync available" and skip.
-_loop: "asyncio.AbstractEventLoop | None" = None
+# and cleared again when it stops - handing a coroutine to a loop that is no longer running never
+# completes, so a stale value here would block the reset for the whole timeout and then lie about why.
+_loop: asyncio.AbstractEventLoop | None = None
 
 
 def enabled() -> bool:
@@ -125,9 +126,13 @@ def run_once_blocking(timeout: float = RESET_SYNC_TIMEOUT_SECONDS) -> tuple[int,
 
     Returns (total, adopted), or None when no pass could run - sync disabled, no relay connected, the
     relay went away mid-pass, or it did not answer in time. Every one of those is a skip rather than a
-    failure: a reset must not fail because GP happened to be unreachable."""
+    failure: a reset must not fail because GP happened to be unreachable.
+
+    `enabled()` is re-checked here rather than inferred from `_loop` being None. The kill switch and
+    the loop handle are two different facts, and a caller that blocks for 90 seconds should not depend
+    on the lifespan wiring never changing."""
     loop = _loop
-    if loop is None or not relay_gateway.connected:
+    if not enabled() or loop is None or not loop.is_running() or not relay_gateway.connected:
         return None
     try:
         return asyncio.run_coroutine_threadsafe(run_once(), loop).result(timeout=timeout)
@@ -148,25 +153,31 @@ async def run_forever() -> None:
     _wake_event = asyncio.Event()
     _loop = asyncio.get_running_loop()
     logger.info("gp job sync started")
-    while True:
-        try:
-            if relay_gateway.connected and relay_gateway.company:
-                total, adopted = await run_once()
-                if adopted:
-                    logger.info("gp job sync: adopted %s of %s GP jobs", adopted, total)
-        except asyncio.CancelledError:
-            raise
-        except (RelayUnavailableError, RelayTimeoutError) as e:
-            # The relay went away between the guard above and the call, or mid-pass. Routine - relays
-            # restart, get updated, and flap - and the next tick retries. Logging a traceback for every
-            # relay restart would bury a real fault in noise.
-            logger.info("gp job sync: relay unavailable this pass (%s); retrying later", e.message)
-        except Exception:  # noqa: BLE001
-            logger.exception("gp job sync iteration failed")
+    try:
+        while True:
+            try:
+                if relay_gateway.connected and relay_gateway.company:
+                    total, adopted = await run_once()
+                    if adopted:
+                        logger.info("gp job sync: adopted %s of %s GP jobs", adopted, total)
+            except asyncio.CancelledError:
+                raise
+            except (RelayUnavailableError, RelayTimeoutError) as e:
+                # The relay went away between the guard above and the call, or mid-pass. Routine - relays
+                # restart, get updated, and flap - and the next tick retries. Logging a traceback for every
+                # relay restart would bury a real fault in noise.
+                logger.info("gp job sync: relay unavailable this pass (%s); retrying later", e.message)
+            except Exception:  # noqa: BLE001
+                logger.exception("gp job sync iteration failed")
 
-        try:
-            await asyncio.wait_for(_wake_event.wait(), timeout=POLL_SECONDS)
-        except TimeoutError:
-            pass
-        finally:
-            _wake_event.clear()
+            try:
+                await asyncio.wait_for(_wake_event.wait(), timeout=POLL_SECONDS)
+            except TimeoutError:
+                pass
+            finally:
+                _wake_event.clear()
+    finally:
+        # Shutdown, or the task being cancelled. Drop the handles so run_once_blocking skips instead of
+        # scheduling a coroutine onto a loop that will never run it.
+        _loop = None
+        _wake_event = None

--- a/backend/app/services/reset_preservation.py
+++ b/backend/app/services/reset_preservation.py
@@ -31,12 +31,14 @@ their original UUIDs.
 """
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
-from sqlalchemy import insert, select
+from sqlalchemy import Select, delete, insert, select
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.engine import Connection
 
+from app.models import Base
 from app.models.buyer_assignment import BuyerAssignment, buyer_assignment_projects
 from app.models.manufacturer_vendor_map import ManufacturerVendorMap
 from app.models.po_document_settings import PODocumentSettings
@@ -56,6 +58,17 @@ PRESERVED_MODELS = (
     PODocumentSettings,
 )
 
+# Human labels for the reset's summary line. `/admin/reset-data` returns `message` and the frontend
+# alerts it verbatim, so the counts have to agree in number and read as English rather than as table
+# names ("1 relay install", not "1 relay_installs").
+PRESERVED_LABELS: dict[str, tuple[str, str]] = {
+    "relay_installs": ("relay install", "relay installs"),
+    "warehouses": ("warehouse", "warehouses"),
+    "buyer_assignments": ("buyer assignment", "buyer assignments"),
+    "manufacturer_vendor_map": ("manufacturer/vendor mapping", "manufacturer/vendor mappings"),
+    "po_document_settings": ("PO document setting", "PO document settings"),
+}
+
 
 @dataclass
 class ResetSnapshot:
@@ -72,7 +85,7 @@ class ResetSnapshot:
         return {table: len(rows) for table, rows in self.rows.items()}
 
 
-def preserved_columns(model, live_column_names) -> list[str]:
+def preserved_columns(model: type[Base], live_column_names: Iterable[str]) -> list[str]:
     """The model's columns that the live table also has, in model declaration order.
 
     Pure function over names - the unit test for this needs no database. The intersection is the
@@ -83,7 +96,7 @@ def preserved_columns(model, live_column_names) -> list[str]:
     return [c.name for c in model.__table__.columns if c.name in live]
 
 
-def snapshot_statement(model, live_column_names):
+def snapshot_statement(model: type[Base], live_column_names: Iterable[str]) -> Select | None:
     """The SELECT that reads one preserved table, or None when nothing about it is preservable.
 
     Split out from `snapshot` so it can be asserted on without a database - it is the statement that
@@ -101,18 +114,28 @@ def snapshot(conn: Connection) -> ResetSnapshot:
     database: a table that isn't there yet is simply not preserved, which is exactly the state a reset
     exists to clear."""
     inspector = sa_inspect(conn)
+    # One round trip for the whole table list instead of a has_table call per model; this runs against
+    # managed Postgres over a network hop, where each extra round trip is a real cost.
+    live_tables = set(inspector.get_table_names())
     snap = ResetSnapshot()
 
     for model in PRESERVED_MODELS:
         table = model.__table__
-        if not inspector.has_table(table.name):
+        if table.name not in live_tables:
             continue
         stmt = snapshot_statement(model, [c["name"] for c in inspector.get_columns(table.name)])
         if stmt is None:
             continue
         snap.rows[table.name] = [dict(r) for r in conn.execute(stmt).mappings()]
 
-    if inspector.has_table(buyer_assignment_projects.name) and inspector.has_table(Project.__table__.name):
+    # Only worth collecting when the left-hand side of the link is itself preserved: a pair whose
+    # `buyer_assignments` row never comes back would fail the FK on relink, after the schema has already
+    # been rebuilt and committed.
+    if (
+        BuyerAssignment.__table__.name in snap.rows
+        and buyer_assignment_projects.name in live_tables
+        and Project.__table__.name in live_tables
+    ):
         projects = Project.__table__
         pairs = select(
             buyer_assignment_projects.c.buyer_assignment_id,
@@ -125,16 +148,38 @@ def snapshot(conn: Connection) -> ResetSnapshot:
 
 
 def restore(conn: Connection, snap: ResetSnapshot) -> dict[str, int]:
-    """Insert the snapshotted rows back into the rebuilt schema, original UUIDs intact.
+    """Put the snapshotted rows back into the rebuilt schema, original UUIDs intact. Returns the count
+    actually restored per table, which is not always the count snapshotted - see below.
 
-    Runs before anything can lazily seed a default row - `PODocumentSettings` in particular is read
-    through a get-or-create helper, so restoring first is what stops a defaults row being seeded
-    alongside the admin-edited one."""
+    **The snapshot wins over whatever the rebuild left in the table.** `alembic upgrade head` replays
+    every migration, and some of them seed the table they create: 033 seeds `warehouses` with Warden
+    and VP. Those seeds are the previous cycle's rows under fresh UUIDs, so inserting the snapshot on
+    top of them is a duplicate-key failure on `uq_warehouses_name`, not a merge. The same window lets
+    a concurrent read seed the single `po_document_settings` row through its get-or-create helper
+    before the restore lands. Clearing the table first makes the preserved rows authoritative in both
+    cases. A table the snapshot has nothing for is left alone, so a fresh database keeps its seeds.
+
+    **One table's failure must not take the others down.** Each table restores inside its own
+    SAVEPOINT: relay_installs is the row set whose loss means a GP outage until someone walks to the
+    workstation, and it must not be rolled back because some later table hit a constraint."""
+    restored: dict[str, int] = {}
     for model in PRESERVED_MODELS:
-        rows = snap.rows.get(model.__table__.name)
-        if rows:
-            conn.execute(insert(model.__table__), rows)
-    return snap.counts
+        table = model.__table__
+        rows = snap.rows.get(table.name)
+        if rows is None:
+            continue
+        restored[table.name] = 0
+        if not rows:
+            continue
+        try:
+            with conn.begin_nested():
+                conn.execute(delete(table))
+                conn.execute(insert(table), rows)
+        except Exception:  # noqa: BLE001 - one unrestorable table must not discard the rest
+            logger.exception("reset: could not restore %s; its %s preserved rows are lost", table.name, len(rows))
+            continue
+        restored[table.name] = len(rows)
+    return restored
 
 
 def relink_buyer_projects(conn: Connection, pairs: list[dict]) -> tuple[int, int]:
@@ -148,11 +193,27 @@ def relink_buyer_projects(conn: Connection, pairs: list[dict]) -> tuple[int, int
 
     projects = Project.__table__
     by_job = {row.project_id: row.id for row in conn.execute(select(projects.c.project_id, projects.c.id))}
+    # A buyer whose own row failed to restore has nothing to hang the link on; inserting anyway would
+    # fail the FK and 500 the reset after the schema is already rebuilt and committed.
+    live_buyers = {row.id for row in conn.execute(select(BuyerAssignment.__table__.c.id))}
     rows = [
         {"buyer_assignment_id": pair["buyer_assignment_id"], "project_id": by_job[pair["job_number"]]}
         for pair in pairs
-        if pair["job_number"] in by_job
+        if pair["job_number"] in by_job and pair["buyer_assignment_id"] in live_buyers
     ]
     if rows:
         conn.execute(insert(buyer_assignment_projects), rows)
     return len(rows), len(pairs) - len(rows)
+
+
+def describe_counts(counts: dict[str, int]) -> list[str]:
+    """ "1 relay install", "3 warehouses" - the pieces of the reset's summary line.
+
+    The endpoint's `message` is alerted to the user verbatim, so a count of one has to read as one."""
+    described = []
+    for table, count in counts.items():
+        if not count:
+            continue
+        singular, plural = PRESERVED_LABELS.get(table, (table, table))
+        described.append(f"{count} {singular if count == 1 else plural}")
+    return described

--- a/backend/app/services/reset_preservation.py
+++ b/backend/app/services/reset_preservation.py
@@ -1,0 +1,158 @@
+"""The configuration that survives POST /admin/reset-data (#410, #411).
+
+A reset drops and rebuilds the whole public schema. That is the point - it exists to clear project
+data - but a handful of tables hold *setup*, not data, and wiping them turns a dev convenience into
+an afternoon of re-entry (or, for `relay_installs`, into a GP outage until someone walks to the
+workstation and re-enrols the relay).
+
+So the reset snapshots those tables, rebuilds, and puts the rows back with their original UUIDs.
+`PRESERVED_MODELS` is the whole list; adding a table to it is a one-line change.
+
+**Columns are derived from the model, never listed by hand** (#411). The previous version named all
+13 `relay_installs` columns twice in raw SQL, so a migration adding a column left it NULL on every
+preserved row after the next reset, silently. `preserved_columns` takes the names off
+`Model.__table__.columns` and intersects them with what the live table actually has - the
+intersection is what keeps a half-migrated database (one predating a column the model already
+declares) from crashing the snapshot, which is the same tolerance the `has_table` guard gives.
+
+**Statements are built through SQLAlchemy Core, not string SQL.** Two of the preserved models store
+JSON (`BuyerAssignment.cost_codes`, and four columns on `PODocumentSettings`). Round-tripping those
+through `text()` bind params does not work: psycopg2 adapts a Python list to a Postgres *array*, so
+the restore fails with "column is of type json but expression is of type text[]". Core carries the
+column types, so JSON, UUID, enum and datetime all serialize correctly, and a column the snapshot is
+missing falls back to the model's Python-side default instead of being inserted as NULL.
+
+One table cannot be restored by row. `buyer_assignment_projects` is keyed on `projects.id`, and
+projects do not survive a reset - they are re-adopted from GP afterwards with **new** UUIDs, so every
+snapshotted `project_id` is stale the moment the schema drops. It is snapshotted as
+`(buyer_assignment_id, GP job number)` pairs instead and re-linked by job number once the GP sync has
+re-adopted the projects. The left side stays valid because `buyer_assignments` rows do come back with
+their original UUIDs.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+from sqlalchemy import insert, select
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.engine import Connection
+
+from app.models.buyer_assignment import BuyerAssignment, buyer_assignment_projects
+from app.models.manufacturer_vendor_map import ManufacturerVendorMap
+from app.models.po_document_settings import PODocumentSettings
+from app.models.project import Project
+from app.models.relay_install import RelayInstall
+from app.models.warehouse import Warehouse
+
+logger = logging.getLogger(__name__)
+
+# Restored in this order. None of these reference each other, so the order is presentational rather
+# than load-bearing - but keep any future FK-dependent table after the one it points at.
+PRESERVED_MODELS = (
+    RelayInstall,
+    Warehouse,
+    BuyerAssignment,
+    ManufacturerVendorMap,
+    PODocumentSettings,
+)
+
+
+@dataclass
+class ResetSnapshot:
+    """Everything read out of the database before the schema is dropped."""
+
+    # Table name -> the rows to put back, as plain dicts. Plain on purpose: the ORM model is about to
+    # have its table dropped, so nothing here may hold a live identity-mapped instance.
+    rows: dict[str, list[dict]] = field(default_factory=dict)
+    # (buyer_assignment_id, job_number) pairs - see the module docstring for why these are not rows.
+    buyer_project_pairs: list[dict] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        return {table: len(rows) for table, rows in self.rows.items()}
+
+
+def preserved_columns(model, live_column_names) -> list[str]:
+    """The model's columns that the live table also has, in model declaration order.
+
+    Pure function over names - the unit test for this needs no database. The intersection is the
+    half-migrated tolerance: a column the model declares but the live table predates is skipped on the
+    way out rather than crashing the SELECT, and a column the live table has but the model no longer
+    declares is dropped, which is correct because the rebuilt schema will not have it either."""
+    live = set(live_column_names)
+    return [c.name for c in model.__table__.columns if c.name in live]
+
+
+def snapshot_statement(model, live_column_names):
+    """The SELECT that reads one preserved table, or None when nothing about it is preservable.
+
+    Split out from `snapshot` so it can be asserted on without a database - it is the statement that
+    used to be a hand-written column list, and the whole of #411 is that it must never drift from the
+    model again."""
+    cols = preserved_columns(model, live_column_names)
+    if not cols:
+        return None
+    table = model.__table__
+    return select(*[table.c[name] for name in cols])
+
+
+def snapshot(conn: Connection) -> ResetSnapshot:
+    """Read every preserved table, plus the buyer/project link pairs. Safe on a fresh or half-migrated
+    database: a table that isn't there yet is simply not preserved, which is exactly the state a reset
+    exists to clear."""
+    inspector = sa_inspect(conn)
+    snap = ResetSnapshot()
+
+    for model in PRESERVED_MODELS:
+        table = model.__table__
+        if not inspector.has_table(table.name):
+            continue
+        stmt = snapshot_statement(model, [c["name"] for c in inspector.get_columns(table.name)])
+        if stmt is None:
+            continue
+        snap.rows[table.name] = [dict(r) for r in conn.execute(stmt).mappings()]
+
+    if inspector.has_table(buyer_assignment_projects.name) and inspector.has_table(Project.__table__.name):
+        projects = Project.__table__
+        pairs = select(
+            buyer_assignment_projects.c.buyer_assignment_id,
+            # projects.project_id IS the GP job number; there is no schedule_id column.
+            projects.c.project_id.label("job_number"),
+        ).select_from(buyer_assignment_projects.join(projects, projects.c.id == buyer_assignment_projects.c.project_id))
+        snap.buyer_project_pairs = [dict(r) for r in conn.execute(pairs).mappings()]
+
+    return snap
+
+
+def restore(conn: Connection, snap: ResetSnapshot) -> dict[str, int]:
+    """Insert the snapshotted rows back into the rebuilt schema, original UUIDs intact.
+
+    Runs before anything can lazily seed a default row - `PODocumentSettings` in particular is read
+    through a get-or-create helper, so restoring first is what stops a defaults row being seeded
+    alongside the admin-edited one."""
+    for model in PRESERVED_MODELS:
+        rows = snap.rows.get(model.__table__.name)
+        if rows:
+            conn.execute(insert(model.__table__), rows)
+    return snap.counts
+
+
+def relink_buyer_projects(conn: Connection, pairs: list[dict]) -> tuple[int, int]:
+    """Re-attach each buyer assignment to its projects by GP job number. Returns (restored, dropped).
+
+    Call this only after the GP job sync has re-adopted the projects; before that, `projects` is empty
+    and every pair drops. A pair whose job no longer exists in GP matches nothing and is dropped by
+    design - the buyer keeps their row and cost codes, they just lose a link to a job that is gone."""
+    if not pairs:
+        return 0, 0
+
+    projects = Project.__table__
+    by_job = {row.project_id: row.id for row in conn.execute(select(projects.c.project_id, projects.c.id))}
+    rows = [
+        {"buyer_assignment_id": pair["buyer_assignment_id"], "project_id": by_job[pair["job_number"]]}
+        for pair in pairs
+        if pair["job_number"] in by_job
+    ]
+    if rows:
+        conn.execute(insert(buyer_assignment_projects), rows)
+    return len(rows), len(pairs) - len(rows)

--- a/backend/main.py
+++ b/backend/main.py
@@ -298,17 +298,23 @@ def reset_data(request: Request):
     environment check. TESTING_ENABLED keeps it off any deployment that isn't a test target, and
     require_admin_request means it is not enough to merely reach the box.
 
-    It also PRESERVES relay_installs across the rebuild. Dropping those rows silently orphans the
-    on-prem relay: its enrolled secret no longer matches any row, so /relay-link refuses every
-    handshake and all GP writes fail until someone re-enrols on the workstation. A dev-convenience
-    reset must not take GP down as a side effect."""
+    It also PRESERVES the tables that hold setup rather than project data - app/services/
+    reset_preservation.py owns that list and the reasoning per table. relay_installs is the one that
+    hurts most: dropping those rows silently orphans the on-prem relay, because its enrolled secret no
+    longer matches any row, so /relay-link refuses every handshake and all GP writes fail until someone
+    re-enrols on the workstation. A dev-convenience reset must not take GP down as a side effect.
+
+    Projects are deliberately NOT preserved - they are re-adopted straight from GP by a forced sync
+    pass right after the rebuild, since GP owns them. That pass is also what makes the buyer/project
+    links restorable: re-adopted projects get new UUIDs, so the links come back matched on GP job
+    number rather than on the id they used to point at (#410)."""
     from alembic.config import Config
-    from sqlalchemy import inspect as sa_inspect
     from sqlalchemy import text
 
     from alembic import command
     from app.config import TESTING_ENABLED
     from app.database import engine
+    from app.services import reset_preservation
 
     if not TESTING_ENABLED:
         return JSONResponse(status_code=403, content={"error": "Data reset is not enabled on this deployment"})
@@ -319,23 +325,8 @@ def reset_data(request: Request):
         status = 403 if e.code == "FORBIDDEN" else 401
         return JSONResponse(status_code=status, content={"error": str(e), "code": e.code})
 
-    # Snapshot the relay enrolments before the schema goes. Read as plain mappings: the ORM model is
-    # about to have its table dropped and recreated, so nothing here may hold a live identity-mapped
-    # instance. The table is absent on a fresh or half-migrated database, which must not block a reset -
-    # that is exactly the state a reset exists to clear.
-    relay_rows: list[dict] = []
     with engine.connect() as conn:
-        if sa_inspect(conn).has_table("relay_installs"):
-            relay_rows = [
-                dict(r)
-                for r in conn.execute(
-                    text(
-                        "SELECT id, label, company, hostname, secret_hash, secret_encrypted, "
-                        "enrollment_token_hash, enrollment_token_expires_at, enrolled_at, last_seen_at, "
-                        "created_at, adopted_at, adopted_by FROM relay_installs"
-                    )
-                ).mappings()
-            ]
+        snap = reset_preservation.snapshot(conn)
 
     with engine.connect() as conn:
         conn.execute(text("DROP SCHEMA public CASCADE"))
@@ -347,24 +338,42 @@ def reset_data(request: Request):
     command.upgrade(alembic_cfg, "head")
 
     with engine.connect() as conn:
-        for row in relay_rows:
-            conn.execute(
-                text(
-                    "INSERT INTO relay_installs (id, label, company, hostname, secret_hash, "
-                    "secret_encrypted, enrollment_token_hash, enrollment_token_expires_at, enrolled_at, "
-                    "last_seen_at, created_at, adopted_at, adopted_by) VALUES (:id, :label, :company, "
-                    ":hostname, :secret_hash, :secret_encrypted, :enrollment_token_hash, "
-                    ":enrollment_token_expires_at, :enrolled_at, :last_seen_at, :created_at, "
-                    ":adopted_at, :adopted_by)"
-                ),
-                row,
-            )
+        preserved = reset_preservation.restore(conn, snap)
         conn.commit()
+
+    # Re-adopt every GP job before re-linking, not after: the links are matched on job number, so a
+    # projects table that is still empty here drops every one of them. Skipped silently when no relay
+    # is connected - see run_once_blocking; the buyer rows and their cost codes survive either way, and
+    # the background poll re-adopts the projects later (it just has nothing left to re-link them to).
+    sync_result = gp_job_sync.run_once_blocking()
+
+    with engine.connect() as conn:
+        links_restored, links_dropped = reset_preservation.relink_buyer_projects(conn, snap.buyer_project_pairs)
+        conn.commit()
+
+    # The frontend alerts `message` verbatim, so it carries the summary; the fields below are for
+    # anyone reading the response itself.
+    parts = [f"{count} {table}" for table, count in preserved.items() if count]
+    message = "Schema dropped and rebuilt"
+    if parts:
+        message += f". Preserved {', '.join(parts)}"
+    if sync_result:
+        message += f". Re-adopted {sync_result[1]} of {sync_result[0]} GP jobs"
+    else:
+        message += ". GP job sync did not run, so projects were not re-adopted"
+    if snap.buyer_project_pairs:
+        message += f". Buyer project links: {links_restored} restored, {links_dropped} dropped"
 
     return {
         "status": "ok",
-        "message": "Schema dropped and rebuilt",
-        "relay_installs_preserved": len(relay_rows),
+        "message": message,
+        "preserved": preserved,
+        "relay_installs_preserved": preserved.get("relay_installs", 0),
+        # null, not 0, when no sync pass ran - "GP had no new jobs" and "GP was never asked" are
+        # different answers and the second one explains any dropped buyer links.
+        "jobs_adopted": sync_result[1] if sync_result else None,
+        "buyer_links_restored": links_restored,
+        "buyer_links_dropped": links_dropped,
     }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -353,12 +353,13 @@ def reset_data(request: Request):
 
     # The frontend alerts `message` verbatim, so it carries the summary; the fields below are for
     # anyone reading the response itself.
-    parts = [f"{count} {table}" for table, count in preserved.items() if count]
+    parts = reset_preservation.describe_counts(preserved)
     message = "Schema dropped and rebuilt"
     if parts:
         message += f". Preserved {', '.join(parts)}"
     if sync_result:
-        message += f". Re-adopted {sync_result[1]} of {sync_result[0]} GP jobs"
+        total, adopted = sync_result
+        message += f". Re-adopted {adopted} of {total} GP {'job' if total == 1 else 'jobs'}"
     else:
         message += ". GP job sync did not run, so projects were not re-adopted"
     if snap.buyer_project_pairs:

--- a/backend/tests/test_reset_preservation.py
+++ b/backend/tests/test_reset_preservation.py
@@ -14,7 +14,13 @@ from sqlalchemy import inspect as sa_inspect
 from app.models.buyer_assignment import BuyerAssignment
 from app.models.project import Project
 from app.models.relay_install import RelayInstall
-from app.services.reset_preservation import PRESERVED_MODELS, preserved_columns, snapshot_statement
+from app.services.reset_preservation import (
+    PRESERVED_LABELS,
+    PRESERVED_MODELS,
+    describe_counts,
+    preserved_columns,
+    snapshot_statement,
+)
 
 
 def _all_columns(model) -> list[str]:
@@ -101,9 +107,23 @@ def test_preserved_models_carry_json_columns():
     assert json_columns, "expected at least one JSON column among the preserved models"
 
 
+def test_every_preserved_model_has_a_human_label():
+    """The reset's `message` is alerted to the user verbatim, so a new preserved table must not leak its
+    raw table name into it."""
+    assert {m.__tablename__ for m in PRESERVED_MODELS} <= set(PRESERVED_LABELS)
+
+
+def test_counts_agree_in_number():
+    """One is singular. The reset used to render "1 relay_installs"."""
+    assert describe_counts({"relay_installs": 1, "warehouses": 3}) == ["1 relay install", "3 warehouses"]
+    # A table that preserved nothing is not worth a clause.
+    assert describe_counts({"relay_installs": 0, "warehouses": 2}) == ["2 warehouses"]
+
+
 def test_snapshot_statement_targets_the_models_own_table():
     """Sanity check that the derived SELECT reads the table it claims to - a wrong FROM would preserve
-    the wrong rows silently."""
+    the wrong rows silently. Asserted on the compiled FROM clause, not on a substring of the SQL: every
+    column is prefixed with its own table name, so a substring check can never fail."""
     for model in PRESERVED_MODELS:
         stmt = snapshot_statement(model, _all_columns(model))
-        assert sa_inspect(model).local_table.name in str(stmt)
+        assert stmt.get_final_froms() == [sa_inspect(model).local_table]

--- a/backend/tests/test_reset_preservation.py
+++ b/backend/tests/test_reset_preservation.py
@@ -1,0 +1,109 @@
+"""Column derivation for the tables that survive /admin/reset-data (#410, #411).
+
+The bug being locked down is a silent one. The reset used to name all 13 `relay_installs` columns by
+hand, twice, in raw SQL - so a migration that added a column left it NULL on every preserved row after
+the next reset, with nothing failing and nothing logged. The fix is that the column list comes off the
+model, and these tests assert it stays that way.
+
+All pure string/metadata work, so they need no Postgres and run in the local suite as well as CI.
+"""
+
+import pytest
+from sqlalchemy import inspect as sa_inspect
+
+from app.models.buyer_assignment import BuyerAssignment
+from app.models.project import Project
+from app.models.relay_install import RelayInstall
+from app.services.reset_preservation import PRESERVED_MODELS, preserved_columns, snapshot_statement
+
+
+def _all_columns(model) -> list[str]:
+    return [c.name for c in model.__table__.columns]
+
+
+@pytest.mark.parametrize("model", PRESERVED_MODELS, ids=lambda m: m.__tablename__)
+def test_every_model_column_is_preserved_when_the_table_is_current(model):
+    """The everyday case: live table matches the model, so nothing is left behind."""
+    assert preserved_columns(model, _all_columns(model)) == _all_columns(model)
+
+
+def test_selects_every_relay_install_column():
+    """#411 exactly: the generated SELECT must name every column RelayInstall declares. Add a column
+    to the model and this passes for free - which is the entire point of deriving it."""
+    stmt = snapshot_statement(RelayInstall, _all_columns(RelayInstall))
+    selected = [c.name for c in stmt.selected_columns]
+
+    assert selected == _all_columns(RelayInstall)
+    # secret_encrypted is the one a reader is most likely to assume got dropped (it is legacy, #382),
+    # and losing it would silently orphan a pre-067 relay across a reset.
+    assert "secret_encrypted" in selected
+
+
+def test_skips_a_column_the_live_table_does_not_have_yet():
+    """Half-migrated database: the model already declares a column the table predates. Selecting it
+    would crash the snapshot, so it is dropped - the same tolerance the has_table guard gives."""
+    live = [c for c in _all_columns(RelayInstall) if c != "adopted_by"]
+
+    cols = preserved_columns(RelayInstall, live)
+
+    assert "adopted_by" not in cols
+    assert cols == live
+
+
+def test_ignores_a_live_column_the_model_no_longer_declares():
+    """The other direction: a column dropped from the model but still on the live table. It must not
+    be carried over, because the rebuilt schema will not have anywhere to put it."""
+    cols = preserved_columns(RelayInstall, [*_all_columns(RelayInstall), "column_from_a_past_life"])
+
+    assert cols == _all_columns(RelayInstall)
+
+
+def test_preserves_model_declaration_order_regardless_of_live_order():
+    """Order comes from the model, not from whatever the inspector happens to report, so the SELECT
+    and the rows it produces always line up."""
+    cols = preserved_columns(RelayInstall, list(reversed(_all_columns(RelayInstall))))
+
+    assert cols == _all_columns(RelayInstall)
+
+
+def test_no_statement_when_nothing_overlaps():
+    """A table that exists but shares no column with the model preserves nothing rather than emitting
+    an empty SELECT."""
+    assert preserved_columns(RelayInstall, ["totally", "unrelated"]) == []
+    assert snapshot_statement(RelayInstall, ["totally", "unrelated"]) is None
+
+
+def test_projects_are_not_preserved():
+    """GP owns jobs, so projects are re-adopted by the forced sync after the rebuild instead of being
+    restored. Preserving them would resurrect projects deleted in GP and defeat the reset."""
+    assert Project not in PRESERVED_MODELS
+
+
+def test_buyer_assignments_are_preserved_with_their_cost_codes():
+    """The buyer's cost codes are the part that cannot be recovered from GP - the project links can be
+    (by job number), the designated cost codes cannot."""
+    assert BuyerAssignment in PRESERVED_MODELS
+    assert "cost_codes" in preserved_columns(BuyerAssignment, _all_columns(BuyerAssignment))
+
+
+def test_preserved_models_carry_json_columns():
+    """Guards the reason this module builds statements through Core instead of text(): psycopg2 adapts
+    a Python list to a Postgres array, so a JSON column round-tripped through a text() bind param fails
+    the restore. If this ever stops being true the Core requirement can be revisited - until then it
+    is load-bearing."""
+    json_columns = [
+        (model.__tablename__, c.name)
+        for model in PRESERVED_MODELS
+        for c in model.__table__.columns
+        if c.type.__class__.__name__ in ("JSON", "JSONB")
+    ]
+
+    assert json_columns, "expected at least one JSON column among the preserved models"
+
+
+def test_snapshot_statement_targets_the_models_own_table():
+    """Sanity check that the derived SELECT reads the table it claims to - a wrong FROM would preserve
+    the wrong rows silently."""
+    for model in PRESERVED_MODELS:
+        stmt = snapshot_statement(model, _all_columns(model))
+        assert sa_inspect(model).local_table.name in str(stmt)


### PR DESCRIPTION
three issues, one branch.

#411 + #410 - reset_data preservation

preservation list of models in app/services/reset_preservation.py, restored in order:
RelayInstall
Warehouse
BuyerAssignment
ManufacturerVendorMap
PODocumentSettings

column list per model = Model.__table__.columns intersected with the live table's columns, in model declaration order. the intersection keeps a half-migrated DB from crashing the SELECT, same tolerance the has_table guard gives.

statements built through SQLAlchemy Core, not string SQL - deviation from the plan. BuyerAssignment.cost_codes and four PODocumentSettings columns are JSON; psycopg2 adapts a Python list to a Postgres array -> a text() bind param fails the restore with "column is of type json but expression is of type text[]". relay_installs alone never hit this, it has no JSON column. Core also falls back to the model's Python-side default for a column the snapshot is missing, instead of inserting NULL.

buyer_assignment_projects cannot be row-restored - FKs projects.id, re-adopted projects get new UUIDs. snapshotted as (buyer_assignment_id, job_number) pairs, re-linked by job number after the sync.

GP job sync after restore via new gp_job_sync.run_once_blocking(). _loop captured at run_forever start, next to _wake_event. reset_data is a sync def in the threadpool -> hands run_once() to that loop via asyncio.run_coroutine_threadsafe -> blocks on the result, 90s timeout. sync disabled, no relay, relay vanished mid-pass, or timeout all return None and skip.

response JSON now carries:
per-table preserved counts
relay_installs_preserved, kept
jobs_adopted, null when no pass ran
buyer_links_restored
buyer_links_dropped
message, carrying the summary

PODocumentSettings restore lands before its get-or-create seed.

crypto.py docstring updated - dropping secret_encrypted no longer has to touch the reset-data SQL.

#402 - migration 073

two idempotent UPDATEs, no-op on clean data, applied on every deploy by the entrypoint's alembic upgrade head.

rows pointing at a CANCELLED or soft-deleted PO -> state AVAILABLE, po_line_item_id NULL, no state filter
IN_PO rows with po_line_item_id NULL -> state AVAILABLE

downgrade is a no-op.

#407 is not in this PR, no repo change. Railway CLI upgraded 4.66.0 -> 5.30.1 on this machine, global CLAUDE.md updated with the version and the whoami -> /mcp reconnect recovery.

14 new tests in backend/tests/test_reset_preservation.py, no Postgres needed. ruff check and ruff format clean. alembic heads reports 073 as the single head.

Closes #410, closes #411, closes #402
