### PR TITLE
fix(relay): seeding log tells the truth, inheritance timing documented, branch builds for op PRs (#431)

### DIFF
--- a/.github/workflows/relay-release.yml
+++ b/.github/workflows/relay-release.yml
@@ -5,6 +5,12 @@ name: Relay Release
 # - push a tag like `relay-v0.1.0`               -> builds + attaches the zip to that GitHub Release
 # - run manually (workflow_dispatch)             -> builds + uploads the zip as a workflow artifact
 # path filters are not applied to tag pushes, so a `relay-v*` tag always builds regardless of what it touched.
+# workflow_dispatch works on any branch in this repo (`gh workflow run relay-release.yml --ref <branch>`) and
+# publishes nothing - that is how a PR adding an op to `_OPS` gets a build the workstation can serve it from
+# (#431). A branch build is stamped `relay-v<ver>-branch.<branch>.<sha>`, deliberately WITHOUT a `build.<N>`
+# number, so the updater reads it as older than every release and restores the published build on its own
+# instead of leaving a workstation on an unpublished build that looks like a release. See relay/README.md.
+# path filters do not apply to a dispatch either, so a PR that only touches backend/ still builds.
 # Onedir (not onefile) so the C-extension .pyd are permanent files, not re-extracted to %TEMP% on every
 # launch - that per-launch extraction collides with Windows Defender on a fresh self-update and crashes the
 # relaunched relay. DPAPI happens on the workstation at enroll time, so the CI build carries no secret -
@@ -45,15 +51,28 @@ jobs:
         # Write the release tag into _build.py so the packaged exe knows its own version, which the UI's
         # updater compares against the latest GitHub release. Matches the tag the publish steps below use
         # (github.ref_name for a tag push, relay-v<version>-build.<run_number> for a master push).
+        #
+        # A dispatch on a branch other than master is the PR-testing build (#431) and is stamped
+        # `relay-v<version>-branch.<slug>.<sha7>` instead. Two reasons the shape matters:
+        #  - it carries no `build.<N>`, so updater.build_number reads -1 and every published release
+        #    counts as newer. A `build.<run_number>` stamp would be HIGHER than the latest release (run
+        #    numbers only climb), so the workstation would sit on an unpublished branch build forever
+        #    while Admin -> Relay Installs showed something that looks exactly like a release.
+        #  - the branch and sha are visible in the reported build tag and in the artifact name, so two
+        #    branch builds cannot be mistaken for each other.
         shell: bash
         run: |
+          version=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             build="${{ github.ref_name }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref_name }}" != "master" ]]; then
+            slug=$(printf '%s' "${{ github.ref_name }}" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-40)
+            build="relay-v${version}-branch.${slug}.${GITHUB_SHA:0:7}"
           else
-            version=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
             build="relay-v${version}-build.${{ github.run_number }}"
           fi
           echo "BUILD = \"$build\"" > src/ucnexus_relay/_build.py
+          echo "BUILD_TAG=$build" >> "$GITHUB_ENV"
           echo "stamped $build -> src/ucnexus_relay/_build.py"
 
       - name: Build exe
@@ -78,10 +97,13 @@ jobs:
         shell: pwsh
 
       - name: Upload artifact (manual runs)
+        # Named after the stamped build, so a zip downloaded from an old run cannot be confused with the
+        # one from the branch under test (#431). Nothing is published here - a dispatch never cuts a
+        # Release, so a PR-branch build reaches only whoever downloads it deliberately.
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: ucnexus-relay-zip
+          name: ucnexus-relay-zip-${{ env.BUILD_TAG }}
           path: "relay/dist/ucnexus-relay.zip"
 
       - name: Publish to Release (tag pushes)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,8 +10,10 @@ CLERK_SECRET_KEY=sk_test_replace_me
 
 # SHA-256 hex of the workstation relay's Bearer secret, copied from Admin -> Relay Installs
 # ("Seed hash" on the enrolled row). Lets a non-production backend accept that relay without a
-# provision + enroll cycle (#414). Set it on the Railway environment PR deploys are cloned from,
-# NEVER on production - the backend refuses to seed there anyway. Blank disables seeding.
+# provision + enroll cycle (#414). On Railway it belongs on PRODUCTION, sitting there inert: a PR
+# environment is cloned from production and inherits it, and the backend refuses to seed in production
+# (#431). That inheritance is taken at environment creation, so a PR environment that already existed
+# needs the variable set on its own backend service as well. Blank disables seeding.
 RELAY_SEED_SECRET_HASH=
 
 # Railway S3-compatible bucket (optional locally). Leave blank to skip; document-upload

--- a/backend/app/services/relay_seed.py
+++ b/backend/app/services/relay_seed.py
@@ -15,13 +15,18 @@ existing workstation relay authenticate there with the secret it already holds -
 new credential, and nothing replayable stored in Railway (a digest cannot be presented as a Bearer
 token; only its preimage can, and that never leaves the workstation).
 
-Two guards keep this out of production. Railway PR environments duplicate the base environment's
-variables, so `RELAY_SEED_SECRET_HASH` will be visible in production too - `seed_from_env` refuses
-outright when `RAILWAY_ENVIRONMENT_NAME` says production, rather than trusting the variable to be
-absent. And the seeded install is pinned to `TUBC`: the relay's own `allowed_companies` guardrail
-already blocks production GP companies, and `relay_gateway.relay_call` refuses any company that does
-not match the registered install's, so a PR backend cannot reach past the sandbox even if someone
-sets the variable somewhere unexpected.
+Two guards keep this out of production, and the variable is SUPPOSED to be set there (#431). Railway
+clones a new PR environment from production directly - there is no separate base environment - so
+production is the only place `RELAY_SEED_SECRET_HASH` can sit for a PR environment to inherit it at
+all. It is inert there: `seed_from_env` refuses outright when `RAILWAY_ENVIRONMENT_NAME` says
+production, rather than trusting the variable to be absent, and set-but-ignored on production is the
+intended steady state, not a misconfiguration to clean up. (That inheritance is taken at environment
+creation and never refreshed, so a PR environment that already existed when the variable was set on
+production needs it set on that environment's own backend service too.) And the seeded install is
+pinned to `TUBC`: the relay's own `allowed_companies` guardrail already blocks production GP
+companies, and `relay_gateway.relay_call` refuses any company that does not match the registered
+install's, so a PR backend cannot reach past the sandbox even if someone sets the variable somewhere
+unexpected.
 """
 
 import logging
@@ -89,10 +94,14 @@ def seed_from_env(session: Session, *, environment_name: str, secret_hash: str) 
         return None
 
     if _is_production(environment_name):
-        logger.error(
-            "RELAY_SEED_SECRET_HASH is set in the production environment and was IGNORED. Railway "
-            "duplicates variables into PR environments, so this belongs only on the environment PR "
-            "deploys are cloned from - remove it from production.",
+        # INFO, not ERROR (#431): this is the intended steady state, not an operator mistake. Railway
+        # clones a PR environment from production, so the variable has to live here for a new PR
+        # environment to inherit it - an ERROR line invites someone to "fix" production by deleting it,
+        # which silently breaks every PR environment created afterwards.
+        logger.info(
+            "RELAY_SEED_SECRET_HASH is set here and seeding was skipped, which is correct: seeding never "
+            "runs in production. Leave the variable in place - Railway clones a new PR environment from "
+            "production, so this is where a PR environment inherits it from.",
         )
         return None
 

--- a/backend/tests/test_relay_seed.py
+++ b/backend/tests/test_relay_seed.py
@@ -8,6 +8,7 @@ The tests that matter most are the refusals: this writes a working credential in
 only things keeping that acceptable are the production kill-switch and the sandbox company pin.
 """
 
+import logging
 import uuid
 from datetime import datetime
 
@@ -23,10 +24,22 @@ HASH = hash_secret(SECRET)
 
 
 def test_production_is_refused_outright(db_session):
-    # Railway duplicates variables into PR environments, so this WILL be visible in production. The
-    # guard is the reason that is survivable - it must not depend on the variable being absent.
+    # Railway clones a PR environment from production, so the variable is SET in production by design
+    # (#431) and will always be visible here. The guard is the reason that is survivable - it must not
+    # depend on the variable being absent.
     assert relay_seed.seed_from_env(db_session, environment_name="production", secret_hash=HASH) is None
     assert db_session.query(RelayInstall).filter(RelayInstall.secret_hash == HASH).count() == 0
+
+
+def test_the_production_refusal_reads_as_expected_not_as_a_misconfiguration(db_session, caplog):
+    # #431: the original message logged at ERROR and told the operator to remove the variable from
+    # production. Following it breaks every PR environment created afterwards, because production is
+    # the only place a new one can inherit the variable from.
+    with caplog.at_level(logging.INFO, logger=relay_seed.__name__):
+        assert relay_seed.seed_from_env(db_session, environment_name="production", secret_hash=HASH) is None
+    record = next(r for r in caplog.records if "RELAY_SEED_SECRET_HASH" in r.getMessage())
+    assert record.levelno == logging.INFO
+    assert "remove" not in record.getMessage().lower()
 
 
 @pytest.mark.parametrize("name", ["Production", "  PRODUCTION  "])

--- a/relay/README.md
+++ b/relay/README.md
@@ -134,6 +134,16 @@ ASK for; `ops.check_company_allowed` still decides what this workstation will se
 `[gp] allowed_companies` from config.toml. a workstation set up only for production companies refuses
 every PR-environment job with `company_not_allowed`. nothing checks the two lists intersect at startup.
 
+**the backend side of this - `RELAY_SEED_SECRET_HASH` - lives on the PRODUCTION backend service, and a
+PR environment inherits it only at creation (#431).** Railway clones a new PR environment from
+production, so production is the only place the variable can sit for a PR environment to get it at all;
+the production backend refuses to seed and logs that refusal, which is the intended steady state rather
+than something to clean up. the copy is taken when the environment is created and is never refreshed
+afterwards, so setting it on production does NOT reach a PR environment that already exists - set it on
+that environment's own backend service as well (verified 2026-07-30: pr-430 predated the variable and
+could not read GP until it had its own copy). seeding runs at backend startup, so either way the change
+lands on that service's next deploy.
+
 the URL list is read once at `serve` start, so adding or removing a test backend needs a relay restart
 (the app's Restart Relay button). the enrolled secret is still re-read on every reconnect, unchanged,
 and a config.toml that fails to parse mid-edit no longer kills the channel - it retries with the last
@@ -143,3 +153,37 @@ otherwise (quietly: a non-production channel logs a repeated failure once, then 
 
 the ops newer than `create_po` / `create_receipt` are channel-only - they have no HTTP route, because
 the browser hop is no longer the live path.
+
+testing a PR that adds a new op (#431)
+
+`extra_backend_urls` above gets a PR environment served by the relay already installed on the
+workstation, but that relay is the published release build: an op the PR adds to `_OPS` does not exist
+in it, so the backend refuses the call off the advertised op-set with `RELAY_OP_UNSUPPORTED` before it
+is even sent (#315). testing that op end to end needs a relay built from the PR's branch, installed on
+the workstation for the length of the session. the install step is manual on purpose - nothing reaches
+the workstation remotely.
+
+1. **build it**: `gh workflow run relay-release.yml --ref <branch>`. any branch in this repo works (a
+   fork's branch cannot be dispatched; the workflow definition used is the one on that branch). the run
+   builds the same onedir bundle and uploads it as a workflow artifact - a dispatch publishes NO
+   Release, so no other workstation ever sees it.
+2. **download it**: `gh run download <run-id>`. the artifact is named
+   `ucnexus-relay-zip-relay-v<version>-branch.<branch>.<sha>`, so two branch builds cannot be swapped by
+   accident.
+3. **install it over the release build**: quit the relay app first (X on the window, then confirm - the
+   installer deletes the app folder the running exe holds open), then `install\install-relay-user.ps1
+   -ZipPath <the zip> -StartNow` (or `install-relay.ps1` on an admin/scheduled-task install). it
+   re-extracts the bundle, repoints the `current` junction, and leaves `config.toml` and the enrolled
+   DPAPI secret alone, so no re-enrollment is involved. Admin -> Relay Installs reports the live build
+   tag - confirm it reads `relay-v<version>-branch.<branch>.<sha>` before testing anything.
+4. **restore the release build** when the session is done: re-run the same installer with
+   `ucnexus-relay.zip` from the latest `relay-v*` GitHub Release, or press Update now on the app's
+   Updates tab. a branch build is stamped without a `build.<N>` number, so every release counts as newer
+   than it and the update is offered rather than refused as a downgrade.
+
+that last point cuts both ways, deliberately: the app's auto-update poller reads the branch build as
+behind too, so it will pull the workstation back to the latest release on its own - first check 10-15
+minutes after the app starts, daily after that. a branch build therefore cannot quietly become the
+fleet's permanent build, but a long session can have the build swapped underneath it. if a run suddenly
+starts answering `RELAY_OP_UNSUPPORTED` again, check the build tag before anything else and re-install
+the branch zip.

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -19,7 +19,7 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
 > practice. If you are reading a stale copy of that guidance somewhere else - the global
 > `~/.claude/CLAUDE.md` said the same thing - this block supersedes it.
 
-- **Railway PR environments (the testing target)** (ENABLED 2026-07-29, `prDeploys` on the project; bot PRs like dependabot deliberately excluded): every non-draft PR gets a full ephemeral replica (frontend + backend + fresh empty Postgres, migrated on boot) named `uc-nexus-pr-<N>`. Do not wait for a Railway bot comment - none was observed; the URLs are derivable: `https://backend-uc-nexus-pr-<N>.up.railway.app` / `https://frontend-uc-nexus-pr-<N>.up.railway.app`. Substitute them into the sign-in flow below; verified live on PR #401 (`/health` 200, `/testing/clerk-sign-in` mints tokens, GraphQL serves the fresh DB). Data starts empty; seed via the import fixture. No PR open for what you need to test? Open a throwaway one - that is cheaper than the alternative. `VITE_GRAPHQL_URL` is a reference variable (`https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/graphql`) so each environment self-wires; `TESTING_ENABLED` and Clerk keys inherit from production. **A PR that only touches one service's directory only deploys that service in its environment** (root-directory change filtering - PR #401 was backend-only and the frontend showed `latestDeployment: null`); trigger the missing one from the dashboard or via the API (`serviceInstanceDeployV2(environmentId, serviceId)`). Environments auto-delete when the PR closes.
+- **Railway PR environments (the testing target)** (ENABLED 2026-07-29, `prDeploys` on the project; bot PRs like dependabot deliberately excluded): every non-draft PR gets a full ephemeral replica (frontend + backend + fresh empty Postgres, migrated on boot) named `uc-nexus-pr-<N>`. Do not wait for a Railway bot comment - none was observed; the URLs are derivable: `https://backend-uc-nexus-pr-<N>.up.railway.app` / `https://frontend-uc-nexus-pr-<N>.up.railway.app`. Substitute them into the sign-in flow below; verified live on PR #401 (`/health` 200, `/testing/clerk-sign-in` mints tokens, GraphQL serves the fresh DB). Data starts empty; seed via the import fixture. No PR open for what you need to test? Open a throwaway one - that is cheaper than the alternative. `VITE_GRAPHQL_URL` is a reference variable (`https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/graphql`) so each environment self-wires; `TESTING_ENABLED` and Clerk keys inherit from production. **That inheritance is a copy taken when the environment is created, not a live link** (#431): a variable added to production afterwards never reaches a PR environment that already exists, so set it on that environment's own backend service too and let it redeploy. Found the hard way with `RELAY_SEED_SECRET_HASH` on pr-430 - see the relay section below. **A PR that only touches one service's directory only deploys that service in its environment** (root-directory change filtering - PR #401 was backend-only and the frontend showed `latestDeployment: null`); trigger the missing one from the dashboard or via the API (`serviceInstanceDeployV2(environmentId, serviceId)`). Environments auto-delete when the PR closes.
 - **Local (manual fallback)**: frontend `http://localhost:5173`, backend `http://localhost:8000`. Run the backend with `poetry run uvicorn main:app --reload` (from `backend/`) and the frontend with `npm run dev` (from `frontend/`). Needs a local Postgres (not provided; the worktree-localdev adoption was dropped).
 - **Auth**: Clerk sign-in, automated via one-time sign-in tokens (no manual password/verification needed).
   - Backend endpoint `GET /testing/clerk-sign-in` generates the token (requires `TESTING_ENABLED=true`).
@@ -70,8 +70,15 @@ changes it. Two independent reasons, both addressed by #414 but neither automati
 2. Relay installs live in Postgres and a PR environment boots a fresh empty one, so the handshake is
    refused (4403) even if the relay does dial. Since #414 the backend seeds a trusted install on
    startup from `RELAY_SEED_SECRET_HASH` - the SHA-256 already in production's row, copyable from
-   Admin -> Relay Installs ("Seed hash" column). That variable has to be set on the environment PR
-   deploys are cloned from; it is deliberately refused in production.
+   Admin -> Relay Installs ("Seed hash" column). Where that variable goes is the part that catches
+   people out (#431):
+   - It belongs on the **production** backend service and stays there inert. PR environments are cloned
+     from production, so that is the only place a new one can inherit it from; production refuses to
+     seed and logs the refusal at INFO, which is the intended steady state, not something to tidy up.
+   - **Inheritance happens at environment creation only.** Setting it on production does nothing for a
+     PR environment that already exists - set it on that environment's own backend service as well.
+     Verified 2026-07-30: pr-430 predated the variable and stayed GP-blind until it had its own copy.
+   - Seeding runs at backend startup, so the variable only takes effect on that service's next deploy.
 
 Read the default state as a free test fixture rather than a limitation. The relay-down half of any
 GP-gated feature - disabled controls, "not connected" copy, held values still displaying, buttons that
@@ -82,10 +89,13 @@ A PR environment with a connected relay is pinned to **TUBC** and refuses every 
 `company_not_allowed_on_channel`, reads and writes alike. Reads and writes both work against TUBC;
 that pin is what makes serving writes off a test backend acceptable at all.
 
-What a PR environment still cannot show is a NEW op. The workstation runs a packaged build, so a PR
-that adds to `_OPS` answers `unknown_op` -> `RELAY_OP_UNSUPPORTED` there just as it does on production
-before the relay is rebuilt (its own distinct UI state, worth checking on purpose during the
-deploy-before-rebuild window).
+What a PR environment cannot show out of the box is a NEW op. The workstation runs a packaged build, so
+a PR that adds to `_OPS` answers `unknown_op` -> `RELAY_OP_UNSUPPORTED` there just as it does on
+production before the relay is rebuilt (its own distinct UI state, worth checking on purpose during the
+deploy-before-rebuild window). To exercise the op itself, build the PR's branch with
+`gh workflow run relay-release.yml --ref <branch>` and install that zip on the workstation for the
+session - the full procedure, including how the release build gets restored afterwards, is the
+"testing a PR that adds a new op" section of `relay/README.md`. It is a manual install by design.
 
 Verified on PR #412 (issue #409's buyer dropdown), in the default disconnected state: the field
 rendered `role="combobox"`, disabled, still showing the stored `mira`, with "The GP relay is not


### PR DESCRIPTION
Closes #431. three follow-ups from #414's live verification.

1) production refusal message rewritten - the old text told the operator to remove RELAY_SEED_SECRET_HASH from production, which is exactly backwards: Railway clones PR environments from production directly (no base environment), so production is the only place the variable can sit for a new PR environment to inherit it. new message says set-but-ignored is the intended steady state. severity dropped ERROR -> INFO: an ERROR invites someone to "fix" production by deleting the variable, silently breaking every PR environment created afterwards. module docstring + .env.example ("NEVER on production") corrected to match. new test locks INFO level and that the message does not contain "remove".

2) creation-time-only inheritance documented in relay/README.md (multi-backend section) and testing/CLAUDE.md (PR-environment bullets): the variable copy is taken when the environment is created, never refreshed - a pre-existing PR environment needs it set on its own backend service (verified on pr-430).

3) branch builds for PRs that add a relay op. nothing blocked workflow_dispatch on a branch; two real problems fixed in relay-release.yml:
- artifact name was the constant ucnexus-relay-zip; now ucnexus-relay-zip-<build tag>
- a dispatch stamped relay-v<ver>-build.<run_number>, and run numbers only climb - so a branch build would read as NEWER than every release, the updater would report already-latest, and the workstation would sit on an unpublished build indistinguishable from a release. non-master dispatches now stamp relay-v<ver>-branch.<slug>.<sha7>, no build.<N>, so build_number reads -1, every release counts as newer, and the update poller restores the published build on its own. slug regex checked against the adversarial branch name chore/build.9 (sha suffix protects the anchor).

procedure documented in relay/README.md ("testing a PR that adds a new op"): dispatch on the branch, gh run download, quit the app, install-relay-user.ps1 -ZipPath <zip> -StartNow (keeps config.toml + DPAPI secret, no re-enrollment), verify build tag on Admin -> Relay Installs, restore via latest release zip or Update now.

verified end-to-end: dispatched run 30524362930 on this branch - green in ~1.5 min, stamped relay-v0.1.0-branch.fix-431-relay-seed-followups.af74f60, artifact named to match, both publish steps skipped, no Release cut.

known tradeoff, documented: the update poller pulls the workstation back to the latest release on its own schedule (first check 10-15 min after app start, daily after), so a long test session can have the branch build swapped underneath it - re-run the installer with the zip and carry on. a pause-updates switch would be a bigger change, deliberately not built.

backend ruff clean; test_relay_seed 2 passed / 20 skipped locally (DB tests are CI-only). workflow yaml parses and ran green on GitHub.