### PR TITLE
fix(security): take the audit actor from the auth gate, scope buyerAssignments to the caller (#427, #428)

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -33,6 +33,13 @@ _CLERK_JWKS_URL = "https://api.clerk.com/v1/jwks"
 _JWKS_TTL_SECONDS = 3600.0
 _jwks_cache: dict[str, Any] = {"data": None, "fetched_at": 0.0}
 
+# Display names are looked up per audit-writing mutation since #427, which put a Clerk round-trip on
+# hot write paths that never had one - savePickDraft fires on every keystroke batch of a pick sheet.
+# A name only changes through `updateUserName` (an admin action, which invalidates this), so a short
+# TTL costs nothing in accuracy and keeps the picker's save at one Postgres transaction.
+_DISPLAY_NAME_TTL_SECONDS = 300.0
+_display_name_cache: dict[str, tuple[float, str]] = {}
+
 
 class AuthError(AppError):
     def __init__(self, message: str = "Authentication required"):
@@ -133,10 +140,28 @@ def require_user(info) -> dict:
 def resolve_display_name(user_id: str) -> str:
     """Full name (falling back to email, then the Clerk user id) for the acting user - issue #199's
     server-side received_by, so a receive records the Clerk-authenticated caller, not the relay's
-    Windows account. Mirrors the frontend's useIdentity() fullName-or-email convention."""
+    Windows account. Mirrors the frontend's useIdentity() fullName-or-email convention.
+
+    Issue #427 made this the source of EVERY actor stamped on an audit or history row, not just a
+    receive's. Before that each mutation took the name from its own arguments, so a signed-in user
+    could attribute their action to anyone: `completePullRequest(id, completedBy: "Someone Else")`
+    put that name on every opening the pull staged. The client no longer gets a say - the name comes
+    from the same Clerk token the gate already verified."""
+    cached = _display_name_cache.get(user_id)
+    now = time.monotonic()
+    if cached is not None and (now - cached[0]) < _DISPLAY_NAME_TTL_SECONDS:
+        return cached[1]
     profile = user_repository.get_user(user_id)
     full_name = f"{profile['first_name']} {profile['last_name']}".strip()
-    return full_name or profile["email"] or user_id
+    name = full_name or profile["email"] or user_id
+    _display_name_cache[user_id] = (now, name)
+    return name
+
+
+def invalidate_display_name(user_id: str) -> None:
+    """Drop a cached display name so a rename shows up on the next audit row instead of up to
+    `_DISPLAY_NAME_TTL_SECONDS` later. Called by `updateUserName`, the only thing that changes one."""
+    _display_name_cache.pop(user_id, None)
 
 
 def require_admin_request(request) -> dict:

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -78,10 +78,12 @@ type Query {
 type Mutation {
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
-  # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
-  # display name. Accept mints the warehouse PullRequest; the warehouse approve handles shortfalls.
-  acceptShippingOutRequest(id: ID!, acceptedBy: String!): ShippingOutRequest!
-  rejectShippingOutRequest(id: ID!, rejectedBy: String!, reason: String): ShippingOutRequest!
+  # Accept gate (#293). Any signed-in user (require_user). Accept mints the warehouse PullRequest;
+  # the warehouse approve handles shortfalls. The approval is recorded against the
+  # Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED, kept only so
+  # a frontend from the previous deploy still validates.
+  acceptShippingOutRequest(id: ID!, acceptedBy: String @deprecated(reason: "ignored; actor is the caller")): ShippingOutRequest!
+  rejectShippingOutRequest(id: ID!, rejectedBy: String @deprecated(reason: "ignored; actor is the caller"), reason: String): ShippingOutRequest!
   # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
   # PullRequest. Refused if the warehouse has already worked the pull.
   reopenShippingOutRequest(id: ID!): ShippingOutRequest!

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -315,12 +315,13 @@ type Mutation {
   # VALIDATION_ERROR if more than has arrived; INVALID_STATE_TRANSITION if the leaf is still on the
   # bench (record it as progress instead) or has already shipped (that is reallocation's problem).
   installReplacement(input: InstallReplacementInput!): OpeningItem!
-  # Accept gate (#293). Any signed-in user (require_user). acceptedBy/rejectedBy is the caller's
-  # display name. Accept mints the warehouse PullRequest and is a **pure human gate** since #342: the
-  # hardware was reserved when the request was created, so nothing is re-checked here. Reject is what
-  # releases that reservation.
-  acceptShopAssemblyRequest(id: ID!, acceptedBy: String!): ShopAssemblyRequest!
-  rejectShopAssemblyRequest(id: ID!, rejectedBy: String!, reason: String): ShopAssemblyRequest!
+  # Accept gate (#293). Any signed-in user (require_user). Accept mints the warehouse PullRequest and
+  # is a **pure human gate** since #342: the hardware was reserved when the request was created, so
+  # nothing is re-checked here. Reject is what releases that reservation. The approval is recorded
+  # against the Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED,
+  # kept only so a frontend from the previous deploy still validates.
+  acceptShopAssemblyRequest(id: ID!, acceptedBy: String @deprecated(reason: "ignored; actor is the caller")): ShopAssemblyRequest!
+  rejectShopAssemblyRequest(id: ID!, rejectedBy: String @deprecated(reason: "ignored; actor is the caller"), reason: String): ShopAssemblyRequest!
   # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
   # PullRequest and re-points the openings off it. Refused if the warehouse has already worked the pull.
   reopenShopAssemblyRequest(id: ID!): ShopAssemblyRequest!

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -548,24 +548,29 @@ type Query {
 
 type Mutation {
   createReceive(input: CreateReceiveInput!): ReceiveRecord!
+  # Issue #427: the actor on every audit and history row is the Clerk-authenticated caller
+  # (require_user -> resolve_display_name), never an argument. The startedBy / enteredBy / pickedBy /
+  # fetchedBy / completedBy arguments below are accepted and IGNORED, and are nullable so they can
+  # carry @deprecated; they exist only so a frontend from the previous deploy still validates, and
+  # are dropped once none reference them.
   # Claim a pending pull and open it for picking (#367). Nothing moves in inventory - this is what
-  # approvePullRequest was, minus everything that touched stock.
-  startPullRequestPick(id: ID!, startedBy: String!): PullRequest!
+  # approvePullRequest was, minus everything that touched stock. The pull is assigned to the caller.
+  startPullRequestPick(id: ID!, startedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequest!
   # Save the half-keyed pick sheet (#367). Replace-all, not merge: the paper is the authority.
   # Shape is validated, availability deliberately is not - a draft is a note, not a claim.
-  savePickDraft(pullRequestId: ID!, lines: [PickLineInput!]!, enteredBy: String!): PickSheet!
+  savePickDraft(pullRequestId: ID!, lines: [PickLineInput!]!, enteredBy: String @deprecated(reason: "ignored; actor is the caller")): PickSheet!
   # Deduct exactly the rows the picker dictated and consume the claim behind them (#367). Three hard
   # ceilings: the row's available units, what the pull asked for, and what is free once other
   # requests' reservations are counted (CONFLICT when that one is hit, so #342 holds). A
   # confirmation that does not cover everything returns SHORT and is resumable.
-  confirmPick(pullRequestId: ID!, lines: [PickLineInput!]!, pickedBy: String!): ConfirmPickResult!
+  confirmPick(pullRequestId: ID!, lines: [PickLineInput!]!, pickedBy: String @deprecated(reason: "ignored; actor is the caller")): ConfirmPickResult!
   # Tick (or untick) one assembled leaf off a shipping pull's fetch list (#367). Nothing moves in
   # inventory - the leaf's hardware left it at assembly.
-  setPullItemFetched(itemId: ID!, fetched: Boolean!, fetchedBy: String!): PullRequestItem!
+  setPullItemFetched(itemId: ID!, fetched: Boolean!, fetchedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequestItem!
   # Close the whole pull. Since #343 this reads as "stage everything still outstanding and finish":
-  # any opening not yet confirmed individually is flipped to PULLED and stamped with completedBy.
+  # any opening not yet confirmed individually is flipped to PULLED and stamped with the caller.
   # Refused until the pick is confirmed (#367).
-  completePullRequest(id: ID!, completedBy: String): PullRequest!
+  completePullRequest(id: ID!, completedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequest!
   # Confirm that the carts for these openings of a picked shop-assembly pull are built (#343).
   # Each one becomes assignable and workable immediately; staging the last completes the pull.
   # Nothing moves in inventory - the deduction and the source request's reservation were both spent

--- a/backend/app/repositories/buyer_repository.py
+++ b/backend/app/repositories/buyer_repository.py
@@ -10,7 +10,7 @@ blocked legitimate registrations. Whatever GP reports active for the job is now 
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import NotFoundError, ValidationError
@@ -35,6 +35,25 @@ def get_assignment(session: Session, buyer_id: str) -> BuyerAssignment | None:
         select(BuyerAssignment)
         .options(selectinload(BuyerAssignment.projects))
         .where(BuyerAssignment.buyer_id == _clean_buyer_id(buyer_id))
+    )
+    return session.scalars(stmt).unique().first()
+
+
+def get_assignment_for_identity(session: Session, buyer_id: str) -> BuyerAssignment | None:
+    """The assignment for a GP buyer identity, matched the way `_assert_buyer_identity` matches it:
+    case-insensitively and whitespace-tolerantly, because GP stores BUYERID char-padded uppercase
+    while the value linked to a Nexus account (#216) is whatever an admin typed.
+
+    Separate from `get_assignment`, which is the exact-key accessor the admin upsert and delete need
+    - those address one row by its primary identifier and must not silently hit a differently-cased
+    neighbour. This one answers "which row is the caller's", the question #428's scoped
+    `buyerAssignments` asks; before that scoping the frontend did the same case-insensitive match
+    client-side over the whole table, so keeping the tolerance here is what makes the two equivalent."""
+    cleaned = _clean_buyer_id(buyer_id)
+    stmt = (
+        select(BuyerAssignment)
+        .options(selectinload(BuyerAssignment.projects))
+        .where(func.lower(BuyerAssignment.buyer_id) == cleaned.lower())
     )
     return session.scalars(stmt).unique().first()
 

--- a/backend/app/repositories/warehouse/inventory.py
+++ b/backend/app/repositories/warehouse/inventory.py
@@ -355,9 +355,15 @@ def get_opening_item_details(session: Session, oi_id: uuid.UUID) -> OpeningItemM
 
 
 def adjust_inventory_quantity(
-    session: Session, inv_id: uuid.UUID, adjustment: int, reason: str
+    session: Session, inv_id: uuid.UUID, adjustment: int, reason: str, *, performed_by: str
 ) -> InventoryLocationModel:
-    """Adjust the quantity of an InventoryLocation by a positive or negative amount."""
+    """Adjust the quantity of an InventoryLocation by a positive or negative amount.
+
+    `performed_by` is keyword-only and required (#427). This function used to take no actor at all
+    and hardcode "Admin/Manager" on its audit row, so every quantity adjustment in the system was
+    filed under an admin no matter who made it - and, worse, the resolver had no way to pass the
+    truth through even once somebody noticed. Requiring it means a new caller has to answer the
+    question rather than inherit a wrong answer."""
     il = session.get(InventoryLocationModel, inv_id)
     if il is None:
         raise NotFoundError(f"Inventory location {inv_id} not found")
@@ -378,7 +384,7 @@ def adjust_inventory_quantity(
         entity_type=AuditEntityType.INVENTORY_LOCATION,
         entity_id=il.id,
         action=AuditAction.ADJUSTMENT,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={
             "oldQuantity": old_quantity,
             "newQuantity": new_quantity,

--- a/backend/app/repositories/warehouse/locations.py
+++ b/backend/app/repositories/warehouse/locations.py
@@ -391,9 +391,13 @@ def merge_locations(
 
 
 def move_inventory_location(
-    session: Session, inv_id: uuid.UUID, new_aisle: str, new_row: str, new_bay: str
+    session: Session, inv_id: uuid.UUID, new_aisle: str, new_row: str, new_bay: str, *, performed_by: str
 ) -> InventoryLocationModel:
-    """Move an InventoryLocation to a new aisle/row/bay."""
+    """Move an InventoryLocation to a new aisle/row/bay.
+
+    `performed_by` is keyword-only and required (#427): the six put-away/unlocate/move helpers below
+    all hardcoded "Admin/Manager", which is what the location history panel showed for every physical
+    move of stock regardless of who made it."""
     il = session.get(InventoryLocationModel, inv_id)
     if il is None:
         raise NotFoundError(f"Inventory location {inv_id} not found")
@@ -411,7 +415,7 @@ def move_inventory_location(
         entity_type=AuditEntityType.INVENTORY_LOCATION,
         entity_id=il.id,
         action=AuditAction.MOVE,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={
             "fromLocation": {"aisle": old_aisle, "row": old_row, "bay": old_bay},
             "toLocation": {"aisle": new_aisle, "row": new_row, "bay": new_bay},
@@ -421,7 +425,7 @@ def move_inventory_location(
     return il
 
 
-def mark_inventory_unlocated(session: Session, inv_id: uuid.UUID) -> InventoryLocationModel:
+def mark_inventory_unlocated(session: Session, inv_id: uuid.UUID, *, performed_by: str) -> InventoryLocationModel:
     """Clear the aisle/row/bay on an InventoryLocation."""
     il = session.get(InventoryLocationModel, inv_id)
     if il is None:
@@ -438,7 +442,7 @@ def mark_inventory_unlocated(session: Session, inv_id: uuid.UUID) -> InventoryLo
         entity_type=AuditEntityType.INVENTORY_LOCATION,
         entity_id=il.id,
         action=AuditAction.UNLOCATE,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={"fromLocation": {"aisle": old_aisle, "row": old_row, "bay": old_bay}},
     )
 
@@ -446,7 +450,7 @@ def mark_inventory_unlocated(session: Session, inv_id: uuid.UUID) -> InventoryLo
 
 
 def assign_inventory_location(
-    session: Session, inv_id: uuid.UUID, aisle: str, row: str, bay: str
+    session: Session, inv_id: uuid.UUID, aisle: str, row: str, bay: str, *, performed_by: str
 ) -> InventoryLocationModel:
     """Assign aisle/row/bay to an InventoryLocation."""
     il = session.get(InventoryLocationModel, inv_id)
@@ -465,7 +469,7 @@ def assign_inventory_location(
         entity_type=AuditEntityType.INVENTORY_LOCATION,
         entity_id=il.id,
         action=AuditAction.PUT_AWAY,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={"toLocation": {"aisle": aisle, "row": row, "bay": bay}},
     )
 
@@ -479,6 +483,8 @@ def move_opening_item_location(
     row: str,
     bay: str,
     warehouse_id: uuid.UUID | None = None,
+    *,
+    performed_by: str,
 ) -> OpeningItemModel:
     """Move an OpeningItem (whole kit) to a new aisle/row/bay, optionally a different warehouse."""
     oi = session.get(OpeningItemModel, oi_id)
@@ -504,7 +510,7 @@ def move_opening_item_location(
         entity_type=AuditEntityType.OPENING_ITEM,
         entity_id=oi.id,
         action=AuditAction.MOVE,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={
             "fromWarehouseId": str(old_wh),
             "fromLocation": {"aisle": old_aisle, "row": old_row, "bay": old_bay},
@@ -516,7 +522,7 @@ def move_opening_item_location(
     return oi
 
 
-def mark_opening_item_unlocated(session: Session, oi_id: uuid.UUID) -> OpeningItemModel:
+def mark_opening_item_unlocated(session: Session, oi_id: uuid.UUID, *, performed_by: str) -> OpeningItemModel:
     """Clear the aisle/row/bay on an OpeningItem."""
     oi = session.get(OpeningItemModel, oi_id)
     if oi is None:
@@ -533,7 +539,7 @@ def mark_opening_item_unlocated(session: Session, oi_id: uuid.UUID) -> OpeningIt
         entity_type=AuditEntityType.OPENING_ITEM,
         entity_id=oi.id,
         action=AuditAction.UNLOCATE,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={"fromLocation": {"aisle": old_aisle, "row": old_row, "bay": old_bay}},
     )
 
@@ -541,7 +547,7 @@ def mark_opening_item_unlocated(session: Session, oi_id: uuid.UUID) -> OpeningIt
 
 
 def assign_opening_item_location(
-    session: Session, oi_id: uuid.UUID, aisle: str, row: str, bay: str
+    session: Session, oi_id: uuid.UUID, aisle: str, row: str, bay: str, *, performed_by: str
 ) -> OpeningItemModel:
     """Assign aisle/row/bay to an OpeningItem."""
     oi = session.get(OpeningItemModel, oi_id)
@@ -560,7 +566,7 @@ def assign_opening_item_location(
         entity_type=AuditEntityType.OPENING_ITEM,
         entity_id=oi.id,
         action=AuditAction.PUT_AWAY,
-        performed_by="Admin/Manager",
+        performed_by=performed_by,
         detail={"toLocation": {"aisle": aisle, "row": row, "bay": bay}},
     )
 

--- a/backend/app/schemas/buyer.py
+++ b/backend/app/schemas/buyer.py
@@ -7,7 +7,7 @@ import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.repositories import buyer_repository
+from app.repositories import buyer_repository, user_repository
 
 from .converters import buyer_assignment_to_type
 from .types import BuyerAssignment
@@ -17,10 +17,38 @@ from .types import BuyerAssignment
 class BuyerQueries:
     @strawberry.field
     def buyer_assignments(self, info: strawberry.Info) -> list[BuyerAssignment]:
-        """Issue #216: which projects each buyer may create POs for. The PO dialog reads this to
-        filter its project options; the create/register mutations re-enforce it server-side.
-        require_user, not admin (#415), because that dialog is a PO-user screen."""
-        require_user(info)
+        """Issue #216: which projects the CALLER's buyer identity may create POs for. The PO dialog
+        reads this to filter its project options; the create/register mutations re-enforce it
+        server-side. require_user, not admin (#415), because that dialog is a PO-user screen.
+
+        Scoped to the caller's own row as of #428. It used to return the whole table, so any signed-in
+        account - Shop Assembly, Shipping Out, Warehouse Staff - could enumerate which buyer owns
+        which project. Not an escalation (createPo and registerPoInGp already check the caller's own
+        assignment), but the dialog never needed anyone else's row: it looks up exactly the one
+        matching the caller's GP buyer id and ignores the rest. An account with no GP buyer id linked
+        yet gets an empty list rather than an error - it simply cannot create project POs, which is
+        the state the dialog already handles. `allBuyerAssignments` is the admin-gated whole-table
+        read for the Buyers page."""
+        auth = require_user(info)
+        # Same identity registerPoInGp enforces the PO against, so the dialog and the mutation can
+        # never disagree about which assignment applies.
+        buyer_id = user_repository.get_user_gp_buyer_id(auth["user_id"])
+        if not buyer_id:
+            return []
+        with SessionLocal() as session:
+            assignment = buyer_repository.get_assignment_for_identity(session, buyer_id)
+            return [buyer_assignment_to_type(assignment)] if assignment is not None else []
+
+    @strawberry.field
+    def all_buyer_assignments(self, info: strawberry.Info) -> list[BuyerAssignment]:
+        """Every buyer's assignment, for the Buyers admin page (#428).
+
+        This is what `buyerAssignments` used to be. It stayed a single require_user resolver because
+        one admin screen and one PO-user dialog happened to want the same shape - but the dialog only
+        ever wants its own row, and the whole table is a map of which buyer owns which project. The
+        page that genuinely needs all of them is admin-only anyway, so the whole-table read is gated
+        to match."""
+        require_admin(info)
         with SessionLocal() as session:
             return [buyer_assignment_to_type(a) for a in buyer_repository.list_assignments(session)]
 

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Annotated
 
 import strawberry
 
@@ -10,6 +11,19 @@ from .enums import (
     ReturnDisposition,
     TransferSourceType,
 )
+
+# Issue #427: every mutation that stamps an actor on an audit or history row now takes that actor
+# from the Clerk token the gate verified, never from its arguments - the old way let any signed-in
+# user file their work under someone else's name.
+#
+# The arguments themselves stay in the schema, accepted and ignored, for the same reason #430 kept
+# `saveBuyerAssignment(costCodes:)`: a tab loaded against the previous deploy still sends them, and
+# an unknown argument fails GraphQL validation outright, so removing them would break every open
+# session at once. They also became nullable, because a required argument cannot carry @deprecated -
+# and widening required to optional is safe in the other direction, since old clients still send a
+# value. Dropped once no deployed frontend references them.
+ACTOR_IGNORED = "the actor is taken from the authenticated caller (#427); this value is ignored"
+IgnoredActorArg = Annotated[str | None, strawberry.argument(deprecation_reason=ACTOR_IGNORED)]
 
 
 @strawberry.input
@@ -324,7 +338,7 @@ class TransferInventoryInput:
     dest_aisle: str
     dest_row: str
     dest_bay: str
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -444,7 +458,7 @@ class ShipmentItemInput:
 class ConfirmShipmentInput:
     project_id: strawberry.ID
     packing_slip_number: str
-    shipped_by: str
+    shipped_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     items: list[ShipmentItemInput] = strawberry.field(default_factory=list)
 
 
@@ -461,7 +475,7 @@ class ShipmentReturnItemInput:
 class CreateShipmentReturnInput:
     packing_slip_id: strawberry.ID
     warehouse_id: strawberry.ID
-    returned_by: str
+    returned_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     reference: str | None = None
     items: list[ShipmentReturnItemInput] = strawberry.field(default_factory=list)
 
@@ -498,8 +512,7 @@ class AssemblyProgressItemInput:
 class RecordAssemblyProgressInput:
     opening_id: strawberry.ID
     items: list[AssemblyProgressItemInput] = strawberry.field(default_factory=list)
-    # The assembler; recorded as the actor on the progress audit rows and on any deficiency return.
-    performed_by: str | None = None
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -509,7 +522,7 @@ class InstallReplacementInput:
 
     shop_assembly_opening_item_id: strawberry.ID
     quantity: int
-    performed_by: str | None = None
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -535,7 +548,7 @@ class StagePullOpeningsInput:
 
     pull_request_id: strawberry.ID
     opening_ids: list[strawberry.ID]
-    staged_by: str
+    staged_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -546,7 +559,7 @@ class CancelPullRequestInput:
     and the refusal names them. `reason` is optional but shown to whoever raised the pull."""
 
     id: strawberry.ID
-    cancelled_by: str
+    cancelled_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     reason: str | None = None
 
 
@@ -556,7 +569,7 @@ class CompleteOpeningInput:
     aisle: str | None = None
     row: str | None = None
     bay: str | None = None
-    completed_by: str | None = None
+    completed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 # ---------------------------------------------------------------------------
@@ -573,7 +586,7 @@ class DestockInventoryInput:
     target_aisle: str | None = None
     target_row: str | None = None
     target_bay: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -586,7 +599,7 @@ class AllocateStockToProjectInput:
     target_aisle: str | None = None
     target_row: str | None = None
     target_bay: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -594,7 +607,7 @@ class AdjustStockQuantityInput:
     stock_item_id: strawberry.ID
     new_quantity: int
     reason_text: str
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -603,7 +616,7 @@ class MoveStockLocationInput:
     new_aisle: str
     new_row: str
     new_bay: str
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -613,7 +626,7 @@ class ReclassifyStockItemInput:
     new_product_code: str
     quantity: int
     reason_text: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -621,7 +634,7 @@ class ReportInventoryDeficiencyInput:
     inventory_location_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -641,7 +654,7 @@ class OverrideInventoryQuantityInput:
     reason_text: str
     # required when new_quantity increases the row; ignored on a decrease. quantities must sum to the delta.
     destinations: list[OverrideDestinationInput] = strawberry.field(default_factory=list)
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -649,7 +662,7 @@ class ReportStockDeficiencyInput:
     stock_item_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -657,7 +670,7 @@ class ReportDeficiencyAtAssemblyInput:
     shop_assembly_opening_item_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str = ""
+    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -670,4 +683,4 @@ class ResolveDeficiencyInput:
     reason_text: str | None = None
     rma_reference: str | None = None
     destock_source: DestockSource | None = None
-    reviewed_by: str = ""
+    reviewed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -4,7 +4,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user
+from app.auth import require_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import shipping_repository
 
@@ -15,7 +15,7 @@ from .converters import (
     shipping_out_request_to_type,
 )
 from .enums import ShippingOutRequestStatus
-from .inputs import ConfirmShipmentInput, CreateShipmentReturnInput
+from .inputs import ConfirmShipmentInput, CreateShipmentReturnInput, IgnoredActorArg
 from .types import (
     PackingSlip,
     ReturnableLine,
@@ -94,28 +94,34 @@ class ShippingQueries:
 class ShippingMutations:
     @strawberry.mutation
     def accept_shipping_out_request(
-        self, info: strawberry.Info, id: strawberry.ID, accepted_by: str
+        self, info: strawberry.Info, id: strawberry.ID, accepted_by: IgnoredActorArg = None
     ) -> ShippingOutRequest:
         """Accept a PENDING shipping-out request (#293). Open to any signed-in user. Mints the
         warehouse PullRequest (SHIPPING_OUT, PENDING) from the request's items; the warehouse
-        approve handles any inventory shortfall (no gate here)."""
-        require_user(info)
+        approve handles any inventory shortfall (no gate here).
+
+        The approval names the Clerk-authenticated caller (#427), and carries onto the minted pull's
+        `requestedBy`."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
-            shipping_repository.accept_shipping_out_request(session, request_id, accepted_by)
+            shipping_repository.accept_shipping_out_request(session, request_id, actor)
             session.commit()
             refreshed = shipping_repository.get_shipping_out_request(session, request_id)
             return shipping_out_request_to_type(refreshed)
 
     @strawberry.mutation
     def reject_shipping_out_request(
-        self, info: strawberry.Info, id: strawberry.ID, rejected_by: str, reason: str | None = None
+        self, info: strawberry.Info, id: strawberry.ID, rejected_by: IgnoredActorArg = None, reason: str | None = None
     ) -> ShippingOutRequest:
-        """Reject a PENDING shipping-out request (#293). Open to any signed-in user."""
-        require_user(info)
+        """Reject a PENDING shipping-out request (#293). Open to any signed-in user. Recorded against
+        the Clerk-authenticated caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
-            shipping_repository.reject_shipping_out_request(session, request_id, rejected_by, reason)
+            shipping_repository.reject_shipping_out_request(session, request_id, actor, reason)
             session.commit()
             refreshed = shipping_repository.get_shipping_out_request(session, request_id)
             return shipping_out_request_to_type(refreshed)
@@ -136,7 +142,13 @@ class ShippingMutations:
 
     @strawberry.mutation
     def confirm_shipment(self, info: strawberry.Info, input: ConfirmShipmentInput) -> PackingSlip:
-        require_user(info)
+        """Cut the packing slip for what actually went on the truck.
+
+        `shippedBy` is printed on the slip and shown in the shipments grid, so it is the record of
+        who released the hardware. It is the Clerk-authenticated caller as of #427; the input field
+        is still accepted and ignored."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         from app.models.enums import PullRequestItemType
 
         project_id = uuid.UUID(str(input.project_id))
@@ -161,7 +173,7 @@ class ShippingMutations:
                 session,
                 project_id,
                 input.packing_slip_number,
-                input.shipped_by,
+                actor,
                 items_data,
             )
             session.commit()
@@ -170,7 +182,10 @@ class ShippingMutations:
 
     @strawberry.mutation
     def create_shipment_return(self, info: strawberry.Info, input: CreateShipmentReturnInput) -> ShipmentReturn:
-        require_user(info)
+        """Book hardware back off a packing slip. `returnedBy` is the Clerk-authenticated caller
+        (#427); the input field is still accepted and ignored."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         from app.models.enums import ReturnDisposition
 
         items_data = [
@@ -189,7 +204,7 @@ class ShippingMutations:
                 session,
                 packing_slip_id=uuid.UUID(str(input.packing_slip_id)),
                 warehouse_id=uuid.UUID(str(input.warehouse_id)),
-                returned_by=input.returned_by,
+                returned_by=actor,
                 reference=input.reference,
                 items=items_data,
             )

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -4,7 +4,7 @@ import uuid
 
 import strawberry
 
-from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, require_role, require_user
+from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, require_role, require_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import shop_assembly_repository, user_repository
 from app.repositories import warehouse as warehouse_repository
@@ -22,6 +22,7 @@ from .enums import ShopAssemblyRequestStatus
 from .inputs import (
     AssignOpeningsInput,
     CompleteOpeningInput,
+    IgnoredActorArg,
     InstallReplacementInput,
     RecordAssemblyProgressInput,
 )
@@ -155,31 +156,38 @@ class ShopAssemblyQueries:
 class ShopAssemblyMutations:
     @strawberry.mutation
     def accept_shop_assembly_request(
-        self, info: strawberry.Info, id: strawberry.ID, accepted_by: str
+        self, info: strawberry.Info, id: strawberry.ID, accepted_by: IgnoredActorArg = None
     ) -> ShopAssemblyRequest:
         """Accept a PENDING shop-assembly request (#293). Open to any signed-in user.
 
         A pure human approval gate since #342: it mints the warehouse PullRequest and approves the
         request, and re-checks nothing. The hardware was reserved when the request was created, so
         it already belongs to this request - there is no shortfall left for the acceptor to be shown
-        and nothing they could do about one if there were."""
-        require_user(info)
+        and nothing they could do about one if there were.
+
+        The approval is recorded against the Clerk-authenticated caller (#427). It is the whole
+        content of the gate: an approval attributable to anyone the client names is not an approval.
+        The name also becomes the minted pull's `requestedBy`."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
-            shop_assembly_repository.accept_shop_assembly_request(session, request_id, accepted_by)
+            shop_assembly_repository.accept_shop_assembly_request(session, request_id, actor)
             session.commit()
             refreshed = shop_assembly_repository.get_request_with_openings(session, request_id)
             return shop_assembly_request_to_type(refreshed)
 
     @strawberry.mutation
     def reject_shop_assembly_request(
-        self, info: strawberry.Info, id: strawberry.ID, rejected_by: str, reason: str | None = None
+        self, info: strawberry.Info, id: strawberry.ID, rejected_by: IgnoredActorArg = None, reason: str | None = None
     ) -> ShopAssemblyRequest:
-        """Reject a PENDING shop-assembly request (#293). Open to any signed-in user."""
-        require_user(info)
+        """Reject a PENDING shop-assembly request (#293). Open to any signed-in user. Recorded
+        against the Clerk-authenticated caller (#427), same reasoning as the accept."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
-            shop_assembly_repository.reject_shop_assembly_request(session, request_id, rejected_by, reason)
+            shop_assembly_repository.reject_shop_assembly_request(session, request_id, actor, reason)
             session.commit()
             refreshed = shop_assembly_repository.get_request_with_openings(session, request_id)
             return shop_assembly_request_to_type(refreshed)
@@ -251,8 +259,12 @@ class ShopAssemblyMutations:
         the opening flips to IN_PROGRESS on the first save and stays in the assembler's My Work, and
         any units flagged deficient are returned to inventory and given a replacement pull line
         immediately rather than waiting for completion. Open to any signed-in user - it moves
-        inventory when a deficiency is flagged, so it must not be reachable anonymously."""
-        require_user(info)
+        inventory when a deficiency is flagged, so it must not be reachable anonymously.
+
+        The assembler on the progress rows and on any deficiency return is the Clerk-authenticated
+        caller (#427), not the request's `performedBy`."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         updates = [
             shop_assembly_repository.AssemblyProgressUpdate(
                 shop_assembly_opening_item_id=uuid.UUID(str(item.shop_assembly_opening_item_id)),
@@ -267,7 +279,7 @@ class ShopAssemblyMutations:
                 session,
                 uuid.UUID(str(input.opening_id)),
                 updates,
-                performed_by=input.performed_by,
+                performed_by=actor,
             )
             session.commit()
             refreshed = shop_assembly_repository.get_openings_with_items(session, [result.id])[0]
@@ -282,14 +294,16 @@ class ShopAssemblyMutations:
         replacement_pending to installed on the source checklist line, so the completion invariant
         holds throughout. It can only spend units the replacement pull actually delivered, and it
         refuses a leaf that has already shipped. Open to any signed-in user - it changes what an
-        assembled leaf is recorded as carrying, so it must not be reachable anonymously."""
-        require_user(info)
+        assembled leaf is recorded as carrying, so it must not be reachable anonymously, and the
+        person recorded as fitting it is the Clerk-authenticated caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = shop_assembly_repository.install_replacement(
                 session,
                 uuid.UUID(str(input.shop_assembly_opening_item_id)),
                 input.quantity,
-                performed_by=input.performed_by,
+                performed_by=actor,
             )
             session.commit()
             refreshed = warehouse_repository.get_opening_item_details(session, result.id)
@@ -306,8 +320,10 @@ class ShopAssemblyMutations:
 
         Takes no checklist (#340): completion reads the per-item counts recordAssemblyProgress has
         been persisting, and is refused while any unit is still unaccounted for. Open to any signed-in
-        user - it writes inventory, so it must not be reachable anonymously."""
-        require_user(info)
+        user - it writes inventory, so it must not be reachable anonymously. Who completed the leaf is
+        the Clerk-authenticated caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = shop_assembly_repository.complete_opening(
                 session,
@@ -315,7 +331,7 @@ class ShopAssemblyMutations:
                 input.aisle,
                 input.row,
                 input.bay,
-                completed_by=input.completed_by,
+                completed_by=actor,
             )
             session.commit()
             # Re-load with installed_hardware

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -1,10 +1,18 @@
-"""Stock pool + deficiency queries and mutations."""
+"""Stock pool + deficiency queries and mutations.
+
+Every mutation here writes an audit row, and since #427 the actor on it is the Clerk-authenticated
+caller (`require_user` -> `resolve_display_name`), never the request's own `performedBy`/`reviewedBy`
+field. Those input fields are still accepted so a frontend from the previous deploy keeps working;
+they are ignored. Before the change these rows carried whatever the client sent, defaulting to the
+literal strings "Admin/Manager" or "Warehouse" - which is what most of them actually stored, because
+the stock modals hardcoded exactly those two.
+"""
 
 import uuid
 
 import strawberry
 
-from app.auth import require_user
+from app.auth import require_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import stock as stock_repository
 
@@ -119,7 +127,8 @@ class StockQueries:
 class StockMutations:
     @strawberry.mutation
     def destock_inventory(self, info: strawberry.Info, input: DestockInventoryInput) -> StockItem:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.destock_inventory(
                 session,
@@ -130,7 +139,7 @@ class StockMutations:
                 target_aisle=input.target_aisle,
                 target_row=input.target_row,
                 target_bay=input.target_bay,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -138,7 +147,8 @@ class StockMutations:
 
     @strawberry.mutation
     def transfer_inventory(self, info: strawberry.Info, input: TransferInventoryInput) -> TransferResult:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.transfer_inventory(
                 session,
@@ -149,7 +159,7 @@ class StockMutations:
                 dest_aisle=input.dest_aisle,
                 dest_row=input.dest_row,
                 dest_bay=input.dest_bay,
-                performed_by=input.performed_by or "Warehouse",
+                performed_by=actor,
             )
             session.commit()
             return TransferResult(
@@ -160,7 +170,8 @@ class StockMutations:
 
     @strawberry.mutation
     def allocate_stock_to_project(self, info: strawberry.Info, input: AllocateStockToProjectInput) -> InventoryLocation:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.allocate_stock_to_project(
                 session,
@@ -172,7 +183,7 @@ class StockMutations:
                 target_aisle=input.target_aisle,
                 target_row=input.target_row,
                 target_bay=input.target_bay,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -180,14 +191,15 @@ class StockMutations:
 
     @strawberry.mutation
     def adjust_stock_quantity(self, info: strawberry.Info, input: AdjustStockQuantityInput) -> StockItem:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.adjust_stock_quantity(
                 session,
                 stock_item_id=uuid.UUID(str(input.stock_item_id)),
                 new_quantity=input.new_quantity,
                 reason_text=input.reason_text,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -195,7 +207,8 @@ class StockMutations:
 
     @strawberry.mutation
     def move_stock_location(self, info: strawberry.Info, input: MoveStockLocationInput) -> StockItem:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.move_stock_location(
                 session,
@@ -203,7 +216,7 @@ class StockMutations:
                 new_aisle=input.new_aisle,
                 new_row=input.new_row,
                 new_bay=input.new_bay,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -218,7 +231,8 @@ class StockMutations:
         row: str,
         bay: str,
     ) -> StockItem:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.assign_stock_item_location(
                 session,
@@ -226,7 +240,7 @@ class StockMutations:
                 aisle=aisle,
                 row=row,
                 bay=bay,
-                performed_by="Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -234,12 +248,13 @@ class StockMutations:
 
     @strawberry.mutation
     def mark_stock_item_unlocated(self, info: strawberry.Info, stock_item_id: strawberry.ID) -> StockItem:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.mark_stock_item_unlocated(
                 session,
                 stock_item_id=uuid.UUID(str(stock_item_id)),
-                performed_by="Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -247,7 +262,8 @@ class StockMutations:
 
     @strawberry.mutation
     def reclassify_stock_item(self, info: strawberry.Info, input: ReclassifyStockItemInput) -> ReclassifyStockResult:
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             new_row, original = stock_repository.reclassify_stock_item(
                 session,
@@ -256,7 +272,7 @@ class StockMutations:
                 new_product_code=input.new_product_code,
                 quantity=input.quantity,
                 reason_text=input.reason_text,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(new_row)
@@ -273,14 +289,15 @@ class StockMutations:
     ) -> InventoryLocation:
         """Condemn units on a project inventory row. Open to any signed-in user - it makes stock
         unavailable to every other request in the project, so it must not be reachable anonymously."""
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             il = stock_repository.report_inventory_deficiency(
                 session,
                 inventory_location_id=uuid.UUID(str(input.inventory_location_id)),
                 quantity=input.quantity,
                 reason_text=input.reason_text,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(il)
@@ -290,14 +307,15 @@ class StockMutations:
     def report_stock_deficiency(self, info: strawberry.Info, input: ReportStockDeficiencyInput) -> StockItem:
         """Condemn units on a stock-pool row. Open to any signed-in user - same reasoning as
         reportInventoryDeficiency: it takes stock out of circulation."""
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             si = stock_repository.report_stock_deficiency(
                 session,
                 stock_item_id=uuid.UUID(str(input.stock_item_id)),
                 quantity=input.quantity,
                 reason_text=input.reason_text,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(si)
@@ -309,14 +327,15 @@ class StockMutations:
     ) -> SAReplacementResult:
         """Flag a unit deficient at the bench. Open to any signed-in user - it writes project
         inventory and mints a replacement pull request, so it must not be reachable anonymously."""
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             il, pri = stock_repository.report_deficiency_at_assembly(
                 session,
                 sa_opening_item_id=uuid.UUID(str(input.shop_assembly_opening_item_id)),
                 quantity=input.quantity,
                 reason_text=input.reason_text,
-                performed_by=input.performed_by or "Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(il)
@@ -330,7 +349,8 @@ class StockMutations:
     def resolve_deficiency(self, info: strawberry.Info, input: ResolveDeficiencyInput) -> DeficiencyReview:
         """Disposition a condemned batch (scrap, repair, RMA, destock). Open to any signed-in user -
         it moves or writes off real stock, so it must not be reachable anonymously."""
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             review = stock_repository.resolve_deficiency(
                 session,
@@ -343,7 +363,7 @@ class StockMutations:
                 reason_text=input.reason_text,
                 rma_reference=input.rma_reference,
                 destock_source=input.destock_source,
-                reviewed_by=input.reviewed_by or "Admin/Manager",
+                reviewed_by=actor,
             )
             session.commit()
             session.refresh(review)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -9,7 +9,7 @@ roles and GP buyer id. The three writes are only ever issued by the admin User M
 
 import strawberry
 
-from app.auth import require_admin
+from app.auth import invalidate_display_name, require_admin
 from app.repositories import user_repository
 
 from .converters import clerk_user_to_type
@@ -36,9 +36,15 @@ class UserMutations:
 
     @strawberry.mutation
     def update_user_name(self, info: strawberry.Info, user_id: str, first_name: str, last_name: str) -> ClerkUser:
-        """Issue #240: admin-driven display-name change (Clerk first/last name)."""
+        """Issue #240: admin-driven display-name change (Clerk first/last name).
+
+        Drops the cached display name too. Since #427 every audit and history row is stamped with
+        `resolve_display_name`, which caches for a few minutes to keep a Clerk round-trip off hot
+        write paths; without this the rows would keep naming the old spelling until that expired."""
         require_admin(info)
-        return clerk_user_to_type(user_repository.update_user_name(user_id, first_name, last_name))
+        updated = clerk_user_to_type(user_repository.update_user_name(user_id, first_name, last_name))
+        invalidate_display_name(user_id)
+        return updated
 
     @strawberry.mutation
     def update_user_gp_buyer_id(self, info: strawberry.Info, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -32,6 +32,7 @@ from .inputs import (
     CancelPullRequestInput,
     CreateReceiveInput,
     CreateWarehouseInput,
+    IgnoredActorArg,
     OverrideInventoryQuantityInput,
     PickLineInput,
     StagePullOpeningsInput,
@@ -776,7 +777,9 @@ class WarehouseMutations:
 
     # Pull Requests - the pick (#367)
     @strawberry.mutation
-    def start_pull_request_pick(self, info: strawberry.Info, id: strawberry.ID, started_by: str) -> PullRequest:
+    def start_pull_request_pick(
+        self, info: strawberry.Info, id: strawberry.ID, started_by: IgnoredActorArg = None
+    ) -> PullRequest:
         """Claim a pending pull and open it for picking (#367). Nothing moves in inventory.
 
         This is what `approvePullRequest` used to be, minus everything that touched stock. The
@@ -785,10 +788,12 @@ class WarehouseMutations:
         was picked or from where.
 
         Open to any signed-in user - it assigns the pull to the caller, so it must not be reachable
-        anonymously."""
-        require_user(info)
+        anonymously. The pull is assigned to the Clerk-authenticated caller (#427), not to whatever
+        `startedBy` said - the assignment is what the whole pick is then attributed to."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
-            pr = warehouse_repository.start_pull_request_pick(session, uuid.UUID(str(id)), started_by)
+            pr = warehouse_repository.start_pull_request_pick(session, uuid.UUID(str(id)), actor)
             session.commit()
             pr = warehouse_repository.get_pull_request_details(session, pr.id)
             staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
@@ -800,7 +805,7 @@ class WarehouseMutations:
         info: strawberry.Info,
         pull_request_id: strawberry.ID,
         lines: list[PickLineInput],
-        entered_by: str,
+        entered_by: IgnoredActorArg = None,
     ) -> PickSheet:
         """Save the half-keyed pick sheet without moving anything (#367).
 
@@ -810,14 +815,15 @@ class WarehouseMutations:
         exactly when it is wanted.
 
         Open to any signed-in user - it attributes a user action, same rationale as
-        `saveAssemblyProgress`."""
-        require_user(info)
+        `saveAssemblyProgress`. Who entered it is the Clerk-authenticated caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             sheet = warehouse_repository.save_pick_draft(
                 session,
                 uuid.UUID(str(pull_request_id)),
                 _pick_lines_from_input(lines),
-                entered_by,
+                actor,
             )
             # `save_pick_draft` already returns the rebuilt sheet, so it is converted here rather
             # than read a second time: this is the picker's most frequent action, and re-running the
@@ -836,7 +842,7 @@ class WarehouseMutations:
         info: strawberry.Info,
         pull_request_id: strawberry.ID,
         lines: list[PickLineInput],
-        picked_by: str,
+        picked_by: IgnoredActorArg = None,
     ) -> ConfirmPickResult:
         """Deduct exactly the rows the picker dictated, and consume the claim behind them (#367).
 
@@ -850,14 +856,18 @@ class WarehouseMutations:
         everything returns SHORT: what was entered is deducted, the pull stays In Progress and
         un-picked, purchasing is notified once, and a later confirmation enters the remainder.
 
-        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously."""
-        require_user(info)
+        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously.
+        The deduction is stamped with the Clerk-authenticated caller (#427): this is the audit row
+        that says who took the stock off the rack, and it is worth nothing if the client picks the
+        name on it."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.confirm_pick(
                 session,
                 uuid.UUID(str(pull_request_id)),
                 _pick_lines_from_input(lines),
-                picked_by,
+                actor,
             )
             notification = notification_to_type(result.notification) if result.notification else None
             shortfalls = [
@@ -896,7 +906,7 @@ class WarehouseMutations:
         info: strawberry.Info,
         item_id: strawberry.ID,
         fetched: bool,
-        fetched_by: str,
+        fetched_by: IgnoredActorArg = None,
     ) -> PullRequestItem:
         """Tick (or untick) one assembled leaf off a shipping pull's fetch list (#367).
 
@@ -904,25 +914,31 @@ class WarehouseMutations:
         persisted so it survives a reload or a shift change, and unticking is supported because a
         picker who ticked the wrong leaf must be able to say so.
 
-        Open to any signed-in user - it attributes a user action."""
-        require_user(info)
+        Open to any signed-in user - it attributes a user action, and since #427 it attributes it to
+        the Clerk-authenticated caller: the tick is a claim that a specific person has the leaf."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
-            item = warehouse_repository.set_pull_item_fetched(session, uuid.UUID(str(item_id)), fetched, fetched_by)
+            item = warehouse_repository.set_pull_item_fetched(session, uuid.UUID(str(item_id)), fetched, actor)
             session.commit()
             session.refresh(item)
             return pull_request_item_to_type(item)
 
     @strawberry.mutation
     def complete_pull_request(
-        self, info: strawberry.Info, id: strawberry.ID, completed_by: str | None = None
+        self, info: strawberry.Info, id: strawberry.ID, completed_by: IgnoredActorArg = None
     ) -> PullRequest:
         """Close the whole pull in one go. Since #343 this reads as "stage everything still
         outstanding and finish": any opening not yet confirmed individually is flipped to PULLED and
-        stamped here. `completedBy` is optional and additive - it only names the actor on those
-        stamps, so existing callers are unaffected."""
-        require_user(info)
+        stamped here.
+
+        That stamp is the Clerk-authenticated caller as of #427. It was the client's `completedBy`
+        string, which made this the clearest example of the bug: one call could put any name on every
+        opening the pull staged, and the staging panel shows exactly that name."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
-            pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)), completed_by=completed_by)
+            pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)), completed_by=actor)
             session.commit()
             pr = warehouse_repository.get_pull_request_details(session, pr.id)
             staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
@@ -940,14 +956,15 @@ class WarehouseMutations:
         replacement-arrival application still happen exactly once.
 
         Open to any signed-in user - it makes hardware workable, so it must not be reachable
-        anonymously."""
-        require_user(info)
+        anonymously. Each opening is stamped with the Clerk-authenticated caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.stage_pull_openings(
                 session,
                 uuid.UUID(str(input.pull_request_id)),
                 [uuid.UUID(str(oid)) for oid in input.opening_ids],
-                input.staged_by,
+                actor,
             )
             session.commit()
             pr = warehouse_repository.get_pull_request_details(session, result.pull_request.id)
@@ -972,13 +989,16 @@ class WarehouseMutations:
         its claim is re-created from the returned quantities if availability still allows; if it does
         not, the request is left unreserved and flagged rather than half-claimed.
 
-        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously."""
-        require_user(info)
+        Open to any signed-in user - it writes inventory, so it must not be reachable anonymously.
+        The cancellation and every restock audit row it writes name the Clerk-authenticated caller
+        (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.cancel_pull_request(
                 session,
                 uuid.UUID(str(input.id)),
-                input.cancelled_by,
+                actor,
                 input.reason,
             )
             session.commit()
@@ -1004,10 +1024,18 @@ class WarehouseMutations:
     def adjust_inventory_quantity(
         self, info: strawberry.Info, inventory_location_id: strawberry.ID, adjustment: int, reason: str
     ) -> InventoryLocation:
-        require_user(info)
+        """Move a project inventory row's count by a delta, with a reason, writing an ADJUSTMENT
+        audit row.
+
+        Every one of those rows said "Admin/Manager" until #427, whoever actually made the change:
+        the repository hardcoded it and there was no parameter to pass the truth through. `auditLog`,
+        the location history panel and the recent-activity feed all read that column, so the one
+        record of who altered a count was uniformly wrong."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.adjust_inventory_quantity(
-                session, uuid.UUID(str(inventory_location_id)), adjustment, reason
+                session, uuid.UUID(str(inventory_location_id)), adjustment, reason, performed_by=actor
             )
             session.commit()
             session.refresh(result)
@@ -1024,7 +1052,8 @@ class WarehouseMutations:
 
         Gating it would also buy nothing while `adjustInventoryQuantity` next door stays open to any
         signed-in user: the same end quantity is reachable by passing the delta instead."""
-        require_user(info)
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.override_inventory_quantity(
                 session,
@@ -1034,7 +1063,7 @@ class WarehouseMutations:
                 destinations=[
                     {"aisle": d.aisle, "row": d.row, "bay": d.bay, "quantity": d.quantity} for d in input.destinations
                 ],
-                performed_by=input.performed_by or "Warehouse",
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -1049,10 +1078,13 @@ class WarehouseMutations:
         new_row: str,
         new_bay: str,
     ) -> InventoryLocation:
-        require_user(info)
+        """Relocate a project inventory row, writing a MOVE audit row naming the caller (#427); it
+        used to name "Admin/Manager" regardless of who moved the stock."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.move_inventory_location(
-                session, uuid.UUID(str(inventory_location_id)), new_aisle, new_row, new_bay
+                session, uuid.UUID(str(inventory_location_id)), new_aisle, new_row, new_bay, performed_by=actor
             )
             session.commit()
             session.refresh(result)
@@ -1062,9 +1094,14 @@ class WarehouseMutations:
     def mark_inventory_unlocated(
         self, info: strawberry.Info, inventory_location_id: strawberry.ID
     ) -> InventoryLocation:
-        require_user(info)
+        """Clear a project inventory row's location, writing an UNLOCATE audit row naming the
+        caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
-            result = warehouse_repository.mark_inventory_unlocated(session, uuid.UUID(str(inventory_location_id)))
+            result = warehouse_repository.mark_inventory_unlocated(
+                session, uuid.UUID(str(inventory_location_id)), performed_by=actor
+            )
             session.commit()
             session.refresh(result)
             return inventory_location_to_type(result)
@@ -1078,10 +1115,12 @@ class WarehouseMutations:
         row: str,
         bay: str,
     ) -> InventoryLocation:
-        require_user(info)
+        """Put a project inventory row away, writing a PUT_AWAY audit row naming the caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.assign_inventory_location(
-                session, uuid.UUID(str(inventory_location_id)), aisle, row, bay
+                session, uuid.UUID(str(inventory_location_id)), aisle, row, bay, performed_by=actor
             )
             session.commit()
             session.refresh(result)
@@ -1097,7 +1136,9 @@ class WarehouseMutations:
         bay: str,
         warehouse_id: strawberry.ID | None = None,
     ) -> OpeningItem:
-        require_user(info)
+        """Relocate an assembled leaf, writing a MOVE audit row naming the caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.move_opening_item_location(
                 session,
@@ -1106,6 +1147,7 @@ class WarehouseMutations:
                 row,
                 bay,
                 warehouse_id=uuid.UUID(str(warehouse_id)) if warehouse_id else None,
+                performed_by=actor,
             )
             session.commit()
             session.refresh(result)
@@ -1113,9 +1155,13 @@ class WarehouseMutations:
 
     @strawberry.mutation
     def mark_opening_item_unlocated(self, info: strawberry.Info, opening_item_id: strawberry.ID) -> OpeningItem:
-        require_user(info)
+        """Clear an assembled leaf's location, writing an UNLOCATE audit row naming the caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
-            result = warehouse_repository.mark_opening_item_unlocated(session, uuid.UUID(str(opening_item_id)))
+            result = warehouse_repository.mark_opening_item_unlocated(
+                session, uuid.UUID(str(opening_item_id)), performed_by=actor
+            )
             session.commit()
             session.refresh(result)
             return opening_item_to_type(result)
@@ -1129,10 +1175,12 @@ class WarehouseMutations:
         row: str,
         bay: str,
     ) -> OpeningItem:
-        require_user(info)
+        """Put an assembled leaf away, writing a PUT_AWAY audit row naming the caller (#427)."""
+        auth = require_user(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.assign_opening_item_location(
-                session, uuid.UUID(str(opening_item_id)), aisle, row, bay
+                session, uuid.UUID(str(opening_item_id)), aisle, row, bay, performed_by=actor
             )
             session.commit()
             session.refresh(result)
@@ -1150,8 +1198,11 @@ class WarehouseMutations:
         to_bay: str,
     ) -> LocationMergeResult:
         """Admin-gated (#415): rewrites the location of every inventory row, opening item and stock
-        item at the source location. It already stamps its audit rows "Admin/Manager"."""
-        require_admin(info)
+        item at the source location. Its audit rows name the admin who ran it (#427) rather than the
+        literal "Admin/Manager" - the gate already proves the role, so the row may as well say which
+        admin, given a merge can touch hundreds of rows at once."""
+        auth = require_admin(info)
+        actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             counts = warehouse_repository.merge_locations(
                 session,
@@ -1161,7 +1212,7 @@ class WarehouseMutations:
                 to_aisle=to_aisle,
                 to_row=to_row,
                 to_bay=to_bay,
-                performed_by="Admin/Manager",
+                performed_by=actor,
             )
             session.commit()
             return LocationMergeResult(

--- a/backend/tests/test_resolver_actor_provenance.py
+++ b/backend/tests/test_resolver_actor_provenance.py
@@ -1,0 +1,194 @@
+"""The actor on an audit or history row comes from the authenticated caller, never from input (#427).
+
+Sibling of `test_resolver_gate_completeness.py`, and the same shape: an AST sweep over every
+`@strawberry.field` / `@strawberry.mutation` under `app/schemas/`, no database, no Strawberry
+introspection. That file asks whether a resolver checked *who* the caller is. This one asks whether
+it then *believed* them about it.
+
+The bug it pins: every mutation that stamps a name on a row took that name from its own arguments.
+`completePullRequest(id, completedBy: "Someone Else")` wrote that string onto every opening the pull
+staged, and the staging panel showed it. The same shape covered `performedBy` on inventory
+corrections, `pickedBy` on the pick, `shippedBy` on a packing slip, `acceptedBy` on an approval - the
+whole audit trail was a field the client filled in. `resolve_display_name` had existed since #199 for
+exactly this, but only `createReceive` used it.
+
+The check is deliberately mechanical rather than clever, so a reviewer can predict it:
+
+  A. No resolver body may read an actor-named attribute off `input`, or read back an actor-named
+     argument of its own. Those are the two ways a client value reaches a repository call.
+  B. No actor-named keyword argument may be a string literal. That is the other historical wrong
+     answer - `performed_by="Admin/Manager"` hardcoded on inventory adjustments and location moves,
+     which made every one of those rows claim an admin did it.
+
+What is left once both hold is a name derived from the Clerk token (`resolve_display_name`, or the
+gate's own `user_id`) or read back off a row the server already wrote - which is the point.
+
+Known limits, stated so nobody mistakes this for more than it is:
+
+  - It reads syntax, not data flow. `actor = request.headers["X-Who"]` followed by
+    `performed_by=actor` passes. It catches the shape the codebase actually had, not every
+    conceivable one.
+  - An actor passed POSITIONALLY (`repository.confirm_pick(session, pr_id, lines, actor)`) is invisible
+    to rule B, because there is no argument name to match. Rule A still covers it: the dangerous value
+    has to come from `input.x` or a parameter to get there, and both are refused.
+  - It says nothing about resolvers that should stamp an actor and do not.
+
+`assignedTo` / `assignedToUserId` on `assignOpenings` are deliberately absent from ACTOR_NAMES. They
+name the person work is being given TO, not the person doing the giving, and a manager assigning to
+someone else is the whole feature - that value MUST come from the client. The gate for it is
+`require_role`, not this test.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "app" / "schemas"
+
+# Field names that mean "the person who did this", across the audit log, the pull/request lifecycle
+# stamps and the shipping documents. Kept as a flat vocabulary rather than per-module lists so a new
+# mutation inherits the rule by naming its column the way every other one does.
+ACTOR_NAMES = {
+    "accepted_by",
+    "approved_by",
+    "armed_by",
+    "cancelled_by",
+    "completed_by",
+    "created_by",
+    "entered_by",
+    "fetched_by",
+    "performed_by",
+    "picked_by",
+    "received_by",
+    "rejected_by",
+    "requested_by",
+    "returned_by",
+    "reviewed_by",
+    "shipped_by",
+    "staged_by",
+    "started_by",
+}
+
+# The Strawberry convention in this codebase: the client's payload arrives as a parameter called
+# `input`. Reading an actor off it is the exact defect #427 fixed.
+_CLIENT_INPUT = "input"
+
+
+def _resolver_functions(tree: ast.Module):
+    """Yield every function decorated @strawberry.field / @strawberry.mutation, at any nesting.
+
+    Same predicate as test_resolver_gate_completeness, deliberately duplicated rather than shared:
+    two independent copies of the walk cannot both silently stop collecting a module.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(target, ast.Attribute) and target.attr in {"field", "mutation"}:
+                yield node
+                break
+
+
+def _all_resolvers():
+    rows = []
+    for path in sorted(_SCHEMAS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for fn in _resolver_functions(tree):
+            rows.append((path.stem, fn))
+    return rows
+
+
+_RESOLVERS = _all_resolvers()
+
+
+def _parameter_names(fn) -> set[str]:
+    a = fn.args
+    names = {arg.arg for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+    if a.vararg:
+        names.add(a.vararg.arg)
+    if a.kwarg:
+        names.add(a.kwarg.arg)
+    return names
+
+
+def _client_supplied_actor_reads(fn) -> list[str]:
+    """Every place the body takes an actor from something the caller controls.
+
+    Two forms, which is all there are: off the input object (`input.performed_by`) or off the
+    resolver's own argument list (`completed_by`). A local assigned from `resolve_display_name` is
+    neither, which is why the fix reads as a two-line preamble in every resolver.
+    """
+    params = _parameter_names(fn)
+    hits = []
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.ctx, ast.Load)
+            and node.attr in ACTOR_NAMES
+            and isinstance(node.value, ast.Name)
+            and node.value.id == _CLIENT_INPUT
+        ):
+            hits.append(f"{_CLIENT_INPUT}.{node.attr} (line {node.lineno})")
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id in ACTOR_NAMES:
+            if node.id in params:
+                hits.append(f"argument {node.id} (line {node.lineno})")
+    return hits
+
+
+def _hardcoded_actor_keywords(fn) -> list[str]:
+    """Actor keyword arguments whose value is a bare string, e.g. performed_by="Admin/Manager"."""
+    hits = []
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg in ACTOR_NAMES and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                hits.append(f"{kw.arg}={kw.value.value!r} (line {kw.value.lineno})")
+    return hits
+
+
+def test_the_actor_vocabulary_is_actually_present_in_the_schemas():
+    """Guard the guard. If the field names were renamed wholesale, both checks below would pass
+    vacuously on a codebase full of client-supplied actors under new names. Assert the vocabulary
+    still matches reality by requiring a decent share of it to appear somewhere in app/schemas/."""
+    text = "\n".join(p.read_text(encoding="utf-8") for p in _SCHEMAS_DIR.rglob("*.py"))
+    present = {name for name in ACTOR_NAMES if name in text}
+    assert len(present) >= 10, (
+        f"only {sorted(present)} of the actor vocabulary appears in app/schemas/ - either the fields "
+        f"were renamed (update ACTOR_NAMES) or this test is no longer checking anything."
+    )
+
+
+@pytest.mark.parametrize(
+    "module, fn",
+    _RESOLVERS,
+    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
+)
+def test_resolver_does_not_take_its_actor_from_the_client(module, fn):
+    hits = _client_supplied_actor_reads(fn)
+    assert not hits, (
+        f"{module}.{fn.name} (line {fn.lineno}) reads the acting user from client input: "
+        f"{', '.join(hits)}. Whoever is signed in could then file the action under someone else's "
+        f"name. Take it from the gate instead:\n"
+        f"    auth = require_user(info)\n"
+        f"    actor = resolve_display_name(auth['user_id'])\n"
+        f"The argument may stay in the GraphQL schema, accepted and ignored, so a frontend from the "
+        f"previous deploy keeps working - it just must not reach the repository."
+    )
+
+
+@pytest.mark.parametrize(
+    "module, fn",
+    _RESOLVERS,
+    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
+)
+def test_resolver_does_not_hardcode_its_actor(module, fn):
+    hits = _hardcoded_actor_keywords(fn)
+    assert not hits, (
+        f"{module}.{fn.name} (line {fn.lineno}) writes a constant as the acting user: "
+        f"{', '.join(hits)}. A row that says 'Admin/Manager' for every caller records nothing - it "
+        f"is the same defect as trusting the client, with the wrong answer baked in instead. Resolve "
+        f"the caller with resolve_display_name(auth['user_id'])."
+    )

--- a/frontend/src/components/RequestsReviewPage.tsx
+++ b/frontend/src/components/RequestsReviewPage.tsx
@@ -15,7 +15,6 @@ import { ChevronDown, Check, X, Undo2 } from 'lucide-react';
 import { useMutation } from '@apollo/client/react';
 import type { DocumentNode } from 'graphql';
 import { useToast } from './Toast';
-import { useIdentity } from '../hooks/useIdentity';
 import ConfirmDialog from './ConfirmDialog';
 import { RESERVATION_STALE_ROOT_FIELDS } from '../graphql/refetch';
 import { monoSx } from '../theme';
@@ -87,7 +86,6 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
   note,
 }: RequestsReviewPageProps<TRequest>) {
   const { showToast } = useToast();
-  const { displayName } = useIdentity();
   // Which request is mid-flight, and which action - drives per-button spinners while every button on
   // that request disables so the actions can't race each other.
   const [pending, setPending] = useState<{ id: string; action: 'accept' | 'reject' | 'reopen' } | null>(null);
@@ -128,12 +126,12 @@ export default function RequestsReviewPage<TRequest extends ReviewableRequest>({
 
   const handleAccept = (id: string) => {
     setPending({ id, action: 'accept' });
-    acceptRequest({ variables: { id, acceptedBy: displayName } });
+    acceptRequest({ variables: { id } });
   };
 
   const handleReject = (id: string) => {
     setPending({ id, action: 'reject' });
-    rejectRequest({ variables: { id, rejectedBy: displayName, reason: null } });
+    rejectRequest({ variables: { id, reason: null } });
   };
 
   const handleReopen = (id: string) => {

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -195,9 +195,26 @@ export const GET_OPENING_LEAF_STATUS = gql`
   }
 `;
 
+// The caller's OWN buyer assignment, for the register-PO dialog's project filter (#216). Scoped
+// server-side as of #428, so this returns at most one row - the one matching the caller's linked GP
+// buyer id - or none if no id is linked yet. The whole table is `allBuyerAssignments`, admin only.
 export const GET_BUYER_ASSIGNMENTS = gql`
   query GetBuyerAssignments {
     buyerAssignments {
+      buyerId
+      projects {
+        id
+        projectId
+        description
+      }
+    }
+  }
+`;
+
+// Every buyer's assignment, for the Buyers admin page. Admin-gated (#428).
+export const GET_ALL_BUYER_ASSIGNMENTS = gql`
+  query GetAllBuyerAssignments {
+    allBuyerAssignments {
       buyerId
       projects {
         id

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -99,8 +99,8 @@ export const GET_SHIPPING_OUT_REQUESTS = gql`
 `;
 
 export const ACCEPT_SHIPPING_OUT_REQUEST = gql`
-  mutation AcceptShippingOutRequest($id: ID!, $acceptedBy: String!) {
-    acceptShippingOutRequest(id: $id, acceptedBy: $acceptedBy) {
+  mutation AcceptShippingOutRequest($id: ID!) {
+    acceptShippingOutRequest(id: $id) {
       id
       status
     }
@@ -108,8 +108,8 @@ export const ACCEPT_SHIPPING_OUT_REQUEST = gql`
 `;
 
 export const REJECT_SHIPPING_OUT_REQUEST = gql`
-  mutation RejectShippingOutRequest($id: ID!, $rejectedBy: String!, $reason: String) {
-    rejectShippingOutRequest(id: $id, rejectedBy: $rejectedBy, reason: $reason) {
+  mutation RejectShippingOutRequest($id: ID!, $reason: String) {
+    rejectShippingOutRequest(id: $id, reason: $reason) {
       id
       status
     }

--- a/frontend/src/graphql/shop-assembly.ts
+++ b/frontend/src/graphql/shop-assembly.ts
@@ -253,8 +253,8 @@ export const GET_SHOP_ASSEMBLY_REQUESTS = gql`
 `;
 
 export const ACCEPT_SHOP_ASSEMBLY_REQUEST = gql`
-  mutation AcceptShopAssemblyRequest($id: ID!, $acceptedBy: String!) {
-    acceptShopAssemblyRequest(id: $id, acceptedBy: $acceptedBy) {
+  mutation AcceptShopAssemblyRequest($id: ID!) {
+    acceptShopAssemblyRequest(id: $id) {
       id
       status
     }
@@ -262,8 +262,8 @@ export const ACCEPT_SHOP_ASSEMBLY_REQUEST = gql`
 `;
 
 export const REJECT_SHOP_ASSEMBLY_REQUEST = gql`
-  mutation RejectShopAssemblyRequest($id: ID!, $rejectedBy: String!, $reason: String) {
-    rejectShopAssemblyRequest(id: $id, rejectedBy: $rejectedBy, reason: $reason) {
+  mutation RejectShopAssemblyRequest($id: ID!, $reason: String) {
+    rejectShopAssemblyRequest(id: $id, reason: $reason) {
       id
       status
     }

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -558,9 +558,12 @@ const PULL_STAGING_OPENING_FIELDS = `
   items { id shopAssemblyOpeningId hardwareCategory productCode quantity allocatedQuantity }
 `;
 
+// #427: who did it is taken from the Clerk token server-side, so these mutations no longer send an
+// actor. The arguments still exist in the schema (accepted and ignored) so a tab loaded against the
+// previous deploy keeps working; they are dropped once no deployed frontend references them.
 export const START_PULL_REQUEST_PICK = gql`
-  mutation StartPullRequestPick($id: ID!, $startedBy: String!) {
-    startPullRequestPick(id: $id, startedBy: $startedBy) { ${PULL_REQUEST_FIELDS} }
+  mutation StartPullRequestPick($id: ID!) {
+    startPullRequestPick(id: $id) { ${PULL_REQUEST_FIELDS} }
   }
 `;
 
@@ -571,16 +574,16 @@ export const GET_PULL_PICK_SHEET = gql`
 `;
 
 export const SAVE_PICK_DRAFT = gql`
-  mutation SavePickDraft($pullRequestId: ID!, $lines: [PickLineInput!]!, $enteredBy: String!) {
-    savePickDraft(pullRequestId: $pullRequestId, lines: $lines, enteredBy: $enteredBy) {
+  mutation SavePickDraft($pullRequestId: ID!, $lines: [PickLineInput!]!) {
+    savePickDraft(pullRequestId: $pullRequestId, lines: $lines) {
       ${PICK_SHEET_FIELDS}
     }
   }
 `;
 
 export const CONFIRM_PICK = gql`
-  mutation ConfirmPick($pullRequestId: ID!, $lines: [PickLineInput!]!, $pickedBy: String!) {
-    confirmPick(pullRequestId: $pullRequestId, lines: $lines, pickedBy: $pickedBy) {
+  mutation ConfirmPick($pullRequestId: ID!, $lines: [PickLineInput!]!) {
+    confirmPick(pullRequestId: $pullRequestId, lines: $lines) {
       pullRequest { ${PULL_REQUEST_FIELDS} }
       outcome
       appliedQuantity
@@ -595,8 +598,8 @@ export const CONFIRM_PICK = gql`
 `;
 
 export const SET_PULL_ITEM_FETCHED = gql`
-  mutation SetPullItemFetched($itemId: ID!, $fetched: Boolean!, $fetchedBy: String!) {
-    setPullItemFetched(itemId: $itemId, fetched: $fetched, fetchedBy: $fetchedBy) {
+  mutation SetPullItemFetched($itemId: ID!, $fetched: Boolean!) {
+    setPullItemFetched(itemId: $itemId, fetched: $fetched) {
       id pullRequestId itemType openingNumber openingItemId leaf
       hardwareCategory productCode requestedQuantity fetchedAt fetchedBy
     }
@@ -604,8 +607,8 @@ export const SET_PULL_ITEM_FETCHED = gql`
 `;
 
 export const COMPLETE_PULL_REQUEST = gql`
-  mutation CompletePullRequest($id: ID!, $completedBy: String) {
-    completePullRequest(id: $id, completedBy: $completedBy) { ${PULL_REQUEST_FIELDS} }
+  mutation CompletePullRequest($id: ID!) {
+    completePullRequest(id: $id) { ${PULL_REQUEST_FIELDS} }
   }
 `;
 

--- a/frontend/src/modules/admin/BuyersPage.tsx
+++ b/frontend/src/modules/admin/BuyersPage.tsx
@@ -19,7 +19,7 @@ import {
 import { AlertTriangle, Plus, Trash2 } from 'lucide-react';
 import { DataGrid, type GridColDef, type GridRowParams } from '@mui/x-data-grid';
 import { useMutation, useQuery } from '@apollo/client/react';
-import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/shared';
+import { GET_ALL_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/shared';
 import { DELETE_BUYER_ASSIGNMENT, SAVE_BUYER_ASSIGNMENT } from '../../graphql/admin';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
@@ -50,13 +50,15 @@ export default function BuyersPage() {
   const { isAdmin } = useIdentity();
   const { showToast } = useToast();
 
-  const { data, loading } = useQuery<{ buyerAssignments: BuyerAssignmentRow[] }>(GET_BUYER_ASSIGNMENTS, {
+  // #428: the admin whole-table read. `buyerAssignments` is scoped to the caller's own row now, so
+  // this page - the one screen that genuinely needs every buyer - uses the admin-gated resolver.
+  const { data, loading } = useQuery<{ allBuyerAssignments: BuyerAssignmentRow[] }>(GET_ALL_BUYER_ASSIGNMENTS, {
     skip: !isAdmin,
     fetchPolicy: 'cache-and-network',
   });
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS, { skip: !isAdmin });
   const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
-  const rows = useMemo(() => data?.buyerAssignments ?? [], [data]);
+  const rows = useMemo(() => data?.allBuyerAssignments ?? [], [data]);
 
   // Edit dialog state. isNew drives whether the buyer id is editable (it's the row key).
   const [editOpen, setEditOpen] = useState(false);
@@ -74,7 +76,7 @@ export default function BuyersPage() {
   const canFlagUnregistered = !gpBuyers.unavailable && !gpBuyers.loading && gpBuyers.buyers.length > 0;
 
   const [saveAssignment, { loading: saving }] = useMutation(SAVE_BUYER_ASSIGNMENT, {
-    refetchQueries: [{ query: GET_BUYER_ASSIGNMENTS }],
+    refetchQueries: [{ query: GET_ALL_BUYER_ASSIGNMENTS }],
     onCompleted: () => {
       showToast('Buyer assignment saved', 'success');
       setEditOpen(false);
@@ -83,7 +85,7 @@ export default function BuyersPage() {
   });
 
   const [deleteAssignment] = useMutation(DELETE_BUYER_ASSIGNMENT, {
-    refetchQueries: [{ query: GET_BUYER_ASSIGNMENTS }],
+    refetchQueries: [{ query: GET_ALL_BUYER_ASSIGNMENTS }],
     onCompleted: () => {
       showToast('Buyer assignment deleted', 'success');
       setDeleteTarget(null);

--- a/frontend/src/modules/admin/InventoryCorrectionModal.tsx
+++ b/frontend/src/modules/admin/InventoryCorrectionModal.tsx
@@ -14,7 +14,6 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
-import { useIdentity } from '../../hooks/useIdentity';
 import { FONT_MONO, microLabelSx, monoSx, tabularSx } from '../../theme';
 import { OVERRIDE_INVENTORY_QUANTITY, ASSIGN_OPENING_ITEM_LOCATION } from '../../graphql/admin';
 import { MOVE_INVENTORY_LOCATION, MARK_INVENTORY_UNLOCATED, ASSIGN_INVENTORY_LOCATION, MOVE_OPENING_ITEM_LOCATION, MARK_OPENING_ITEM_UNLOCATED } from '../../graphql/shared';
@@ -136,7 +135,6 @@ export default function InventoryCorrectionModal({
   onSuccess,
 }: InventoryCorrectionModalProps) {
   const { showToast } = useToast();
-  const { displayName } = useIdentity();
 
   // Determine smart default correction type
   const defaultCorrectionType: CorrectionType = hasLocation(item) ? 'moveLocation' : 'assignLocation';
@@ -395,7 +393,6 @@ export default function InventoryCorrectionModal({
                         quantity: Number(d.quantity),
                       }))
                     : [],
-                performedBy: displayName,
               },
             },
           });

--- a/frontend/src/modules/admin/__tests__/BuyersPage.test.tsx
+++ b/frontend/src/modules/admin/__tests__/BuyersPage.test.tsx
@@ -3,7 +3,7 @@ import { MockedProvider, type MockedResponse } from '@apollo/client/testing/reac
 import { ToastProvider } from '../../../components/Toast';
 import BuyersPage from '../BuyersPage';
 import { GET_GP_BUYERS_DETAILED } from '../../../graphql/admin';
-import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS, GET_RELAY_STATUS } from '../../../graphql/shared';
+import { GET_ALL_BUYER_ASSIGNMENTS, GET_PROJECTS, GET_RELAY_STATUS } from '../../../graphql/shared';
 
 vi.setConfig({ testTimeout: 30_000 });
 
@@ -56,11 +56,11 @@ function relayStatusMock(connected: boolean): MockedResponse {
 
 function assignmentsMock(buyerIds: string[]): MockedResponse {
   return {
-    request: { query: GET_BUYER_ASSIGNMENTS },
+    request: { query: GET_ALL_BUYER_ASSIGNMENTS },
     maxUsageCount: INFINITE,
     result: {
       data: {
-        buyerAssignments: buyerIds.map((buyerId) => ({
+        allBuyerAssignments: buyerIds.map((buyerId) => ({
           buyerId,
           projects: [],
           __typename: 'BuyerAssignment',

--- a/frontend/src/modules/shipping/PackingSlipForm.tsx
+++ b/frontend/src/modules/shipping/PackingSlipForm.tsx
@@ -147,7 +147,6 @@ export default function PackingSlipForm({ open, onClose, onShipped, projectId, p
           input: {
             projectId,
             packingSlipNumber,
-            shippedBy: displayName,
             items: shipmentItems,
           },
         },

--- a/frontend/src/modules/shipping/ReturnShipmentDialog.tsx
+++ b/frontend/src/modules/shipping/ReturnShipmentDialog.tsx
@@ -17,7 +17,6 @@ import {
 import { useMutation, useQuery } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
-import { useIdentity } from '../../hooks/useIdentity';
 import { GET_WAREHOUSES } from '../../graphql/shared';
 import { GET_RETURNABLE_LINES, CREATE_SHIPMENT_RETURN } from '../../graphql/shipping';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
@@ -77,7 +76,6 @@ interface Props {
 }
 
 export default function ReturnShipmentDialog({ slip, onClose, onCompleted }: Props) {
-  const { displayName } = useIdentity();
   const { showToast } = useToast();
 
   const { data, loading, error } = useQuery<{ returnableLines: ReturnableLine[] }>(GET_RETURNABLE_LINES, {
@@ -186,7 +184,6 @@ export default function ReturnShipmentDialog({ slip, onClose, onCompleted }: Pro
         input: {
           packingSlipId: slip.id,
           warehouseId: effectiveWarehouseId,
-          returnedBy: displayName,
           reference: reference.trim() || null,
           items: built.items,
         },

--- a/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/PackingSlipForm.test.tsx
@@ -55,7 +55,6 @@ const CONFIRM_VARS = {
   input: {
     projectId: PROJECT_ID,
     packingSlipNumber: 'PS-0019-L1',
-    shippedBy: 'Me',
     items: [{ itemType: 'OPENING_ITEM', openingItemId: 'oi-1', quantity: 1 }],
   },
 };

--- a/frontend/src/modules/shop-assembly/AssembleListPage.tsx
+++ b/frontend/src/modules/shop-assembly/AssembleListPage.tsx
@@ -386,7 +386,6 @@ export default function AssembleListPage() {
             setCompletingId(null);
             refetch();
           }}
-          completedBy={displayName}
         />
       )}
     </Box>

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -67,9 +67,6 @@ interface AssemblyDetailModalProps {
   onClose: () => void;
   // Called once the leaf is finished and minted as an OpeningItem - the caller closes and refetches.
   onCompleted: () => void;
-  // The logged-in assembler; recorded as the performer on progress saves, on the completion, and on
-  // any deficiency return so the audit trail names a real user, not the generic "Assembler".
-  completedBy?: string;
 }
 
 const MAX_REASON_LENGTH = 500;
@@ -79,7 +76,6 @@ export default function AssemblyDetailModal({
   opening,
   onClose,
   onCompleted,
-  completedBy,
 }: AssemblyDetailModalProps) {
   const { showToast } = useToast();
   const [aisle, setAisle] = useState('');
@@ -216,12 +212,12 @@ export default function AssemblyDetailModal({
       return;
     }
     const result = await recordProgress({
-      variables: { input: { openingId: opening.id, items, performedBy: completedBy || null } },
+      variables: { input: { openingId: opening.id, items } },
     });
     if (result.data) showToast('Progress saved', 'success');
     // The modal deliberately stays open: a save is a checkpoint mid-job, not the end of it, and the
     // leaf stays in My Work as In Progress.
-  }, [progressPayload, recordProgress, opening.id, completedBy, showToast]);
+  }, [progressPayload, recordProgress, opening.id, showToast]);
 
   const handleConfirmComplete = useCallback(async () => {
     setConfirmOpen(false);
@@ -230,7 +226,7 @@ export default function AssemblyDetailModal({
     const items = progressPayload();
     if (items.length > 0) {
       const saved = await recordProgress({
-        variables: { input: { openingId: opening.id, items, performedBy: completedBy || null } },
+        variables: { input: { openingId: opening.id, items } },
       });
       if (!saved.data) return;
     }
@@ -241,11 +237,10 @@ export default function AssemblyDetailModal({
           aisle: aisle || null,
           row: row || null,
           bay: bay || null,
-          completedBy: completedBy || null,
         },
       },
     });
-  }, [progressPayload, recordProgress, completeOpening, opening.id, aisle, row, bay, completedBy]);
+  }, [progressPayload, recordProgress, completeOpening, opening.id, aisle, row, bay]);
 
   // --- deficiency flagging -------------------------------------------------------------------
 
@@ -291,7 +286,6 @@ export default function AssemblyDetailModal({
               deficientReason: flagReason.trim(),
             },
           ],
-          performedBy: completedBy || null,
         },
       },
     });
@@ -307,7 +301,7 @@ export default function AssemblyDetailModal({
         'success'
       );
     }
-  }, [flagging, recordProgress, opening.id, flagQuantity, flagReason, completedBy, showToast]);
+  }, [flagging, recordProgress, opening.id, flagQuantity, flagReason, showToast]);
 
   return (
     <>

--- a/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
+++ b/frontend/src/modules/shop-assembly/AssignmentBoard.tsx
@@ -390,7 +390,6 @@ export default function AssignmentBoard() {
             setCompletingId(null);
             refetch();
           }}
-          completedBy={displayName}
         />
       )}
     </Box>

--- a/frontend/src/modules/shop-assembly/MyWorkPage.tsx
+++ b/frontend/src/modules/shop-assembly/MyWorkPage.tsx
@@ -139,7 +139,7 @@ const columns: GridColDef[] = [
 ];
 
 export default function MyWorkPage() {
-  const { displayName, userId } = useIdentity();
+  const { userId } = useIdentity();
   // Hold the id, not the row. The modal writes progress and the list refetches; keeping the object
   // would pin the modal to a snapshot taken before the save, so a just-flagged deficiency would not
   // appear in it.
@@ -191,7 +191,7 @@ export default function MyWorkPage() {
       {/* Leaves this assembler already finished that are owed replacement hardware (#341). Kept out
           of the grid above because those rows are unfinished openings and these are complete ones -
           folding them in would mean either reopening a finished work unit or mislabelling it. */}
-      <ReplacementWorkPanel assignedToUserId={userId} performedBy={displayName} />
+      <ReplacementWorkPanel assignedToUserId={userId} />
 
       {selectedOpening && (
         <AssemblyDetailModal
@@ -202,7 +202,6 @@ export default function MyWorkPage() {
           opening={selectedOpening}
           onClose={() => setSelectedOpeningId(null)}
           onCompleted={handleCompleted}
-          completedBy={displayName}
         />
       )}
     </Box>

--- a/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
+++ b/frontend/src/modules/shop-assembly/ReplacementWorkPanel.tsx
@@ -30,8 +30,6 @@ export interface ReplacementWorkRow {
 interface ReplacementWorkPanelProps {
   /** The signed-in assembler; the panel shows only the work assigned to them. */
   assignedToUserId: string | null;
-  /** Recorded as the performer on the install audit row. */
-  performedBy?: string;
 }
 
 /**
@@ -46,7 +44,7 @@ interface ReplacementWorkPanelProps {
  * listed, because the hardware is real and must not be silently stranded; it just cannot be
  * installed from here.
  */
-export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: ReplacementWorkPanelProps) {
+export default function ReplacementWorkPanel({ assignedToUserId }: ReplacementWorkPanelProps) {
   const { showToast } = useToast();
   const [pending, setPending] = useState<ReplacementWorkRow | null>(null);
 
@@ -77,7 +75,6 @@ export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: 
           // The whole pending quantity: the units arrived together on one pull line, and splitting
           // them would be an invented distinction the assembler has no way to act on.
           quantity: row.pendingQuantity,
-          performedBy,
         },
       },
     });
@@ -87,7 +84,7 @@ export default function ReplacementWorkPanel({ assignedToUserId, performedBy }: 
         'success',
       );
     }
-  }, [pending, installReplacement, performedBy, showToast]);
+  }, [pending, installReplacement, showToast]);
 
   const rows = data?.replacementWork ?? [];
   if (!assignedToUserId || loading || rows.length === 0) return null;

--- a/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
@@ -69,7 +69,6 @@ const saveMock: MockedResponse = {
       input: {
         openingId: 'o1',
         items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
-        performedBy: 'Ada Lovelace',
       },
     },
   },

--- a/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
@@ -50,7 +50,6 @@ function renderModal(
           opening={opening(items)}
           onClose={vi.fn()}
           onCompleted={onCompleted}
-          completedBy="Ada"
         />
       </ToastProvider>
     </MockedProvider>
@@ -132,7 +131,6 @@ describe('AssemblyDetailModal progress editor', () => {
           input: {
             openingId: 'o1',
             items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
-            performedBy: 'Ada',
           },
         },
       },
@@ -182,7 +180,6 @@ describe('AssemblyDetailModal progress editor', () => {
           input: {
             openingId: 'o1',
             items: [{ shopAssemblyOpeningItemId: 'i1', installedQuantity: 2 }],
-            performedBy: 'Ada',
           },
         },
       },
@@ -219,7 +216,6 @@ describe('AssemblyDetailModal progress editor', () => {
             aisle: null,
             row: null,
             bay: null,
-            completedBy: 'Ada',
           },
         },
       },

--- a/frontend/src/modules/shop-assembly/__tests__/ReplacementWorkPanel.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/ReplacementWorkPanel.test.tsx
@@ -46,7 +46,7 @@ function installMock(quantity: number): MockedResponse {
     request: {
       query: INSTALL_REPLACEMENT,
       variables: {
-        input: { shopAssemblyOpeningItemId: 'sai-1', quantity, performedBy: 'Ada' },
+        input: { shopAssemblyOpeningItemId: 'sai-1', quantity },
       },
     },
     result: {
@@ -76,7 +76,7 @@ function renderPanel(mocks: MockedResponse[], userId: string | null = 'user_1') 
   return render(
     <MockedProvider mocks={mocks}>
       <ToastProvider>
-        <ReplacementWorkPanel assignedToUserId={userId} performedBy='Ada' />
+        <ReplacementWorkPanel assignedToUserId={userId} />
       </ToastProvider>
     </MockedProvider>
   );

--- a/frontend/src/modules/warehouse/FetchListPanel.tsx
+++ b/frontend/src/modules/warehouse/FetchListPanel.tsx
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react';
 import { Box, Checkbox, Chip, Stack, Typography } from '@mui/material';
 import { useMutation } from '@apollo/client/react';
 import { SET_PULL_ITEM_FETCHED } from '../../graphql/warehouse';
-import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { leafIdentity } from '../../utils/leaf';
@@ -43,7 +42,6 @@ type FetchOverride = { fetchedAt: string | null; fetchedBy: string | null };
  * means walking the rack twice.
  */
 export default function FetchListPanel({ items, editable }: FetchListPanelProps) {
-  const { displayName } = useIdentity();
   const { showToast } = useToast();
   const [overrides, setOverrides] = useState<Record<string, FetchOverride>>({});
   // Per row, not one shared flag: ticking leaf 1 must not freeze the other twenty-nine checkboxes
@@ -127,7 +125,6 @@ export default function FetchListPanel({ items, editable }: FetchListPanelProps)
                           variables: {
                             itemId: item.pullRequestItemId,
                             fetched: e.target.checked,
-                            fetchedBy: displayName,
                           },
                         }).catch(() => settle(item.pullRequestItemId));
                       }}

--- a/frontend/src/modules/warehouse/HardwareItemsTab.tsx
+++ b/frontend/src/modules/warehouse/HardwareItemsTab.tsx
@@ -404,7 +404,6 @@ function ProductCodeDetail({
                   inventoryLocationId: il.id,
                   quantity: q,
                   reasonText: reason,
-                  performedBy: 'Warehouse',
                 },
               },
             });

--- a/frontend/src/modules/warehouse/PickPage.tsx
+++ b/frontend/src/modules/warehouse/PickPage.tsx
@@ -150,15 +150,15 @@ export default function PickPage() {
 
   const handleSaveDraft = useCallback(() => {
     saveDraft({
-      variables: { pullRequestId: id, lines: toPickLines(sections, entries), enteredBy: displayName },
+      variables: { pullRequestId: id, lines: toPickLines(sections, entries) },
     });
-  }, [saveDraft, id, sections, entries, displayName]);
+  }, [saveDraft, id, sections, entries]);
 
   const handleConfirm = useCallback(() => {
     confirmPick({
-      variables: { pullRequestId: id, lines: toPickLines(sections, entries), pickedBy: displayName },
+      variables: { pullRequestId: id, lines: toPickLines(sections, entries) },
     });
-  }, [confirmPick, id, sections, entries, displayName]);
+  }, [confirmPick, id, sections, entries]);
 
   const handlePrint = useCallback(async () => {
     if (!pr) return;

--- a/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
+++ b/frontend/src/modules/warehouse/PullRequestDetailModal.tsx
@@ -238,14 +238,14 @@ export default function PullRequestDetailModal({
   // --- Handlers ---
 
   const handleComplete = () => {
-    completePR({ variables: { id: pr.id, completedBy: displayName } });
+    completePR({ variables: { id: pr.id } });
   };
 
   const handleCancel = () => {
     setCancelBlockedMessage(null);
     cancelPR({
       variables: {
-        input: { id: pr.id, cancelledBy: displayName, reason: cancelReason.trim() || null },
+        input: { id: pr.id, reason: cancelReason.trim() || null },
       },
     });
   };
@@ -296,7 +296,7 @@ export default function PullRequestDetailModal({
       <Button
         variant="contained"
         color="secondary"
-        onClick={() => startPick({ variables: { id: pr.id, startedBy: displayName } })}
+        onClick={() => startPick({ variables: { id: pr.id } })}
         disabled={startLoading}
       >
         {startLoading ? 'Starting...' : 'Start pick'}

--- a/frontend/src/modules/warehouse/PullStagingPanel.tsx
+++ b/frontend/src/modules/warehouse/PullStagingPanel.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../graphql/refetch';
 import { useToast } from '../../components/Toast';
 import ConfirmDialog from '../../components/ConfirmDialog';
-import { useIdentity } from '../../hooks/useIdentity';
 import { isStageable, type PullStagingOpening } from './pullStaging';
 import { leafIdentity } from '../../utils/leaf';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
@@ -63,7 +62,6 @@ export default function PullStagingPanel({
   onStaged,
 }: PullStagingPanelProps) {
   const { showToast } = useToast();
-  const { displayName } = useIdentity();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -124,7 +122,6 @@ export default function PullStagingPanel({
         input: {
           pullRequestId,
           openingIds: Array.from(selected),
-          stagedBy: displayName,
         },
       },
     });

--- a/frontend/src/modules/warehouse/TransferDialog.tsx
+++ b/frontend/src/modules/warehouse/TransferDialog.tsx
@@ -15,7 +15,6 @@ import { useQuery, useMutation } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import LocationAutocomplete from '../../components/LocationAutocomplete';
 import { useToast } from '../../components/Toast';
-import { useIdentity } from '../../hooks/useIdentity';
 import { GET_WAREHOUSES } from '../../graphql/shared';
 import { GET_LOCATION_DISTINCT_VALUES, TRANSFER_INVENTORY } from '../../graphql/warehouse';
 import { WAREHOUSE_REFETCH_QUERIES } from '../../graphql/refetch';
@@ -46,7 +45,6 @@ interface TransferDialogProps {
 
 export default function TransferDialog({ source, onClose, onSuccess }: TransferDialogProps) {
   const { showToast } = useToast();
-  const { displayName } = useIdentity();
 
   const { data: warehousesData } = useQuery<{ warehouses: WarehouseOption[] }>(GET_WAREHOUSES, {
     variables: { includeInactive: false },
@@ -104,7 +102,6 @@ export default function TransferDialog({ source, onClose, onSuccess }: TransferD
           destAisle: aisle.trim(),
           destRow: row.trim(),
           destBay: bay.trim(),
-          performedBy: displayName,
         },
       },
     });

--- a/frontend/src/modules/warehouse/__tests__/PullRequestCancel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullRequestCancel.test.tsx
@@ -64,7 +64,7 @@ const openingsMock: MockedResponse = {
 };
 
 function cancelVariables(reason: string | null) {
-  return { input: { id: 'pr-1', cancelledBy: 'Picker', reason } };
+  return { input: { id: 'pr-1', reason } };
 }
 
 function cancelSuccessMock(integrityNote: string | null = null): MockedResponse {

--- a/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/PullStagingPanel.test.tsx
@@ -67,7 +67,7 @@ function stageMock(openingIds: string[], completed: boolean, resulting: unknown[
   return {
     request: {
       query: STAGE_PULL_OPENINGS,
-      variables: { input: { pullRequestId: 'pr-1', openingIds, stagedBy: 'Picker' } },
+      variables: { input: { pullRequestId: 'pr-1', openingIds } },
     },
     result: {
       data: {

--- a/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AdjustStockModal.tsx
@@ -41,7 +41,6 @@ export default function AdjustStockModal({ item, onClose, onSuccess }: Props) {
           stockItemId: item.id,
           newQuantity: newQ,
           reasonText: reason.trim(),
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/AllocateStockModal.tsx
@@ -85,7 +85,6 @@ export default function AllocateStockModal({
           targetAisle: aisle.trim() || null,
           targetRow: row.trim() || null,
           targetBay: bay.trim() || null,
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
+++ b/frontend/src/modules/warehouse/stock/DestockInventoryModal.tsx
@@ -81,7 +81,6 @@ export default function DestockInventoryModal({ inventoryLocation, onClose, onSu
           targetAisle: overrideLoc ? aisle.trim() || null : null,
           targetRow: overrideLoc ? row.trim() || null : null,
           targetBay: overrideLoc ? bay.trim() || null : null,
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
+++ b/frontend/src/modules/warehouse/stock/MoveStockLocationModal.tsx
@@ -41,7 +41,6 @@ export default function MoveStockLocationModal({ item, onClose, onSuccess }: Pro
           newAisle: aisle.trim(),
           newRow: row.trim(),
           newBay: bay.trim(),
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReclassifyStockModal.tsx
@@ -51,7 +51,6 @@ export default function ReclassifyStockModal({ item, onClose, onSuccess }: Props
           newProductCode: newCode.trim(),
           quantity: q,
           reasonText: reason.trim() || null,
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ReportStockDeficiencyModal.tsx
@@ -40,7 +40,6 @@ export default function ReportStockDeficiencyModal({ item, onClose, onSuccess }:
           stockItemId: item.id,
           quantity: q,
           reasonText: reason.trim() || null,
-          performedBy: 'Warehouse',
         },
       },
     });

--- a/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
+++ b/frontend/src/modules/warehouse/stock/ResolveDeficiencyModal.tsx
@@ -78,7 +78,6 @@ export default function ResolveDeficiencyModal({ row, onClose, onSuccess }: Prop
           reasonText: reason.trim() || null,
           rmaReference: needsRma ? rma.trim() : null,
           destockSource: resolution === 'SEND_TO_STOCK' ? 'DEFICIENT_SWAP' : null,
-          reviewedBy: 'Warehouse',
         },
       },
     });


### PR DESCRIPTION
Closes #427. Closes #428.

## #428 buyer assignment scoping

buyerAssignments returned the whole table to any signed-in account - Shop Assembly, Shipping Out, Warehouse Staff could all enumerate which buyer owns which project. not an escalation (createPo and registerPoInGp already re-check the caller's own assignment) but the PO dialog only ever wanted its own row.

- buyerAssignments resolves the caller's GP buyer id via user_repository.get_user_gp_buyer_id - the same identity registerPoInGp enforces, so dialog and mutation cannot disagree - and returns at most that one row. no linked buyer id returns [], not an error.
- new allBuyerAssignments, require_admin, whole table, for the Buyers admin page.
- buyer_repository.get_assignment_for_identity is case/whitespace tolerant on purpose: get_assignment matches exact case, and the PO dialog previously did its own case-insensitive match client-side over the full table. an exact-match lookup would have silently broken any account whose linked id differs in case from the stored row.
- frontend: BuyersPage switched to GET_ALL_BUYER_ASSIGNMENTS. GpPurchaseOrderDialog unchanged - it already filtered to its own row, which is now all it receives.

## #427 audit actor

every resolver that stamps an actor now does `auth = require_user(info)` then `resolve_display_name(auth["user_id"])`. the client no longer gets a say.

warehouse: startPullRequestPick, savePickDraft, confirmPick, setPullItemFetched, completePullRequest, stagePullOpenings, cancelPullRequest, adjustInventoryQuantity, overrideInventoryQuantity, moveInventoryLocation, markInventoryUnlocated, assignInventoryLocation, moveOpeningItemLocation, markOpeningItemUnlocated, assignOpeningItemLocation, mergeLocations. createReceive was already correct from #199.

stock: destockInventory, transferInventory, allocateStockToProject, adjustStockQuantity, moveStockLocation, assignStockItemLocation, markStockItemUnlocated, reclassifyStockItem, reportInventoryDeficiency, reportStockDeficiency, reportDeficiencyAtAssembly, resolveDeficiency.

shop assembly: acceptShopAssemblyRequest (approved_by + the minted pull's requested_by), rejectShopAssemblyRequest, recordAssemblyProgress, installReplacement, completeOpening.

shipping: acceptShippingOutRequest, rejectShippingOutRequest, confirmShipment (shipped_by, printed on the slip), createShipmentReturn.

adjust_inventory_quantity and the six locations.py helpers gained a REQUIRED keyword-only performed_by - they previously had no parameter and hardcoded "Admin/Manager", so every adjustment was attributed to an admin regardless of who made it. required, not defaulted, so a future caller has to answer.

deliberately unchanged: assignOpenings' assignedTo/assignedToUserId names the assignee, not the actor - a manager assigning to someone else is the feature. excluded from the new test with a comment.

## backward compatibility

27 client-supplied actor arguments and input fields kept in the schema, nullable + @deprecated, accepted and discarded server-side - same shape as #430's saveBuyerAssignment(costCodes:). required args were widened to optional, which is the safe direction (a required arg cannot carry @deprecated per spec). dropping them outright would break any tab loaded before this deploy, which LazyBoundary cannot catch. frontend no longer sends any of them. follow-up to drop all 27 filed separately.

## new test

backend/tests/test_resolver_actor_provenance.py, AST sweep over app/schemas/ in the shape of test_resolver_gate_completeness.py, no DB, 323 cases. rule A: a resolver body may not read input.<actor> nor read back an actor-named argument of its own. rule B: an actor-named keyword argument may not be a string literal, catching a reintroduced performed_by="Admin/Manager". plus a guard-the-guard asserting the actor vocabulary still appears, so a rename cannot make it pass vacuously. verified against synthetic fixtures for all four historical shapes.

limits, stated in its docstring: syntax not data flow; a positionally-passed actor is invisible to rule B (rule A still covers it); it says nothing about resolvers that should stamp an actor and do not.

## display name cache

resolve_display_name is now on ~30 write paths that previously had no Clerk round trip, and savePickDraft fires on every keystroke batch of a pick sheet. added a 5 minute TTL cache in app/auth.py plus invalidate_display_name, called from updateUserName - the only thing that changes a name. process-local, so a multi-replica backend can show a stale name for up to 5 minutes after a rename; acceptable for a display string on an audit row, flag if not.

backend ruff clean, 832 passed / 513 skipped (skips are the no-local-Postgres set). frontend lint 0 errors / 18 warnings (2 fewer than master), 365 tests / 36 files, build clean.