### PR TITLE
docs(testing): PR environments are the only e2e target, production is not

### DIFF
--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -8,15 +8,31 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
 
 ## Environment
 
-**Railway is the default** for simulated user testing (issue #182 pivot - the localdev runtime was dropped for UC Nexus e2e; zero local setup needed).
+**A Railway PR environment is the only place end-to-end testing happens** (issue #182 pivot - the localdev runtime was dropped for UC Nexus e2e; zero local setup needed).
 
-- **Railway production (default)**: frontend `https://frontend-production-34fc.up.railway.app/`, backend `https://backend-production-7866.up.railway.app/`. Deploys from master after CI passes.
-- **Railway PR environments** (ENABLED 2026-07-29, `prDeploys` on the project; bot PRs like dependabot deliberately excluded): every non-draft PR gets a full ephemeral replica (frontend + backend + fresh empty Postgres, migrated on boot) named `uc-nexus-pr-<N>`. Do not wait for a Railway bot comment - none was observed; the URLs are derivable: `https://backend-uc-nexus-pr-<N>.up.railway.app` / `https://frontend-uc-nexus-pr-<N>.up.railway.app`. Substitute them into the sign-in flow below; verified live on PR #401 (`/health` 200, `/testing/clerk-sign-in` mints tokens, GraphQL serves the fresh DB). Data starts empty; seed via the import fixture. `VITE_GRAPHQL_URL` is a reference variable (`https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/graphql`) so each environment self-wires; `TESTING_ENABLED` and Clerk keys inherit from production. **A PR that only touches one service's directory only deploys that service in its environment** (root-directory change filtering - PR #401 was backend-only and the frontend showed `latestDeployment: null`); trigger the missing one from the dashboard or via the API (`serviceInstanceDeployV2(environmentId, serviceId)`). Environments auto-delete when the PR closes.
+> **The `*-production-*` Railway services are REAL PRODUCTION.** Real customer data, real users.
+> Never point a testing session at them, and never fire mutation probes at them - not to "just check"
+> something after a merge, and not because a change is already deployed there. If a thing genuinely
+> can only be observed on production, ask a human first.
+>
+> This file used to call production "the default" runtime for testing, and that was followed in
+> practice. If you are reading a stale copy of that guidance somewhere else - the global
+> `~/.claude/CLAUDE.md` said the same thing - this block supersedes it.
+
+- **Railway PR environments (the testing target)** (ENABLED 2026-07-29, `prDeploys` on the project; bot PRs like dependabot deliberately excluded): every non-draft PR gets a full ephemeral replica (frontend + backend + fresh empty Postgres, migrated on boot) named `uc-nexus-pr-<N>`. Do not wait for a Railway bot comment - none was observed; the URLs are derivable: `https://backend-uc-nexus-pr-<N>.up.railway.app` / `https://frontend-uc-nexus-pr-<N>.up.railway.app`. Substitute them into the sign-in flow below; verified live on PR #401 (`/health` 200, `/testing/clerk-sign-in` mints tokens, GraphQL serves the fresh DB). Data starts empty; seed via the import fixture. No PR open for what you need to test? Open a throwaway one - that is cheaper than the alternative. `VITE_GRAPHQL_URL` is a reference variable (`https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/graphql`) so each environment self-wires; `TESTING_ENABLED` and Clerk keys inherit from production. **A PR that only touches one service's directory only deploys that service in its environment** (root-directory change filtering - PR #401 was backend-only and the frontend showed `latestDeployment: null`); trigger the missing one from the dashboard or via the API (`serviceInstanceDeployV2(environmentId, serviceId)`). Environments auto-delete when the PR closes.
 - **Local (manual fallback)**: frontend `http://localhost:5173`, backend `http://localhost:8000`. Run the backend with `poetry run uvicorn main:app --reload` (from `backend/`) and the frontend with `npm run dev` (from `frontend/`). Needs a local Postgres (not provided; the worktree-localdev adoption was dropped).
 - **Auth**: Clerk sign-in, automated via one-time sign-in tokens (no manual password/verification needed).
   - Backend endpoint `GET /testing/clerk-sign-in` generates the token (requires `TESTING_ENABLED=true`).
   - Navigate to the frontend URL with `?__clerk_ticket=TOKEN` to auto-authenticate.
   - Tokens are one-time use; fetch a fresh one each session. Works on any runtime with the same Clerk dev instance.
+  - **Every environment inherits production Clerk keys**, so the accounts in a PR environment are real
+    staff accounts and a session minted there is a real session. The Postgres data in a PR environment
+    is disposable; the identities are not. Sign in as the account you were given, and do not mint
+    tokens for colleagues' accounts to test role behaviour - ask instead.
+  - That this endpoint will mint a session for any email with no authentication is itself a
+    vulnerability, tracked in #422 / #424. Use it as the sanctioned test flow, but do not treat its
+    availability on a given host as evidence that the host is a test environment - production answers
+    it too, which is exactly the bug.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
 
 ### Every resolver needs a token now (#415)
@@ -199,16 +215,23 @@ import-created draft otherwise blocks the register dialog with per-line `Require
 
 ## Getting Started (Every Session)
 
-1. **Sign in**: Use `evaluate_script` to fetch a sign-in token and navigate with it. Railway production (default):
+0. **Pick the environment first.** Testing runs against the PR environment for the PR you are working on. Set `PR` once and let both URLs derive from it, so there is no production URL in the snippet to fat-finger:
+   ```js
+   const PR = 420;  // <- the PR number under test
+   const BACKEND  = `https://backend-uc-nexus-pr-${PR}.up.railway.app`;
+   const FRONTEND = `https://frontend-uc-nexus-pr-${PR}.up.railway.app`;
+   ```
+1. **Sign in**: Use `evaluate_script` to fetch a sign-in token and navigate with it:
    ```js
    (async () => {
-     const resp = await fetch('https://backend-production-7866.up.railway.app/testing/clerk-sign-in');
+     const PR = 420;  // <- the PR number under test
+     const resp = await fetch(`https://backend-uc-nexus-pr-${PR}.up.railway.app/testing/clerk-sign-in`);
      const { token } = await resp.json();
-     window.location.href = 'https://frontend-production-34fc.up.railway.app/?__clerk_ticket=' + token + '&cb=' + Date.now();
+     window.location.href = `https://frontend-uc-nexus-pr-${PR}.up.railway.app/?__clerk_ticket=${token}&cb=${Date.now()}`;
      return 'Navigating with sign-in token...';
    })()
    ```
-   For a PR environment, swap in the URLs from the Railway bot's PR comment. For the local fallback, use `http://localhost:8000` / `http://localhost:5173`.
+   For the local fallback, use `http://localhost:8000` / `http://localhost:5173`. Do not substitute the production hosts here - see the Environment section.
    - Clerk auto-authenticates — no email, password, or verification code needed.
    - You land on `/app` (Module Selector) fully signed in.
 2. **Reset data** (if needed): Click the "DevAction: drop and rebuild schema" button in the app bar.
@@ -823,7 +846,7 @@ Inventory quantity corrections are NOT here — they live in the Warehouse modul
 
 - `fill_form` is much more reliable than sequential `fill` calls for forms with many fields.
 - After "DevAction: drop and rebuild schema", there are TWO dialogs: a MUI confirm dialog, then a `window.alert()`. Must handle both.
-- Clerk sign-in tokens: Fetch from `GET /testing/clerk-sign-in` on the backend, then navigate to the frontend with `?__clerk_ticket=TOKEN`. Railway production is the default runtime (issue #182); PR environments and localhost use the same flow with their own URLs. Clerk auto-authenticates - no form fill, no verification code. Tokens are one-time use; fetch a fresh one each session.
+- Clerk sign-in tokens: Fetch from `GET /testing/clerk-sign-in` on the backend, then navigate to the frontend with `?__clerk_ticket=TOKEN`. The runtime is the PR environment for the PR under test (issue #182 moved e2e onto Railway; production is not a testing target). Clerk auto-authenticates - no form fill, no verification code. Tokens are one-time use; fetch a fresh one each session.
 - When viewing "All Projects", `projectId` is undefined/null in queries — this returns all POs across projects.
 - To test the Warehouse Receiving wizard's "Enter Quantities" step, you need at least one PO in ORDERED (or higher) status. DRAFT POs do not appear in the receiving wizard's PO selection list.
 - The line item field formerly called "Vendor Alias" is now called "Order As" in pre-order screens (Create PO dialog, PO detail modal) and "Ordered As" in post-order screens (Warehouse receiving wizard).


### PR DESCRIPTION
testing/CLAUDE.md called the Railway `*-production-*` pair "Railway production (default)" for simulated user testing, and its Getting Started sign-in snippet hardcoded those two hosts. they are real production, with real data and real users.

following it during #415/#420 ran a full testing session against real production
- unauthenticated probes read the live Clerk roster
- signed-in admin session
- destructive mutation probes
  `deleteWarehouse`
  `mergeLocations`
  `overrideInventoryQuantity`
  `createVendor`

nothing mutated - the gates the PR added rejected all of them, residue check confirmed. the only thing between that session and a junk write on production was the fix being correct.

- Environment section now opens with a warning block - the `*-production-*` services are real production, never a testing target, ask a human rather than "just checking" something after a merge. names the stale global `~/.claude/CLAUDE.md` guidance it supersedes, which said the same thing.
- PR environments relabelled as the testing target, not one option among three. open a throwaway PR if none is open for what you need.
- Getting Started gains a step 0 setting a `PR` number once, both URLs derived from it. copy-paste snippet contains no production host. previously the snippet was production and the PR-environment case was a sentence telling you to substitute.
- Clerk bullet records that every environment inherits production Clerk keys - PR-environment accounts are real staff accounts, a session minted there is a real session. the Postgres data is disposable, the identities are not. do not mint tokens for colleagues' accounts to test role behaviour.
- points at #422 / #424 for the trap - `/testing/clerk-sign-in` answering on a host is not evidence the host is a test environment, because production answers it too.

docs only, no code. no `production-34fc` / `production-7866` string remains anywhere in the guide.

scope is the environment classification and the sign-in flow. module guides and workflow notes untouched, so no conflict with #417, #419, #421, which edit other regions of the same file.
