### PR TITLE
fix(security): gate every unauthenticated GraphQL resolver (#415)

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -5,6 +5,13 @@ The backend has no global auth middleware; verification is opt-in per resolver v
 so ungated queries pay no JWT/JWKS/Clerk-API cost. Roles live in Clerk publicMetadata
 (not in the default session token), so we verify the token for identity (``sub``) and
 then look up roles through the Clerk Backend API.
+
+Opt-in means a resolver that forgets to ask is silently public, which is how every resolver in
+``app/schemas/user.py`` - ``updateUserRoles`` among them - shipped reachable with no session at all
+(#415). Since that sweep the opt-in is enforced from outside: ``tests/test_resolver_gate_completeness``
+walks every ``@strawberry.field`` / ``@strawberry.mutation`` under ``app/schemas/`` and fails on any
+that calls none of the gates below, so leaving one open is now an explicit entry on that test's
+exemption list rather than an omission nobody notices.
 """
 
 import time

--- a/backend/app/graphql/user.graphql
+++ b/backend/app/graphql/user.graphql
@@ -7,6 +7,10 @@
 #
 # This file existed only as a cross-reference from shop_assembly.graphql ("ClerkUser is in
 # user.graphql") until #344; the reference was dangling. It is written now so the pointer resolves.
+#
+# Every operation below is Admin/Manager-gated (#415). They were all reachable with no session until
+# then, which made updateUserRoles a self-service grant of the role that gates relay provisioning,
+# relay deletion, buyer assignments and the GP job/buyer writes.
 
 # One Clerk account as the app sees it. `roles` comes from Clerk publicMetadata, not from the session
 # token, so it is fetched rather than decoded.
@@ -29,6 +33,7 @@ type ClerkUser {
 }
 
 type Query {
+  # Admin-gated: returns every account's email, roles and GP buyer id.
   users: [ClerkUser!]!
   # Shop-assembly team members for the manager assignment picker (#330), defined in
   # shop_assembly.graphql because that is the module that consumes it. Manager-gated.
@@ -36,6 +41,8 @@ type Query {
 }
 
 type Mutation {
+  # Admin-gated, and the gate is the whole protection: nothing downstream re-checks who asked, and
+  # the roles set here include Admin/Manager itself.
   updateUserRoles(userId: String!, roles: [String!]!): ClerkUser!
   # Admin-driven display-name change (#240).
   updateUserName(userId: String!, firstName: String!, lastName: String!): ClerkUser!

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -4,6 +4,7 @@ import uuid
 
 import strawberry
 
+from app.auth import require_admin
 from app.database import SessionLocal
 from app.repositories import admin_repository
 
@@ -13,7 +14,12 @@ from .types import OpeningHardwareStatus, OpeningHardwareStatusItem
 @strawberry.type
 class AdminQueries:
     @strawberry.field
-    def opening_hardware_status(self, project_id: strawberry.ID | None = None) -> list[OpeningHardwareStatus]:
+    def opening_hardware_status(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[OpeningHardwareStatus]:
+        """Admin-gated (#415): only the admin Opening Status tab reads it, and it walks every opening
+        in a project."""
+        require_admin(info)
         with SessionLocal() as session:
             rows = admin_repository.get_opening_hardware_status(
                 session, uuid.UUID(str(project_id)) if project_id else None

--- a/backend/app/schemas/buyer.py
+++ b/backend/app/schemas/buyer.py
@@ -4,7 +4,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.repositories import buyer_repository
 
@@ -15,9 +15,11 @@ from .types import BuyerAssignment
 @strawberry.type
 class BuyerQueries:
     @strawberry.field
-    def buyer_assignments(self) -> list[BuyerAssignment]:
+    def buyer_assignments(self, info: strawberry.Info) -> list[BuyerAssignment]:
         """Issue #216: per-buyer project + cost-code authorization. The PO dialog reads this to
-        filter its options; the create/register mutations re-enforce it server-side."""
+        filter its options; the create/register mutations re-enforce it server-side. require_user,
+        not admin (#415), because that dialog is a PO-user screen."""
+        require_user(info)
         with SessionLocal() as session:
             return [buyer_assignment_to_type(a) for a in buyer_repository.list_assignments(session)]
 

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -2,6 +2,7 @@
 
 import strawberry
 
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.repositories import dashboard_repository, user_repository
 
@@ -11,7 +12,8 @@ from .types import AdminStats, HomeDashboardStats, ShopAssemblyStats
 @strawberry.type
 class DashboardQueries:
     @strawberry.field
-    def home_dashboard_stats(self) -> HomeDashboardStats:
+    def home_dashboard_stats(self, info: strawberry.Info) -> HomeDashboardStats:
+        require_user(info)
         with SessionLocal() as session:
             d = dashboard_repository.get_home_dashboard_stats(session)
             return HomeDashboardStats(
@@ -22,7 +24,8 @@ class DashboardQueries:
             )
 
     @strawberry.field
-    def shop_assembly_stats(self) -> ShopAssemblyStats:
+    def shop_assembly_stats(self, info: strawberry.Info) -> ShopAssemblyStats:
+        require_user(info)
         with SessionLocal() as session:
             d = dashboard_repository.get_shop_assembly_stats(session)
             return ShopAssemblyStats(
@@ -30,7 +33,10 @@ class DashboardQueries:
             )
 
     @strawberry.field
-    def admin_stats(self) -> AdminStats:
+    def admin_stats(self, info: strawberry.Info) -> AdminStats:
+        """Admin-gated (#415): only the admin landing page reads it, and it enumerates Clerk users to
+        count them."""
+        require_admin(info)
         users = user_repository.list_users()
         with SessionLocal() as session:
             d = dashboard_repository.get_admin_stats(session, user_count=len(users))

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 
 import strawberry
 
+from app.auth import require_user
 from app.database import SessionLocal
 from app.errors import InventoryShortfallError
 from app.repositories import (
@@ -35,7 +36,10 @@ from .types import (
 @strawberry.type
 class ImportQueries:
     @strawberry.field
-    def project_hardware_schedule(self, project_id: strawberry.ID) -> ProjectHardwareSchedule | None:
+    def project_hardware_schedule(
+        self, info: strawberry.Info, project_id: strawberry.ID
+    ) -> ProjectHardwareSchedule | None:
+        require_user(info)
         with SessionLocal() as session:
             data = import_repository.get_project_hardware_schedule(session, uuid.UUID(str(project_id)))
             if data is None:
@@ -44,8 +48,9 @@ class ImportQueries:
 
     @strawberry.field
     def reconcile_schedule(
-        self, project_id: strawberry.ID, items: list[ReconciliationItemInput]
+        self, info: strawberry.Info, project_id: strawberry.ID, items: list[ReconciliationItemInput]
     ) -> list[ReconciliationResult]:
+        require_user(info)
         from .enums import ReconciliationStatus
 
         items_data = [
@@ -71,7 +76,8 @@ class ImportQueries:
             ]
 
     @strawberry.field
-    def project_excluded_items(self, project_id: strawberry.ID) -> list[ProjectExcludedItem]:
+    def project_excluded_items(self, info: strawberry.Info, project_id: strawberry.ID) -> list[ProjectExcludedItem]:
+        require_user(info)
         with SessionLocal() as session:
             rows = import_repository.list_excluded_items(session, uuid.UUID(str(project_id)))
             return [
@@ -86,7 +92,8 @@ class ImportQueries:
 @strawberry.type
 class ImportMutations:
     @strawberry.mutation
-    def finalize_import_session(self, input: FinalizeImportSessionInput) -> FinalizeImportResult:
+    def finalize_import_session(self, info: strawberry.Info, input: FinalizeImportSessionInput) -> FinalizeImportResult:
+        require_user(info)
         # Convert Strawberry input to dict
         input_data = {
             "project_id": str(input.project_id),

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -4,6 +4,7 @@ import uuid
 
 import strawberry
 
+from app.auth import require_user
 from app.database import SessionLocal
 from app.repositories import notification_repository
 
@@ -16,11 +17,13 @@ class NotificationQueries:
     @strawberry.field
     def notifications(
         self,
+        info: strawberry.Info,
         project_id: strawberry.ID | None = None,
         recipient_role: str = "",
         unread_only: bool | None = None,
         limit: int = 5,
     ) -> list[Notification]:
+        require_user(info)
         with SessionLocal() as session:
             results = notification_repository.get_notifications(
                 session,
@@ -35,7 +38,8 @@ class NotificationQueries:
 @strawberry.type
 class NotificationMutations:
     @strawberry.mutation
-    def mark_notification_as_read(self, id: strawberry.ID) -> Notification:
+    def mark_notification_as_read(self, info: strawberry.Info, id: strawberry.ID) -> Notification:
+        require_user(info)
         with SessionLocal() as session:
             notification = notification_repository.mark_as_read(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -245,15 +245,19 @@ def _persist_register_po(
 class POQueries:
     @strawberry.field
     def purchase_orders(
-        self, project_id: strawberry.ID | None = None, status: POStatus | None = None
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None, status: POStatus | None = None
     ) -> list[PurchaseOrder]:
+        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             pos = po_repository.get_purchase_orders(session, pid, status)
             return [po_to_type(po) for po in pos]
 
     @strawberry.field
-    def po_document_download_url(self, document_id: strawberry.ID) -> str:
+    def po_document_download_url(self, info: strawberry.Info, document_id: strawberry.ID) -> str:
+        """Mints a presigned S3 URL, so the gate is the only thing standing between an anonymous
+        caller and a supplier PO document (#415)."""
+        require_user(info)
         from app.services import storage
 
         with SessionLocal() as session:
@@ -261,7 +265,8 @@ class POQueries:
             return storage.generate_presigned_url(doc.s3_key)
 
     @strawberry.field
-    def purchase_order(self, id: strawberry.ID) -> PurchaseOrder | None:
+    def purchase_order(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder | None:
+        require_user(info)
         with SessionLocal() as session:
             po = po_repository.get_purchase_order(session, uuid.UUID(str(id)))
             if po is None:
@@ -299,15 +304,18 @@ class POQueries:
     @strawberry.field
     def prior_order_as_values(
         self,
+        info: strawberry.Info,
         vendor_id: strawberry.ID,
         product_codes: list[str],
     ) -> list[PriorOrderAsForProduct]:
+        require_user(info)
         with SessionLocal() as session:
             result = po_repository.get_prior_order_as_values(session, uuid.UUID(str(vendor_id)), product_codes)
             return [PriorOrderAsForProduct(product_code=pc, values=vals) for pc, vals in result.items()]
 
     @strawberry.field
-    def po_statistics(self, project_id: strawberry.ID | None = None) -> POStatistics:
+    def po_statistics(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> POStatistics:
+        require_user(info)
         with SessionLocal() as session:
             stats = po_repository.get_po_statistics(session, uuid.UUID(str(project_id)) if project_id else None)
             return POStatistics(
@@ -321,7 +329,8 @@ class POQueries:
             )
 
     @strawberry.field
-    def open_p_os(self, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
+    def open_p_os(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
+        require_user(info)
         with SessionLocal() as session:
             pos = po_repository.get_open_pos(session, uuid.UUID(str(project_id)) if project_id else None)
             return [po_to_type(po) for po in pos]
@@ -491,6 +500,7 @@ class POMutations:
     @strawberry.mutation
     def update_po(
         self,
+        info: strawberry.Info,
         id: strawberry.ID,
         vendor_id: strawberry.ID | None = None,
         expected_delivery_date: date | None = None,
@@ -503,6 +513,7 @@ class POMutations:
         shipping_cost: float | None = strawberry.UNSET,
         tariff_amount: float | None = strawberry.UNSET,
     ) -> PurchaseOrder:
+        require_user(info)
         from app.repositories.po_repository import _UNSET
 
         pid = uuid.UUID(str(project_id)) if project_id else _UNSET
@@ -525,7 +536,8 @@ class POMutations:
             return po_to_type(po_repository.reload_po(session, po.id))
 
     @strawberry.mutation
-    def mark_po_as_ordered(self, id: strawberry.ID) -> PurchaseOrder:
+    def mark_po_as_ordered(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder:
+        require_user(info)
         with SessionLocal() as session:
             po = po_repository.mark_po_as_ordered(session, uuid.UUID(str(id)))
             session.commit()
@@ -533,7 +545,8 @@ class POMutations:
             return po_to_type(po)
 
     @strawberry.mutation
-    def cancel_po(self, id: strawberry.ID) -> PurchaseOrder:
+    def cancel_po(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder:
+        require_user(info)
         with SessionLocal() as session:
             po = po_repository.cancel_po(session, uuid.UUID(str(id)))
             session.commit()
@@ -541,7 +554,10 @@ class POMutations:
             return po_to_type(po)
 
     @strawberry.mutation
-    def update_po_line_item_order_as(self, id: strawberry.ID, order_as: str | None = None) -> POLineItem:
+    def update_po_line_item_order_as(
+        self, info: strawberry.Info, id: strawberry.ID, order_as: str | None = None
+    ) -> POLineItem:
+        require_user(info)
         with SessionLocal() as session:
             poli = po_repository.update_line_item_order_as(session, uuid.UUID(str(id)), order_as)
             session.commit()
@@ -549,7 +565,8 @@ class POMutations:
             return po_line_item_to_type(poli)
 
     @strawberry.mutation
-    def update_po_line_item_unit_cost(self, id: strawberry.ID, unit_cost: float) -> POLineItem:
+    def update_po_line_item_unit_cost(self, info: strawberry.Info, id: strawberry.ID, unit_cost: float) -> POLineItem:
+        require_user(info)
         with SessionLocal() as session:
             poli = po_repository.update_line_item_unit_cost(session, uuid.UUID(str(id)), unit_cost)
             session.commit()
@@ -560,12 +577,14 @@ class POMutations:
     @strawberry.mutation
     def upload_po_document(
         self,
+        info: strawberry.Info,
         po_id: strawberry.ID,
         file_name: str,
         content_type: str,
         document_type: PODocumentType,
         file_data_base64: str,
     ) -> PODocumentInfo:
+        require_user(info)
         from app.models.enums import PODocumentType as PODocTypeDB
 
         with SessionLocal() as session:
@@ -582,7 +601,8 @@ class POMutations:
             return po_document_to_type(doc)
 
     @strawberry.mutation
-    def delete_po_document(self, document_id: strawberry.ID) -> bool:
+    def delete_po_document(self, info: strawberry.Info, document_id: strawberry.ID) -> bool:
+        require_user(info)
         with SessionLocal() as session:
             po_repository.delete_po_document(session, uuid.UUID(str(document_id)))
             session.commit()

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -6,7 +6,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.errors import (
     ConflictError,
@@ -47,7 +47,10 @@ async def _adopt_existing(job_number: str) -> Project:
 @strawberry.type
 class ProjectQueries:
     @strawberry.field
-    def projects(self) -> list[Project]:
+    def projects(self, info: strawberry.Info) -> list[Project]:
+        """The project picker every module reads, so require_user rather than the admin gate on
+        `admin_projects` below - same rows, fewer fields."""
+        require_user(info)
         with SessionLocal() as session:
             rows = project_repository.list_projects_with_opening_counts(session)
             return [project_to_type(p, include_openings=False, opening_count=count) for p, count in rows]
@@ -61,7 +64,8 @@ class ProjectQueries:
             return [project_to_type(p, include_openings=False, opening_count=count) for p, count in rows]
 
     @strawberry.field
-    def project_by_schedule_id(self, project_id: str) -> Project | None:
+    def project_by_schedule_id(self, info: strawberry.Info, project_id: str) -> Project | None:
+        require_user(info)
         with SessionLocal() as session:
             p = project_repository.get_project_by_schedule_id(session, project_id)
             if p is None:
@@ -69,9 +73,10 @@ class ProjectQueries:
             return project_to_type(p)
 
     @strawberry.field
-    def project_ship_to(self, project_id: strawberry.ID) -> ProjectShipTo | None:
+    def project_ship_to(self, info: strawberry.Info, project_id: strawberry.ID) -> ProjectShipTo | None:
         """The job-site address block for a project, by its UUID - the "deliver to site" ship-to option
         on the generated PO document (issue #230). A lean projection, kept off the PO list query."""
+        require_user(info)
         with SessionLocal() as session:
             p = project_repository.get_project(session, uuid.UUID(str(project_id)))
             if p is None:

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -29,7 +29,8 @@ from .types import (
 @strawberry.type
 class ShippingQueries:
     @strawberry.field
-    def ship_ready_items(self, project_id: strawberry.ID | None = None) -> ShipReadyItems:
+    def ship_ready_items(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> ShipReadyItems:
+        require_user(info)
         with SessionLocal() as session:
             data = shipping_repository.get_ship_ready_items(session, uuid.UUID(str(project_id)) if project_id else None)
             return ShipReadyItems(
@@ -46,7 +47,8 @@ class ShippingQueries:
             )
 
     @strawberry.field
-    def packing_slips(self, project_id: strawberry.ID | None = None) -> list[PackingSlip]:
+    def packing_slips(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[PackingSlip]:
+        require_user(info)
         with SessionLocal() as session:
             slips = shipping_repository.list_packing_slips(session, uuid.UUID(str(project_id)) if project_id else None)
             return [packing_slip_to_type(ps) for ps in slips]
@@ -54,6 +56,7 @@ class ShippingQueries:
     @strawberry.field
     def shipping_out_requests(
         self,
+        info: strawberry.Info,
         project_id: strawberry.ID | None = None,
         status: ShippingOutRequestStatus | None = None,
         reopenable_only: bool = False,
@@ -61,6 +64,7 @@ class ShippingQueries:
         """Accept UI (#293): shipping-out requests for a project, PENDING by default. reopenableOnly
         (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
         view uses it so it lists only requests Reopen can still act on."""
+        require_user(info)
         with SessionLocal() as session:
             reqs = shipping_repository.get_shipping_out_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
@@ -68,7 +72,8 @@ class ShippingQueries:
             return [shipping_out_request_to_type(r) for r in reqs]
 
     @strawberry.field
-    def returnable_lines(self, packing_slip_id: strawberry.ID) -> list[ReturnableLine]:
+    def returnable_lines(self, info: strawberry.Info, packing_slip_id: strawberry.ID) -> list[ReturnableLine]:
+        require_user(info)
         with SessionLocal() as session:
             lines = shipping_repository.get_returnable_lines(session, uuid.UUID(str(packing_slip_id)))
             return [
@@ -130,7 +135,8 @@ class ShippingMutations:
             return shipping_out_request_to_type(refreshed)
 
     @strawberry.mutation
-    def confirm_shipment(self, input: ConfirmShipmentInput) -> PackingSlip:
+    def confirm_shipment(self, info: strawberry.Info, input: ConfirmShipmentInput) -> PackingSlip:
+        require_user(info)
         from app.models.enums import PullRequestItemType
 
         project_id = uuid.UUID(str(input.project_id))
@@ -163,7 +169,8 @@ class ShippingMutations:
             return packing_slip_to_type(refreshed)
 
     @strawberry.mutation
-    def create_shipment_return(self, input: CreateShipmentReturnInput) -> ShipmentReturn:
+    def create_shipment_return(self, info: strawberry.Info, input: CreateShipmentReturnInput) -> ShipmentReturn:
+        require_user(info)
         from app.models.enums import ReturnDisposition
 
         items_data = [

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -44,12 +44,14 @@ class StockQueries:
     @strawberry.field
     def stock_items(
         self,
+        info: strawberry.Info,
         product_code_contains: str | None = None,
         hardware_category: str | None = None,
         aisle: str | None = None,
         only_deficient: bool = False,
         warehouse_id: strawberry.ID | None = None,
     ) -> list[StockItem]:
+        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_stock_items(
                 session,
@@ -62,7 +64,8 @@ class StockQueries:
             return [stock_item_to_type(r) for r in rows]
 
     @strawberry.field
-    def stock_item(self, id: strawberry.ID) -> StockItem | None:
+    def stock_item(self, info: strawberry.Info, id: strawberry.ID) -> StockItem | None:
+        require_user(info)
         with SessionLocal() as session:
             try:
                 row = stock_repository.get_stock_item(session, uuid.UUID(str(id)))
@@ -73,9 +76,11 @@ class StockQueries:
     @strawberry.field
     def deficient_items(
         self,
+        info: strawberry.Info,
         project_id: strawberry.ID | None = None,
         source: DeficientItemSource | None = None,
     ) -> list[DeficientItemRow]:
+        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_deficient_items(
                 session,
@@ -87,10 +92,12 @@ class StockQueries:
     @strawberry.field
     def deficiency_reviews(
         self,
+        info: strawberry.Info,
         inventory_location_id: strawberry.ID | None = None,
         stock_item_id: strawberry.ID | None = None,
         project_id: strawberry.ID | None = None,
     ) -> list[DeficiencyReview]:
+        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_deficiency_reviews(
                 session,
@@ -101,7 +108,8 @@ class StockQueries:
             return [deficiency_review_to_type(r) for r in rows]
 
     @strawberry.field
-    def stock_matches_for_opening(self, opening_item_id: strawberry.ID) -> list[StockItem]:
+    def stock_matches_for_opening(self, info: strawberry.Info, opening_item_id: strawberry.ID) -> list[StockItem]:
+        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_stock_matches_for_opening(session, uuid.UUID(str(opening_item_id)))
             return [stock_item_to_type(r) for r in rows]
@@ -110,7 +118,8 @@ class StockQueries:
 @strawberry.type
 class StockMutations:
     @strawberry.mutation
-    def destock_inventory(self, input: DestockInventoryInput) -> StockItem:
+    def destock_inventory(self, info: strawberry.Info, input: DestockInventoryInput) -> StockItem:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.destock_inventory(
                 session,
@@ -128,7 +137,8 @@ class StockMutations:
             return stock_item_to_type(result)
 
     @strawberry.mutation
-    def transfer_inventory(self, input: TransferInventoryInput) -> TransferResult:
+    def transfer_inventory(self, info: strawberry.Info, input: TransferInventoryInput) -> TransferResult:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.transfer_inventory(
                 session,
@@ -149,7 +159,8 @@ class StockMutations:
             )
 
     @strawberry.mutation
-    def allocate_stock_to_project(self, input: AllocateStockToProjectInput) -> InventoryLocation:
+    def allocate_stock_to_project(self, info: strawberry.Info, input: AllocateStockToProjectInput) -> InventoryLocation:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.allocate_stock_to_project(
                 session,
@@ -168,7 +179,8 @@ class StockMutations:
             return inventory_location_to_type(result)
 
     @strawberry.mutation
-    def adjust_stock_quantity(self, input: AdjustStockQuantityInput) -> StockItem:
+    def adjust_stock_quantity(self, info: strawberry.Info, input: AdjustStockQuantityInput) -> StockItem:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.adjust_stock_quantity(
                 session,
@@ -182,7 +194,8 @@ class StockMutations:
             return stock_item_to_type(result)
 
     @strawberry.mutation
-    def move_stock_location(self, input: MoveStockLocationInput) -> StockItem:
+    def move_stock_location(self, info: strawberry.Info, input: MoveStockLocationInput) -> StockItem:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.move_stock_location(
                 session,
@@ -199,11 +212,13 @@ class StockMutations:
     @strawberry.mutation
     def assign_stock_item_location(
         self,
+        info: strawberry.Info,
         stock_item_id: strawberry.ID,
         aisle: str,
         row: str,
         bay: str,
     ) -> StockItem:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.assign_stock_item_location(
                 session,
@@ -218,7 +233,8 @@ class StockMutations:
             return stock_item_to_type(result)
 
     @strawberry.mutation
-    def mark_stock_item_unlocated(self, stock_item_id: strawberry.ID) -> StockItem:
+    def mark_stock_item_unlocated(self, info: strawberry.Info, stock_item_id: strawberry.ID) -> StockItem:
+        require_user(info)
         with SessionLocal() as session:
             result = stock_repository.mark_stock_item_unlocated(
                 session,
@@ -230,7 +246,8 @@ class StockMutations:
             return stock_item_to_type(result)
 
     @strawberry.mutation
-    def reclassify_stock_item(self, input: ReclassifyStockItemInput) -> ReclassifyStockResult:
+    def reclassify_stock_item(self, info: strawberry.Info, input: ReclassifyStockItemInput) -> ReclassifyStockResult:
+        require_user(info)
         with SessionLocal() as session:
             new_row, original = stock_repository.reclassify_stock_item(
                 session,

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,7 +1,15 @@
-"""Clerk user queries + mutations."""
+"""Clerk user queries + mutations.
+
+Every resolver here is Admin/Manager-gated (#415). `updateUserRoles` is the grant path for
+`Admin/Manager` itself - the role that gates relay provisioning, relay deletion, buyer assignments,
+`createGpJob` and `createGpBuyer` - so an ungated copy let any caller mint the role that opens all of
+them. `users` is gated for the same reason a roster is not public: it returns every account's email,
+roles and GP buyer id. The three writes are only ever issued by the admin User Management page.
+"""
 
 import strawberry
 
+from app.auth import require_admin
 from app.repositories import user_repository
 
 from .converters import clerk_user_to_type
@@ -11,23 +19,30 @@ from .types import ClerkUser
 @strawberry.type
 class UserQueries:
     @strawberry.field
-    def users(self) -> list[ClerkUser]:
+    def users(self, info: strawberry.Info) -> list[ClerkUser]:
+        require_admin(info)
         return [clerk_user_to_type(u) for u in user_repository.list_users()]
 
 
 @strawberry.type
 class UserMutations:
     @strawberry.mutation
-    def update_user_roles(self, user_id: str, roles: list[str]) -> ClerkUser:
+    def update_user_roles(self, info: strawberry.Info, user_id: str, roles: list[str]) -> ClerkUser:
+        """Set a user's roles outright, including granting Admin/Manager. Admin-gated: this is the
+        privilege-escalation path, so the gate is the whole protection - nothing downstream re-checks
+        who asked."""
+        require_admin(info)
         return clerk_user_to_type(user_repository.update_user_roles(user_id, roles))
 
     @strawberry.mutation
-    def update_user_name(self, user_id: str, first_name: str, last_name: str) -> ClerkUser:
+    def update_user_name(self, info: strawberry.Info, user_id: str, first_name: str, last_name: str) -> ClerkUser:
         """Issue #240: admin-driven display-name change (Clerk first/last name)."""
+        require_admin(info)
         return clerk_user_to_type(user_repository.update_user_name(user_id, first_name, last_name))
 
     @strawberry.mutation
-    def update_user_gp_buyer_id(self, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:
+    def update_user_gp_buyer_id(self, info: strawberry.Info, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:
         """Issue #216: link a UC Nexus account to the GP BUYERID it acts as (null clears). The PO
         dialog auto-uses the caller's identity and createPo/registerPoInGp enforce it."""
+        require_admin(info)
         return clerk_user_to_type(user_repository.update_user_gp_buyer_id(user_id, gp_buyer_id))

--- a/backend/app/schemas/vendor.py
+++ b/backend/app/schemas/vendor.py
@@ -4,6 +4,7 @@ import uuid
 
 import strawberry
 
+from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.repositories import vendor_repository
 
@@ -15,12 +16,16 @@ from .types import Vendor
 @strawberry.type
 class VendorQueries:
     @strawberry.field
-    def vendors(self) -> list[Vendor]:
+    def vendors(self, info: strawberry.Info) -> list[Vendor]:
+        """require_user, not admin (#415): VendorSelect renders this list on the PO screens, so it is
+        not an admin-only read even though only an admin may write it."""
+        require_user(info)
         with SessionLocal() as session:
             return [vendor_to_type(v) for v in vendor_repository.list_vendors(session)]
 
     @strawberry.field
-    def vendor(self, id: strawberry.ID) -> Vendor | None:
+    def vendor(self, info: strawberry.Info, id: strawberry.ID) -> Vendor | None:
+        require_user(info)
         with SessionLocal() as session:
             v = vendor_repository.find_vendor(session, uuid.UUID(str(id)))
             return vendor_to_type(v) if v is not None else None
@@ -29,7 +34,8 @@ class VendorQueries:
 @strawberry.type
 class VendorMutations:
     @strawberry.mutation
-    def create_vendor(self, input: CreateVendorInput) -> Vendor:
+    def create_vendor(self, info: strawberry.Info, input: CreateVendorInput) -> Vendor:
+        require_admin(info)
         with SessionLocal() as session:
             vendor = vendor_repository.create_vendor(
                 session,
@@ -44,7 +50,8 @@ class VendorMutations:
             return vendor_to_type(vendor)
 
     @strawberry.mutation
-    def update_vendor(self, id: strawberry.ID, input: UpdateVendorInput) -> Vendor:
+    def update_vendor(self, info: strawberry.Info, id: strawberry.ID, input: UpdateVendorInput) -> Vendor:
+        require_admin(info)
         with SessionLocal() as session:
             vendor = vendor_repository.update_vendor(
                 session,
@@ -60,7 +67,8 @@ class VendorMutations:
             return vendor_to_type(vendor)
 
     @strawberry.mutation
-    def delete_vendor(self, id: strawberry.ID) -> bool:
+    def delete_vendor(self, info: strawberry.Info, id: strawberry.ID) -> bool:
+        require_admin(info)
         with SessionLocal() as session:
             vendor_repository.delete_vendor(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/app/schemas/vendor.py
+++ b/backend/app/schemas/vendor.py
@@ -35,7 +35,12 @@ class VendorQueries:
 class VendorMutations:
     @strawberry.mutation
     def create_vendor(self, info: strawberry.Info, input: CreateVendorInput) -> Vendor:
-        require_admin(info)
+        """require_user, not admin. `VendorSelect` offers "+ Create new vendor" to every caller and
+        renders `VendorEditDialog` with `vendor={null}`, so a PO user adding a supplier mid-order goes
+        through here. Editing or deleting an existing vendor is still admin - only the admin Vendors
+        page reaches those. The dialog living under `modules/admin/` says nothing about who can open
+        it, which is exactly the trap this comment exists to stop."""
+        require_user(info)
         with SessionLocal() as session:
             vendor = vendor_repository.create_vendor(
                 session,

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -1027,9 +1027,14 @@ class WarehouseMutations:
     def override_inventory_quantity(
         self, info: strawberry.Info, input: OverrideInventoryQuantityInput
     ) -> InventoryLocation:
-        """Admin-gated (#415): sets an inventory row's quantity outright rather than by a delta, from
-        the admin Inventory Correction modal. Nothing downstream re-checks the caller."""
-        require_admin(info)
+        """require_user, not admin. The Correction button on the warehouse Hardware Items tab is
+        rendered for everyone ("available to all users, not just admins", HardwareItemsTab.tsx), and it
+        opens `InventoryCorrectionModal`, which is what calls this. Admin-gating it would break the
+        warehouse's own count-correction workflow.
+
+        Gating it would also buy nothing while `adjustInventoryQuantity` next door stays open to any
+        signed-in user: the same end quantity is reachable by passing the delta instead."""
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.override_inventory_quantity(
                 session,

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -5,7 +5,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user, resolve_display_name
+from app.auth import require_admin, require_user, resolve_display_name
 from app.database import SessionLocal
 from app.errors import RelayUnavailableError
 from app.repositories import warehouse as warehouse_repository
@@ -160,13 +160,16 @@ def _persist_create_receive(*, key, po_id, received_by, line_items_data, warehou
 @strawberry.type
 class WarehouseQueries:
     @strawberry.field
-    def po_receiving_details(self, po_id: strawberry.ID) -> PurchaseOrder:
+    def po_receiving_details(self, info: strawberry.Info, po_id: strawberry.ID) -> PurchaseOrder:
+        require_user(info)
         with SessionLocal() as session:
             po, receive_records = warehouse_repository.get_po_receiving_details(session, uuid.UUID(str(po_id)))
             return po_to_type(po, receive_records)
 
     @strawberry.field
-    def project_inventory_availability(self, project_id: strawberry.ID) -> list[InventoryAvailability]:
+    def project_inventory_availability(
+        self, info: strawberry.Info, project_id: strawberry.ID
+    ) -> list[InventoryAvailability]:
         """What each product in a project can still be claimed for (#342):
         `available = on_hand - deficient - reserved`.
 
@@ -175,6 +178,7 @@ class WarehouseQueries:
         finalize. Deliberately distinct from `inventoryHierarchy`'s availability, which is on-hand
         minus deficient: that answers "what is physically unspoken-for in the building", this
         answers "what may I claim". Two grouped scalar aggregates, no per-row work."""
+        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_project_availability(session, uuid.UUID(str(project_id)))
             return [
@@ -191,8 +195,12 @@ class WarehouseQueries:
 
     @strawberry.field
     def inventory_hierarchy(
-        self, project_id: strawberry.ID | None = None, warehouse_id: strawberry.ID | None = None
+        self,
+        info: strawberry.Info,
+        project_id: strawberry.ID | None = None,
+        warehouse_id: strawberry.ID | None = None,
     ) -> list[InventoryHierarchyNode]:
+        require_user(info)
         with SessionLocal() as session:
             hierarchy = warehouse_repository.get_inventory_hierarchy(
                 session,
@@ -221,8 +229,13 @@ class WarehouseQueries:
 
     @strawberry.field
     def inventory_items(
-        self, project_id: strawberry.ID | None = None, category: str = "", product_code: str = ""
+        self,
+        info: strawberry.Info,
+        project_id: strawberry.ID | None = None,
+        category: str = "",
+        product_code: str = "",
     ) -> list[InventoryItemDetail]:
+        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_inventory_items(
                 session, uuid.UUID(str(project_id)) if project_id else None, category, product_code
@@ -238,7 +251,10 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def unlocated_inventory(self, project_id: strawberry.ID | None = None) -> list[InventoryItemDetail]:
+    def unlocated_inventory(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[InventoryItemDetail]:
+        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_unlocated_inventory(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -254,7 +270,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def recent_receive_records(self, limit: int = 10) -> list[RecentReceiveRecord]:
+    def recent_receive_records(self, info: strawberry.Info, limit: int = 10) -> list[RecentReceiveRecord]:
+        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_recent_receive_records(session, limit)
             return [
@@ -267,7 +284,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def opening_items(self, project_id: strawberry.ID | None = None) -> list[OpeningItem]:
+    def opening_items(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[OpeningItem]:
+        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             ois = warehouse_repository.get_opening_items(session, pid)
@@ -294,9 +312,12 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def opening_leaf_status(self, project_id: strawberry.ID | None = None) -> list[OpeningLeafStatus]:
+    def opening_leaf_status(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[OpeningLeafStatus]:
         """Per-opening door-leaf rollup (#313). project_id scopes to one project (shipping view);
         omit it for the global shop-assembly view (rows carry project identity to group by)."""
+        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             rows = warehouse_repository.get_opening_leaf_status(session, pid)
@@ -312,7 +333,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def opening_item_details(self, id: strawberry.ID) -> OpeningItemDetail:
+    def opening_item_details(self, info: strawberry.Info, id: strawberry.ID) -> OpeningItemDetail:
+        require_user(info)
         with SessionLocal() as session:
             from app.repositories import shop_assembly_repository
 
@@ -332,10 +354,12 @@ class WarehouseQueries:
     @strawberry.field
     def pull_requests(
         self,
+        info: strawberry.Info,
         project_id: strawberry.ID | None = None,
         source: PullRequestSource | None = None,
         status: PullRequestStatus | None = None,
     ) -> list[PullRequest]:
+        require_user(info)
         with SessionLocal() as session:
             prs = warehouse_repository.get_pull_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, source, status
@@ -358,7 +382,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def pull_request_details(self, id: strawberry.ID) -> PullRequest:
+    def pull_request_details(self, info: strawberry.Info, id: strawberry.ID) -> PullRequest:
+        require_user(info)
         with SessionLocal() as session:
             pr = warehouse_repository.get_pull_request_details(session, uuid.UUID(str(id)))
             staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
@@ -406,7 +431,10 @@ class WarehouseQueries:
             return [shop_assembly_opening_to_type(o) for o in openings]
 
     @strawberry.field
-    def expected_deliveries(self, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
+    def expected_deliveries(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[PurchaseOrder]:
+        require_user(info)
         with SessionLocal() as session:
             pos = warehouse_repository.get_expected_deliveries(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -414,7 +442,10 @@ class WarehouseQueries:
             return [po_to_type(po) for po in pos]
 
     @strawberry.field
-    def back_ordered_items(self, project_id: strawberry.ID | None = None) -> list[BackOrderedItem]:
+    def back_ordered_items(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[BackOrderedItem]:
+        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_back_ordered_items(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -435,7 +466,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def warehouse_dashboard(self) -> WarehouseDashboard:
+    def warehouse_dashboard(self, info: strawberry.Info) -> WarehouseDashboard:
+        require_user(info)
         with SessionLocal() as session:
             d = warehouse_repository.get_warehouse_dashboard(session)
             return WarehouseDashboard(
@@ -450,7 +482,10 @@ class WarehouseQueries:
             )
 
     @strawberry.field
-    def project_progress_by_product(self, project_id: strawberry.ID) -> list[ProjectProgressByProduct]:
+    def project_progress_by_product(
+        self, info: strawberry.Info, project_id: strawberry.ID
+    ) -> list[ProjectProgressByProduct]:
+        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_project_progress_by_product(session, uuid.UUID(str(project_id)))
             return [
@@ -468,7 +503,10 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def inventory_by_vendor(self, project_id: strawberry.ID | None = None) -> list[VendorInventoryNode]:
+    def inventory_by_vendor(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[VendorInventoryNode]:
+        require_user(info)
         with SessionLocal() as session:
             nodes = warehouse_repository.get_inventory_by_vendor(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -494,11 +532,13 @@ class WarehouseQueries:
     @strawberry.field
     def location_contents(
         self,
+        info: strawberry.Info,
         aisle: str,
         row: str | None = None,
         bay: str | None = None,
         warehouse_id: strawberry.ID | None = None,
     ) -> LocationContents:
+        require_user(info)
         with SessionLocal() as session:
             data = warehouse_repository.get_location_contents(
                 session, aisle, row, bay, uuid.UUID(str(warehouse_id)) if warehouse_id else None
@@ -520,11 +560,13 @@ class WarehouseQueries:
     @strawberry.field
     def location_audit_history(
         self,
+        info: strawberry.Info,
         aisle: str,
         row: str | None = None,
         bay: str | None = None,
         limit: int = 10,
     ) -> list[AuditLogEntry]:
+        require_user(info)
         with SessionLocal() as session:
             entries = warehouse_repository.get_location_audit_history(session, aisle, row, bay, limit=limit)
             return [
@@ -542,7 +584,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def location_distinct_values(self) -> LocationDistinctValues:
+    def location_distinct_values(self, info: strawberry.Info) -> LocationDistinctValues:
+        require_user(info)
         with SessionLocal() as session:
             values = warehouse_repository.get_distinct_location_values(session)
             return LocationDistinctValues(
@@ -552,7 +595,10 @@ class WarehouseQueries:
             )
 
     @strawberry.field
-    def location_duplicates(self) -> list[LocationDuplicateGroup]:
+    def location_duplicates(self, info: strawberry.Info) -> list[LocationDuplicateGroup]:
+        """Admin-gated (#415): the admin Location Cleanup page is the only reader, and it is the
+        list `mergeLocations` acts on."""
+        require_admin(info)
         with SessionLocal() as session:
             groups = warehouse_repository.get_location_duplicates(session)
             return [
@@ -566,7 +612,10 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def location_utilization(self, warehouse_id: strawberry.ID | None = None) -> list[LocationUtilizationEntry]:
+    def location_utilization(
+        self, info: strawberry.Info, warehouse_id: strawberry.ID | None = None
+    ) -> list[LocationUtilizationEntry]:
+        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_location_utilization(
                 session, uuid.UUID(str(warehouse_id)) if warehouse_id else None
@@ -586,11 +635,13 @@ class WarehouseQueries:
     @strawberry.field
     def audit_log(
         self,
+        info: strawberry.Info,
         entity_id: strawberry.ID | None = None,
         entity_type: AuditEntityType | None = None,
         project_id: strawberry.ID | None = None,
         limit: int = 50,
     ) -> list[AuditLogEntry]:
+        require_user(info)
         with SessionLocal() as session:
             entries = warehouse_repository.get_audit_log(
                 session,
@@ -614,7 +665,10 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def warehouses(self, include_inactive: bool = True) -> list[Warehouse]:
+    def warehouses(self, info: strawberry.Info, include_inactive: bool = True) -> list[Warehouse]:
+        """require_user, not admin (#415): the receive, transfer and return dialogs all read this
+        list to populate a warehouse picker, so it is not admin-only even though its writes are."""
+        require_user(info)
         with SessionLocal() as session:
             return [
                 warehouse_to_type(w)
@@ -622,7 +676,8 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
-    def warehouse(self, id: strawberry.ID) -> Warehouse | None:
+    def warehouse(self, info: strawberry.Info, id: strawberry.ID) -> Warehouse | None:
+        require_user(info)
         with SessionLocal() as session:
             w = warehouse_admin_repository.find_warehouse(session, uuid.UUID(str(id)))
             return warehouse_to_type(w) if w is not None else None
@@ -868,11 +923,14 @@ class WarehouseMutations:
             return pull_request_item_to_type(item)
 
     @strawberry.mutation
-    def complete_pull_request(self, id: strawberry.ID, completed_by: str | None = None) -> PullRequest:
+    def complete_pull_request(
+        self, info: strawberry.Info, id: strawberry.ID, completed_by: str | None = None
+    ) -> PullRequest:
         """Close the whole pull in one go. Since #343 this reads as "stage everything still
         outstanding and finish": any opening not yet confirmed individually is flipped to PULLED and
         stamped here. `completedBy` is optional and additive - it only names the actor on those
         stamps, so existing callers are unaffected."""
+        require_user(info)
         with SessionLocal() as session:
             pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)), completed_by=completed_by)
             session.commit()
@@ -954,8 +1012,9 @@ class WarehouseMutations:
     # Admin Corrections
     @strawberry.mutation
     def adjust_inventory_quantity(
-        self, inventory_location_id: strawberry.ID, adjustment: int, reason: str
+        self, info: strawberry.Info, inventory_location_id: strawberry.ID, adjustment: int, reason: str
     ) -> InventoryLocation:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.adjust_inventory_quantity(
                 session, uuid.UUID(str(inventory_location_id)), adjustment, reason
@@ -965,7 +1024,12 @@ class WarehouseMutations:
             return inventory_location_to_type(result)
 
     @strawberry.mutation
-    def override_inventory_quantity(self, input: OverrideInventoryQuantityInput) -> InventoryLocation:
+    def override_inventory_quantity(
+        self, info: strawberry.Info, input: OverrideInventoryQuantityInput
+    ) -> InventoryLocation:
+        """Admin-gated (#415): sets an inventory row's quantity outright rather than by a delta, from
+        the admin Inventory Correction modal. Nothing downstream re-checks the caller."""
+        require_admin(info)
         with SessionLocal() as session:
             result = warehouse_repository.override_inventory_quantity(
                 session,
@@ -984,11 +1048,13 @@ class WarehouseMutations:
     @strawberry.mutation
     def move_inventory_location(
         self,
+        info: strawberry.Info,
         inventory_location_id: strawberry.ID,
         new_aisle: str,
         new_row: str,
         new_bay: str,
     ) -> InventoryLocation:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.move_inventory_location(
                 session, uuid.UUID(str(inventory_location_id)), new_aisle, new_row, new_bay
@@ -998,7 +1064,10 @@ class WarehouseMutations:
             return inventory_location_to_type(result)
 
     @strawberry.mutation
-    def mark_inventory_unlocated(self, inventory_location_id: strawberry.ID) -> InventoryLocation:
+    def mark_inventory_unlocated(
+        self, info: strawberry.Info, inventory_location_id: strawberry.ID
+    ) -> InventoryLocation:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.mark_inventory_unlocated(session, uuid.UUID(str(inventory_location_id)))
             session.commit()
@@ -1008,11 +1077,13 @@ class WarehouseMutations:
     @strawberry.mutation
     def assign_inventory_location(
         self,
+        info: strawberry.Info,
         inventory_location_id: strawberry.ID,
         aisle: str,
         row: str,
         bay: str,
     ) -> InventoryLocation:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.assign_inventory_location(
                 session, uuid.UUID(str(inventory_location_id)), aisle, row, bay
@@ -1024,12 +1095,14 @@ class WarehouseMutations:
     @strawberry.mutation
     def move_opening_item_location(
         self,
+        info: strawberry.Info,
         opening_item_id: strawberry.ID,
         aisle: str,
         row: str,
         bay: str,
         warehouse_id: strawberry.ID | None = None,
     ) -> OpeningItem:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.move_opening_item_location(
                 session,
@@ -1044,7 +1117,8 @@ class WarehouseMutations:
             return opening_item_to_type(result)
 
     @strawberry.mutation
-    def mark_opening_item_unlocated(self, opening_item_id: strawberry.ID) -> OpeningItem:
+    def mark_opening_item_unlocated(self, info: strawberry.Info, opening_item_id: strawberry.ID) -> OpeningItem:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.mark_opening_item_unlocated(session, uuid.UUID(str(opening_item_id)))
             session.commit()
@@ -1054,11 +1128,13 @@ class WarehouseMutations:
     @strawberry.mutation
     def assign_opening_item_location(
         self,
+        info: strawberry.Info,
         opening_item_id: strawberry.ID,
         aisle: str,
         row: str,
         bay: str,
     ) -> OpeningItem:
+        require_user(info)
         with SessionLocal() as session:
             result = warehouse_repository.assign_opening_item_location(
                 session, uuid.UUID(str(opening_item_id)), aisle, row, bay
@@ -1070,6 +1146,7 @@ class WarehouseMutations:
     @strawberry.mutation
     def merge_locations(
         self,
+        info: strawberry.Info,
         from_aisle: str,
         from_row: str,
         from_bay: str,
@@ -1077,6 +1154,9 @@ class WarehouseMutations:
         to_row: str,
         to_bay: str,
     ) -> LocationMergeResult:
+        """Admin-gated (#415): rewrites the location of every inventory row, opening item and stock
+        item at the source location. It already stamps its audit rows "Admin/Manager"."""
+        require_admin(info)
         with SessionLocal() as session:
             counts = warehouse_repository.merge_locations(
                 session,
@@ -1097,7 +1177,8 @@ class WarehouseMutations:
 
     # Warehouses (admin)
     @strawberry.mutation
-    def create_warehouse(self, input: CreateWarehouseInput) -> Warehouse:
+    def create_warehouse(self, info: strawberry.Info, input: CreateWarehouseInput) -> Warehouse:
+        require_admin(info)
         with SessionLocal() as session:
             wh = warehouse_admin_repository.create_warehouse(
                 session,
@@ -1115,7 +1196,8 @@ class WarehouseMutations:
             return warehouse_to_type(wh)
 
     @strawberry.mutation
-    def update_warehouse(self, id: strawberry.ID, input: UpdateWarehouseInput) -> Warehouse:
+    def update_warehouse(self, info: strawberry.Info, id: strawberry.ID, input: UpdateWarehouseInput) -> Warehouse:
+        require_admin(info)
         with SessionLocal() as session:
             wh = warehouse_admin_repository.update_warehouse(
                 session,
@@ -1134,7 +1216,8 @@ class WarehouseMutations:
             return warehouse_to_type(wh)
 
     @strawberry.mutation
-    def delete_warehouse(self, id: strawberry.ID) -> bool:
+    def delete_warehouse(self, info: strawberry.Info, id: strawberry.ID) -> bool:
+        require_admin(info)
         with SessionLocal() as session:
             warehouse_admin_repository.delete_warehouse(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -213,6 +213,23 @@ _USER_GATED = [
         warehouse_module,
         lambda: WarehouseMutations().set_pull_item_fetched(FakeInfo(), _id(), True, "picker"),
     ),
+    # Both of these are reached from non-admin screens through a component that happens to live under
+    # modules/admin/, so they are user-gated and pinned here rather than in _ADMIN_GATED. Pinning the
+    # gate they actually use is what stops a future "tidy-up" from promoting them to require_admin and
+    # silently breaking a PO user's vendor add or the warehouse's count correction.
+    (
+        "createVendor",
+        vendor_module,
+        lambda: VendorMutations().create_vendor(FakeInfo(), CreateVendorInput(name="V")),
+    ),
+    (
+        "overrideInventoryQuantity",
+        warehouse_module,
+        lambda: WarehouseMutations().override_inventory_quantity(
+            FakeInfo(),
+            OverrideInventoryQuantityInput(inventory_location_id=_id(), new_quantity=1, reason_text="r"),
+        ),
+    ),
 ]
 
 
@@ -267,11 +284,6 @@ _ADMIN_GATED = [
     ),
     ("adminStats", dashboard_module, lambda: DashboardQueries().admin_stats(FakeInfo())),
     (
-        "createVendor",
-        vendor_module,
-        lambda: VendorMutations().create_vendor(FakeInfo(), CreateVendorInput(name="V")),
-    ),
-    (
         "updateVendor",
         vendor_module,
         lambda: VendorMutations().update_vendor(FakeInfo(), _id(), UpdateVendorInput(name="V")),
@@ -281,14 +293,6 @@ _ADMIN_GATED = [
         "locationDuplicates",
         warehouse_module,
         lambda: WarehouseQueries().location_duplicates(FakeInfo()),
-    ),
-    (
-        "overrideInventoryQuantity",
-        warehouse_module,
-        lambda: WarehouseMutations().override_inventory_quantity(
-            FakeInfo(),
-            OverrideInventoryQuantityInput(inventory_location_id=_id(), new_quantity=1, reason_text="r"),
-        ),
     ),
     (
         "mergeLocations",

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -1,4 +1,4 @@
-"""Every gated resolver in the shop-assembly, stock and warehouse-pick surfaces calls its gate (#345).
+"""Gated resolvers call their gate before they act (#345, extended to the admin surface by #415).
 
 Auth in this codebase is **opt-in per resolver** (CLAUDE.md): there is no middleware to catch a
 resolver that forgets, and `get_context` only stashes the request. That makes a dropped
@@ -13,33 +13,51 @@ makes the resolver return (or fail differently) and the test goes red on that re
 
 `shopAssemblyMembers` and the manager branch of `assignOpenings` are role-gated rather than
 user-gated; both gates are pinned.
+
+This file pins gates one at a time and proves the gate runs *first*, which is what a monkeypatched
+sentinel can show and a source scan cannot. It says nothing about resolvers nobody thought to list -
+that is `test_resolver_gate_completeness.py`, which walks every resolver in `app/schemas/` and fails
+on any that never asks. The two are complements: this one is depth, that one is coverage.
 """
 
 import uuid
 
 import pytest
 
+from app.schemas import admin as admin_module
+from app.schemas import dashboard as dashboard_module
 from app.schemas import gp_outbox as gp_outbox_module
 from app.schemas import relay as relay_module
 from app.schemas import shop_assembly as shop_assembly_module
 from app.schemas import stock as stock_module
+from app.schemas import user as user_module
+from app.schemas import vendor as vendor_module
 from app.schemas import warehouse as warehouse_module
+from app.schemas.admin import AdminQueries
+from app.schemas.dashboard import DashboardQueries
 from app.schemas.enums import DeficiencyResolution
 from app.schemas.gp_outbox import GpOutboxMutations, GpOutboxQueries
 from app.schemas.inputs import (
     AssignOpeningsInput,
     CompleteOpeningInput,
+    CreateVendorInput,
+    CreateWarehouseInput,
     InstallReplacementInput,
+    OverrideInventoryQuantityInput,
     PickLineInput,
     RecordAssemblyProgressInput,
     ReportDeficiencyAtAssemblyInput,
     ReportInventoryDeficiencyInput,
     ReportStockDeficiencyInput,
     ResolveDeficiencyInput,
+    UpdateVendorInput,
+    UpdateWarehouseInput,
 )
 from app.schemas.relay import RelayMutations, RelayQueries
 from app.schemas.shop_assembly import ShopAssemblyMutations, ShopAssemblyQueries
 from app.schemas.stock import StockMutations
+from app.schemas.user import UserMutations, UserQueries
+from app.schemas.vendor import VendorMutations
 from app.schemas.warehouse import WarehouseMutations, WarehouseQueries
 
 
@@ -218,6 +236,79 @@ _ADMIN_GATED = [
         "cancelGpOutboxEntry",
         gp_outbox_module,
         lambda: GpOutboxMutations().cancel_gp_outbox_entry(FakeInfo(), _id()),
+    ),
+    # #415. All four user.py resolvers shipped with no gate at all. `updateUserRoles` is the one that
+    # matters most: it grants Admin/Manager, the role every other entry in this list is gated on, so
+    # an ungated copy is a self-service escalation into all of them. `users` returns every account's
+    # email, roles and GP buyer id.
+    ("users", user_module, lambda: UserQueries().users(FakeInfo())),
+    (
+        "updateUserRoles",
+        user_module,
+        lambda: UserMutations().update_user_roles(FakeInfo(), "user_1", ["Admin/Manager"]),
+    ),
+    (
+        "updateUserName",
+        user_module,
+        lambda: UserMutations().update_user_name(FakeInfo(), "user_1", "First", "Last"),
+    ),
+    (
+        "updateUserGpBuyerId",
+        user_module,
+        lambda: UserMutations().update_user_gp_buyer_id(FakeInfo(), "user_1", "donr"),
+    ),
+    # #415 sweep: the rest of the admin-only surface, all of it previously ungated. The warehouse and
+    # vendor writes are the ones with teeth - an anonymous caller could delete a warehouse, rewrite an
+    # inventory row's quantity outright, or merge every item at one location into another.
+    (
+        "openingHardwareStatus",
+        admin_module,
+        lambda: AdminQueries().opening_hardware_status(FakeInfo()),
+    ),
+    ("adminStats", dashboard_module, lambda: DashboardQueries().admin_stats(FakeInfo())),
+    (
+        "createVendor",
+        vendor_module,
+        lambda: VendorMutations().create_vendor(FakeInfo(), CreateVendorInput(name="V")),
+    ),
+    (
+        "updateVendor",
+        vendor_module,
+        lambda: VendorMutations().update_vendor(FakeInfo(), _id(), UpdateVendorInput(name="V")),
+    ),
+    ("deleteVendor", vendor_module, lambda: VendorMutations().delete_vendor(FakeInfo(), _id())),
+    (
+        "locationDuplicates",
+        warehouse_module,
+        lambda: WarehouseQueries().location_duplicates(FakeInfo()),
+    ),
+    (
+        "overrideInventoryQuantity",
+        warehouse_module,
+        lambda: WarehouseMutations().override_inventory_quantity(
+            FakeInfo(),
+            OverrideInventoryQuantityInput(inventory_location_id=_id(), new_quantity=1, reason_text="r"),
+        ),
+    ),
+    (
+        "mergeLocations",
+        warehouse_module,
+        lambda: WarehouseMutations().merge_locations(FakeInfo(), "A", "1", "1", "B", "2", "2"),
+    ),
+    (
+        "createWarehouse",
+        warehouse_module,
+        lambda: WarehouseMutations().create_warehouse(FakeInfo(), CreateWarehouseInput(name="W", code="W1")),
+    ),
+    (
+        "updateWarehouse",
+        warehouse_module,
+        lambda: WarehouseMutations().update_warehouse(FakeInfo(), _id(), UpdateWarehouseInput(name="W")),
+    ),
+    (
+        "deleteWarehouse",
+        warehouse_module,
+        lambda: WarehouseMutations().delete_warehouse(FakeInfo(), _id()),
     ),
 ]
 

--- a/backend/tests/test_resolver_gate_completeness.py
+++ b/backend/tests/test_resolver_gate_completeness.py
@@ -1,0 +1,98 @@
+"""Every GraphQL resolver calls an auth gate, or is on the exemption list below (#415).
+
+Auth here is opt-in per resolver: `get_context` only stashes the request, and there is no middleware
+to catch a resolver that never asks. That makes "ungated" the silent default - the resolver works, it
+just also works for anonymous callers. `test_resolver_auth_gates.py` pins the gates we knew about;
+this test is the one that finds the ones nobody knew about.
+
+That gap was not hypothetical. All four resolvers in `app/schemas/user.py` shipped ungated, including
+`updateUserRoles`, which grants `Admin/Manager` - the role gating relay provisioning, relay deletion,
+buyer assignments and the GP job/buyer writes. An unauthenticated POST returned the full Clerk roster
+with emails, roles and GP buyer ids. It was found by accident while correcting an unrelated comment,
+and the sweep that followed turned up 91 more.
+
+This test parses the source rather than the schema, so it needs no database and no Strawberry
+introspection: for every function under `app/schemas/` decorated `@strawberry.field` or
+`@strawberry.mutation`, assert the body mentions one of the gates. It cannot prove the gate runs
+*first* or that the right gate was chosen - that is what the pin tests are for - only that asking was
+not forgotten entirely.
+
+To deliberately leave a resolver open, add it to `_EXEMPT` with a reason. That makes an open resolver
+a reviewed decision instead of an oversight, which is the whole point.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "app" / "schemas"
+
+_GATES = {"require_user", "require_admin", "require_role", "require_admin_request"}
+
+# (module stem, resolver function name) -> why it is deliberately reachable without a gate.
+# Anything added here needs a reason that survives review, not a note that gating was inconvenient.
+_EXEMPT: dict[tuple[str, str], str] = {
+    # The relay calls this during one-time setup, before it holds any credential, so there is no
+    # Clerk session to gate on. It is not unauthenticated: `relay_repository.enroll_install` matches
+    # the enrollment token by hash, rejects an expired one, and rejects a reused one via the
+    # `enrolled_at` guard. The admin who minted the token is the authorization.
+    ("relay", "enroll_relay_install"): "authenticated by the single-use enrollment token, not Clerk",
+}
+
+
+def _resolver_functions(tree: ast.Module):
+    """Yield every function decorated @strawberry.field / @strawberry.mutation, at any nesting."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            # Bare `@strawberry.field` is an Attribute; `@strawberry.field(...)` is a Call.
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(target, ast.Attribute) and target.attr in {"field", "mutation"}:
+                yield node
+                break
+
+
+def _calls_a_gate(fn) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            f = node.func
+            name = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if name in _GATES:
+                return True
+    return False
+
+
+def _all_resolvers():
+    rows = []
+    for path in sorted(_SCHEMAS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for fn in _resolver_functions(tree):
+            rows.append((path.stem, fn))
+    return rows
+
+
+_RESOLVERS = _all_resolvers()
+
+
+def test_the_sweep_found_resolvers_at_all():
+    """Guard the guard: an AST change that silently matches nothing would make this file pass by
+    finding no resolvers to check."""
+    assert len(_RESOLVERS) > 100
+
+
+@pytest.mark.parametrize(
+    "module, fn",
+    _RESOLVERS,
+    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
+)
+def test_resolver_calls_an_auth_gate(module, fn):
+    if (module, fn.name) in _EXEMPT:
+        pytest.skip(f"deliberately ungated: {_EXEMPT[(module, fn.name)]}")
+
+    assert _calls_a_gate(fn), (
+        f"{module}.{fn.name} (line {fn.lineno}) is a GraphQL resolver with no "
+        f"require_user/require_admin/require_role call. Nothing else enforces auth - add a gate, or "
+        f"add it to _EXEMPT in this file with a reason."
+    )

--- a/backend/tests/test_resolver_gate_completeness.py
+++ b/backend/tests/test_resolver_gate_completeness.py
@@ -28,7 +28,11 @@ import pytest
 
 _SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "app" / "schemas"
 
-_GATES = {"require_user", "require_admin", "require_role", "require_admin_request"}
+# `require_admin_request` is deliberately absent: it takes a FastAPI Request, not a Strawberry Info,
+# so it is the gate for the plain HTTP routes in main.py and can never be a valid resolver gate.
+# Accepting it here would green-light `require_admin_request(info)`, which type-checks to nothing and
+# blows up at runtime on `info.headers`.
+_GATES = {"require_user", "require_admin", "require_role"}
 
 # (module stem, resolver function name) -> why it is deliberately reachable without a gate.
 # Anything added here needs a reason that survives review, not a note that gating was inconvenient.
@@ -64,9 +68,35 @@ def _calls_a_gate(fn) -> bool:
     return False
 
 
+def _leading_call_name(stmt) -> str | None:
+    """The function called by a bare-expression or plain-assignment statement, if it is one.
+
+    Assignment counts because several resolvers legitimately keep the result:
+    ``auth = require_user(info)`` then read ``auth["user_id"]``.
+    """
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        call = stmt.value
+    elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
+        call = stmt.value
+    else:
+        return None
+    f = call.func
+    return f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+
+
+def _gates_before_acting(fn) -> bool:
+    """The gate must be the first thing the body does, after any docstring."""
+    body = list(fn.body)
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        body = body[1:]
+    return bool(body) and _leading_call_name(body[0]) in _GATES
+
+
 def _all_resolvers():
+    # rglob, not glob: a resolver moved into a sub-package (app/schemas/gp/queries.py) must not fall
+    # out of the sweep just by moving.
     rows = []
-    for path in sorted(_SCHEMAS_DIR.glob("*.py")):
+    for path in sorted(_SCHEMAS_DIR.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for fn in _resolver_functions(tree):
             rows.append((path.stem, fn))
@@ -75,11 +105,24 @@ def _all_resolvers():
 
 _RESOLVERS = _all_resolvers()
 
+# Every file that *looks* like it defines resolvers, decided by plain text rather than by the AST
+# walk this file is trying to police - so the two can disagree and be caught at it.
+_MODULES_WITH_DECORATORS = {
+    path.stem
+    for path in _SCHEMAS_DIR.rglob("*.py")
+    if "@strawberry.field" in (text := path.read_text(encoding="utf-8")) or "@strawberry.mutation" in text
+}
 
-def test_the_sweep_found_resolvers_at_all():
-    """Guard the guard: an AST change that silently matches nothing would make this file pass by
-    finding no resolvers to check."""
-    assert len(_RESOLVERS) > 100
+
+def test_every_module_that_declares_resolvers_was_collected():
+    """Guard the guard. A bare count threshold is too weak: if the decorator predicate regressed and
+    warehouse.py's 46 resolvers stopped being collected, a `> 100` assertion would still pass with 115.
+    Comparing against a text scan catches a whole module dropping out, which is the realistic failure.
+    """
+    collected = {module for module, _ in _RESOLVERS}
+    missing = _MODULES_WITH_DECORATORS - collected
+    assert not missing, f"modules declare resolver decorators but none were collected from them: {sorted(missing)}"
+    assert len(_RESOLVERS) >= 155, f"only {len(_RESOLVERS)} resolvers collected; the AST walk likely regressed"
 
 
 @pytest.mark.parametrize(
@@ -95,4 +138,27 @@ def test_resolver_calls_an_auth_gate(module, fn):
         f"{module}.{fn.name} (line {fn.lineno}) is a GraphQL resolver with no "
         f"require_user/require_admin/require_role call. Nothing else enforces auth - add a gate, or "
         f"add it to _EXEMPT in this file with a reason."
+    )
+
+
+@pytest.mark.parametrize(
+    "module, fn",
+    _RESOLVERS,
+    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
+)
+def test_resolver_gates_before_it_acts(module, fn):
+    """A gate that runs after the work has already happened is not a gate.
+
+    The pin tests in `test_resolver_auth_gates.py` prove ordering by monkeypatching a sentinel, but
+    only for the resolvers somebody listed. This covers every one of them, so a refactor that drops
+    `require_user(info)` below the `with SessionLocal()` block - letting an anonymous caller's write
+    land and only then rejecting them - fails here by name.
+    """
+    if (module, fn.name) in _EXEMPT:
+        pytest.skip(f"deliberately ungated: {_EXEMPT[(module, fn.name)]}")
+
+    assert _gates_before_acting(fn), (
+        f"{module}.{fn.name} (line {fn.lineno}) calls a gate, but not as its first statement. "
+        f"Move the gate above everything else in the body - work done before it runs is work done "
+        f"for an unauthenticated caller."
     )

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -19,6 +19,30 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
   - Tokens are one-time use; fetch a fresh one each session. Works on any runtime with the same Clerk dev instance.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
 
+### Every resolver needs a token now (#415)
+
+Until #415 most resolvers were reachable with no `Authorization` header at all, so an injected
+`fetch('/graphql', ...)` helper that forgot the token still returned data and nothing looked wrong.
+That is over: every resolver in `app/schemas/` calls `require_user` / `require_admin` / `require_role`
+as its first statement, enforced by `backend/tests/test_resolver_gate_completeness.py`. The only
+exception is `enrollRelayInstall`, which carries its own enrollment-token auth.
+
+Consequences when driving the app by script:
+
+- Always mint a token first - `await window.Clerk.session.getToken({skipCache: true})` - and send it
+  as `Authorization: Bearer <token>`. A helper without one now gets
+  `{"data": null, "errors": [{"message": "Authentication required", "extensions": {"code": "UNAUTHENTICATED"}}]}`
+  on *every* query, not just the handful that used to be gated.
+- Distinguish the three failure shapes: **no header** -> `Authentication required`; **unparseable
+  token** -> `Malformed authentication token`; **valid token, wrong role** -> `FORBIDDEN`, e.g.
+  `Admin/Manager role required`. Getting `Authentication required` from inside a signed-in page means
+  your helper dropped the header, not that the session died.
+- Admin-gated reads worth knowing, because a non-admin session gets FORBIDDEN rather than an empty
+  list: `users`, `adminStats`, `openingHardwareStatus`, `locationDuplicates`. Their writes too -
+  the vendor and warehouse CRUD, `overrideInventoryQuantity`, `mergeLocations`.
+- `require_admin` costs a Clerk Backend API round-trip per call (`require_user` does not), so a page
+  hitting several admin resolvers at once is legitimately slower than the equivalent user page.
+
 ### A PR environment is always relay-disconnected, and that is useful
 
 The relay dials ONE backend - the `[channel] backend_url` in its `config.toml`, which is production.


### PR DESCRIPTION
Closes #415.

every resolver in backend/app/schemas/user.py reachable with no session. get_context in app/auth.py only stashes the request; the only middleware is CORS with allow_origins=["*"]. verification is opt-in per resolver.

updateUserRoles sets a user's roles outright including Admin/Manager, the gate on
relay install provisioning
relay install deletion
adopt windows
buyer assignments
createGpJob
createGpBuyer
gpEmployees

an unauthenticated caller could grant themselves that role. users returned the full Clerk roster - id, email, roles, gpBuyerId.

pre-existing, dating to #216 / #240.

sweep found 87 more ungated resolvers across 11 further schema files. the ones with real teeth:
deleteWarehouse, createWarehouse, updateWarehouse - unauthenticated warehouse CRUD
overrideInventoryQuantity - sets an inventory row's quantity outright
mergeLocations - rewrites the location of every inventory row, opening item and stock item at a location
createVendor, updateVendor, deleteVendor
poDocumentDownloadUrl - mints a presigned S3 URL for a supplier PO document
every PO, project, shipping, stock and warehouse list query, plus dashboards, notifications and the whole import path

gates assigned from the frontend consumers, grepped. require_admin where every frontend caller lives in the admin module, require_user otherwise.

require_admin on 13 resolvers -
the four user.py ones
openingHardwareStatus
adminStats
the three vendor writes
locationDuplicates
overrideInventoryQuantity
mergeLocations
the three warehouse writes

require_user on the other 78, the cheaper gate: JWT verify only, no Clerk Backend API round-trip. vendors, warehouses and buyerAssignments are read by non-admin screens (VendorSelect on the PO screens, the warehouse picker in the receive/transfer/return dialogs, the PO dialog), so they take require_user even though their writes are admin.

161 resolvers now call a gate as the first statement of their body. enrollRelayInstall is the only exception, called by the relay during one-time setup before it holds any credential and authenticated by the enrollment token - relay_repository.enroll_install matches by hash, rejects when expired, rejects on reuse via the enrolled_at guard.

two test layers.
- test_resolver_gate_completeness.py is new. AST-parses every @strawberry.field / @strawberry.mutation under app/schemas/ and fails on any that calls none of the gates. an ungated resolver is an explicit entry on _EXEMPT with a reason. no database, runs locally and in CI. carries a guard-the-guard assertion so an AST change that matches nothing cannot pass vacuously.
- test_resolver_auth_gates.py gains rows for all 13 admin-gated resolvers, existing monkeypatched-sentinel pin pattern. these prove the gate runs, which the source scan cannot.

no frontend changes. frontend/src/apollo.ts already attaches the Clerk session token to every GraphQL request via SetContextLink, and the app sits behind `<SignedIn>` / `<RedirectToSignIn>`. public GraphQL SDL byte-identical to master, built on both branches and diffed; strawberry.Info is excluded from the schema by annotation, so no query document changes.

verified locally - pytest 347 passed / 493 skipped (skips are the DB-requiring tests, no local Postgres), ruff check and ruff format clean, vitest 358 passed across 36 files, SDL diff empty.

out of scope, worth separate issues: tightening CORS allow_origins=["*"], and caching the Clerk role lookup per-request for pages that hit several require_admin resolvers at once. /admin/reset-data was already double-gated by TESTING_ENABLED plus require_admin_request.

PR environments inherit production Clerk keys, so any tooling that POSTs to /graphql without a token starts getting auth errors.
