### PR TITLE
fix(relay): name every /relay-link disconnect on both ends (#384)

### DIFF
--- a/backend/app/services/relay_gateway.py
+++ b/backend/app/services/relay_gateway.py
@@ -10,14 +10,28 @@ pending calls now happens only on a genuine disconnect (unregister), where the r
 A briefly half-dead incumbent is detected by the app-level heartbeat (issue #277): the /relay-link route
 pings the relay on a data message every HEARTBEAT_INTERVAL_SECONDS and, after HEARTBEAT_MAX_MISSED
 unanswered pings, closes the socket - which fires unregister, frees the slot, and flips relayStatus
-within ~a minute instead of the ~hour it took the platform to reap the dead TCP connection."""
+within ~a minute instead of the ~hour it took the platform to reap the dead TCP connection.
+
+Every connection-slot transition is logged (issue #384). On 2026-07-28 the relay dropped for ~5 minutes
+and reconnected on its own, and the backend logs could not say when it went, why, or how long it had
+been up: unregister wrote nothing, and the only relay line uvicorn emits is the access log for the
+accepted socket, so a socket held open for days produced exactly one log line for its whole lifetime.
+An absent disconnect line carries no information, so there was nothing to correlate against the relay's
+own logs. The gateway now names the disconnect and, crucially, says WHOSE fault it was: a heartbeat reap
+(we closed a relay that stopped answering) and a peer close (the socket went away under us) are different
+failures with different owners, and by the time unregister runs in the route's `finally` neither is
+distinguishable from the other."""
 
 import asyncio
+import logging
+import time
 import uuid
 
 from fastapi import WebSocket
 
 from app.errors import RelayCallError, RelayOpUnsupportedError, RelayTimeoutError, RelayUnavailableError
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -40,6 +54,14 @@ HEARTBEAT_MAX_MISSED_UNARMED = 4
 # tell a deploy from a network blip and reconnect immediately instead of backing off (#353 PR F).
 SERVICE_RESTART_CLOSE_CODE = 1012
 _SHUTDOWN_TIMEOUT_SECONDS = 2.0
+
+# Why the live socket went away (issue #384). unregister() is called from the /relay-link route's
+# `finally`, which by then cannot tell one ending from another - a heartbeat reap, the relay closing,
+# and the TCP connection dying all just end the read loop. So whichever path DECIDES the disconnect
+# stamps its reason on the gateway first, and unregister reports what it finds. No stamp means nobody
+# on this side decided, i.e. the peer closed or the socket dropped under us.
+DISCONNECT_REASON_PEER = "peer closed or socket dropped"
+DISCONNECT_REASON_SHUTDOWN = "closed for server shutdown"
 
 
 class RelayGateway:
@@ -64,6 +86,13 @@ class RelayGateway:
         # just falls back to the old disconnect-on-read behaviour.
         self._unanswered_pings = 0
         self._heartbeat_armed = False
+        # Disconnect diagnosability (issue #384). `_registered_at` is a monotonic stamp taken when the
+        # connection slot is claimed, so the disconnect line can report how long the socket was actually
+        # held - the difference between "it had been up for days" and "it never got past the handshake"
+        # is most of the diagnosis. `_disconnect_reason` is stamped by whichever path decided the
+        # disconnect (see DISCONNECT_REASON_* above); None at unregister time means the peer did.
+        self._registered_at: float | None = None
+        self._disconnect_reason: str | None = None
 
     @property
     def connected(self) -> bool:
@@ -94,6 +123,29 @@ class RelayGateway:
         takes the single connection slot when it's free; returns False (route closes the socket) when a
         relay is already connected, so the incumbent's in-flight calls are never disturbed."""
         if self._socket is not None and self._socket is not websocket:
+            # A refused reconnect is otherwise completely silent (issue #384), and it is exactly what a
+            # zombie incumbent looks like from the outside: the real relay dialling back in every few
+            # seconds and being turned away while a dead socket holds the slot, until the heartbeat
+            # reaps it up to HEARTBEAT_INTERVAL_SECONDS * HEARTBEAT_MAX_MISSED later. Name the incumbent
+            # and how long it has held the slot so that window is readable in the logs.
+            logger.warning(
+                "relay connection refused: slot already held (holder install=%s company=%s build=%s "
+                "held_seconds=%s, refused install=%s company=%s)",
+                self._install_id,
+                self._company,
+                self._build,
+                self._held_seconds(),
+                install_id,
+                company,
+                extra={
+                    "install_id": str(self._install_id) if self._install_id is not None else None,
+                    "company": self._company,
+                    "build": self._build,
+                    "held_seconds": self._held_seconds(),
+                    "refused_install_id": str(install_id) if install_id is not None else None,
+                    "refused_company": company,
+                },
+            )
             return False
         self._socket = websocket
         self._company = company
@@ -102,19 +154,74 @@ class RelayGateway:
         self._ops = None
         self._unanswered_pings = 0
         self._heartbeat_armed = False
+        self._registered_at = time.monotonic()
+        self._disconnect_reason = None
         return True
 
     def unregister(self, websocket: WebSocket) -> None:
-        """Called by the /relay-link route when its socket disconnects."""
-        if self._socket is websocket:
-            self._socket = None
-            self._company = None
-            self._install_id = None
-            self._build = None
-            self._ops = None
-            self._unanswered_pings = 0
-            self._heartbeat_armed = False
-            self._fail_all("relay disconnected")
+        """Called by the /relay-link route's `finally` when its socket disconnects, and by
+        close_for_shutdown once it has said goodbye.
+
+        The identity check is load-bearing, not defensive noise: a second relay refused at try_register
+        (the route closes it 4409) shares this gateway with the live one, so tearing that socket down
+        must not clear the incumbent's company/install/heartbeat state, consume its stamped disconnect
+        reason, or log the live connection away as if it had dropped.
+
+        Logs the disconnect (issue #384) with everything needed to correlate against the relay's own
+        logs: which install and company, which relay build (learned from the hello frame), how long the
+        socket was held, how many in-flight calls died with it, and - the part nothing else can
+        reconstruct after the fact - whether we reaped it or it went away on its own."""
+        if self._socket is not websocket:
+            return
+        reason = self._disconnect_reason or DISCONNECT_REASON_PEER
+        # A shutdown is not a relay failure: the deploy closed the socket on purpose and the relay is
+        # already reconnecting (close code 1012). Logging it at WARNING beside genuine drops would
+        # train everyone to ignore the warning that matters. Note that INFO is effectively dev-only
+        # here - uvicorn's default logging config configures only the `uvicorn*` loggers, so records
+        # from app modules reach an unconfigured root logger and render through logging.lastResort,
+        # which is WARNING-and-above - but a deploy is already visible in uvicorn's own shutdown lines.
+        level = logging.INFO if reason == DISCONNECT_REASON_SHUTDOWN else logging.WARNING
+        # The facts are repeated into the message rather than left to `extra` alone, for that same
+        # reason: lastResort renders "%(message)s" and drops every extra field, so anything not in the
+        # message is invisible in exactly the Railway logs this line exists to serve. `extra` is kept
+        # for whenever a structured handler is configured, matching how the rest of the backend logs.
+        logger.log(
+            level,
+            "relay disconnected: %s (install=%s company=%s build=%s held_seconds=%s pending_calls=%d)",
+            reason,
+            self._install_id,
+            self._company,
+            self._build,
+            self._held_seconds(),
+            len(self._pending),
+            extra={
+                "install_id": str(self._install_id) if self._install_id is not None else None,
+                "company": self._company,
+                "build": self._build,
+                "held_seconds": self._held_seconds(),
+                "reason": reason,
+                "pending_calls": len(self._pending),
+            },
+        )
+        self._socket = None
+        self._company = None
+        self._install_id = None
+        self._build = None
+        self._ops = None
+        self._unanswered_pings = 0
+        self._heartbeat_armed = False
+        self._registered_at = None
+        self._disconnect_reason = None
+        # The reason rides the error too: it lands on the failed GraphQL call and on any outbox row, so
+        # the person looking at "relay unavailable" in the UI sees the same cause as the log line.
+        self._fail_all(f"relay disconnected: {reason}")
+
+    def _held_seconds(self) -> float | None:
+        """How long the live socket has held the connection slot, None when nothing is registered.
+        Monotonic, so it survives a clock adjustment on the host (issue #384)."""
+        if self._registered_at is None:
+            return None
+        return round(time.monotonic() - self._registered_at, 1)
 
     def note_hello(self, build: object, ops: object) -> None:
         """Called by the route's read loop for the relay's one {"type": "hello", build, ops} frame,
@@ -150,7 +257,19 @@ class RelayGateway:
         (try_register -> close 4409) and failing every GP write for the duration."""
         self._unanswered_pings += 1
         limit = HEARTBEAT_MAX_MISSED if self._heartbeat_armed else HEARTBEAT_MAX_MISSED_UNARMED
-        return self._unanswered_pings >= limit
+        if self._unanswered_pings < limit:
+            return False
+        # Stamp the reason for the disconnect this return value is about to cause (issue #384). The
+        # heartbeat loop closes the socket on True, which ends the read loop and lands in the route's
+        # `finally` -> unregister, where nothing can tell a reap from the relay having dropped on its
+        # own. Recording it here is the only moment that knowledge exists. Counts come from the live
+        # constants so the line stays true if the limits are retuned.
+        self._disconnect_reason = (
+            f"reaped after {self._unanswered_pings} missed pings "
+            f"({'armed' if self._heartbeat_armed else 'unarmed'} limit {limit}, "
+            f"{HEARTBEAT_INTERVAL_SECONDS:g}s interval)"
+        )
+        return True
 
     async def close_for_shutdown(self) -> None:
         """Say goodbye to the relay before the process goes (#353 PR F).
@@ -165,6 +284,11 @@ class RelayGateway:
         socket = self._socket
         if socket is None:
             return
+        # Stamp before the goodbye, not after: the send/close below can wake the route's read loop and
+        # get it to unregister first, and either way this is the one path that knows the drop was ours
+        # and deliberate. Without the stamp a deploy reads in the logs exactly like a relay failure
+        # (issue #384).
+        self._disconnect_reason = DISCONNECT_REASON_SHUTDOWN
         try:
             await asyncio.wait_for(socket.send_json({"type": "going_away"}), timeout=_SHUTDOWN_TIMEOUT_SECONDS)
         except Exception:

--- a/backend/tests/test_relay_gateway.py
+++ b/backend/tests/test_relay_gateway.py
@@ -4,11 +4,18 @@ Plain `def test_...(): asyncio.run(...)` throughout (no pytest-asyncio dependenc
 no async test infra yet, and this keeps that decision out of scope for this slice."""
 
 import asyncio
+import logging
+import uuid
 
 import pytest
 
 from app.errors import RelayCallError, RelayOpUnsupportedError, RelayTimeoutError, RelayUnavailableError
-from app.services.relay_gateway import RelayGateway
+from app.services.relay_gateway import (
+    DISCONNECT_REASON_PEER,
+    DISCONNECT_REASON_SHUTDOWN,
+    HEARTBEAT_MAX_MISSED,
+    RelayGateway,
+)
 
 
 class FakeWebSocket:
@@ -367,8 +374,6 @@ def test_relay_call_maps_an_unknown_op_reply_to_op_unsupported():
 
 
 def test_try_register_records_the_install_backing_the_connection():
-    import uuid
-
     gateway = RelayGateway()
     assert gateway.install_id is None
     install_id = uuid.uuid4()
@@ -377,8 +382,6 @@ def test_try_register_records_the_install_backing_the_connection():
 
 
 def test_unregister_clears_the_install_id():
-    import uuid
-
     gateway = RelayGateway()
     ws = FakeWebSocket()
     gateway.try_register("TUBC", ws, uuid.uuid4())
@@ -393,3 +396,178 @@ def test_an_older_caller_that_omits_the_install_id_still_registers():
     gateway = RelayGateway()
     assert gateway.try_register("TUBC", FakeWebSocket()) is True
     assert gateway.install_id is None
+
+
+# --- disconnect diagnosability (#384) -----------------------------------------------------------------
+# The relay dropped for ~5 minutes on 2026-07-28 and reconnected on its own, and the logs could not say
+# when it went, why, or for how long it had been up: unregister wrote nothing, so a socket held open for
+# days produced exactly one log line (uvicorn's access log for the accept) for its entire lifetime.
+
+
+def _records(caplog, level: int) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.levelno == level and r.name == "app.services.relay_gateway"]
+
+
+def test_unregister_logs_the_disconnect_with_the_identity_and_how_long_it_was_held(caplog):
+    gateway = RelayGateway()
+    ws = FakeWebSocket()
+    install_id = uuid.uuid4()
+    gateway.try_register("TUBC", ws, install_id)
+    gateway.note_hello("relay-v0.1.0-build.30", ["list_vendors"])
+
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(ws)
+
+    warnings = _records(caplog, logging.WARNING)
+    assert len(warnings) == 1
+    record = warnings[0]
+    # Everything a disconnect has to be correlated against the relay's own logs must be IN THE MESSAGE,
+    # not only in `extra`: uvicorn configures no root handler, so app records render through
+    # logging.lastResort as the bare message and every extra field is dropped in production.
+    assert str(install_id) in record.getMessage()
+    assert "TUBC" in record.getMessage()
+    assert "relay-v0.1.0-build.30" in record.getMessage()
+    assert "held_seconds=" in record.getMessage()
+    assert record.install_id == str(install_id)
+    assert record.company == "TUBC"
+    assert record.build == "relay-v0.1.0-build.30"
+    assert record.held_seconds >= 0
+
+
+def test_a_plain_disconnect_is_reported_as_peer_initiated(caplog):
+    # Nothing on this side decided the disconnect, so the socket went away under us - a different
+    # failure with a different owner than a reap, and the distinction is unrecoverable after the fact.
+    gateway = RelayGateway()
+    ws = FakeWebSocket()
+    gateway.try_register("TUBC", ws)
+
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(ws)
+
+    record = _records(caplog, logging.WARNING)[0]
+    assert record.reason == DISCONNECT_REASON_PEER
+    assert DISCONNECT_REASON_PEER in record.getMessage()
+
+
+def test_a_heartbeat_reap_is_reported_as_a_reap_with_the_miss_count(caplog):
+    # register_ping_miss returning True is what makes main.py's heartbeat close the socket, which ends
+    # the read loop and lands in the route's finally -> unregister. That moment is the only one that
+    # knows we killed it, so the reason is stamped there and read back here.
+    gateway = RelayGateway()
+    ws = FakeWebSocket()
+    gateway.try_register("TUBC", ws)
+    gateway.note_pong()  # arm the reaper, so the tighter armed limit applies
+    while not gateway.register_ping_miss():
+        pass
+
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(ws)
+
+    record = _records(caplog, logging.WARNING)[0]
+    assert record.reason.startswith("reaped after")
+    assert f"{HEARTBEAT_MAX_MISSED} missed pings" in record.reason
+    assert "armed" in record.reason
+    assert record.reason in record.getMessage()
+
+
+def test_a_reaped_reason_does_not_leak_into_the_next_connection(caplog):
+    # try_register clears the stamp, so a relay that reconnects and later drops on its own is not
+    # blamed for the previous connection's reap.
+    gateway = RelayGateway()
+    first_ws = FakeWebSocket()
+    gateway.try_register("TUBC", first_ws)
+    while not gateway.register_ping_miss():
+        pass
+    gateway.unregister(first_ws)
+
+    second_ws = FakeWebSocket()
+    gateway.try_register("TUBC", second_ws)
+    caplog.clear()  # drop the first connection's disconnect line; only the second one is under test
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(second_ws)
+
+    assert _records(caplog, logging.WARNING)[0].reason == DISCONNECT_REASON_PEER
+
+
+def test_the_failed_pending_calls_carry_the_disconnect_reason():
+    # The reason rides the RelayUnavailableError too, so "relay unavailable" in the UI and in an outbox
+    # row names the same cause as the log line.
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        call_task = asyncio.create_task(gateway.relay_call("TUBC", "list_vendors", timeout=1))
+        while not ws.sent:
+            await asyncio.sleep(0)
+        while not gateway.register_ping_miss():
+            pass
+        gateway.unregister(ws)
+
+        with pytest.raises(RelayUnavailableError) as exc_info:
+            await call_task
+        assert "reaped after" in exc_info.value.message
+
+    asyncio.run(run())
+
+
+def test_unregistering_a_refused_socket_leaves_the_incumbent_alone(caplog):
+    # The 4409 path: a second relay is refused at try_register and torn down, sharing this gateway with
+    # the live one. unregister compares identity, so that teardown must not log the incumbent away,
+    # clear its company/install/build, or consume the reason stamped for its eventual disconnect.
+    gateway = RelayGateway()
+    live_ws = FakeWebSocket()
+    install_id = uuid.uuid4()
+    gateway.try_register("TUBC", live_ws, install_id)
+    gateway.note_hello("relay-v0.1.0-build.30", ["list_vendors"])
+    while not gateway.register_ping_miss():
+        pass
+
+    refused_ws = FakeWebSocket()
+    assert gateway.try_register("TUBC", refused_ws, uuid.uuid4()) is False
+    caplog.clear()  # the refusal logs a line of its own; what is under test is the teardown after it
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(refused_ws)
+
+    assert _records(caplog, logging.WARNING) == []  # nothing was disconnected
+    assert gateway.connected is True
+    assert gateway.company == "TUBC"
+    assert gateway.install_id == install_id
+    assert gateway.build == "relay-v0.1.0-build.30"
+
+    # ...and the incumbent's own disconnect still reports the reap it had already earned.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        gateway.unregister(live_ws)
+    assert _records(caplog, logging.WARNING)[0].reason.startswith("reaped after")
+
+
+def test_a_refused_connection_is_logged_against_the_incumbent(caplog):
+    # A refused reconnect is what a zombie incumbent looks like from outside - the real relay dialling
+    # back in every few seconds while a dead socket holds the slot - and it used to be silent.
+    gateway = RelayGateway()
+    gateway.try_register("TUBC", FakeWebSocket(), uuid.uuid4())
+
+    with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+        assert gateway.try_register("TUBC", FakeWebSocket()) is False
+
+    record = _records(caplog, logging.WARNING)[0]
+    assert "slot already held" in record.getMessage()
+    assert record.held_seconds >= 0
+
+
+def test_close_for_shutdown_does_not_log_the_relay_as_failed(caplog):
+    # A deploy closed the socket on purpose and the relay is already reconnecting (close code 1012).
+    # Logging that at WARNING beside genuine drops would train everyone to ignore the one that matters.
+    async def run():
+        gateway = RelayGateway()
+        ws = FakeWebSocket()
+        gateway.try_register("TUBC", ws)
+        with caplog.at_level(logging.INFO, logger="app.services.relay_gateway"):
+            await gateway.close_for_shutdown()
+
+        assert _records(caplog, logging.WARNING) == []
+        infos = _records(caplog, logging.INFO)
+        assert len(infos) == 1
+        assert infos[0].reason == DISCONNECT_REASON_SHUTDOWN
+
+    asyncio.run(run())

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -523,7 +523,25 @@ async def _run_channel(url: str, stop_event: asyncio.Event | None = None) -> Non
         try:
             await _run_once(url, secret, cfg)
             backoff = cfg.reconnect_min_seconds  # clean run - reset backoff before the next attempt
-            prev_category = None
+            # A clean return - the socket closed without raising - used to log NOTHING, so the only
+            # trace of the drop was the next "channel connected" line with no warning before it
+            # (issue #384). The 2026-07-28 outage reads in relay.log as a bare reconnect out of
+            # nowhere for exactly this reason, which is what made the drop undiagnosable from either
+            # end. Same shape as the classified failures below so the desktop UI and anyone grepping
+            # relay.log treat it like any other reconnect event.
+            #
+            # It goes through the same quiet_repeat demotion for the same #414 reason: a PR
+            # environment torn down when its PR closed can sit in config.toml closing cleanly in a
+            # loop, and that must not bury production's own reconnect events. The secret_rejected arm
+            # of the rule below cannot apply here, so the primary channel never demotes this one -
+            # a production channel that keeps closing cleanly is exactly what we want to see.
+            quiet_repeat = prev_category == "closed_clean" and not primary
+            logger.log(
+                logging.DEBUG if quiet_repeat else logging.WARNING,
+                "channel closed without an error; reconnecting",
+                extra={"category": "closed_clean", "url": url, "backoff": backoff},
+            )
+            prev_category = "closed_clean"
             _mark_disconnected(url)  # _run_once returned -> socket closed; reconnecting on the next loop
         except asyncio.CancelledError:
             raise

--- a/relay/src/ucnexus_relay/ui.py
+++ b/relay/src/ucnexus_relay/ui.py
@@ -147,15 +147,19 @@ def recent_log_events(config_path: str | Path | None = None, limit: int = 200) -
 
 def channel_state(config_path: str | Path | None = None) -> dict:
     """Infer the live channel state from the newest channel-related log event. The #204 fix tags a failed
-    connect with a `category` (secret_rejected / slot_busy / dropped); a success logs 'channel connected'.
+    connect with a `category` (secret_rejected / slot_busy / dropped); a clean socket close is tagged
+    closed_clean (#384); a success logs 'channel connected'.
     Returns state in {connected, secret_rejected, slot_busy, disconnected, unknown}."""
     for row in reversed(recent_log_events(config_path, limit=400)):
         msg = (row.get("message") or "").lower()
         cat = row.get("category")
         if "channel connected" in msg:
             return {"state": "connected", "at": row.get("time")}
-        if cat in ("secret_rejected", "slot_busy", "dropped"):
-            mapped = "disconnected" if cat == "dropped" else cat
+        # closed_clean has to be listed here, not left to fall through: it is a DISCONNECT, and an
+        # unrecognised category walks further back in the log to the "channel connected" that opened
+        # the socket which just closed - so the panel would report a dead channel as connected (#384).
+        if cat in ("secret_rejected", "slot_busy", "dropped", "closed_clean"):
+            mapped = cat if cat in ("secret_rejected", "slot_busy") else "disconnected"
             return {"state": mapped, "at": row.get("time"), "message": row.get("message")}
         if "channel connection dropped" in msg:  # pre-#204 relays logged this without a category
             return {"state": "disconnected", "at": row.get("time")}

--- a/relay/tests/test_channel_reconnect.py
+++ b/relay/tests/test_channel_reconnect.py
@@ -3,6 +3,9 @@
 every failure to a generic "retrying". Uses the real websockets exception types so an upgrade that
 renames the attributes the classifier reads is caught here."""
 
+import asyncio
+import functools
+import logging
 import time
 
 from websockets.datastructures import Headers
@@ -10,7 +13,9 @@ from websockets.exceptions import ConnectionClosedError, InvalidStatusCode
 from websockets.frames import Close
 
 from ucnexus_relay import channel
-from ucnexus_relay.config import PRODUCTION_BACKEND_URL
+from ucnexus_relay.config import PRODUCTION_BACKEND_URL, get_settings
+
+PR_URL = "wss://backend-uc-nexus-pr-384.up.railway.app/relay-link"
 
 
 def test_http_403_handshake_rejection_is_secret_rejected():
@@ -94,3 +99,81 @@ def test_a_generic_close_is_still_a_plain_drop():
     # The 1012 case must not swallow ordinary drops, which still deserve a growing backoff.
     exc = ConnectionClosedError(Close(1006, ""), None)
     assert channel._classify_connect_failure(exc)[0] == "dropped"
+
+
+# --- the clean-close blind spot (issue #384) ---------------------------------------------------------
+# Only an EXCEPTIONAL close reaches _classify_connect_failure. When _run_once returned normally - the
+# socket closed without raising - _run_channel reset its backoff and redialled in silence, so relay.log
+# showed a bare "channel connected" with no drop line before it. That is exactly what the 2026-07-28
+# outage looks like in the relay's own log, and it is why neither end could say when the channel went.
+
+
+def _use_fast_config(monkeypatch, tmp_path) -> None:
+    """Point channel.get_settings at a config with no reconnect delay, so a test can drive the retry
+    loop without sleeping through it.
+
+    lru_cache-wrapped rather than a bare lambda because _run_channel calls get_settings.cache_clear()
+    on every iteration - that is how a re-enrolment self-heals without a restart - and a stub without
+    it raises into the "could not re-read config.toml" branch, adding a warning per iteration."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[auth]\nshared_secret = "s3cret"\n\n[channel]\nreconnect_min_seconds = 0.0\nreconnect_max_seconds = 0.0\n',
+        encoding="utf-8",
+    )
+    get_settings.cache_clear()
+    monkeypatch.setattr(channel, "get_settings", functools.lru_cache(maxsize=1)(lambda: get_settings(str(cfg))))
+
+
+def _clean_closes(monkeypatch, tmp_path, url: str, times: int) -> None:
+    """Run the real _run_channel against a _run_once that returns normally `times` times, then stops."""
+    stop = asyncio.Event()
+    runs: list[str] = []
+
+    async def fake_run_once(u, secret, cfg):
+        runs.append(u)
+        if len(runs) >= times:
+            stop.set()
+
+    monkeypatch.setattr(channel, "_run_once", fake_run_once)
+    _use_fast_config(monkeypatch, tmp_path)
+    asyncio.run(channel._run_channel(url, stop))
+    assert len(runs) == times
+
+
+def _closed_clean_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if getattr(r, "category", None) == "closed_clean"]
+
+
+def test_a_clean_close_logs_a_reconnect_event(monkeypatch, tmp_path, caplog, clean_channel_states):
+    with caplog.at_level(logging.DEBUG):
+        _clean_closes(monkeypatch, tmp_path, PRODUCTION_BACKEND_URL, 1)
+
+    records = _closed_clean_records(caplog)
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    assert records[0].message == "channel closed without an error; reconnecting"
+    assert records[0].url == PRODUCTION_BACKEND_URL
+    assert records[0].backoff == 0.0  # a clean run still resets the backoff before redialling
+    assert channel._STATES[PRODUCTION_BACKEND_URL]["state"] == "disconnected"
+
+
+def test_repeated_clean_closes_on_a_test_channel_are_demoted(monkeypatch, tmp_path, caplog, clean_channel_states):
+    # #414: a PR environment is torn down when its PR closes and its URL then sits in config.toml
+    # failing forever. Its noise must not bury production's own reconnect events, so the second and
+    # later repeats of the same category drop to DEBUG - the same rule the classified failures use.
+    with caplog.at_level(logging.DEBUG):
+        _clean_closes(monkeypatch, tmp_path, PR_URL, 3)
+
+    levels = [r.levelno for r in _closed_clean_records(caplog)]
+    assert levels == [logging.WARNING, logging.DEBUG, logging.DEBUG]
+
+
+def test_repeated_clean_closes_on_the_production_channel_stay_loud(monkeypatch, tmp_path, caplog, clean_channel_states):
+    # The primary channel demotes only secret_rejected, which cannot self-heal until someone re-enrols.
+    # A production channel that keeps closing cleanly is a real, distinct event every time - and the
+    # exact symptom issue #384 was opened about, so it must never be quietened.
+    with caplog.at_level(logging.DEBUG):
+        _clean_closes(monkeypatch, tmp_path, PRODUCTION_BACKEND_URL, 3)
+
+    levels = [r.levelno for r in _closed_clean_records(caplog)]
+    assert levels == [logging.WARNING, logging.WARNING, logging.WARNING]

--- a/relay/tests/test_ui.py
+++ b/relay/tests/test_ui.py
@@ -116,6 +116,24 @@ def test_channel_state_secret_rejected(tmp_path):
     assert ui.channel_state(p)["state"] == "secret_rejected"
 
 
+def test_channel_state_clean_close_reads_as_disconnected(tmp_path):
+    # issue #384: a socket that closed without raising is tagged closed_clean. An unrecognised category
+    # walks further back in the log and finds the 'channel connected' that OPENED the socket which just
+    # closed, so the panel would report a dead channel as connected.
+    p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
+    _log(
+        tmp_path,
+        {"asctime": "t1", "levelname": "INFO", "message": "channel connected"},
+        {
+            "asctime": "t2",
+            "levelname": "WARNING",
+            "message": "channel closed without an error; reconnecting",
+            "category": "closed_clean",
+        },
+    )
+    assert ui.channel_state(p)["state"] == "disconnected"
+
+
 def test_channel_state_unknown_without_log(tmp_path):
     p = _cfg(tmp_path, '[logging]\nfile = "relay.log"\n')
     assert ui.channel_state(p)["state"] == "unknown"


### PR DESCRIPTION
Closes #384.

the 2026-07-28 drop was undiagnosable from either end: RelayGateway.unregister logged nothing, and relay.log showed only bare "channel connected" lines with no drop before them. both silences fixed.

backend (relay_gateway.py)
- unregister logs the disconnect: reason, install id, company, build tag (from the hello frame), held_seconds (monotonic, stamped at try_register), pending in-flight calls. WARNING for real drops, INFO for shutdown.
- reap vs peer close distinguished. whichever path decides the disconnect stamps the reason first: register_ping_miss stamps "reaped after N missed pings (armed limit M, 20s interval)" at the moment it returns True; close_for_shutdown stamps before the goodbye frame so a deploy does not read like a relay failure; no stamp = "peer closed or socket dropped".
- the identity check in unregister is load-bearing: a 4409-refused second socket must not clear the incumbent's state, consume its stamped reason, or log the live connection away.
- a refused reconnect (try_register, 4409 path) now logs the holder + refused identities and how long the holder has held the slot - a zombie incumbent turning away the real relay was equally silent before.
- the reason also rides the RelayUnavailableError that fails in-flight calls, so the UI/outbox names the same cause as the log.
- facts are repeated into the message string, not left to extra: uvicorn's default config leaves app loggers to logging.lastResort, which renders %(message)s at WARNING+ and drops every extra field - anything not in the message is invisible in exactly the Railway logs this exists for. extra kept for a future structured handler.

relay (channel.py, ui.py)
- root cause of the "bare channel connected" pattern: _run_channel's clean-return path (socket closed without raising) logged NOTHING before redialling. it now logs "channel closed without an error; reconnecting" with category closed_clean, through the same quiet_repeat demotion as classified failures (#414: a torn-down PR env closing cleanly in a loop must not bury production's events; the primary channel never demotes this line).
- ui.py channel_state handles closed_clean -> disconnected. unhandled it would walk back to the "channel connected" that opened the just-closed socket and show a dead channel as connected.

deliberately NOT done: surfacing last-disconnect on relayInstalls (issue item 3). keeps the handshake path free of DB writes; the logs now carry everything, revisit if occurrences continue.

tests: +8 backend (test_relay_gateway.py) incl. reason correctness, no-leak across reconnects, refused-socket isolation, shutdown not WARNING; +3 relay reconnect (clean-return logging, non-primary demotes, primary never demotes), +1 ui (closed_clean reads disconnected).

backend: ruff clean, 515 passed / 513 skipped (DB tests are CI-only). relay: ruff clean, 353 passed.