### PR TITLE
feat(gp): quarantine projects whose GP job setup points at nonexistent accounts (#425)

### DIFF
--- a/backend/alembic/versions/075_project_gp_setup_health.py
+++ b/backend/alembic/versions/075_project_gp_setup_health.py
@@ -1,0 +1,48 @@
+"""Per-project GP setup verdict (#425)
+
+Revision ID: 075
+Revises: 074
+Create Date: 2026-07-30
+
+Receiving PO0000070 in TUBC failed with eConnect 4612 "Invalid Account Index": the PO line carried
+INVINDX=1617, copied from JC00701 (job 23093, cost code 210-200-2) when the WennSoft integration
+registered it. 1617 does not exist in UBC/TUBC's GL00105 - it is a UCSH index, left by the pre-2023
+UCSH -> UBC job replication which copied JC00701 account indexes raw. Production UBC holds 1504 such
+rows across 62 jobs. A job-cost PO against any of them registers fine and can never be received.
+
+Repairing GP is accounting's job. What Nexus owes is detection, so the gp_job_sync pass now asks the
+relay for a per-job verdict and stamps it here:
+  gp_setup_ok         - False quarantines the project's write actions
+  gp_setup_detail     - JSON list of {cost_code, account_index}, so the banner names what is broken
+  gp_setup_checked_at - when the stamp was taken, so a stale verdict is visible as stale
+
+All three are NULLABLE and null is NOT a quarantine. Never-checked has to stay distinguishable from
+checked-and-broken: the sync only runs while a relay is connected, and defaulting to False would mean
+a relay outage - or a fresh database before its first pass - froze every project in Nexus. A down
+relay already blocks the GP writes it is actually needed for; it must not also block importing a
+schedule.
+
+No index: the columns are read alongside the project row that was already being loaded, never
+filtered on. `downgrade()` drops all three, losing only a verdict the next sync pass restamps.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "075"
+down_revision = "074"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("gp_setup_ok", sa.Boolean(), nullable=True))
+    op.add_column("projects", sa.Column("gp_setup_detail", sa.Text(), nullable=True))
+    op.add_column("projects", sa.Column("gp_setup_checked_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "gp_setup_checked_at")
+    op.drop_column("projects", "gp_setup_detail")
+    op.drop_column("projects", "gp_setup_ok")

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -17,8 +17,29 @@ class NotFoundError(AppError):
 
 
 class ConflictError(AppError):
-    def __init__(self, message: str, field: str | None = None):
-        super().__init__(message, "CONFLICT", field)
+    def __init__(self, message: str, field: str | None = None, code: str = "CONFLICT"):
+        super().__init__(message, code, field)
+
+
+class GpSetupInvalidError(ConflictError):
+    """This project's GP job is not set up well enough to act on (#425).
+
+    Its JC00701 cost codes point at GL account indexes that do not exist in the company's chart - the
+    residue of the pre-2023 UCSH -> UBC job copy, 1504 rows across 62 production jobs. A job-cost PO
+    on such a code registers cleanly and then fails FOREVER at receipt with eConnect 4612 "Invalid
+    Account Index", so the hardware arrives, gets counted, and cannot be booked in.
+
+    A conflict rather than a validation failure: nothing about the request is wrong. The state of the
+    world is, and no amount of re-entering the form fixes it - accounting has to repair GP. The
+    distinct code lets the frontend recognise a quarantine and show the banner naming the codes,
+    instead of rendering it as one more red toast the user is expected to act on.
+
+    `issues` carries the parsed {cost_code, account_index} pairs so a caller can reformat them; the
+    message already names them, because a raw GraphQL error is what most callers will show."""
+
+    def __init__(self, message: str, issues: list[dict] | None = None):
+        super().__init__(message, code="GP_SETUP_INVALID")
+        self.issues = issues or []
 
 
 class InsufficientInventoryError(AppError):

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, ForeignKey, Index, Integer, SmallInteger, String, UniqueConstraint, false
+from sqlalchemy import Boolean, ForeignKey, Index, Integer, SmallInteger, String, Text, UniqueConstraint, false
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
@@ -33,6 +33,17 @@ class Project(Base):
     gc_contact_name: Mapped[str | None] = mapped_column(String, nullable=True)
     gc_phone: Mapped[str | None] = mapped_column(String, nullable=True)
     gc_email: Mapped[str | None] = mapped_column(String, nullable=True)
+    # GP job setup verdict, stamped by every gp_job_sync pass (#425). The project's GP job may carry
+    # JC00701 cost codes pointing at GL account indexes this company does not have - a legacy of the
+    # pre-2023 UCSH -> UBC job copy - which makes a PO on that job registerable but never receivable.
+    #
+    # NULL means never checked, and never-checked does NOT quarantine: the sync only runs while a
+    # relay is connected, so a relay outage would otherwise freeze all of Nexus. Only an explicit
+    # False blocks. gp_setup_detail is a JSON list of {cost_code, account_index} so the quarantine
+    # banner can name the codes accounting has to fix rather than saying "something is wrong".
+    gp_setup_ok: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    gp_setup_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gp_setup_checked_at: Mapped[datetime | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -48,6 +48,7 @@ from app.models.shop_assembly import (
 from app.models.shop_assembly import (
     ShopAssemblyRequest as SARModel,
 )
+from app.repositories import project_repository
 
 
 def get_project_hardware_schedule(
@@ -631,6 +632,14 @@ def finalize_import_session(
 
     if project is None:
         raise NotFoundError(f"Project {project_id} not found")
+
+    # #425: quarantine gate. This one mutation is BOTH of Start a Task's write actions - it persists
+    # the schedule, and it creates the shop-assembly and shipping-out requests that reserve inventory
+    # against it. A project whose GP job cannot be received against must not accumulate any of that:
+    # the requests would reserve stock, the POs drafted off the schedule would be unregisterable, and
+    # someone would have to unpick all of it once accounting fixed the job. Passes when the verdict is
+    # null (never checked) - see require_gp_setup_ok.
+    project_repository.require_gp_setup_ok(session, project.id)
 
     # 2. Wipe AVAILABLE hardware items for this project — they are pure XML-derived rows
     # that will be regenerated from the current input. Existing IN_PO rows (attached to

--- a/backend/app/repositories/project_repository.py
+++ b/backend/app/repositories/project_repository.py
@@ -1,13 +1,18 @@
 """Repository for project CRUD operations."""
 
+import json
+import logging
 import uuid
+from datetime import datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.errors import ConflictError, NotFoundError, ValidationError
+from app.errors import ConflictError, GpSetupInvalidError, NotFoundError, ValidationError
 from app.models.project import Opening as OpeningModel
 from app.models.project import Project as ProjectModel
+
+logger = logging.getLogger(__name__)
 
 
 def list_projects_with_opening_counts(session: Session) -> list[tuple[ProjectModel, int]]:
@@ -63,6 +68,118 @@ def adopt_gp_job(session: Session, job_number: str, job_name: str | None) -> Pro
     session.add(project)
     session.flush()
     return project
+
+
+def parse_gp_setup_issues(detail: str | None) -> list[dict]:
+    """The {cost_code, account_index} pairs out of a project's gp_setup_detail column (#425).
+
+    Tolerant on purpose. The column is JSON text written by the sync from whatever the relay reported,
+    and it is read on every project query and in every quarantine message - a malformed or
+    old-shaped value must degrade to "broken, details unavailable" rather than 500 the project list.
+    Anything unparseable, or not a list of objects, yields []."""
+    if not detail:
+        return []
+    try:
+        parsed = json.loads(detail)
+    except (TypeError, ValueError):
+        logger.warning("gp_setup_detail is not valid JSON; treating as no detail")
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [
+        {"cost_code": str(item.get("cost_code") or ""), "account_index": int(item.get("account_index") or 0)}
+        for item in parsed
+        if isinstance(item, dict)
+    ]
+
+
+def _describe_gp_setup_issues(issues: list[dict]) -> str:
+    """The human half of the quarantine message: the cost codes and the accounts they point at.
+
+    Capped at three because the point is recognition, not enumeration - the 62 affected production
+    jobs average 24 broken codes each, and an error message listing all of them is one nobody reads."""
+    if not issues:
+        return "its GP cost codes point at general ledger accounts that do not exist in this company"
+    shown = ", ".join(f"{i['cost_code']} -> GL account index {i['account_index']}" for i in issues[:3])
+    if len(issues) > 3:
+        shown += f", and {len(issues) - 3} more"
+    return f"these cost codes point at general ledger accounts that do not exist in this company: {shown}"
+
+
+def require_gp_setup_ok(session: Session, project_id: uuid.UUID | None) -> None:
+    """Refuse to act on a project whose GP job setup is known broken (#425).
+
+    The single server-side quarantine gate, called by every action that would put work into GP or
+    commit hardware to a job: schedule import / Start a Task (finalize_import_session), registering a
+    PO, receiving against one, and confirming a shipment. It is server-side because the frontend
+    banner is a courtesy - a stale tab, a replayed mutation or a direct GraphQL call must hit the same
+    wall.
+
+    Only `gp_setup_ok is False` blocks. None (never checked) and True both pass:
+      - None is what a project looks like before the first sync pass reaches it, and while no relay is
+        connected at all. Quarantining on None would let a relay outage freeze every project in Nexus,
+        including the actions that never touch GP.
+      - the stamp can be stale by up to one poll interval, which is why register_po_in_gp additionally
+        re-checks the job LIVE at submit time. This gate is the floor, not the ceiling.
+
+    project_id None is a no-op: a draft PO with no project has no GP job to be broken."""
+    if project_id is None:
+        return
+    row = session.execute(
+        select(ProjectModel.project_id, ProjectModel.gp_setup_ok, ProjectModel.gp_setup_detail).where(
+            ProjectModel.id == project_id
+        )
+    ).first()
+    if row is None or row.gp_setup_ok is not False:
+        return
+    issues = parse_gp_setup_issues(row.gp_setup_detail)
+    raise GpSetupInvalidError(
+        f"GP job {row.project_id} is not set up correctly, so this project is on hold: "
+        f"{_describe_gp_setup_issues(issues)}. A purchase order on this job would register in GP but "
+        f"could never be received. Accounting has to correct the job's cost-code accounts in GP "
+        f"before work on this project can continue.",
+        issues=issues,
+    )
+
+
+def stamp_gp_setup_health(session: Session, verdicts: dict[str, dict]) -> int:
+    """Record the relay's per-job GP setup verdict on every project it covers (#425). Returns how many
+    projects were stamped. The caller commits.
+
+    `verdicts` is keyed by GP job number, which is the project's `project_id`, and each value is the
+    relay's {ok, issues} for that job. Projects GP did not report are left ALONE rather than reset to
+    null: a job filtered out of the answer (the single-job re-check, a job deleted in GP) says nothing
+    about whether its setup was fine an hour ago, and blanking the verdict would silently un-quarantine
+    a broken project.
+
+    One UPDATE per changed project inside the caller's transaction, and the whole thing is skipped for
+    a project whose verdict has not moved - the sync runs every five minutes over ~900 projects, and
+    rewriting an unchanged row 900 times per pass would churn the table for nothing. checked_at is
+    stamped on every pass though, changed or not: "last confirmed" is the useful reading of it."""
+    now = datetime.utcnow()
+    stamped = 0
+    projects = session.scalars(select(ProjectModel).where(ProjectModel.project_id.in_(list(verdicts)))).all()
+    for project in projects:
+        verdict = verdicts.get(project.project_id)
+        if verdict is None:
+            continue
+        ok = bool(verdict.get("ok"))
+        issues = verdict.get("issues") or []
+        # Serialized here rather than by the caller so the shape parse_gp_setup_issues expects is
+        # decided in exactly one place.
+        detail = json.dumps(
+            [
+                {"cost_code": str(i.get("cost_code") or ""), "account_index": int(i.get("account_index") or 0)}
+                for i in issues
+                if isinstance(i, dict)
+            ]
+        )
+        project.gp_setup_ok = ok
+        project.gp_setup_detail = detail if issues else None
+        project.gp_setup_checked_at = now
+        stamped += 1
+    session.flush()
+    return stamped
 
 
 def update_project(

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -39,6 +39,7 @@ from app.models.shipping_out_request import (
     ShippingOutRequestItem,
 )
 from app.models.warehouse import Warehouse
+from app.repositories import project_repository
 from app.repositories.stock import _find_or_create_stock_row, _log_audit_event
 from app.services import notification_service
 from app.services.locking import lock_rows
@@ -160,6 +161,12 @@ def confirm_shipment(
             - hardware_category: str (for Loose type)
             - quantity: int
     """
+    # 0. #425: quarantine gate. Shipping out is the last thing a project does, and it is the point of
+    # no return - hardware leaves the building against a job whose costs cannot be booked. Blocked
+    # here for the same reason the earlier stages are: everything downstream of a broken GP job has to
+    # stop until accounting has repaired it, or the reconciliation gets worse the longer it runs.
+    project_repository.require_gp_setup_ok(session, project_id)
+
     # 1. Validate packing_slip_number
     if not packing_slip_number or len(packing_slip_number) < 1 or len(packing_slip_number) > 50:
         raise ValidationError("packing_slip_number must be 1-50 characters", field="packing_slip_number")

--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -25,6 +25,7 @@ from app.models.purchase_order import PurchaseOrder as POModel
 from app.models.receiving import ReceiveLineItem as ReceiveLineItemModel
 from app.models.receiving import ReceiveRecord as ReceiveRecordModel
 from app.models.vendor import Vendor as VendorModel
+from app.repositories import project_repository
 from app.services import notification_service
 from app.services.locking import lock_rows
 
@@ -61,6 +62,13 @@ def validate_receive_eligibility(
         raise ValidationError("received_by must be 1-100 characters", field="received_by")
     if not line_items_input:
         raise ValidationError("At least one line item is required", field="line_items")
+    # #425: the quarantine gate for receiving, and it belongs HERE rather than in create_receive.
+    # This runs before the GP receipt is posted; create_receive runs after GP has already committed
+    # it, and refusing there would leave a receipt in GP that Nexus will not book - the exact
+    # split-brain the GP-first ordering exists to avoid. A broken job cannot be received anyway
+    # (taPopRcptLineInsert rejects the line's account index with eConnect 4612), so this turns an
+    # unavoidable failure into one that names the cause.
+    project_repository.require_gp_setup_ok(session, po.project_id)
 
     poli_dict: dict[uuid.UUID, POLineItemModel] = {li.id: li for li in po.line_items}
     receipt_line_items: list[dict] = []

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -7,6 +7,7 @@ performance rules in CLAUDE.md before adding a field that walks a new relationsh
 import strawberry
 
 from app.models.project import Project as ProjectModel
+from app.repositories import project_repository
 
 from .enums import GpOutboxStatus, PipelineStage
 from .types import (
@@ -25,6 +26,7 @@ from .types import (
     GpJob,
     GpOutboxEntry,
     GpOutboxSummary,
+    GpSetupIssue,
     GpTaxDetail,
     GpTaxSchedule,
     GpVendor,
@@ -406,6 +408,15 @@ def project_to_type(
         created_at=p.created_at,
         updated_at=p.updated_at,
         opening_count=opening_count,
+        # #425: scalar columns off the row already loaded, so this is free in both list and detail
+        # contexts and needs no include_ flag. The JSON detail column is parsed here rather than
+        # exposed raw - a GraphQL type is the wrong place for a client-side JSON.parse.
+        gp_setup_ok=p.gp_setup_ok,
+        gp_setup_checked_at=p.gp_setup_checked_at,
+        gp_setup_issues=[
+            GpSetupIssue(cost_code=issue["cost_code"], account_index=issue["account_index"])
+            for issue in project_repository.parse_gp_setup_issues(p.gp_setup_detail)
+        ],
         openings=openings_list,
         purchase_orders=[],  # Loaded on demand in later tickets
     )

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -9,9 +9,21 @@ import strawberry
 
 from app.auth import require_admin, require_user
 from app.database import SessionLocal
-from app.errors import InvalidStateTransitionError, NotFoundError, RelayUnavailableError, ValidationError
-from app.repositories import buyer_repository, po_document_settings_repository, po_repository, user_repository
-from app.services import gp_idempotency, gp_outbox_enqueue, gp_po
+from app.errors import (
+    GpSetupInvalidError,
+    InvalidStateTransitionError,
+    NotFoundError,
+    RelayUnavailableError,
+    ValidationError,
+)
+from app.repositories import (
+    buyer_repository,
+    po_document_settings_repository,
+    po_repository,
+    project_repository,
+    user_repository,
+)
+from app.services import gp_idempotency, gp_job_sync, gp_outbox_enqueue, gp_po
 from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
@@ -175,6 +187,13 @@ def _prepare_register_po(
             if project is None:
                 raise NotFoundError(f"Project {effective_project_id} not found")
             job_number = project.project_id
+
+        # #425: the stamped quarantine gate. Runs here, in the pre-GP pre-flight, and NOT in
+        # po_repository.register_po_in_gp - that one persists after GP has already created the PO, and
+        # refusing there would leave a PO in GP that Nexus never records. The resolver re-checks the
+        # same job live against GP before the push (see register_po_in_gp); this is the floor that
+        # still applies when the live check cannot run.
+        project_repository.require_gp_setup_ok(session, effective_project_id)
 
         # Issue #216: registering a draft is the ordering action - same strict buyer gating.
         buyer_repository.validate_buyer_can_order(session, buyer_id, effective_project_id)
@@ -393,7 +412,22 @@ class POMutations:
 
         Issue #202 #1/#3: idempotency_key makes a retry a no-op in GP; the DRAFT-state guard and fields
         are checked before the relay_call so a double-submit never reaches GP; the DB work is offloaded
-        so no Postgres connection is held across the relay round-trip."""
+        so no Postgres connection is held across the relay round-trip.
+
+        Issue #425 - the two-layer GP setup gate. `_prepare_register_po` applies the STAMPED verdict
+        the sync last wrote on the project; this resolver then re-asks GP about that one job LIVE,
+        immediately before the push, and that live answer is authoritative. Registering is where the
+        damage is done - the WennSoft integration copies the job's cost-code account index onto
+        POP10110.INVINDX, and a dangling index there makes a PO that can never be received - so a
+        verdict up to a poll interval old is not good enough to let a registration through.
+
+        If the live check cannot run (relay down, relay too old for the op, GP slow), the stamped
+        verdict stands and the registration proceeds. That asymmetry is deliberate: the failure being
+        defended against is a job that broke in the last few minutes, which is rare, while relays
+        restart and flap routinely. Refusing every registration whenever the health op is unreachable
+        would trade a rare bad PO for a constantly unusable button - and the relay's own create_po
+        pre-check (cost_code_account_invalid) is still there as the last line of defence, running
+        inside GP's own transaction where it cannot be stale at all."""
         auth = require_user(info)
         # Issue #216: the PO is registered as the caller's own GP buyer identity, never a free pick.
         caller_buyer = await asyncio.to_thread(user_repository.get_user_gp_buyer_id, auth["user_id"])
@@ -436,6 +470,33 @@ class POMutations:
             trade_discount=input.trade_discount,
             project_id=register_project_id,
         )
+
+        # #425 live re-check. The job number is read back off the payload rather than returned
+        # separately, because the payload is the thing actually being pushed - checking anything else
+        # could check a job this PO is not going to GP under. Only job-cost lines carry one; a
+        # non-inventoried PO has no job and nothing to check.
+        job_number = next((line["job_number"] for line in payload["lines"] if line.get("job_number")), None)
+        if job_number:
+            verdict = await gp_job_sync.check_job_setup_live(input.gp_company, job_number)
+            if verdict is not None and not verdict.get("ok"):
+                issues = [
+                    {"cost_code": str(i.get("cost_code") or ""), "account_index": int(i.get("account_index") or 0)}
+                    for i in (verdict.get("issues") or [])
+                    if isinstance(i, dict)
+                ]
+                named = ", ".join(f"{i['cost_code']} -> GL account index {i['account_index']}" for i in issues[:3])
+                raise GpSetupInvalidError(
+                    f"GP job {job_number} is not set up correctly in {input.gp_company}, so this PO "
+                    f"cannot be registered: "
+                    + (
+                        f"these cost codes point at general ledger accounts that do not exist in this company: {named}"
+                        if named
+                        else "the job has no usable cost codes"
+                    )
+                    + ". The PO would register but could never be received. Accounting has to correct "
+                    "the job's cost-code accounts in GP first.",
+                    issues=issues,
+                )
 
         persist_context = {
             "po_id": str(pid),

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -489,6 +489,16 @@ class PurchaseOrder:
 
 
 @strawberry.type
+class GpSetupIssue:
+    """One JC00701 cost code on this project's GP job whose GL account index does not exist in the
+    company's chart (#425). What the quarantine banner names, so the message points at something
+    accounting can look up rather than at "GP setup"."""
+
+    cost_code: str  # 'phase-step-element', as the register-PO dropdown shows it
+    account_index: int  # the dangling index, absent from GL00105
+
+
+@strawberry.type
 class Project:
     id: strawberry.ID
     project_id: str
@@ -513,6 +523,15 @@ class Project:
     created_at: datetime
     updated_at: datetime
     opening_count: int
+    # GP job setup verdict (#425). Plain scalar columns on the project row plus a parse of the JSON
+    # detail column, so no relationship is walked and these are safe on the all-projects list query -
+    # unlike `openings` below, which list callers deliberately leave empty.
+    #
+    # null means never checked (no relay has answered yet) and does NOT quarantine; false does. The
+    # frontend must treat them differently or a relay outage would grey out the whole application.
+    gp_setup_ok: bool | None
+    gp_setup_checked_at: datetime | None
+    gp_setup_issues: list[GpSetupIssue]
     openings: list[Opening]
     purchase_orders: list[PurchaseOrder]
 

--- a/backend/app/services/gp_job_sync.py
+++ b/backend/app/services/gp_job_sync.py
@@ -100,10 +100,79 @@ def _persist_missing(jobs: list[dict]) -> tuple[int, int]:
     return total, adopted
 
 
+def _persist_health(jobs: list[dict]) -> int:
+    """Stamp the relay's GP setup verdicts onto their projects (#425). Returns how many were stamped.
+
+    Its own session and its own commit, separate from _persist_missing's, so a health stamp that fails
+    cannot roll back the adoptions from the same pass. Adoption is the invariant this service exists
+    for; the verdict is an annotation on it."""
+    verdicts = {
+        str(job.get("job_number") or "").strip(): job for job in jobs if str(job.get("job_number") or "").strip()
+    }
+    if not verdicts:
+        return 0
+    with SessionLocal() as session:
+        stamped = project_repository.stamp_gp_setup_health(session, verdicts)
+        session.commit()
+    return stamped
+
+
+async def _stamp_setup_health(company: str) -> None:
+    """Ask the relay for every job's GP setup verdict and record it (#425).
+
+    Swallows everything. This runs inside the adoption pass and must never cost it: a relay too old
+    for the op, a GP read that times out, a malformed answer - all of them leave the existing stamps
+    exactly as they were, which is the correct fallback because a stale verdict is still a verdict and
+    the alternative (blanking it) would un-quarantine a broken project on a transient failure.
+
+    Logged at info without a traceback for the same reason the pass itself is: relays restart, get
+    updated and flap, and a stack trace per flap buries the one that matters."""
+    try:
+        result = await relay_gateway.relay_call(company, "job_setup_health")
+        jobs = (result or {}).get("jobs") or []
+        stamped = await asyncio.to_thread(_persist_health, jobs)
+        unhealthy = sum(1 for job in jobs if not job.get("ok"))
+        if unhealthy:
+            logger.info("gp job sync: %s of %s jobs have broken GP setup", unhealthy, stamped)
+    except Exception as e:  # noqa: BLE001 - a health check must never break job adoption
+        logger.info("gp job sync: could not read GP setup health this pass (%s); stamps left as they were", e)
+
+
+async def check_job_setup_live(company: str, job_number: str) -> dict | None:
+    """The live, authoritative GP setup verdict for ONE job (#425), or None when it could not be read.
+
+    The stamped verdict on the project is at most one poll interval old, and registering a PO is the
+    moment that gap matters most: the PO commits money to a job, and if the job's cost-code accounts
+    broke since the last pass the registration is what makes the unreceivable PO. So the register path
+    re-asks GP directly, using the op's single-job filter so the answer costs two indexed reads rather
+    than a sweep of the whole job master.
+
+    None means "could not check", NOT "healthy" - the caller decides what to do with that, and the
+    register path falls back to the stamped verdict rather than refusing. Bricking PO registration on
+    a relay blip while the stamp says healthy would trade a rare failure for a constant one."""
+    try:
+        result = await relay_gateway.relay_call(company, "job_setup_health", {"job": job_number})
+    except Exception as e:  # noqa: BLE001 - an unavailable check is not a failed job
+        logger.info("gp setup live check: could not read health for job %s (%s)", job_number, e)
+        return None
+    jobs = (result or {}).get("jobs") or []
+    for job in jobs:
+        if str(job.get("job_number") or "").strip() == job_number.strip():
+            return job
+    # GP does not know this job. Not a setup verdict - job_exists is the check for that, and the relay
+    # runs it inside create_po - so this stays "could not check" rather than becoming a refusal here.
+    return None
+
+
 async def run_once() -> tuple[int, int]:
-    """One sync pass: read GP's job master through the relay and create the projects that are missing.
+    """One sync pass: read GP's job master through the relay and create the projects that are missing,
+    then stamp each project with its GP setup verdict (#425).
+
     Returns (total, adopted). Raises RelayUnavailableError if no relay is connected - the admin
-    Sync from GP button surfaces that, while the loop below simply skips the pass."""
+    Sync from GP button surfaces that, while the loop below simply skips the pass.
+
+    The health check runs AFTER adoption, deliberately: a job GP has just started reporting gets its
+    project first and its verdict on the same pass, rather than a pass later."""
     company = relay_gateway.company
     if not company:
         raise RelayUnavailableError(
@@ -112,7 +181,9 @@ async def run_once() -> tuple[int, int]:
     result = await relay_gateway.relay_call(company, "list_jobs")
     jobs = (result or {}).get("jobs") or []
     # Off the event loop: the /relay-link read loop runs on it and must not block on Postgres.
-    return await asyncio.to_thread(_persist_missing, jobs)
+    counts = await asyncio.to_thread(_persist_missing, jobs)
+    await _stamp_setup_health(company)
+    return counts
 
 
 def run_once_blocking(timeout: float = RESET_SYNC_TIMEOUT_SECONDS) -> tuple[int, int] | None:

--- a/backend/tests/test_gp_job_sync.py
+++ b/backend/tests/test_gp_job_sync.py
@@ -38,11 +38,20 @@ def _clean_up_test_projects(_migrate_database):
         session.commit()
 
 
-def _relay(monkeypatch, *, company="TUBC", jobs=None, raises=None):
+def _relay(monkeypatch, *, company="TUBC", jobs=None, raises=None, health=None, health_raises=None):
+    """Fake the relay socket. `health` is the job_setup_health answer (#425); left None it echoes the
+    job list as all-healthy, so the existing adoption tests are unaffected by the health pass."""
     calls: list[tuple] = []
 
     async def _call(_company, op, payload=None, timeout=None):
         calls.append((_company, op, payload))
+        if op == "job_setup_health":
+            if health_raises is not None:
+                raise health_raises
+            if health is not None:
+                return {"jobs": health}
+            reported = JOBS if jobs is None else jobs
+            return {"jobs": [{"job_number": j.get("job_number"), "ok": True, "issues": []} for j in reported]}
         if raises is not None:
             raise raises
         return {"jobs": JOBS if jobs is None else jobs}
@@ -163,3 +172,111 @@ def test_kill_switch_reads_the_environment(monkeypatch):
 def test_wake_is_safe_before_the_loop_has_started(monkeypatch):
     monkeypatch.setattr(gp_job_sync, "_wake_event", None)
     gp_job_sync.wake()  # must not raise - /relay-link calls this on every registration
+
+
+# --- GP setup health stamping (#425) ---------------------------------------------------------------
+# Every pass also asks GP whether each job's cost codes point at accounts this company actually has,
+# and stamps the answer on the project. A job replicated from UCSH before 2023 carries UCSH account
+# indexes, which makes a PO on it registerable and permanently unreceivable - the stamp is how Nexus
+# finds out before somebody spends a PO on it.
+
+
+def _stamps(prefix="SYNC-380-"):
+    with SessionLocal() as session:
+        return {
+            p.project_id: (p.gp_setup_ok, p.gp_setup_detail, p.gp_setup_checked_at is not None)
+            for p in session.query(ProjectModel).filter(ProjectModel.project_id.like(f"{prefix}%")).all()
+        }
+
+
+def test_stamps_the_setup_verdict_on_every_reported_job(monkeypatch):
+    _relay(
+        monkeypatch,
+        health=[
+            {"job_number": "SYNC-380-A", "ok": True, "issues": []},
+            {
+                "job_number": "SYNC-380-B",
+                "ok": False,
+                "issues": [{"cost_code": "210-200-2", "account_index": 1617}],
+            },
+        ],
+    )
+
+    asyncio.run(gp_job_sync.run_once())
+
+    stamps = _stamps()
+    assert stamps["SYNC-380-A"][0] is True
+    assert stamps["SYNC-380-A"][1] is None  # a healthy job carries no stale detail
+    assert stamps["SYNC-380-B"][0] is False
+    assert "210-200-2" in stamps["SYNC-380-B"][1]
+    assert "1617" in stamps["SYNC-380-B"][1]
+    assert all(checked for _, _, checked in stamps.values())
+
+
+def test_a_job_adopted_this_pass_is_stamped_on_the_same_pass(monkeypatch):
+    """The health read runs AFTER adoption on purpose - a job GP has only just started reporting gets
+    its project and its verdict together rather than a whole poll interval apart."""
+    _relay(monkeypatch, health=[{"job_number": "SYNC-380-A", "ok": False, "issues": []}])
+
+    total, adopted = asyncio.run(gp_job_sync.run_once())
+
+    assert adopted == 2
+    assert _stamps()["SYNC-380-A"][0] is False
+
+
+def test_a_failed_health_call_does_not_break_job_adoption(monkeypatch):
+    """The verdict is an annotation; adoption is the invariant this service exists for. A relay too
+    old for the op, or a GP read that times out, must cost the pass nothing."""
+    _relay(monkeypatch, health_raises=RuntimeError("relay too old for job_setup_health"))
+
+    total, adopted = asyncio.run(gp_job_sync.run_once())
+
+    assert (total, adopted) == (2, 2)
+    assert set(_projects()) == {"SYNC-380-A", "SYNC-380-B"}
+    assert all(ok is None for ok, _, _ in _stamps().values())  # nothing stamped, nothing invented
+
+
+def test_a_failed_health_call_leaves_an_existing_stamp_alone(monkeypatch):
+    """Blanking on failure would un-quarantine a broken project on a transient relay blip. A stale
+    verdict is still a verdict."""
+    _relay(monkeypatch, health=[{"job_number": "SYNC-380-A", "ok": False, "issues": []}])
+    asyncio.run(gp_job_sync.run_once())
+
+    _relay(monkeypatch, health_raises=RuntimeError("relay went away"))
+    asyncio.run(gp_job_sync.run_once())
+
+    assert _stamps()["SYNC-380-A"][0] is False
+
+
+def test_the_health_op_is_asked_for_the_whole_company(monkeypatch):
+    # No job filter on the sync pass: one sweep for ~900 jobs, not 900 round trips.
+    calls = _relay(monkeypatch)
+
+    asyncio.run(gp_job_sync.run_once())
+
+    health_calls = [c for c in calls if c[1] == "job_setup_health"]
+    assert len(health_calls) == 1
+    assert health_calls[0][2] in (None, {})
+
+
+def test_the_live_single_job_check_filters_to_that_job(monkeypatch):
+    calls = _relay(monkeypatch, health=[{"job_number": "SYNC-380-B", "ok": False, "issues": []}])
+
+    verdict = asyncio.run(gp_job_sync.check_job_setup_live("TUBC", "SYNC-380-B"))
+
+    assert verdict["ok"] is False
+    assert calls[0] == ("TUBC", "job_setup_health", {"job": "SYNC-380-B"})
+
+
+def test_the_live_check_returns_none_when_it_cannot_run(monkeypatch):
+    """None is "could not check", not "healthy". register_po_in_gp falls back to the stamped verdict
+    on None rather than refusing - a relay blip must not brick PO registration."""
+    _relay(monkeypatch, health_raises=RuntimeError("relay unavailable"))
+
+    assert asyncio.run(gp_job_sync.check_job_setup_live("TUBC", "SYNC-380-A")) is None
+
+
+def test_the_live_check_returns_none_for_a_job_gp_does_not_report(monkeypatch):
+    _relay(monkeypatch, health=[])
+
+    assert asyncio.run(gp_job_sync.check_job_setup_live("TUBC", "GHOST")) is None

--- a/backend/tests/test_gp_setup_quarantine.py
+++ b/backend/tests/test_gp_setup_quarantine.py
@@ -1,0 +1,191 @@
+"""The server-side GP setup quarantine (#425).
+
+A project whose GP job carries JC00701 cost codes pointing at GL account indexes this company does not
+have can be ordered against and never received - eConnect rejects the receipt line with 4612 "Invalid
+Account Index", and by then the hardware is in the building. So the sync stamps a verdict on every
+project and `require_gp_setup_ok` is the wall every write action hits.
+
+The rule that gets tested hardest here is the one that is easy to get wrong in the safe-looking
+direction: **null does not quarantine**. The stamp only exists while a relay is connected, so treating
+"never checked" as "broken" would let a relay outage - or a fresh database - freeze the whole of Nexus,
+including the actions that never touch GP at all.
+"""
+
+import json
+import uuid
+from datetime import datetime
+
+import pytest
+
+from app.errors import GpSetupInvalidError
+from app.models.project import Project as ProjectModel
+from app.repositories import project_repository
+
+pytestmark = pytest.mark.usefixtures("_migrate_database")
+
+
+def _project(session, *, ok=None, detail=None, job=None):
+    project = ProjectModel(
+        id=uuid.uuid4(),
+        project_id=job or f"QT-425-{uuid.uuid4().hex[:8]}",
+        description="Quarantine fixture",
+        gp_setup_ok=ok,
+        gp_setup_detail=detail,
+        gp_setup_checked_at=datetime.utcnow() if ok is not None else None,
+    )
+    session.add(project)
+    session.flush()
+    return project
+
+
+_BROKEN = json.dumps([{"cost_code": "210-200-2", "account_index": 1617}])
+
+
+# --- require_gp_setup_ok: what blocks and what does not ---
+
+
+def test_a_false_verdict_blocks(db_session):
+    project = _project(db_session, ok=False, detail=_BROKEN)
+
+    with pytest.raises(GpSetupInvalidError) as excinfo:
+        project_repository.require_gp_setup_ok(db_session, project.id)
+
+    assert excinfo.value.code == "GP_SETUP_INVALID"
+
+
+def test_a_true_verdict_passes(db_session):
+    project = _project(db_session, ok=True)
+    project_repository.require_gp_setup_ok(db_session, project.id)  # must not raise
+
+
+def test_a_null_verdict_passes(db_session):
+    """Never checked is not broken. The sync only runs while a relay is connected, so quarantining on
+    null would mean a relay outage froze every project in the application."""
+    project = _project(db_session, ok=None)
+    project_repository.require_gp_setup_ok(db_session, project.id)
+
+
+def test_no_project_passes(db_session):
+    # A draft PO with no project has no GP job that could be broken.
+    project_repository.require_gp_setup_ok(db_session, None)
+
+
+def test_an_unknown_project_passes(db_session):
+    # Not this gate's job to decide a missing project is an error; the caller's own lookup says so.
+    project_repository.require_gp_setup_ok(db_session, uuid.uuid4())
+
+
+# --- the message has to name what accounting must fix ---
+
+
+def test_the_message_names_the_cost_code_and_the_account_index(db_session):
+    project = _project(db_session, ok=False, detail=_BROKEN, job="23093")
+
+    with pytest.raises(GpSetupInvalidError) as excinfo:
+        project_repository.require_gp_setup_ok(db_session, project.id)
+
+    message = excinfo.value.message
+    assert "23093" in message
+    assert "210-200-2" in message
+    assert "1617" in message
+    assert excinfo.value.issues == [{"cost_code": "210-200-2", "account_index": 1617}]
+
+
+def test_the_message_caps_the_list_and_says_how_many_were_hidden(db_session):
+    # The 62 affected production jobs average 24 broken codes each; an error listing all of them is
+    # one nobody reads.
+    detail = json.dumps([{"cost_code": f"3{i:02d}-000-3", "account_index": 1600 + i} for i in range(10)])
+    project = _project(db_session, ok=False, detail=detail)
+
+    with pytest.raises(GpSetupInvalidError) as excinfo:
+        project_repository.require_gp_setup_ok(db_session, project.id)
+
+    assert "and 7 more" in excinfo.value.message
+
+
+def test_a_broken_project_with_no_detail_still_blocks(db_session):
+    project = _project(db_session, ok=False, detail=None)
+
+    with pytest.raises(GpSetupInvalidError):
+        project_repository.require_gp_setup_ok(db_session, project.id)
+
+
+def test_unparseable_detail_does_not_break_the_gate(db_session):
+    """gp_setup_detail is JSON text written from whatever the relay reported. Garbage in it must
+    degrade to "broken, details unavailable" - it is read on every project query, so a parse error
+    here would take out the project list, not just this message."""
+    project = _project(db_session, ok=False, detail="{not json")
+
+    with pytest.raises(GpSetupInvalidError) as excinfo:
+        project_repository.require_gp_setup_ok(db_session, project.id)
+
+    assert excinfo.value.issues == []
+
+
+# --- parse_gp_setup_issues ---
+
+
+def test_parse_handles_the_shapes_that_are_not_a_list_of_objects():
+    assert project_repository.parse_gp_setup_issues(None) == []
+    assert project_repository.parse_gp_setup_issues("") == []
+    assert project_repository.parse_gp_setup_issues("nonsense") == []
+    assert project_repository.parse_gp_setup_issues('{"cost_code": "x"}') == []
+    assert project_repository.parse_gp_setup_issues('["bare string"]') == []
+
+
+def test_parse_returns_the_pairs():
+    assert project_repository.parse_gp_setup_issues(_BROKEN) == [{"cost_code": "210-200-2", "account_index": 1617}]
+
+
+# --- stamp_gp_setup_health ---
+
+
+def test_stamping_records_the_verdict_and_the_detail(db_session):
+    project = _project(db_session, job=f"QT-425-{uuid.uuid4().hex[:8]}")
+
+    project_repository.stamp_gp_setup_health(
+        db_session,
+        {
+            project.project_id: {
+                "ok": False,
+                "issues": [{"cost_code": "210-200-2", "account_index": 1617}],
+            }
+        },
+    )
+
+    db_session.refresh(project)
+    assert project.gp_setup_ok is False
+    assert project.gp_setup_checked_at is not None
+    assert json.loads(project.gp_setup_detail) == [{"cost_code": "210-200-2", "account_index": 1617}]
+
+
+def test_a_healthy_verdict_clears_the_detail(db_session):
+    """Once accounting repairs the job, the next pass has to clear the stale list of broken codes -
+    leaving it would keep the banner naming codes that are now fine."""
+    project = _project(db_session, ok=False, detail=_BROKEN)
+
+    project_repository.stamp_gp_setup_health(db_session, {project.project_id: {"ok": True, "issues": []}})
+
+    db_session.refresh(project)
+    assert project.gp_setup_ok is True
+    assert project.gp_setup_detail is None
+
+
+def test_a_project_gp_did_not_report_is_left_alone(db_session):
+    """A verdict absent from the answer says nothing about the job. Blanking it would silently
+    un-quarantine a broken project every time the single-job filter was used."""
+    untouched = _project(db_session, ok=False, detail=_BROKEN)
+    reported = _project(db_session)
+
+    project_repository.stamp_gp_setup_health(db_session, {reported.project_id: {"ok": True, "issues": []}})
+
+    db_session.refresh(untouched)
+    assert untouched.gp_setup_ok is False
+    assert untouched.gp_setup_detail == _BROKEN
+
+
+def test_stamping_an_empty_verdict_map_touches_nothing(db_session):
+    project = _project(db_session, ok=True)
+    assert project_repository.stamp_gp_setup_health(db_session, {}) == 0
+    db_session.refresh(project)
+    assert project.gp_setup_ok is True

--- a/frontend/src/components/GpSetupQuarantineBanner.tsx
+++ b/frontend/src/components/GpSetupQuarantineBanner.tsx
@@ -1,0 +1,116 @@
+import { Alert, AlertTitle, Box, Chip, Tooltip, Typography } from '@mui/material';
+import { TriangleAlert } from 'lucide-react';
+import { isGpSetupBroken, type GpSetupStatus } from '../types/project';
+import { monoSx } from '../theme';
+
+/**
+ * The project quarantine surface for broken GP job setup (#425).
+ *
+ * The job's JC00701 cost codes point at general ledger accounts that do not exist in the GP company -
+ * residue of the pre-2023 UCSH -> UBC job copy, 1504 rows across 62 production jobs. Nothing looks
+ * wrong until a receipt is attempted, at which point eConnect rejects it with "Invalid Account Index"
+ * and there is no way forward: the account was stamped onto the PO line at registration, so the PO is
+ * permanently unreceivable and the hardware is already in the building.
+ *
+ * So the banner is not a warning, it is a stop. It names the cost codes because "GP setup is broken"
+ * sends the user to ask somebody, and "cost code 210-200-2 points at account index 1617" is something
+ * accounting can look up. It never offers a retry or a dismiss - nothing the user does in Nexus can
+ * clear it.
+ *
+ * The server enforces the same rule (project_repository.require_gp_setup_ok), so this is the
+ * explanation, not the enforcement.
+ */
+
+const MAX_LISTED_ISSUES = 6;
+
+interface GpSetupQuarantineBannerProps {
+  project: GpSetupStatus | null | undefined;
+  /** What is being blocked, e.g. 'register this purchase order'. Completes "so you cannot ...". */
+  action?: string;
+  /** Rendered inside a dialog/drawer that supplies its own spacing. */
+  dense?: boolean;
+}
+
+export default function GpSetupQuarantineBanner({
+  project,
+  action,
+  dense = false,
+}: GpSetupQuarantineBannerProps) {
+  // Renders nothing for a healthy project AND for one that has never been checked. See
+  // isGpSetupBroken: a relay that has not answered yet must not look like a broken job.
+  if (!isGpSetupBroken(project)) return null;
+
+  const issues = project?.gpSetupIssues ?? [];
+  const shown = issues.slice(0, MAX_LISTED_ISSUES);
+  const hidden = issues.length - shown.length;
+  const jobLabel = project?.projectId ? `GP job ${project.projectId}` : 'This project’s GP job';
+
+  return (
+    <Alert
+      severity="error"
+      icon={<TriangleAlert size={20} strokeWidth={1.75} />}
+      sx={{ mb: dense ? 1.5 : 2.5 }}
+      data-testid="gp-setup-quarantine-banner"
+    >
+      <AlertTitle>{jobLabel} is not set up correctly in GP</AlertTitle>
+      <Typography variant="body2">
+        {issues.length > 0
+          ? 'These cost codes point at general ledger accounts that do not exist in this company:'
+          : 'Its cost codes point at general ledger accounts that do not exist in this company.'}
+      </Typography>
+      {shown.length > 0 && (
+        <Box component="ul" sx={{ pl: 2.5, my: 0.75 }}>
+          {shown.map((issue) => (
+            <Box component="li" key={`${issue.costCode}-${issue.accountIndex}`}>
+              <Typography variant="body2" component="span" sx={monoSx}>
+                {issue.costCode}
+              </Typography>
+              <Typography variant="body2" component="span">
+                {` → GL account index ${issue.accountIndex}`}
+              </Typography>
+            </Box>
+          ))}
+          {hidden > 0 && (
+            <Box component="li">
+              <Typography variant="body2">{`and ${hidden} more`}</Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+      <Typography variant="body2">
+        {`A purchase order on this job would register in GP but could never be received, so ${
+          action ?? 'work on this project'
+        } is on hold. Accounting has to correct the job’s cost-code accounts in GP first.`}
+      </Typography>
+    </Alert>
+  );
+}
+
+/**
+ * The list/picker form of the same fact (#425): small enough to sit on a project card or a table row,
+ * loud enough that nobody picks a quarantined project and only finds out at the finalize button.
+ * Renders nothing unless the verdict is explicitly false, same rule as the banner.
+ */
+export function GpSetupBadge({ project }: { project: GpSetupStatus | null | undefined }) {
+  if (!isGpSetupBroken(project)) return null;
+  const issues = project?.gpSetupIssues ?? [];
+  const title =
+    issues.length > 0
+      ? `Cost codes point at accounts this GP company does not have: ${issues
+          .slice(0, 3)
+          .map((i) => `${i.costCode} → ${i.accountIndex}`)
+          .join(', ')}${issues.length > 3 ? `, and ${issues.length - 3} more` : ''}`
+      : 'This project’s GP job setup is broken; work on it is on hold.';
+  return (
+    <Tooltip title={title} arrow>
+      <Chip
+        label="GP setup broken"
+        color="error"
+        size="small"
+        variant="outlined"
+        data-testid="gp-setup-badge"
+        sx={{ height: 20, fontSize: '0.7rem' }}
+      />
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/ProjectLandingPage.tsx
+++ b/frontend/src/components/ProjectLandingPage.tsx
@@ -12,6 +12,8 @@ import { Folder, LayoutGrid } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 import { GET_PROJECTS } from '../graphql/shared';
 import type { Project } from '../types/project';
+import { isGpSetupBroken } from '../types/project';
+import { GpSetupBadge } from './GpSetupQuarantineBanner';
 import { monoSx, microLabelSx } from '../theme';
 import { StaggerList, StaggerItem } from '../motion';
 
@@ -131,7 +133,18 @@ export default function ProjectLandingPage({
           {projects.map((p) => (
             <Grid key={p.id} size={CELL}>
               <StaggerItem style={{ height: '100%' }}>
-                <Card variant="outlined" sx={CARD_SX}>
+                {/* #425: a quarantined project is still selectable - the module screen explains why
+                    its actions are off, and refusing the click would leave the user with a card that
+                    does nothing and no reason given. The edge and the chip are what stop somebody
+                    picking it by accident. */}
+                <Card
+                  variant="outlined"
+                  sx={
+                    isGpSetupBroken(p)
+                      ? { ...CARD_SX, borderLeft: '3px solid', borderLeftColor: 'error.main' }
+                      : CARD_SX
+                  }
+                >
                   <CardActionArea onClick={() => onSelect(p)} sx={{ height: '100%' }}>
                     <Box
                       sx={{ px: 2, py: 1.75, display: 'flex', gap: 1.5, alignItems: 'flex-start' }}
@@ -152,6 +165,11 @@ export default function ProjectLandingPage({
                         >
                           {p.description || p.projectId}
                         </Typography>
+                        {isGpSetupBroken(p) && (
+                          <Box sx={{ mt: 0.5 }}>
+                            <GpSetupBadge project={p} />
+                          </Box>
+                        )}
                         {p.projectId && (
                           <Typography
                             component="div"

--- a/frontend/src/components/__tests__/GpSetupQuarantineBanner.test.tsx
+++ b/frontend/src/components/__tests__/GpSetupQuarantineBanner.test.tsx
@@ -1,0 +1,183 @@
+import { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing/react';
+import { MemoryRouter } from 'react-router-dom';
+import GpSetupQuarantineBanner, { GpSetupBadge } from '../GpSetupQuarantineBanner';
+import { ToastProvider } from '../Toast';
+import { isGpSetupBroken, type GpSetupStatus } from '../../types/project';
+import ShippingCart from '../../modules/shipping/ShippingCart';
+import { CartProvider, useCart } from '../../contexts/CartContext';
+
+// ShippingCart mounts PackingSlipForm (closed), which reaches for Clerk and the PDF renderer. Neither
+// runs under jsdom and neither is what is under test here - same two stubs PackingSlipForm's own suite
+// installs.
+vi.mock('../../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    displayName: 'Me',
+    userId: 'me',
+    roles: [],
+    hasRole: () => false,
+    isAdmin: false,
+    gpBuyerId: null,
+    user: null,
+  }),
+}));
+
+vi.mock('@react-pdf/renderer', () => ({
+  pdf: () => ({ toBlob: () => Promise.resolve(new Blob()) }),
+  Document: () => null,
+  Page: () => null,
+  Text: () => null,
+  View: () => null,
+  StyleSheet: { create: (s: unknown) => s },
+}));
+
+/**
+ * The GP setup quarantine surface (#425).
+ *
+ * The rule that has to hold in both directions:
+ *   gpSetupOk === false  -> banner, badge, actions off
+ *   true / null / absent -> nothing at all
+ *
+ * The null case is the one worth the test. The verdict only exists while a relay is connected, so if
+ * "never checked" rendered as "broken", a relay restart would put a red stop banner on every project
+ * in the application and disable actions that have nothing to do with GP.
+ */
+
+const BROKEN: GpSetupStatus = {
+  projectId: '23093',
+  gpSetupOk: false,
+  gpSetupIssues: [
+    { costCode: '210-200-2', accountIndex: 1617 },
+    { costCode: '310-000-3', accountIndex: 1622 },
+  ],
+};
+
+describe('isGpSetupBroken', () => {
+  it('is true only for an explicit false verdict', () => {
+    expect(isGpSetupBroken({ gpSetupOk: false })).toBe(true);
+    expect(isGpSetupBroken({ gpSetupOk: true })).toBe(false);
+    expect(isGpSetupBroken({ gpSetupOk: null })).toBe(false);
+    expect(isGpSetupBroken({})).toBe(false);
+    expect(isGpSetupBroken(null)).toBe(false);
+    expect(isGpSetupBroken(undefined)).toBe(false);
+  });
+});
+
+describe('GpSetupQuarantineBanner', () => {
+  it('names the job, every broken cost code and the account index it points at', () => {
+    render(<GpSetupQuarantineBanner project={BROKEN} action="registering it in GP" />);
+
+    expect(screen.getByTestId('gp-setup-quarantine-banner')).toBeInTheDocument();
+    expect(screen.getByText(/GP job 23093 is not set up correctly/)).toBeInTheDocument();
+    expect(screen.getByText('210-200-2')).toBeInTheDocument();
+    expect(screen.getByText(/GL account index 1617/)).toBeInTheDocument();
+    expect(screen.getByText('310-000-3')).toBeInTheDocument();
+    expect(screen.getByText(/GL account index 1622/)).toBeInTheDocument();
+    // The action being blocked is named, so the banner reads as an explanation of the dead button.
+    expect(screen.getByText(/registering it in GP is on hold/)).toBeInTheDocument();
+  });
+
+  it('caps a long list and says how many were hidden', () => {
+    const many = Array.from({ length: 24 }, (_, i) => ({
+      costCode: `3${String(i).padStart(2, '0')}-000-3`,
+      accountIndex: 1600 + i,
+    }));
+    render(<GpSetupQuarantineBanner project={{ gpSetupOk: false, gpSetupIssues: many }} />);
+
+    expect(screen.getByText('and 18 more')).toBeInTheDocument();
+  });
+
+  it('still renders when the backend recorded no detail', () => {
+    render(<GpSetupQuarantineBanner project={{ projectId: '23093', gpSetupOk: false }} />);
+
+    expect(screen.getByTestId('gp-setup-quarantine-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText(/cost codes point at general ledger accounts that do not exist/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing for a healthy project', () => {
+    render(<GpSetupQuarantineBanner project={{ gpSetupOk: true }} />);
+    expect(screen.queryByTestId('gp-setup-quarantine-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a project that has never been checked', () => {
+    // A relay that has not answered yet must not look like a broken job.
+    render(<GpSetupQuarantineBanner project={{ gpSetupOk: null }} />);
+    expect(screen.queryByTestId('gp-setup-quarantine-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no project at all', () => {
+    render(<GpSetupQuarantineBanner project={null} />);
+    expect(screen.queryByTestId('gp-setup-quarantine-banner')).not.toBeInTheDocument();
+  });
+});
+
+describe('GpSetupBadge', () => {
+  it('marks a quarantined project in a list', () => {
+    render(<GpSetupBadge project={BROKEN} />);
+    expect(screen.getByTestId('gp-setup-badge')).toHaveTextContent('GP setup broken');
+  });
+
+  it('stays out of the way for healthy and unchecked projects', () => {
+    const { rerender } = render(<GpSetupBadge project={{ gpSetupOk: true }} />);
+    expect(screen.queryByTestId('gp-setup-badge')).not.toBeInTheDocument();
+
+    rerender(<GpSetupBadge project={{ gpSetupOk: null }} />);
+    expect(screen.queryByTestId('gp-setup-badge')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * One real screen, to prove the banner is wired to an action and not just rendered next to one.
+ * Shipping out is the last stage of the pipeline and the point of no return - hardware leaves the
+ * building against a job whose costs cannot be booked - so its primary action is the one to pin.
+ */
+describe('ShippingCart under quarantine', () => {
+  /**
+   * The cart is loaded first. An empty cart already disables Proceed to Ship, so asserting on an
+   * empty one would pass whether the quarantine were wired up or not - the healthy control below is
+   * what makes the blocked case mean anything.
+   */
+  function LoadedCart({ project }: { project: GpSetupStatus | null }) {
+    const { addItem, itemCount } = useCart();
+    useEffect(() => {
+      if (itemCount === 0) {
+        addItem({ id: 'c1', itemType: 'Loose', openingNumber: 'A01', productCode: 'HG-100', quantity: 1 });
+      }
+    }, [addItem, itemCount]);
+    if (itemCount === 0) return null;
+    return (
+      <ShippingCart open onClose={() => {}} projectId="p1" projectName="Broken Job" project={project} />
+    );
+  }
+
+  function renderCart(project: GpSetupStatus | null) {
+    return render(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <ToastProvider>
+            <CartProvider>
+              <LoadedCart project={project} />
+            </CartProvider>
+          </ToastProvider>
+        </MemoryRouter>
+      </MockedProvider>,
+    );
+  }
+
+  it('disables Proceed to Ship on a quarantined project and explains why', () => {
+    renderCart(BROKEN);
+
+    expect(screen.getByTestId('gp-setup-quarantine-banner')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Proceed to Ship' })).toBeDisabled();
+  });
+
+  it('leaves a loaded cart shippable when the project has never been checked', () => {
+    renderCart({ projectId: '23090', gpSetupOk: null });
+
+    expect(screen.queryByTestId('gp-setup-quarantine-banner')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Proceed to Ship' })).toBeEnabled();
+  });
+});

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -26,6 +26,12 @@ export const GET_ADMIN_PROJECTS = gql`
       openingCount
       createdAt
       updatedAt
+      gpSetupOk
+      gpSetupCheckedAt
+      gpSetupIssues {
+        costCode
+        accountIndex
+      }
     }
   }
 `;
@@ -217,6 +223,12 @@ export const UPDATE_PROJECT = gql`
       openingCount
       createdAt
       updatedAt
+      gpSetupOk
+      gpSetupCheckedAt
+      gpSetupIssues {
+        costCode
+        accountIndex
+      }
     }
   }
 `;

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -1,5 +1,8 @@
 import { gql } from '@apollo/client/core';
 
+// gpSetupOk / gpSetupIssues (#425) ride along on every project read: they are scalar columns on the
+// project row (no relationship walk, no N+1), and every module that lets a user pick a project has to
+// be able to badge a quarantined one rather than discovering it at the submit button.
 export const GET_PROJECTS = gql`
   query GetProjects {
     projects {
@@ -9,6 +12,12 @@ export const GET_PROJECTS = gql`
       client
       jobSiteName
       openingCount
+      gpSetupOk
+      gpSetupCheckedAt
+      gpSetupIssues {
+        costCode
+        accountIndex
+      }
     }
   }
 `;

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -180,6 +180,10 @@ export const GET_PO_RECEIVING_DETAILS = gql`
       id
       poNumber
       requestNumber
+      # #425: the receive modal joins this to the projects list to find out whether the PO's GP job is
+      # quarantined. A broken job's receipt is rejected by eConnect with "Invalid Account Index", so
+      # the modal has to say so before the warehouse user finishes counting.
+      projectId
       gpCompany
       gpVendorId
       vendorNameSnapshot

--- a/frontend/src/modules/admin/ProjectEditDialog.tsx
+++ b/frontend/src/modules/admin/ProjectEditDialog.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client/react';
 import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
 import { UPDATE_PROJECT, GET_ADMIN_PROJECTS } from '../../graphql/admin';
+import type { GpSetupIssue } from '../../types/project';
 import { microLabelSx, monoSx } from '../../theme';
 
 export interface ProjectFormValue {
@@ -28,6 +29,11 @@ export interface ProjectFormValue {
   submittalAssignmentCount: number | null;
   estimatorCode: string | null;
   titanUserId: string | null;
+  // GP job setup verdict (#425), read-only and stamped by the sync. Present so the admin project grid
+  // can badge a quarantined job; the edit form never writes it.
+  gpSetupOk?: boolean | null;
+  gpSetupCheckedAt?: string | null;
+  gpSetupIssues?: GpSetupIssue[] | null;
 }
 
 interface ProjectEditDialogProps {

--- a/frontend/src/modules/admin/ProjectsPage.tsx
+++ b/frontend/src/modules/admin/ProjectsPage.tsx
@@ -7,6 +7,8 @@ import { GET_ADMIN_PROJECTS, SYNC_GP_JOBS } from '../../graphql/admin';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useToast } from '../../components/Toast';
 import { extractGpError } from '../../graphql/gpError';
+import { GpSetupBadge } from '../../components/GpSetupQuarantineBanner';
+import { isGpSetupBroken } from '../../types/project';
 import { monoSx } from '../../theme';
 import { FadeIn } from '../../motion';
 import ProjectEditDialog, { type ProjectFormValue } from './ProjectEditDialog';
@@ -106,6 +108,16 @@ export default function ProjectsPage() {
         type: 'number',
         headerAlign: 'right',
         align: 'right',
+      },
+      {
+        // #425: the one place an admin can see, across every project at once, which GP jobs are
+        // quarantined - and therefore how much of the estate is waiting on accounting.
+        field: 'gpSetupOk',
+        headerName: 'GP Setup',
+        width: 150,
+        sortable: true,
+        renderCell: (params) =>
+          isGpSetupBroken(params.row) ? <GpSetupBadge project={params.row} /> : <span>—</span>,
       },
     ],
     [],

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -28,6 +28,8 @@ import { useToast } from '../../components/Toast';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import ProgressBar from '../../components/ProgressBar';
 import ValidationSummaryDisplay from '../../components/ValidationSummaryDisplay';
+import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
+import { isGpSetupBroken } from '../../types/project';
 import { useHardwareScheduleParser } from '../../hooks/useHardwareScheduleParser';
 import { useNavigate } from 'react-router-dom';
 import { GET_PROJECT_EXCLUDED_ITEMS, GET_PROJECT_HARDWARE_SCHEDULE, RECONCILE_SCHEDULE, FINALIZE_IMPORT_SESSION } from '../../graphql/import';
@@ -1237,6 +1239,12 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
         </AppBar>
 
         <Box sx={{ p: 3 }}>
+          {/* #425: shown from the first step, not at the finalize button. Everything this wizard does
+              lands on a GP job - the schedule, the POs drafted off it, the requests that reserve
+              inventory against it - so letting somebody parse an XML and assign leaves before telling
+              them none of it can be saved would waste the whole session. */}
+          <GpSetupQuarantineBanner project={project} action="starting a task on it" />
+
           <Stepper activeStep={activeStepIndex} sx={{ mb: 4 }}>
             {steps.map((step) => (
               <Step key={step.id}>
@@ -1684,11 +1692,14 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
                 <Button onClick={handleBack} disabled={finalizeLoading}>
                   Back
                 </Button>
+                {/* #425: the server refuses this outright (finalize_import_session ->
+                    require_gp_setup_ok), so leaving the button live would only buy the user a red
+                    toast after a full wizard run. The banner above says why. */}
                 <Button
                   variant="contained"
                   size="large"
                   startIcon={<FileUp size={18} strokeWidth={1.75} />}
-                  disabled={finalizeLoading}
+                  disabled={finalizeLoading || isGpSetupBroken(project)}
                   onClick={() => setConfirmOpen(true)}
                 >
                   Finish Import Session

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -20,6 +20,8 @@ import { GET_BUYER_ASSIGNMENTS, GET_PROJECTS } from '../../graphql/shared';
 import { useIdentity } from '../../hooks/useIdentity';
 import VendorSelect from '../../components/VendorSelect';
 import type { Project } from '../../types/project';
+import { isGpSetupBroken } from '../../types/project';
+import GpSetupQuarantineBanner, { GpSetupBadge } from '../../components/GpSetupQuarantineBanner';
 import type { PurchaseOrder } from './index';
 import RelayStatusChip from '../../relay/RelayStatusChip';
 import { useRelayStatus } from '../../relay/useRelayStatus';
@@ -737,12 +739,21 @@ export default function GpPurchaseOrderDialog({
       )
     ) : null;
 
+  // #425: only REGISTER is blocked, not draft creation. A draft touches nothing in GP, and forbidding
+  // it would stop purchasing preparing the order that becomes registerable the moment accounting
+  // fixes the job. Registering is the act that stamps the bad account onto the PO line.
+  const gpSetupBlocksRegister = isRegister && isGpSetupBroken(selectedProject);
+
   const actions = (
     <Stack direction="row" spacing={1}>
       <Button onClick={onClose} disabled={busy}>
         Cancel
       </Button>
-      <Button variant="contained" onClick={handleSubmit} disabled={busy || lineItems.length === 0}>
+      <Button
+        variant="contained"
+        onClick={handleSubmit}
+        disabled={busy || lineItems.length === 0 || gpSetupBlocksRegister}
+      >
         {busy ? submitBusyLabel : submitIdleLabel}
       </Button>
     </Stack>
@@ -755,6 +766,7 @@ export default function GpPurchaseOrderDialog({
           <GpErrorAlert error={gpError} onClose={() => setGpError(null)} />
         </Box>
       )}
+      {isRegister && <GpSetupQuarantineBanner project={selectedProject} action="registering it in GP" dense />}
       {/* Issue #216: GP registration happens as YOUR buyer identity, against your assigned projects.
           Drafting (issue #256) is open to everyone, so these gate register mode only. */}
       {isRegister && !gpBuyerId ? (
@@ -787,9 +799,12 @@ export default function GpPurchaseOrderDialog({
           }
         >
           <MenuItem value="">No Project (stock PO)</MenuItem>
+          {/* #425: badged in the picker, not hidden from it. A quarantined project is still the right
+              project for a draft; what it cannot take is a registration. */}
           {projects.map((p) => (
-            <MenuItem key={p.id} value={p.id}>
+            <MenuItem key={p.id} value={p.id} sx={{ gap: 1 }}>
               {p.description || p.projectId}
+              <GpSetupBadge project={p} />
             </MenuItem>
           ))}
         </TextField>

--- a/frontend/src/modules/shipping/ShippingCart.tsx
+++ b/frontend/src/modules/shipping/ShippingCart.tsx
@@ -6,6 +6,8 @@ import {
 import { ShoppingCart, Trash2 } from 'lucide-react';
 import { useCart } from '../../contexts/CartContext';
 import PackingSlipForm from './PackingSlipForm';
+import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
+import { isGpSetupBroken, type GpSetupStatus } from '../../types/project';
 import { leafSuffix } from '../../utils/leaf';
 import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import { AnimatedNumber, StaggerItem, StaggerList } from '../../motion';
@@ -15,9 +17,19 @@ interface ShippingCartProps {
   onClose: () => void;
   projectId: string | undefined;
   projectName: string;
+  // #425: the selected project's GP setup verdict, passed down rather than re-queried - the module
+  // shell already holds the project object the user picked. Undefined in the All Projects view, where
+  // there is no single job to be broken.
+  project?: GpSetupStatus | null;
 }
 
-export default function ShippingCart({ open, onClose, projectId, projectName }: ShippingCartProps) {
+export default function ShippingCart({
+  open,
+  onClose,
+  projectId,
+  projectName,
+  project,
+}: ShippingCartProps) {
   const { items, removeItem, clearCart, itemCount } = useCart();
   const [packingSlipOpen, setPackingSlipOpen] = useState(false);
 
@@ -150,6 +162,10 @@ export default function ShippingCart({ open, onClose, projectId, projectName }: 
           <Divider />
 
           <Box sx={{ p: 2 }}>
+            {/* #425: shown in the cart rather than only on the page behind it, because this drawer is
+                where the ship decision is made and it covers that page while it is open. Clear Cart
+                stays live - putting things back is never the blocked action. */}
+            <GpSetupQuarantineBanner project={project} action="shipping from it" dense />
             <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1.5 }}>
               <Typography sx={microLabelSx}>Total items</Typography>
               <Typography variant="h6" sx={tabularSx}>
@@ -169,7 +185,7 @@ export default function ShippingCart({ open, onClose, projectId, projectName }: 
                 variant="contained"
                 size="small"
                 onClick={() => setPackingSlipOpen(true)}
-                disabled={itemCount === 0}
+                disabled={itemCount === 0 || isGpSetupBroken(project)}
                 sx={{ flexGrow: 1 }}
               >
                 Proceed to Ship

--- a/frontend/src/modules/shipping/index.tsx
+++ b/frontend/src/modules/shipping/index.tsx
@@ -8,6 +8,7 @@ import ShipmentsList from './ShipmentsList';
 import ShippingCart from './ShippingCart';
 import ShippingRequestsPage from './ShippingRequestsPage';
 import ProjectLandingPage from '../../components/ProjectLandingPage';
+import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
 import type { Project } from '../../types/project';
 
 export default function ShippingModule() {
@@ -34,6 +35,9 @@ export default function ShippingModule() {
   const projectId = selectedProject !== 'all' ? selectedProject.id : undefined;
   const projectName =
     selectedProject === 'all' ? 'All Projects' : (selectedProject.description || selectedProject.projectId);
+  // #425: only meaningful for a single project. The All Projects view spans every job, so there is no
+  // one verdict to show and no single action to block - the cart is scoped to a project either way.
+  const gpSetupProject = selectedProject !== 'all' ? selectedProject : null;
 
   return (
     <Box>
@@ -68,6 +72,7 @@ export default function ShippingModule() {
           </IconButton>
         </Box>
       </Box>
+      <GpSetupQuarantineBanner project={gpSetupProject} action="shipping from it" />
       <Routes>
         <Route path="requests" element={<ShippingRequestsPage projectId={projectId} />} />
         <Route path="browse" element={<ShipReadyBrowser projectId={projectId} />} />
@@ -79,6 +84,7 @@ export default function ShippingModule() {
         onClose={() => setCartOpen(false)}
         projectId={projectId}
         projectName={projectName}
+        project={gpSetupProject}
       />
     </Box>
   );

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -30,6 +30,9 @@ import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from '../po/poVendorName';
 import GpErrorAlert from '../../components/GpErrorAlert';
 import { extractGpError, type GpError } from '../../graphql/gpError';
+import { GET_PROJECTS } from '../../graphql/shared';
+import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
+import { isGpSetupBroken, type Project } from '../../types/project';
 import { microLabelSx, monoSx } from '../../theme';
 
 // ---- Types ----
@@ -51,6 +54,9 @@ interface PODetailLineItem {
 interface PODetails {
   id: string;
   poNumber: string | null;
+  // #425: which project (and therefore which GP job) this PO belongs to, so the modal can tell the
+  // warehouse user the receipt will be refused before they finish counting. Null for a stock PO.
+  projectId: string | null;
   // The GP company this PO was registered in. A receive posts to GP, so it can only run against a PO
   // that was registered in GP (has a gpCompany + poNumber). See isPoGpRegistered.
   gpCompany: string | null;
@@ -142,6 +148,12 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
   });
   const warehouses = useMemo(() => warehousesData?.warehouses ?? [], [warehousesData]);
   const [warehouseId, setWarehouseId] = useState<string>('');
+
+  // #425: the GP setup verdict lives on the project, and the PO only carries a project id. Read from
+  // the shared projects query, which every other screen already primes, so this is normally a cache
+  // hit rather than a round trip on modal open.
+  const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS, { skip: !open });
+  const projects = useMemo(() => projectsData?.projects ?? [], [projectsData]);
 
   useEffect(() => {
     if (!warehouseId && warehouses.length > 0) {
@@ -296,6 +308,22 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
     () => poIds.map((id) => poDetailsMap[id]).filter((d): d is PODetails => !!d && !isPoGpRegistered(d)),
     [poIds, poDetailsMap],
   );
+
+  // #425: POs in this batch whose project's GP job setup is broken. Not a Nexus rule - eConnect
+  // rejects the receipt line with "Invalid Account Index" because the account was stamped onto the PO
+  // line at registration, so this receipt cannot post no matter how carefully it is entered. Said up
+  // front, because the alternative is a warehouse user counting a pallet and then being refused.
+  const quarantinedProjects = useMemo(() => {
+    const byId = new Map(projects.map((p) => [p.id, p]));
+    const seen = new Map<string, Project>();
+    for (const id of poIds) {
+      const pid = poDetailsMap[id]?.projectId;
+      if (!pid) continue;
+      const project = byId.get(pid);
+      if (project && isGpSetupBroken(project)) seen.set(pid, project);
+    }
+    return [...seen.values()];
+  }, [poIds, poDetailsMap, projects]);
 
   // Put-away is mandatory: every received unit must land in a valid row and each row's deficient count
   // must be within its quantity. Mirrors the backend contract in warehouse_repository.create_receive
@@ -731,10 +759,18 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
           thing that ever reached it was a unit test mocking createReceive past the gate. The relay state
           is now advisory (the alert above says what will happen), and the warehouse user who has already
           counted the hardware can record it either way. */}
+      {/* #425 is a hard blocker, unlike the relay state above it: an offline relay means "later", a
+          broken GP job means "never, until accounting fixes it". Queuing the receipt would not help -
+          the outbox would drain into the same eConnect rejection. */}
       <Button
         variant="contained"
         disabled={
-          !hasAnyReceiveQuantity || hasQuantityErrors || !putAwayValid || blockedPos.length > 0 || submitting
+          !hasAnyReceiveQuantity ||
+          hasQuantityErrors ||
+          !putAwayValid ||
+          blockedPos.length > 0 ||
+          quarantinedProjects.length > 0 ||
+          submitting
         }
         onClick={() => setConfirmOpen(true)}
       >
@@ -815,6 +851,19 @@ export default function ReceiveModal({ open, onClose, poIds }: ReceiveModalProps
         )}
         {/* Receiving requires a GP-registered PO (issue #177): it can only run against a PO created
             through the relay, which has a GP PO number + company. */}
+        {/* #425: one banner per affected project, not per PO - a batch receive can span several POs on
+            the same broken job, and repeating the same cost-code list four times says nothing new. */}
+        {!poDetailsLoading &&
+          !poDetailsError &&
+          !succeeded &&
+          quarantinedProjects.map((project) => (
+            <GpSetupQuarantineBanner
+              key={project.id}
+              project={project}
+              action="receiving against it"
+              dense
+            />
+          ))}
         {!poDetailsLoading && !poDetailsError && !succeeded && blockedPos.length > 0 && (
           <Alert severity="warning" sx={{ mb: 2 }}>
             {blockedPos.length === 1

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -1,3 +1,13 @@
+/**
+ * One cost code on a project's GP job whose GL account index does not exist in the company's chart
+ * (#425). Jobs replicated from UCSH before 2023 kept UCSH account indexes, so a PO on such a code
+ * registers in GP and then fails forever at receipt with "Invalid Account Index".
+ */
+export interface GpSetupIssue {
+  costCode: string;
+  accountIndex: number;
+}
+
 export interface Project {
   id: string;
   projectId: string;
@@ -5,4 +15,34 @@ export interface Project {
   client: string | null;
   jobSiteName: string | null;
   openingCount: number;
+  // GP job setup verdict (#425). null means the backend has never been able to check - no relay has
+  // answered yet - and is NOT a quarantine. Only an explicit false is.
+  gpSetupOk?: boolean | null;
+  gpSetupCheckedAt?: string | null;
+  gpSetupIssues?: GpSetupIssue[] | null;
+}
+
+/**
+ * The shape every quarantine-aware screen actually needs. Loose on purpose: the PO, receiving and
+ * shipping screens each carry their own project-ish object, and none of them should have to widen to
+ * the full `Project` just to ask this one question.
+ */
+export interface GpSetupStatus {
+  projectId?: string;
+  gpSetupOk?: boolean | null;
+  gpSetupCheckedAt?: string | null;
+  gpSetupIssues?: GpSetupIssue[] | null;
+}
+
+/**
+ * Is this project quarantined for broken GP job setup (#425)?
+ *
+ * Strictly `=== false`. undefined (the field was not requested) and null (never checked) both pass,
+ * and that asymmetry is the whole safety property: the verdict only exists while a relay is
+ * connected, so treating "unknown" as "broken" would grey out the entire application every time the
+ * relay restarted. The server enforces the same rule, so a screen that gets this wrong in the
+ * permissive direction still cannot push bad work through.
+ */
+export function isGpSetupBroken(project: GpSetupStatus | null | undefined): boolean {
+  return project?.gpSetupOk === false;
 }

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -212,6 +212,20 @@ def _run_list_jobs(company: str, payload: dict) -> dict:
     return {"company": company, "jobs": rows}
 
 
+def _run_job_setup_health(company: str, payload: dict) -> dict:
+    """Read-only GP setup verdict per job (#425). The optional `job` filter narrows it to one job for
+    the live re-check register_po_in_gp runs at submit time; without it this answers for every job in
+    the company, which is what the backend's sync pass stamps onto projects.
+
+    Unlike _run_list_cost_codes there is no missing_job error: a blank job is not a mistake here, it
+    is the whole-company sweep."""
+    ops.check_company_allowed(company)
+    job = (payload.get("job") or "").strip() or None
+    with db.get_read_connection(company) as conn:
+        jobs = econnect.job_setup_health(conn, job)
+    return models.JobSetupHealthResponse(company=company, job=job, jobs=jobs).model_dump(mode="json")
+
+
 def _run_read_po_totals(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     po_number = (payload.get("po_number") or "").strip()
@@ -326,6 +340,9 @@ _OPS = {
     # buyer so linking a Nexus account to a GP buyer identity never needs GP opened.
     "list_buyers_detailed": _run_list_buyers_detailed,
     "create_buyer": _run_create_buyer,
+    # issue #425 - jobs replicated from UCSH carry GL account indexes that do not exist in UBC, so a
+    # PO against them registers and can never be received. This is how Nexus finds out which ones.
+    "job_setup_health": _run_job_setup_health,
 }
 
 

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -721,6 +721,165 @@ def list_cost_codes(conn, job_number: str) -> list[dict]:
     ]
 
 
+# --- GP job setup health (issue #425) --------------------------------------
+# Receiving PO0000070 in TUBC failed with eConnect 4612 "Invalid Account Index" from
+# taPopRcptLineInsert. The PO line had been stamped INVINDX=1617 at registration by the WennSoft PO
+# integration, copied straight out of JC00701 (job 23093, cost code 210-200-2). 1617 is not in
+# UBC/TUBC's account index master GL00105 at all - it is a UCSH index, left behind by the pre-2023
+# UCSH -> UBC job replication which copied JC00701 account indexes raw. Production UBC carries 1504
+# such rows across 62 jobs and TUBC, being a clone, mirrors them.
+#
+# The damage is invisible until receipt time: a job-cost PO against one of those jobs registers
+# perfectly and can then never be received. Repairing the data is accounting's job; the relay's job is
+# to make the breakage visible BEFORE somebody spends a PO on it, which is what these three reads do.
+#
+# Rule for "this job is set up": it has at least one active cost code, and every active cost code's
+# WS_Account_Index_1 is either 0 or present in GL00105. Index 0 passes deliberately - eConnect defaults
+# the account at receipt time, so only a non-zero dangling index is the proven failure mode.
+#
+# GL00105 is GP's account index master; ACTINDX is the surrogate key JC00701.WS_Account_Index_1 and
+# POP10110.INVINDX both point at.
+
+_ACTIVE_COST_CODE = "WS_Inactive = 0"
+
+
+def job_setup_health(conn, job_number: str | None = None) -> list[dict]:
+    """Read-only: the per-job GP setup verdict for EVERY job in the company (#425), or for one job
+    when `job_number` is given.
+
+    Two queries regardless of how many jobs there are, because the loop is a sync pass over the whole
+    job master and a per-job round trip over the relay socket would make it unusable:
+
+      1. the verdict: JC00102 left-joined to its active JC00701 rows, each left-joined to GL00105,
+         grouped by job. Driven off the JOB master rather than off JC00701 so a job with zero active
+         cost codes still comes back (it would simply be absent from a JC00701-driven grouping) - that
+         is rule one, and it is a real state: a job nobody has set a cost structure on yet.
+      2. the detail: the individual broken cost codes, so the quarantine banner can name what is wrong
+         rather than saying "something is". Only unhealthy jobs contribute rows, so on a healthy
+         company this returns nothing.
+
+    Returns one dict per job: job_number, ok, active_cost_code_count, and issues (a list of
+    {cost_code, account_index} for the dangling ones, empty when the job is healthy).
+
+    The single-job filter exists for the live re-check register_po_in_gp runs at submit time: reading
+    900 jobs to answer a question about one is the difference between a gate somebody keeps and a gate
+    somebody turns off."""
+    job = (job_number or "").strip() or None
+    cur = conn.cursor()
+
+    verdict_sql = (
+        "SELECT RTRIM(j.WS_Job_Number) AS job_number, "
+        "COUNT(c.WS_Job_Number) AS active_cost_codes, "
+        "SUM(CASE WHEN c.WS_Account_Index_1 <> 0 AND a.ACTINDX IS NULL THEN 1 ELSE 0 END) AS broken_cost_codes "
+        "FROM dbo.JC00102 j "
+        f"LEFT JOIN dbo.JC00701 c ON RTRIM(c.WS_Job_Number) = RTRIM(j.WS_Job_Number) AND c.{_ACTIVE_COST_CODE} "
+        "LEFT JOIN dbo.GL00105 a ON a.ACTINDX = c.WS_Account_Index_1 "
+    )
+    detail_sql = (
+        "SELECT RTRIM(c.WS_Job_Number) AS job_number, RTRIM(c.Cost_Code_Number_1) AS cc1, "
+        "RTRIM(c.Cost_Code_Number_2) AS cc2, c.Cost_Element AS elem, c.WS_Account_Index_1 AS account_index "
+        "FROM dbo.JC00701 c "
+        "LEFT JOIN dbo.GL00105 a ON a.ACTINDX = c.WS_Account_Index_1 "
+        f"WHERE c.{_ACTIVE_COST_CODE} AND c.WS_Account_Index_1 <> 0 AND a.ACTINDX IS NULL "
+    )
+    if job is None:
+        verdict_rows = cur.execute(verdict_sql + "GROUP BY RTRIM(j.WS_Job_Number) ORDER BY 1").fetchall()
+        detail_rows = cur.execute(detail_sql + "ORDER BY 1, 2, 3").fetchall()
+    else:
+        verdict_rows = cur.execute(
+            verdict_sql + "WHERE RTRIM(j.WS_Job_Number) = ? GROUP BY RTRIM(j.WS_Job_Number) ORDER BY 1", job
+        ).fetchall()
+        detail_rows = cur.execute(
+            detail_sql + "AND RTRIM(c.WS_Job_Number) = ? ORDER BY 1, 2, 3", job
+        ).fetchall()
+
+    issues_by_job: dict[str, list[dict]] = {}
+    for r in detail_rows:
+        # 'phase-step-element', the same shape list_cost_codes / the PO cost_code use, so the banner
+        # names a code the user can recognise from the register-PO dropdown.
+        cost_code = f"{r.cc1}-{r.cc2}-{int(r.elem)}"
+        issues_by_job.setdefault(r.job_number, []).append(
+            {"cost_code": cost_code, "account_index": int(r.account_index)}
+        )
+
+    out = []
+    for r in verdict_rows:
+        active = int(r.active_cost_codes or 0)
+        broken = int(r.broken_cost_codes or 0)
+        out.append(
+            {
+                "job_number": r.job_number,
+                "ok": active > 0 and broken == 0,
+                "active_cost_code_count": active,
+                "issues": issues_by_job.get(r.job_number, []),
+            }
+        )
+    return out
+
+
+def cost_code_account_index(conn, job_number: str, cost_code: str) -> int | None:
+    """Read-only: the GL account index (JC00701.WS_Account_Index_1) one active cost code on one job
+    carries (#425). None when there is no such active row - cost_code_on_job is the check for that and
+    runs first, so None here means the code went inactive between the two reads.
+
+    Split from the account_index_exists lookup below rather than answered by one join, because the
+    caller has to name the offending index in its error: "cost code 210-200-2 points at GL account
+    index 1617" is actionable in GP, "that cost code is broken" is not."""
+    cc1, cc2, cc3, cc4, cost_element = split_cost_code(cost_code)
+    row = conn.cursor().execute(
+        "SELECT WS_Account_Index_1 AS account_index FROM dbo.JC00701 "
+        "WHERE RTRIM(WS_Job_Number) = ? AND Cost_Code_Number_1 = ? AND Cost_Code_Number_2 = ? "
+        f"AND Cost_Code_Number_3 = ? AND Cost_Code_Number_4 = ? AND Cost_Element = ? AND {_ACTIVE_COST_CODE}",
+        job_number.strip(), cc1, cc2, cc3, cc4, cost_element,
+    ).fetchone()
+    if row is None or row.account_index is None:
+        return None
+    return int(row.account_index)
+
+
+def account_index_exists(conn, account_index: int) -> bool:
+    """Read-only: is account_index a real row in GP's account index master GL00105 (#425)?
+
+    Index 0 is answered True without a query. It is not an account - it is "GP, pick the account
+    yourself at posting time" - and eConnect honours that, so treating it as dangling would quarantine
+    every job that simply leaves the default in place."""
+    if not account_index:
+        return True
+    row = conn.cursor().execute(
+        "SELECT COUNT(*) AS n FROM dbo.GL00105 WHERE ACTINDX = ?", int(account_index)
+    ).fetchone()
+    return row.n > 0
+
+
+def po_lines_with_dangling_account(conn, po_number: str) -> list[dict]:
+    """Read-only: the PO's lines whose stamped POP10110.INVINDX is not in GL00105 (#425).
+
+    This is the exact condition taPopRcptLineInsert rejects with eConnect 4612 "Invalid Account
+    Index", read before the receipt is attempted so the warehouse user gets "this job's GP setup is
+    broken" instead of a bare error state. INVINDX was copied onto the line from JC00701 at
+    registration, so the account is already wrong by the time anyone opens the receive form - nothing
+    the receiver did causes this and nothing they can do fixes it.
+
+    Returns {ord, item, account_index, job} per broken line, empty when the PO is clean. The caller
+    narrows to the lines actually being received."""
+    rows = conn.cursor().execute(
+        "SELECT l.ORD AS ord, RTRIM(l.ITEMNMBR) AS item, l.INVINDX AS account_index, "
+        "RTRIM(l.JOBNUMBR) AS job FROM dbo.POP10110 l "
+        "LEFT JOIN dbo.GL00105 a ON a.ACTINDX = l.INVINDX "
+        "WHERE l.PONUMBER = ? AND l.INVINDX <> 0 AND a.ACTINDX IS NULL ORDER BY l.ORD",
+        po_number,
+    ).fetchall()
+    return [
+        {
+            "ord": int(r.ord),
+            "item": r.item,
+            "account_index": int(r.account_index),
+            "job": r.job or None,
+        }
+        for r in rows
+    ]
+
+
 # --- create a GP job (issue #380) ------------------------------------------
 # Nexus can adopt an existing GP job as a project; these originate one. The create-job form cannot be
 # composed from anything Nexus stores - customer, address codes, tax schedule, division and the

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -218,6 +218,31 @@ class CostCodesResponse(BaseModel):
     cost_codes: list[CostCodeOut]
 
 
+# --- GP job setup health (issue #425) ---
+# The verdict the backend stamps onto every project each sync pass, so a job whose JC00701 rows point
+# at accounts this company does not have is quarantined before anyone raises a PO on it.
+
+
+class JobSetupIssueOut(BaseModel):
+    cost_code: str      # 'phase-step-element', e.g. '210-200-2' - what the register-PO dropdown shows
+    account_index: int  # the dangling JC00701.WS_Account_Index_1, absent from this company's GL00105
+
+
+class JobSetupOut(BaseModel):
+    job_number: str                 # GP WS_Job_Number (JC00102), which is the Nexus project_id
+    ok: bool                        # has active cost codes AND none of them dangle
+    active_cost_code_count: int     # 0 is itself a failure: a job with no cost structure set up
+    issues: list[JobSetupIssueOut] = []
+
+
+class JobSetupHealthResponse(BaseModel):
+    company: str
+    # Present only when the caller asked about ONE job (the live re-check at PO submit); None for the
+    # whole-company sweep, so the backend can tell a filtered answer from an exhaustive one.
+    job: str | None = None
+    jobs: list[JobSetupOut]
+
+
 # --- create a GP job (issue #380) ---
 # The five reads that feed the create-job form's dropdowns, then the create request itself.
 

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -104,6 +104,25 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
                 "cost_code_not_on_job",
                 f"cost code '{line.cost_code}' is not set up on job '{job}' (JC00701) for {company}",
             )
+        # Issue #425: the cost code exists on the job, but the GL account index it carries may not
+        # exist in this company's chart. That is the pre-2023 UCSH -> UBC job copy's legacy - 1504
+        # JC00701 rows across 62 UBC jobs point at UCSH indexes - and the WennSoft integration copies
+        # the index onto POP10110.INVINDX at step 4 below. Nothing objects at that point; the PO
+        # registers cleanly and then fails FOREVER at receipt with eConnect 4612 "Invalid Account
+        # Index", by which time the hardware is on a truck. Refusing it here costs one SELECT and
+        # turns an unreceivable PO into a message naming the code and the index.
+        account_index = econnect.cost_code_account_index(conn, job, line.cost_code)
+        if account_index is not None and not econnect.account_index_exists(conn, account_index):
+            raise RelayOpError(
+                "cost_code_account_invalid",
+                f"cost code '{line.cost_code}' on job '{job}' points at GL account index "
+                f"{account_index}, which does not exist in {company} (GL00105). A PO on this cost "
+                f"code would register but could never be received; the job's GP setup needs fixing "
+                f"in accounting first.",
+                job=job,
+                cost_code=line.cost_code,
+                account_index=account_index,
+            )
 
     # 1. PO number: use UC Nexus's own number if supplied, else reserve GP's next 'PO' number. A
     #    client-supplied number is rejected if it's already used anywhere in GP - active OR history.
@@ -327,6 +346,27 @@ def create_receipt_op(conn, *, company: str, request: models.ReceiptRequest) -> 
                 f"line ORD {rl.po_line_ord}: qty {rl.quantity} exceeds remaining {remaining} "
                 f"(ordered {pl['qtyorder']}, already received {pl['prev_received']})",
             )
+
+    # Issue #425: pre-flight the account index each line was stamped with at registration.
+    # taPopRcptLineInsert reads POP10110.INVINDX and rejects an index that is not in GL00105 with
+    # eConnect 4612 "Invalid Account Index" - the failure that started this issue. Raised as a
+    # RelayOpError rather than left to the proc for two reasons: 4612 says nothing about which line or
+    # which account, and the whole receipt has already been half-built by the time the proc gets there.
+    # Only the lines being received are checked; an unrelated broken line on the same PO is somebody
+    # else's problem on the day they try to receive it.
+    receiving_ords = {rl.po_line_ord for rl in request.lines}
+    broken = [b for b in econnect.po_lines_with_dangling_account(conn, request.po_number) if b["ord"] in receiving_ords]
+    if broken:
+        first = broken[0]
+        raise RelayOpError(
+            "po_line_account_invalid",
+            f"PO {request.po_number} line {first['ord']} ({first['item']}) is stamped with GL account "
+            f"index {first['account_index']}, which does not exist in {company} (GL00105). This came "
+            f"from job '{first['job'] or 'unknown'}' cost-code setup when the PO was registered, so "
+            f"the receipt cannot be posted until accounting fixes the job's GP setup.",
+            po_number=request.po_number,
+            lines=broken,
+        )
 
     receipt_number = econnect.get_next_receipt_number(conn)
     # eConnect processes receipt LINES before the header (the line proc creates the receipt document;

--- a/relay/tests/test_job_setup_health.py
+++ b/relay/tests/test_job_setup_health.py
@@ -1,0 +1,354 @@
+"""GP job setup health (#425): the read that finds jobs whose JC00701 cost codes point at GL account
+indexes this company does not have, plus the two write-path guards that refuse to let one through.
+
+The failure being defended against is silent until it is expensive: a job-cost PO on such a cost code
+registers perfectly, the WennSoft integration copies the dangling index onto POP10110.INVINDX, and the
+receipt then fails forever with eConnect 4612 "Invalid Account Index" (the PO0000070 / index 1617 case
+that opened the issue). No real GP here - a fake cursor answers each query in turn and records the SQL,
+so these assert the join, the two health rules, the single-job filter, and both refusals.
+"""
+
+from collections import namedtuple
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ucnexus_relay import econnect, models, ops
+from ucnexus_relay.econnect import (
+    account_index_exists,
+    cost_code_account_index,
+    job_setup_health,
+    po_lines_with_dangling_account,
+)
+from ucnexus_relay.ops import RelayOpError
+
+_Verdict = namedtuple("_Verdict", "job_number active_cost_codes broken_cost_codes")
+_Detail = namedtuple("_Detail", "job_number cc1 cc2 elem account_index")
+_Count = namedtuple("_Count", "n")
+_Index = namedtuple("_Index", "account_index")
+_PoLine = namedtuple("_PoLine", "ord item account_index job")
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def execute(self, sql, *params):
+        self._conn.calls.append((sql, params))
+        return self
+
+    def fetchall(self):
+        # job_setup_health runs the verdict query then the detail query, in that order.
+        return self._conn.results.pop(0)
+
+    def fetchone(self):
+        return self._conn.results.pop(0)
+
+
+class _FakeConn:
+    """Answers queries from `results` in call order and keeps every (sql, params) for assertions."""
+
+    def __init__(self, *results):
+        self.results = list(results)
+        self.calls: list[tuple[str, tuple]] = []
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def sql(self, i=0):
+        return self.calls[i][0]
+
+
+# --- job_setup_health: the two rules ---
+
+
+def test_a_job_with_active_codes_and_resolvable_accounts_is_healthy():
+    conn = _FakeConn([_Verdict("23090", 14, 0)], [])
+    assert job_setup_health(conn) == [
+        {"job_number": "23090", "ok": True, "active_cost_code_count": 14, "issues": []}
+    ]
+
+
+def test_a_dangling_account_index_fails_the_job_and_is_named():
+    """The PO0000070 case: job 23093 cost code 210-200-2 -> index 1617, a UCSH account absent from
+    UBC/TUBC's GL00105. The verdict alone would only say "broken"; the detail row is what lets the
+    quarantine banner name the code somebody has to fix."""
+    conn = _FakeConn([_Verdict("23093", 14, 1)], [_Detail("23093", "210", "200", 2, 1617)])
+    assert job_setup_health(conn) == [
+        {
+            "job_number": "23093",
+            "ok": False,
+            "active_cost_code_count": 14,
+            "issues": [{"cost_code": "210-200-2", "account_index": 1617}],
+        }
+    ]
+
+
+def test_a_job_with_no_active_cost_codes_fails_rule_one():
+    """Driven off JC00102, so a job with nothing in JC00701 still comes back - grouped off JC00701 it
+    would simply be missing, and "absent" would read as "fine"."""
+    conn = _FakeConn([_Verdict("23099", 0, 0)], [])
+    verdicts = job_setup_health(conn)
+    assert verdicts[0]["ok"] is False
+    assert verdicts[0]["active_cost_code_count"] == 0
+    assert "JC00102" in conn.sql()
+    assert "LEFT JOIN dbo.JC00701" in conn.sql()
+
+
+def test_index_zero_never_counts_as_dangling():
+    """WS_Account_Index_1 = 0 means "GP picks the account at posting time", which eConnect honours.
+    The join-side predicate has to exclude it or every default-left job quarantines."""
+    conn = _FakeConn([_Verdict("23091", 9, 0)], [])
+    assert job_setup_health(conn)[0]["ok"] is True
+    assert "c.WS_Account_Index_1 <> 0" in conn.sql()
+    assert "a.ACTINDX IS NULL" in conn.sql()
+
+
+def test_health_reads_only_active_cost_codes():
+    conn = _FakeConn([_Verdict("23090", 14, 0)], [])
+    job_setup_health(conn)
+    assert "WS_Inactive = 0" in conn.sql()
+    assert "GL00105" in conn.sql()
+
+
+def test_the_whole_company_sweep_takes_exactly_two_queries():
+    # One round trip per job over the relay socket would make the sync pass unusable at ~900 jobs.
+    conn = _FakeConn(
+        [_Verdict("A", 3, 0), _Verdict("B", 3, 1)],
+        [_Detail("B", "310", "000", 3, 1622)],
+    )
+    out = job_setup_health(conn)
+    assert len(conn.calls) == 2
+    assert [j["ok"] for j in out] == [True, False]
+    assert out[1]["issues"] == [{"cost_code": "310-000-3", "account_index": 1622}]
+
+
+# --- job_setup_health: the single-job filter (the live re-check at PO submit) ---
+
+
+def test_the_job_filter_scopes_both_queries():
+    conn = _FakeConn([_Verdict("23093", 14, 1)], [_Detail("23093", "210", "200", 2, 1617)])
+    job_setup_health(conn, "23093")
+    assert conn.calls[0][1] == ("23093",)
+    assert conn.calls[1][1] == ("23093",)
+    assert "WHERE RTRIM(j.WS_Job_Number) = ?" in conn.sql(0)
+
+
+def test_the_job_filter_strips_whitespace_like_every_other_job_read():
+    conn = _FakeConn([_Verdict("23093", 14, 0)], [])
+    job_setup_health(conn, "  23093 ")
+    assert conn.calls[0][1] == ("23093",)
+
+
+def test_a_blank_job_is_the_whole_company_sweep_not_an_error():
+    conn = _FakeConn([_Verdict("A", 1, 0)], [])
+    job_setup_health(conn, "   ")
+    assert conn.calls[0][1] == ()
+
+
+def test_an_unknown_job_yields_no_verdict_at_all():
+    # Distinguishable from "healthy": the caller sees nothing to stamp rather than a passing verdict.
+    conn = _FakeConn([], [])
+    assert job_setup_health(conn, "NOPE") == []
+
+
+# --- the create_po guard (cost_code_account_invalid) ---
+
+
+def test_cost_code_account_index_reads_the_active_row():
+    conn = _FakeConn(_Index(1617))
+    assert cost_code_account_index(conn, "  23093 ", "210-200-2") == 1617
+    assert conn.calls[0][1] == ("23093", "210", "200", "", "", 2)
+    assert "WS_Inactive = 0" in conn.sql()
+
+
+def test_cost_code_account_index_is_none_when_the_row_vanished():
+    assert cost_code_account_index(_FakeConn(None), "23093", "210-200-2") is None
+
+
+def test_account_index_zero_short_circuits_without_a_query():
+    conn = _FakeConn()
+    assert account_index_exists(conn, 0) is True
+    assert conn.calls == []
+
+
+def test_account_index_exists_checks_gl00105():
+    conn = _FakeConn(_Count(1))
+    assert account_index_exists(conn, 96) is True
+    assert "GL00105" in conn.sql()
+    assert conn.calls[0][1] == (96,)
+
+
+def test_account_index_missing_from_the_chart_is_false():
+    assert account_index_exists(_FakeConn(_Count(0)), 1617) is False
+
+
+def _job_cost_po():
+    return models.CreatePoRequest(
+        company="TUBC",
+        header=models.POHeader(vendor_id="ING100", buyer_id="MIRA", confirm_with="Mira", doc_date=date(2026, 7, 30)),
+        lines=[
+            models.POLine(
+                item_number="ML2010",
+                item_description="ML2010 LOCK",
+                quantity=Decimal("2"),
+                unit_cost=Decimal("12.50"),
+                product_indicator=2,
+                job_number="23093",
+                cost_code="210-200-2",
+            )
+        ],
+    )
+
+
+def _stub_create_po_prechecks(monkeypatch, *, account_index, index_exists):
+    """Everything create_po_op does before the #425 guard, stubbed to pass, so the test isolates the
+    guard itself. Anything AFTER it is left unstubbed on purpose: if the guard fails to raise, the op
+    walks into a missing econnect stub and the test breaks loudly rather than silently passing."""
+    monkeypatch.setattr(econnect, "list_buyers", lambda conn: ["MIRA"])
+    monkeypatch.setattr(econnect, "get_vendor_currency", lambda conn, vendor_id: "CAD")
+    monkeypatch.setattr(econnect, "get_mc_setup", lambda conn: {"functional": "CAD", "purchase_rate_type": "BUY"})
+    monkeypatch.setattr(econnect, "job_exists", lambda conn, job: True)
+    monkeypatch.setattr(econnect, "cost_code_on_job", lambda conn, job, code: True)
+    monkeypatch.setattr(econnect, "cost_code_account_index", lambda conn, job, code: account_index)
+    monkeypatch.setattr(econnect, "account_index_exists", lambda conn, idx: index_exists)
+
+
+def test_create_po_refuses_a_cost_code_whose_account_does_not_exist(monkeypatch):
+    _stub_create_po_prechecks(monkeypatch, account_index=1617, index_exists=False)
+
+    with pytest.raises(RelayOpError) as excinfo:
+        ops.create_po_op(_FakeConn(), company="TUBC", request=_job_cost_po())
+
+    error = excinfo.value
+    assert error.code == "cost_code_account_invalid"
+    # The message has to be actionable in GP: which code, which index, which job.
+    assert "210-200-2" in error.message
+    assert "1617" in error.message
+    assert "23093" in error.message
+    assert error.context["account_index"] == 1617
+
+
+def test_create_po_allows_a_cost_code_whose_account_resolves(monkeypatch):
+    """The guard passing must not be provable by the op simply never reaching it, so this asserts the
+    op got PAST the guard - it fails on the next unstubbed step, not on cost_code_account_invalid."""
+    _stub_create_po_prechecks(monkeypatch, account_index=96, index_exists=True)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: B017 - anything but the guard's own error
+        ops.create_po_op(_FakeConn(), company="TUBC", request=_job_cost_po())
+
+    assert getattr(excinfo.value, "code", None) != "cost_code_account_invalid"
+
+
+def test_create_po_allows_index_zero(monkeypatch):
+    # 0 is "GP defaults the account", not a dangling index, so account_index_exists says True for it.
+    _stub_create_po_prechecks(monkeypatch, account_index=0, index_exists=True)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: B017
+        ops.create_po_op(_FakeConn(), company="TUBC", request=_job_cost_po())
+
+    assert getattr(excinfo.value, "code", None) != "cost_code_account_invalid"
+
+
+# --- the create_receipt pre-flight (po_line_account_invalid) ---
+
+
+def test_po_lines_with_dangling_account_reads_invindx_against_gl00105():
+    conn = _FakeConn([_PoLine(16384, "ML2010", 1617, "23093")])
+    assert po_lines_with_dangling_account(conn, "PO0000070") == [
+        {"ord": 16384, "item": "ML2010", "account_index": 1617, "job": "23093"}
+    ]
+    assert "POP10110" in conn.sql()
+    assert "GL00105" in conn.sql()
+    assert "l.INVINDX <> 0" in conn.sql()
+    assert conn.calls[0][1] == ("PO0000070",)
+
+
+def _receipt_request(*ords):
+    return models.ReceiptRequest(
+        company="TUBC",
+        po_number="PO0000070",
+        lines=[
+            models.ReceiptLine(po_line_ord=o, quantity=Decimal("1"), rack_location="A1-1-1") for o in ords
+        ],
+    )
+
+
+def _po_line_context(*ords):
+    lines = {
+        o: {
+            "item": "ML2010",
+            "itemdesc": "ML2010 LOCK",
+            "vendor": "ING100",
+            "job": "23093",
+            "jobname": "Test job",
+            "locn": "VANCOUVER",
+            "noninven": 1,
+            "uofm": "Each",
+            "vnditnum": "ML2010",
+            "qtyorder": Decimal("5"),
+            "unitcost": Decimal("12.50"),
+            "polnesta": 2,
+            "prev_received": Decimal("0"),
+        }
+        for o in ords
+    }
+    return "ING100", "Ingersoll", lines
+
+
+def test_create_receipt_refuses_a_line_stamped_with_a_dangling_account(monkeypatch):
+    monkeypatch.setattr(econnect, "read_po_receipt_context", lambda conn, po: _po_line_context(16384))
+    monkeypatch.setattr(
+        econnect,
+        "po_lines_with_dangling_account",
+        lambda conn, po: [{"ord": 16384, "item": "ML2010", "account_index": 1617, "job": "23093"}],
+    )
+
+    with pytest.raises(RelayOpError) as excinfo:
+        ops.create_receipt_op(_FakeConn(), company="TUBC", request=_receipt_request(16384))
+
+    error = excinfo.value
+    assert error.code == "po_line_account_invalid"
+    # The whole point of pre-flighting is that the warehouse user reads this instead of "4612".
+    assert "ML2010" in error.message
+    assert "1617" in error.message
+    assert "23093" in error.message
+    assert error.context["lines"][0]["ord"] == 16384
+
+
+def test_create_receipt_ignores_a_broken_line_nobody_is_receiving(monkeypatch):
+    """A PO can hold a broken line that this receipt does not touch. Refusing the whole receipt for it
+    would strand hardware that is physically on the dock over an account nobody is about to post to."""
+    monkeypatch.setattr(econnect, "read_po_receipt_context", lambda conn, po: _po_line_context(16384, 32768))
+    monkeypatch.setattr(
+        econnect,
+        "po_lines_with_dangling_account",
+        lambda conn, po: [{"ord": 32768, "item": "OTHER", "account_index": 1617, "job": "23093"}],
+    )
+    monkeypatch.setattr(econnect, "get_next_receipt_number", lambda conn: "RCT0001")
+    monkeypatch.setattr(econnect, "create_receipt_line", lambda conn, **kw: None)
+    monkeypatch.setattr(econnect, "create_receipt_header", lambda conn, **kw: None)
+
+    response = ops.create_receipt_op(_FakeConn(), company="TUBC", request=_receipt_request(16384))
+
+    assert response.receipt_number == "RCT0001"
+    assert response.lines_received == 1
+
+
+def test_create_receipt_runs_the_preflight_before_reserving_a_receipt_number(monkeypatch):
+    """Order matters: taGetPurchReceiptNextNumber burns a GP number. Refusing after it would leave a
+    gap in the receipt sequence every time somebody tried a job with broken setup."""
+    monkeypatch.setattr(econnect, "read_po_receipt_context", lambda conn, po: _po_line_context(16384))
+    monkeypatch.setattr(
+        econnect,
+        "po_lines_with_dangling_account",
+        lambda conn, po: [{"ord": 16384, "item": "ML2010", "account_index": 1617, "job": "23093"}],
+    )
+    reserved = []
+    monkeypatch.setattr(econnect, "get_next_receipt_number", lambda conn: reserved.append(1) or "RCT0001")
+
+    with pytest.raises(RelayOpError):
+        ops.create_receipt_op(_FakeConn(), company="TUBC", request=_receipt_request(16384))
+
+    assert reserved == []


### PR DESCRIPTION
Closes #425.

receiving PO0000070 (TUBC) failed with eConnect 4612 Invalid Account Index. the PO line was stamped INVINDX=1617 at registration, copied from JC00701 (job 23093, cost code 210-200-2); 1617 is a UCSH index that does not exist in UBC/TUBC. pre-2023 job replication copied account indexes raw - 1504 dangling rows across 62 UBC jobs. a job-cost PO against one of them registers fine and can never be received. this detects and quarantines; the data repair stays with accounting.

relay
- new read-only op job_setup_health, whole company or one job. verdict query drives off JC00102 so a job with zero active cost codes still appears; ok = active_cost_codes > 0 AND broken_cost_codes = 0. index 0 passes (eConnect defaults the account at receipt time), only a non-zero dangling index fails. second query returns per-job detail of the broken codes.
- create_po: account-index check next to the existing cost_code_on_job guard, error cost_code_account_invalid with job, cost code and index.
- create_receipt: pre-flights the POP10110.INVINDX of the ORDs being received against GL00105, BEFORE get_next_receipt_number so a refusal never burns a GP receipt number. error po_line_account_invalid.

column names verified read-only against live TUBC before merge: GL00105.ACTINDX, JC00701.WS_Account_Index_1 and POP10110.INVINDX all exist; the health query returns 234 dangling JC00701 rows there, so it detects the real defect rather than being green by construction.

backend
- migration 075 (down_revision 074): nullable gp_setup_ok, gp_setup_detail, gp_setup_checked_at on projects. nullable so never-checked is distinguishable and does NOT quarantine - a down relay must not freeze all of Nexus.
- gp_job_sync stamps the verdict every pass; a failed health call stamps nothing and cannot break job adoption.
- project_repository.require_gp_setup_ok blocks on False, passes on None/True, message names up to 3 cost codes plus "and N more". new GpSetupInvalidError with code GP_SETUP_INVALID.

guard sites - five actions, four repository functions (import finalize and both Start-a-Task creations are one mutation here, finalizeImportSession carries shopAssemblyOpenings and shippingOutPrDrafts):
- import_repository.finalize_import_session
- _prepare_register_po
- warehouse.receiving.validate_receive_eligibility
- shipping_repository.confirm_shipment

the receiving and PO guards sit on the PRE-GP entry points deliberately, not create_receive / register_po_in_gp - those run after GP has committed, and refusing there would strand a receipt or PO in GP that Nexus never records.

register_po_in_gp live re-check: the resolver reads the job number back off the built payload (the thing actually being pushed) and calls the op's single-job filter. not ok -> refused. None means "could not check", NOT healthy - the check swallows exceptions and registration proceeds on the stamped verdict, so a relay blip cannot brick registration, and the relay's own cost_code_account_invalid still runs inside GP's transaction as the last line of defence.

graphql: Project gains gp_setup_ok, gp_setup_checked_at, gp_setup_issues (new GpSetupIssue type). scalar columns plus a JSON parse, no relationship walk, so no N+1 and no include-flag needed.

frontend: GpSetupQuarantineBanner + GpSetupBadge, rendering only on gpSetupOk === false. banner on ImportWizard (above the stepper, visible before the XML is parsed, Finish disabled), GpPurchaseOrderDialog register mode only (drafting stays open), ReceiveModal one per affected project, ShippingModule header and ShippingCart. badges on ProjectLandingPage cards, the PO project dropdown, and a sortable GP Setup column in the admin projects grid. there is no ProjectContext in this codebase - each module holds its own selectedProject - so the project is threaded through props.

known scope decisions
- draft POs are not blocked, only registration; a quarantined project can accumulate drafts that become registerable once accounting repairs the job.
- a broken line nobody is receiving does not block the receipt - the pre-flight narrows to the ORDs in the request.
- the stamp is never cleared for a job GP stops reporting, so a quarantine cannot be lifted by a job vanishing from the sweep.

backend ruff clean, 507 passed / 536 skipped. relay ruff clean, 371 passed (22 new). frontend 0 lint errors, 376 passed (11 new), build clean. migration applied only in CI (Migration Integrity covers upgrade/downgrade/check); downgrade is symmetric.