### PR TITLE
refactor(auth): deny-by-default root-field authorization in the schema extension (#423)

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,17 +1,32 @@
-"""Clerk authentication for GraphQL resolvers.
+"""Clerk authentication primitives: verify a token, resolve who the caller is, cache both per request.
 
-The backend has no global auth middleware; verification is opt-in per resolver via
-``require_admin(info)``. The Strawberry ``get_context`` getter only stashes the request,
-so ungated queries pay no JWT/JWKS/Clerk-API cost. Roles live in Clerk publicMetadata
-(not in the default session token), so we verify the token for identity (``sub``) and
-then look up roles through the Clerk Backend API.
+Roles live in Clerk publicMetadata rather than in the session token, so identity (the JWT's ``sub``)
+and authorization (roles) are two different lookups - the second one a Clerk Backend API call.
 
-Opt-in means a resolver that forgets to ask is silently public, which is how every resolver in
-``app/schemas/user.py`` - ``updateUserRoles`` among them - shipped reachable with no session at all
-(#415). Since that sweep the opt-in is enforced from outside: ``tests/test_resolver_gate_completeness``
-walks every ``@strawberry.field`` / ``@strawberry.mutation`` under ``app/schemas/`` and fails on any
-that calls none of the gates below, so leaving one open is now an explicit entry on that test's
-exemption list rather than an omission nobody notices.
+**This module no longer decides who may call what.** Until #423 every GraphQL resolver opened with
+its own ``require_user(info)`` / ``require_admin(info)`` line, which made "ungated" the silent
+default: a resolver that forgot the line still worked, it just also worked for anonymous callers.
+That is how all four resolvers in ``app/schemas/user.py``, ``updateUserRoles`` included, shipped
+reachable with no session at all (#415). The decision now lives in one table,
+``app/auth_policy.py``, and is enforced from the schema extension in main.py before any resolver
+runs - so an operation nobody wrote a policy for is REFUSED rather than public.
+
+What is left here is the machinery that table drives, plus the two things a resolver body still
+legitimately does for itself:
+
+  - ``current_user(info)`` - read the identity the extension already verified. A body needs it to
+    stamp the acting user on an audit row (#427) or to scope a read to the caller (#428). It is a
+    dict lookup, not a second verification.
+  - ``require_role(info, role)`` - a CONDITIONAL role check inside a body, for the one requirement
+    that is not a property of the field: ``assignOpenings`` lets anyone self-assign but only a Shop
+    Assembly Manager assign to somebody else (#330).
+
+``require_admin_request`` is separate again: the plain FastAPI routes in main.py have no Strawberry
+info to unwrap and no extension running for them, so they carry their own gate.
+
+Everything is memoised on the Strawberry context dict, which ``get_context`` builds fresh per
+request. A query hitting eight root fields verifies its JWT once and looks up roles at most once,
+where #415's shape paid for both per field.
 """
 
 import time
@@ -104,10 +119,15 @@ def verify_clerk_token(token: str) -> dict:
 
 
 async def get_context(request: Request) -> dict:
-    """Strawberry context_getter: stash the request so resolvers can verify on demand.
+    """Strawberry context_getter: stash the request, and give this request somewhere to memoise.
 
-    The request must be type-annotated; strawberry wraps this as a FastAPI dependency, so an
-    unannotated parameter would be treated as a query parameter and break every request.
+    The dict returned here is the whole per-request store the caches below use. Strawberry wraps this
+    as a FastAPI dependency, so it runs once per HTTP request and returns a NEW dict every time -
+    which is the reason one caller's verified identity or roles can never be served to another. A
+    module-level cache keyed by anything would not have that property.
+
+    The request must be type-annotated; an unannotated parameter would be treated by FastAPI as a
+    query parameter and break every request.
     """
     return {"request": request}
 
@@ -122,19 +142,84 @@ def _bearer_token(request) -> str | None:
     return value.strip()
 
 
-def require_user(info) -> dict:
-    """Enforce that the caller is an authenticated UC Nexus user (any role). Returns {user_id}.
-    No Clerk Backend API role lookup, so it's cheaper than require_admin."""
-    request = info.context["request"]
-    token = _bearer_token(request)
-    if not token:
-        raise AuthError("Authentication required")
+# Keys under which the per-request memos live on the context dict from get_context. Underscored so
+# they read as internal beside the "request" key resolvers do touch.
+_IDENTITY_KEY = "_auth_user_id"
+_ROLES_KEY = "_auth_roles"
+_ROSTER_KEY = "_auth_user_roster"
 
-    claims = verify_clerk_token(token)
-    user_id = claims.get("sub")
-    if not user_id:
-        raise AuthError("Authentication token has no subject")
-    return {"user_id": user_id}
+
+def authenticated_user_id(context) -> str:
+    """The caller's Clerk user id, verifying the request's JWT the first time and reusing it after.
+
+    Both outcomes are memoised, the refusal as well as the identity. A query naming eight root fields
+    resolves eight times through the extension, and an expired token should cost one JWKS/verify
+    round of work for the whole request rather than eight - the failure is a property of the request,
+    not of the field that happened to ask.
+    """
+    cached = context.get(_IDENTITY_KEY)
+    if isinstance(cached, AppError):
+        raise cached
+    if cached is not None:
+        return cached
+
+    try:
+        token = _bearer_token(context["request"])
+        if not token:
+            raise AuthError("Authentication required")
+        claims = verify_clerk_token(token)
+        user_id = claims.get("sub")
+        if not user_id:
+            raise AuthError("Authentication token has no subject")
+    except AppError as e:
+        context[_IDENTITY_KEY] = e
+        raise
+
+    context[_IDENTITY_KEY] = user_id
+    return user_id
+
+
+def caller_roles(context) -> list[str]:
+    """The caller's Clerk roles, looked up once per request.
+
+    Roles are in publicMetadata, not in the session token, so this is a Clerk Backend API call. Under
+    #415 every `require_admin(info)` made its own, meaning the admin landing page paid one per admin
+    query it fired; now the whole request shares this one.
+    """
+    roles = context.get(_ROLES_KEY)
+    if roles is None:
+        roles = context[_ROLES_KEY] = user_repository.get_user_roles(authenticated_user_id(context))
+    return roles
+
+
+def user_roster(context) -> list[dict]:
+    """Every Clerk user, once per request - the roster `users`, `adminStats` and `shopAssemblyMembers`
+    each need in full.
+
+    Loading it also fills the roles memo, because the roster carries roles per user and the caller is
+    one of them. That is what removes `adminStats`' second Clerk round trip: the gate's role lookup
+    and the resolver's own `list_users()` collapse into this single call (see ROSTER_BACKED in
+    app/auth_policy.py).
+    """
+    roster = context.get(_ROSTER_KEY)
+    if roster is None:
+        roster = context[_ROSTER_KEY] = user_repository.list_users()
+    return roster
+
+
+def current_user(info) -> dict:
+    """The authenticated caller, as {user_id}, for a resolver body that needs to know who asked.
+
+    This does NOT gate anything - by the time a body runs, `enforce_root_field` has already refused
+    everyone it was going to (app/auth_policy.py). It is the read of that verified identity, so the
+    bodies that stamp an actor on an audit row (#427) or scope a query to the caller's own buyer
+    assignment (#428) keep working without re-verifying the token.
+
+    It still raises rather than returning None when there is no identity, so calling it from an
+    operation on the OPEN_OPERATIONS allowlist - where no gate ran - fails loudly instead of
+    attributing the action to nobody.
+    """
+    return {"user_id": authenticated_user_id(info.context)}
 
 
 def resolve_display_name(user_id: str) -> str:
@@ -166,9 +251,14 @@ def invalidate_display_name(user_id: str) -> None:
 
 def require_admin_request(request) -> dict:
     """Enforce Admin/Manager on a bare FastAPI Request, for the plain HTTP routes in main.py that have
-    no Strawberry `info` to unwrap. Same verification as require_admin - identity from the Clerk JWT,
-    roles from the Clerk Backend API - so a route and a resolver cannot drift apart on what "admin"
-    means. Returns {user_id, roles}."""
+    no Strawberry `info` to unwrap and no schema extension running for them. Same two lookups the
+    GraphQL path makes - identity from the Clerk JWT, roles from the Clerk Backend API - so a route
+    and a root field cannot drift apart on what "admin" means. Returns {user_id, roles}.
+
+    Deliberately un-memoised: a plain route handles one request and makes one check, so there is no
+    second call to save, and taking the per-request store would mean inventing one for a Request that
+    never goes through `get_context`. `/testing/clerk-sign-in` and `/admin/reset-data` depend on this
+    path staying exactly as it was (#422)."""
     token = _bearer_token(request)
     if not token:
         raise AuthError("Authentication required")
@@ -184,26 +274,19 @@ def require_admin_request(request) -> dict:
     return {"user_id": user_id, "roles": roles}
 
 
-def require_admin(info) -> dict:
-    """Enforce that the caller holds the Admin/Manager role. Returns {user_id, roles}."""
-    return require_admin_request(info.context["request"])
-
-
 def require_role(info, role: str) -> dict:
-    """Enforce that the caller holds a specific role (looked up via the Clerk Backend API, like
-    require_admin). Returns {user_id, roles}. Use for role-gated resolvers other than Admin/Manager,
-    e.g. the shop-assembly manager assignment tools (#330)."""
-    request = info.context["request"]
-    token = _bearer_token(request)
-    if not token:
-        raise AuthError("Authentication required")
+    """Enforce a role from INSIDE a resolver body. Returns {user_id, roles}.
 
-    claims = verify_clerk_token(token)
-    user_id = claims.get("sub")
-    if not user_id:
-        raise AuthError("Authentication token has no subject")
+    Field-level role requirements belong in ROOT_FIELD_POLICY, not here - the extension applies them
+    before the body runs. This is for the requirement that is not a property of the field:
+    `assignOpenings` lets any signed-in user claim work for themselves and only a Shop Assembly
+    Manager hand it to somebody else (#330), so the check depends on the arguments and can only be
+    made once the body has them.
 
-    roles = user_repository.get_user_roles(user_id)
+    Reads the per-request role memo, so a body-level check on a field whose policy already resolved
+    roles adds no Clerk call.
+    """
+    roles = caller_roles(info.context)
     if role not in roles:
         raise ForbiddenError(f"{role} role required")
-    return {"user_id": user_id, "roles": roles}
+    return {"user_id": authenticated_user_id(info.context), "roles": roles}

--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -1,0 +1,320 @@
+"""Deny-by-default authorization for every GraphQL root field (#423).
+
+#415 closed a real hole - `updateUserRoles`, the mutation that grants `Admin/Manager`, was reachable
+with no session at all - by putting `require_user(info)` / `require_admin(info)` at the top of 161
+resolver bodies and policing them with an AST sweep. That worked, and it left three costs:
+
+  - **Opt-in stays opt-in.** A new resolver is public until somebody remembers a line. The AST test
+    catches the omission, but only after it is written, and only because the test exists.
+  - **The rule was spread across 15 modules.** "Who may call `mergeLocations`" was a line in
+    warehouse.py, and answering "what is admin-only" meant grepping.
+  - **`require_admin` cost a Clerk Backend API round trip per root field.** Roles are in Clerk
+    publicMetadata, not in the session token, so each gate did its own `GET /users/{id}`. The admin
+    landing page paid it once per admin query it fired, on top of the JWT verification each gate also
+    redid.
+
+This module inverts the default. `ROOT_FIELD_POLICY` below names every root field and what it
+requires; `OPEN_OPERATIONS` names the ones deliberately reachable without a Clerk session. A field in
+neither is REFUSED - so a resolver shipped without a policy entry fails closed, loudly, instead of
+being silently public until someone notices. `enforce_root_field` is called from the schema
+extension in main.py, before the resolver runs, so ordering is structural rather than a convention
+each body has to honour.
+
+What is deliberately NOT here: `require_admin_request`, the gate for the plain FastAPI routes in
+main.py (`/admin/reset-data`, `/testing/clerk-sign-in`). Those are not GraphQL, no extension runs for
+them, and they keep their own explicit gate - see app/auth.py.
+"""
+
+import logging
+
+from app.auth import (
+    ADMIN_ROLE,
+    SHOP_ASSEMBLY_MANAGER_ROLE,
+    ForbiddenError,
+    authenticated_user_id,
+    caller_roles,
+    user_roster,
+)
+
+logger = logging.getLogger(__name__)
+
+# A signed-in caller with no particular role. Not a Clerk role name, and it cannot collide with one:
+# Clerk roles are human-readable strings an admin types into the User Management page, and none of
+# them can contain a leading "@" the way this sentinel does.
+SIGNED_IN = "@signed-in"
+
+# Root fields whose bodies enumerate the whole Clerk roster anyway (`list_users`, or
+# `list_shop_assembly_members` which wraps it). For these the gate answers "what roles does the
+# caller hold" out of that one roster call instead of adding its own `GET /users/{id}` - which is the
+# `adminStats` double round trip: `require_admin`'s role lookup, then the `list_users` the resolver
+# was always going to make, which already carries roles for every user including the caller.
+#
+# This is a performance hint, NOT an authorization input. The decision of what a field requires is
+# ROOT_FIELD_POLICY and only ROOT_FIELD_POLICY; this only picks which Clerk call answers it. Adding a
+# field here that does not enumerate users makes it slower, never more permissive.
+ROSTER_BACKED = frozenset({"adminStats", "shopAssemblyMembers", "users"})
+
+# Operations reachable without a Clerk session, each with the reason it is safe. This is the whole
+# allowlist: everything else is gated, and anything in neither table is refused outright.
+OPEN_OPERATIONS: dict[str, str] = {
+    # The relay calls this during one-time setup, before it holds any credential, so there is no
+    # Clerk session to gate on. It is not unauthenticated: `relay_repository.enroll_install` matches
+    # the enrollment token by hash, rejects an expired one, and rejects a reused one via the
+    # `enrolled_at` guard. The admin who minted the token is the authorization.
+    "enrollRelayInstall": "authenticated by the single-use enrollment token, not Clerk",
+}
+
+# Every root field in the schema -> what it requires. SIGNED_IN is any authenticated user; anything
+# else is a Clerk role name the caller must hold.
+#
+# Grouped by the app/schemas/ module that defines the resolver, queries before mutations within each
+# group, so this reads as the same map the modules do. The values were lifted from the gate each
+# resolver body called before #423 - this table is that decision, moved, not re-derived.
+ROOT_FIELD_POLICY: dict[str, str] = {
+    # --- admin.py -------------------------------------------------------------------------
+    "openingHardwareStatus": ADMIN_ROLE,
+    # --- buyer.py -------------------------------------------------------------------------
+    # `buyerAssignments` is the PO dialog's read of the CALLER's own row, so any signed-in user;
+    # `allBuyerAssignments` is the whole table (which buyer owns which project) and is admin (#428).
+    "allBuyerAssignments": ADMIN_ROLE,
+    "buyerAssignments": SIGNED_IN,
+    "deleteBuyerAssignment": ADMIN_ROLE,
+    "saveBuyerAssignment": ADMIN_ROLE,
+    # --- dashboard.py ---------------------------------------------------------------------
+    "adminStats": ADMIN_ROLE,
+    "homeDashboardStats": SIGNED_IN,
+    "shopAssemblyStats": SIGNED_IN,
+    # --- gp_outbox.py ---------------------------------------------------------------------
+    # The two reads feed pending chips on the PO and receiving lists, so any signed-in user. The two
+    # writes are admin: retrying an `ambiguous` queued write can duplicate a GP posting, and
+    # cancelling one abandons work somebody has already done (#353 PR E).
+    "gpOutbox": SIGNED_IN,
+    "gpOutboxSummary": SIGNED_IN,
+    "cancelGpOutboxEntry": ADMIN_ROLE,
+    "retryGpOutboxEntry": ADMIN_ROLE,
+    # --- imports.py -----------------------------------------------------------------------
+    "projectExcludedItems": SIGNED_IN,
+    "projectHardwareSchedule": SIGNED_IN,
+    "reconcileSchedule": SIGNED_IN,
+    "finalizeImportSession": SIGNED_IN,
+    # --- notification.py ------------------------------------------------------------------
+    "notifications": SIGNED_IN,
+    "markNotificationAsRead": SIGNED_IN,
+    # --- po.py ----------------------------------------------------------------------------
+    "openPOs": SIGNED_IN,
+    "poDocumentDownloadUrl": SIGNED_IN,
+    "poDocumentSettings": SIGNED_IN,
+    "poOpenings": SIGNED_IN,
+    "poStatistics": SIGNED_IN,
+    "priorOrderAsValues": SIGNED_IN,
+    "purchaseOrder": SIGNED_IN,
+    "purchaseOrders": SIGNED_IN,
+    "cancelPo": SIGNED_IN,
+    "createDraftPo": SIGNED_IN,
+    "deletePoDocument": SIGNED_IN,
+    "markPoAsOrdered": SIGNED_IN,
+    # Signed-in, not admin: which projects a caller may raise a PO against is decided inside the
+    # resolver from the caller's own GP buyer assignment (#216), not by role.
+    "registerPoInGp": SIGNED_IN,
+    "savePoDocumentData": SIGNED_IN,
+    "updatePo": SIGNED_IN,
+    "updatePoDocumentSettings": ADMIN_ROLE,
+    "updatePoLineItemOrderAs": SIGNED_IN,
+    "updatePoLineItemUnitCost": SIGNED_IN,
+    "uploadPoDocument": SIGNED_IN,
+    # --- project.py -----------------------------------------------------------------------
+    "adminProjects": ADMIN_ROLE,
+    "projectByScheduleId": SIGNED_IN,
+    "projectShipTo": SIGNED_IN,
+    "projects": SIGNED_IN,
+    "createGpJob": ADMIN_ROLE,
+    "syncGpJobs": ADMIN_ROLE,
+    "updateProject": ADMIN_ROLE,
+    # --- relay.py -------------------------------------------------------------------------
+    # The gp_* reads are signed-in because every PO screen needs them. The two exceptions are the
+    # ones that return staff rosters by another name: `gpBuyersDetailed` (buyer ids with names) and
+    # `gpEmployees`. Everything that provisions, adopts or deletes a relay install is admin - those
+    # are relay credentials.
+    "gpBuyers": SIGNED_IN,
+    "gpBuyersDetailed": ADMIN_ROLE,
+    "gpCostCodes": SIGNED_IN,
+    "gpCustomerAddresses": SIGNED_IN,
+    "gpCustomers": SIGNED_IN,
+    "gpDivisions": SIGNED_IN,
+    "gpEmployees": ADMIN_ROLE,
+    "gpJobs": SIGNED_IN,
+    "gpPoTotals": SIGNED_IN,
+    "gpTaxDetails": SIGNED_IN,
+    "gpTaxSchedules": SIGNED_IN,
+    "gpVendors": SIGNED_IN,
+    "relayAdoptWindow": ADMIN_ROLE,
+    "relayInstalls": ADMIN_ROLE,
+    "relayStatus": SIGNED_IN,
+    "suggestVendorForManufacturer": SIGNED_IN,
+    "armRelayAdopt": ADMIN_ROLE,
+    "createGpBuyer": ADMIN_ROLE,
+    "deleteRelayInstall": ADMIN_ROLE,
+    "disarmRelayAdopt": ADMIN_ROLE,
+    "provisionRelayInstall": ADMIN_ROLE,
+    # `enrollRelayInstall` is in OPEN_OPERATIONS above, not here.
+    # --- shipping.py ----------------------------------------------------------------------
+    "packingSlips": SIGNED_IN,
+    "returnableLines": SIGNED_IN,
+    "shipReadyItems": SIGNED_IN,
+    "shippingOutRequests": SIGNED_IN,
+    "acceptShippingOutRequest": SIGNED_IN,
+    "confirmShipment": SIGNED_IN,
+    "createShipmentReturn": SIGNED_IN,
+    "rejectShippingOutRequest": SIGNED_IN,
+    "reopenShippingOutRequest": SIGNED_IN,
+    # --- shop_assembly.py -----------------------------------------------------------------
+    # `assignOpenings` is SIGNED_IN here on purpose: its role requirement is CONDITIONAL. Anyone may
+    # self-assign from the "Assign to me" board; assigning to somebody else is Shop Assembly
+    # Manager-only, and that branch cannot be expressed as a field-level requirement, so the body
+    # keeps its own `require_role` call for it (#330).
+    "assembleList": SIGNED_IN,
+    "assemblyPipeline": SIGNED_IN,
+    "assemblyPipelineSummaries": SIGNED_IN,
+    "myWork": SIGNED_IN,
+    "replacementWork": SIGNED_IN,
+    "shopAssemblyMembers": SHOP_ASSEMBLY_MANAGER_ROLE,
+    "shopAssemblyRequests": SIGNED_IN,
+    "acceptShopAssemblyRequest": SIGNED_IN,
+    "assignOpenings": SIGNED_IN,
+    "completeOpening": SIGNED_IN,
+    "installReplacement": SIGNED_IN,
+    "recordAssemblyProgress": SIGNED_IN,
+    "rejectShopAssemblyRequest": SIGNED_IN,
+    "removeOpeningFromUser": SIGNED_IN,
+    "reopenShopAssemblyRequest": SIGNED_IN,
+    # --- stock.py -------------------------------------------------------------------------
+    "deficiencyReviews": SIGNED_IN,
+    "deficientItems": SIGNED_IN,
+    "stockItem": SIGNED_IN,
+    "stockItems": SIGNED_IN,
+    "stockMatchesForOpening": SIGNED_IN,
+    "adjustStockQuantity": SIGNED_IN,
+    "allocateStockToProject": SIGNED_IN,
+    "assignStockItemLocation": SIGNED_IN,
+    "destockInventory": SIGNED_IN,
+    "markStockItemUnlocated": SIGNED_IN,
+    "moveStockLocation": SIGNED_IN,
+    "reclassifyStockItem": SIGNED_IN,
+    "reportDeficiencyAtAssembly": SIGNED_IN,
+    "reportInventoryDeficiency": SIGNED_IN,
+    "reportStockDeficiency": SIGNED_IN,
+    "resolveDeficiency": SIGNED_IN,
+    "transferInventory": SIGNED_IN,
+    # --- user.py --------------------------------------------------------------------------
+    # All four shipped ungated before #415. `updateUserRoles` is the one that matters most: it grants
+    # Admin/Manager, the role every other admin entry in this table is gated on, so an open copy is a
+    # self-service escalation into all of them.
+    "users": ADMIN_ROLE,
+    "updateUserGpBuyerId": ADMIN_ROLE,
+    "updateUserName": ADMIN_ROLE,
+    "updateUserRoles": ADMIN_ROLE,
+    # --- vendor.py ------------------------------------------------------------------------
+    # `createVendor` is signed-in, not admin: it is reached from the PO screens through a component
+    # that happens to live under modules/admin/. Promoting it breaks a PO user's vendor add.
+    "vendor": SIGNED_IN,
+    "vendors": SIGNED_IN,
+    "createVendor": SIGNED_IN,
+    "deleteVendor": ADMIN_ROLE,
+    "updateVendor": ADMIN_ROLE,
+    # --- warehouse.py ---------------------------------------------------------------------
+    # `overrideInventoryQuantity` is signed-in for the same reason as `createVendor`: it is the
+    # warehouse's count correction, not an admin tool, despite where the component lives.
+    "auditLog": SIGNED_IN,
+    "backOrderedItems": SIGNED_IN,
+    "inventoryByVendor": SIGNED_IN,
+    "inventoryHierarchy": SIGNED_IN,
+    "inventoryItems": SIGNED_IN,
+    "locationAuditHistory": SIGNED_IN,
+    "locationContents": SIGNED_IN,
+    "locationDistinctValues": SIGNED_IN,
+    "locationDuplicates": ADMIN_ROLE,
+    "locationUtilization": SIGNED_IN,
+    "openingItemDetails": SIGNED_IN,
+    "openingItems": SIGNED_IN,
+    "openingLeafStatus": SIGNED_IN,
+    "poReceivingDetails": SIGNED_IN,
+    "projectInventoryAvailability": SIGNED_IN,
+    "projectProgressByProduct": SIGNED_IN,
+    "pullPickSheet": SIGNED_IN,
+    "pullRequestDetails": SIGNED_IN,
+    "pullRequestOpenings": SIGNED_IN,
+    "pullRequests": SIGNED_IN,
+    "recentReceiveRecords": SIGNED_IN,
+    "unlocatedInventory": SIGNED_IN,
+    "warehouse": SIGNED_IN,
+    "warehouseDashboard": SIGNED_IN,
+    "warehouses": SIGNED_IN,
+    "adjustInventoryQuantity": SIGNED_IN,
+    "assignInventoryLocation": SIGNED_IN,
+    "assignOpeningItemLocation": SIGNED_IN,
+    "cancelPullRequest": SIGNED_IN,
+    "completePullRequest": SIGNED_IN,
+    "confirmPick": SIGNED_IN,
+    "createReceive": SIGNED_IN,
+    "createWarehouse": ADMIN_ROLE,
+    "deleteWarehouse": ADMIN_ROLE,
+    "markInventoryUnlocated": SIGNED_IN,
+    "markOpeningItemUnlocated": SIGNED_IN,
+    "mergeLocations": ADMIN_ROLE,
+    "moveInventoryLocation": SIGNED_IN,
+    "moveOpeningItemLocation": SIGNED_IN,
+    "overrideInventoryQuantity": SIGNED_IN,
+    "savePickDraft": SIGNED_IN,
+    "setPullItemFetched": SIGNED_IN,
+    "stagePullOpenings": SIGNED_IN,
+    "startPullRequestPick": SIGNED_IN,
+    "updateWarehouse": ADMIN_ROLE,
+}
+
+
+def _roles_for(context, field_name: str) -> list[str]:
+    """The caller's Clerk roles, taken from whichever call this operation was going to make anyway.
+
+    Both paths are memoised on the request context, so a query hitting several role-gated root fields
+    resolves roles once, not once per field."""
+    if field_name in ROSTER_BACKED:
+        user_id = authenticated_user_id(context)
+        for u in user_roster(context):
+            if u.get("id") == user_id:
+                return u.get("roles") or []
+        # The caller is authenticated but absent from the roster Clerk just returned. Fall through to
+        # the single-user lookup rather than treating it as "no roles": a fresh account created
+        # between the two calls must not be silently demoted.
+    return caller_roles(context)
+
+
+def enforce_root_field(field_name: str, context) -> None:
+    """Refuse the caller unless they satisfy this root field's entry in ROOT_FIELD_POLICY.
+
+    Called once per root field (`info.path.prev is None`) by the schema extension in main.py, before
+    the resolver runs. Nested fields are never checked: they are only reachable through a root field
+    that already was, and checking them would put this on every node of every response.
+
+    Raises AuthError (code UNAUTHENTICATED, which the frontend's Apollo link answers by re-minting
+    the Clerk token and replaying once, #429) or ForbiddenError (code FORBIDDEN, which it does not).
+    """
+    if field_name in OPEN_OPERATIONS:
+        return
+
+    requirement = ROOT_FIELD_POLICY.get(field_name)
+    if requirement is None:
+        # A root field nobody wrote a policy for. Refusing is the whole point of the file: the
+        # alternative default - letting it through - is exactly the state #415 had to clean up. The
+        # log line is for us, since the caller cannot fix this and the test suite should have.
+        logger.error(
+            "GraphQL root field %r has no entry in ROOT_FIELD_POLICY and is not in OPEN_OPERATIONS; refusing it",
+            field_name,
+        )
+        raise ForbiddenError(f"'{field_name}' has no authorization policy and cannot be called")
+
+    if requirement == SIGNED_IN:
+        authenticated_user_id(context)
+        return
+
+    if requirement not in _roles_for(context, field_name):
+        raise ForbiddenError(f"{requirement} role required")

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -119,7 +119,7 @@ class RelayOpUnsupportedError(AppError):
 def validation_error_from_relay(e: RelayCallError) -> ValidationError:
     """Turn a relay refusal into a ValidationError that still carries the relay's error body.
 
-    main.py's ErrorHandlerExtension publishes `extensions.relayError` from whatever `.detail` the
+    main.py's ResolverGuardExtension publishes `extensions.relayError` from whatever `.detail` the
     raised error has, and ValidationError has no such field - so converting the error plainly would
     strip the GP proc, the error state and the taErrorCode description on the way to the browser, and
     the dialog's GpErrorAlert would render an empty detail table. That table is the whole point of

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -78,7 +78,7 @@ type Query {
 type Mutation {
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
-  # Accept gate (#293). Any signed-in user (require_user). Accept mints the warehouse PullRequest;
+  # Accept gate (#293). Any signed-in user. Accept mints the warehouse PullRequest;
   # the warehouse approve handles shortfalls. The approval is recorded against the
   # Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED, kept only so
   # a frontend from the previous deploy still validates.

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -269,8 +269,9 @@ input CompleteOpeningInput {
   completed_by: String
 }
 
-# Every field below is gated on an authenticated caller (require_user, #339) except where a
-# stronger role gate is noted. Adding the gate did not change any field's arguments.
+# Every field below is gated on an authenticated caller (#339) except where a stronger role
+# requirement is noted. The requirement lives in ROOT_FIELD_POLICY (app/auth_policy.py) and is
+# applied before the resolver runs (#423); it did not change any field's arguments.
 type Query {
   # projectId is optional; omit it for the cross-project view.
   assembleList(projectId: ID): [ShopAssemblyOpening!]!
@@ -294,7 +295,7 @@ type Query {
 type Mutation {
   # Self-assignment is open to any signed-in user; assigning to *another* user additionally
   # requires the Shop Assembly Manager role (#330).
-  # A manager (the require_role branch) may reassign an opening someone else is holding, including an
+  # A manager (the role-checked branch) may reassign an opening someone else is holding, including an
   # IN_PROGRESS one - progress is persisted, so the handoff is lossless (#340). A self-claim never
   # can: it takes the is-self branch, which does not pass allow_reassign.
   assignOpenings(input: AssignOpeningsInput!): [ShopAssemblyOpening!]!
@@ -315,7 +316,7 @@ type Mutation {
   # VALIDATION_ERROR if more than has arrived; INVALID_STATE_TRANSITION if the leaf is still on the
   # bench (record it as progress instead) or has already shipped (that is reallocation's problem).
   installReplacement(input: InstallReplacementInput!): OpeningItem!
-  # Accept gate (#293). Any signed-in user (require_user). Accept mints the warehouse PullRequest and
+  # Accept gate (#293). Any signed-in user. Accept mints the warehouse PullRequest and
   # is a **pure human gate** since #342: the hardware was reserved when the request was created, so
   # nothing is re-checked here. Reject is what releases that reservation. The approval is recorded
   # against the Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED,

--- a/backend/app/graphql/user.graphql
+++ b/backend/app/graphql/user.graphql
@@ -2,15 +2,17 @@
 # Source of truth: Strawberry resolvers in app/schemas/user.py
 #
 # Users do not live in Postgres. They live in Clerk, and `app/repositories/user_repository.py` talks
-# to the Clerk Backend API - which is why roles are not a database enum and why `require_admin` /
-# `require_role` cost a network call while `require_user` does not (app/auth.py).
+# to the Clerk Backend API - which is why roles are not a database enum, and why a role requirement
+# costs a network call while a plain signed-in one does not. Since #423 that call is made once per
+# request rather than once per gated field (app/auth.py, app/auth_policy.py).
 #
 # This file existed only as a cross-reference from shop_assembly.graphql ("ClerkUser is in
 # user.graphql") until #344; the reference was dangling. It is written now so the pointer resolves.
 #
-# Every operation below is Admin/Manager-gated (#415). They were all reachable with no session until
-# then, which made updateUserRoles a self-service grant of the role that gates relay provisioning,
-# relay deletion, buyer assignments and the GP job/buyer writes.
+# Every operation below is Admin/Manager-gated (#415), now from ROOT_FIELD_POLICY in
+# app/auth_policy.py rather than a line in each resolver (#423). They were all reachable with no
+# session until #415, which made updateUserRoles a self-service grant of the role that gates relay
+# provisioning, relay deletion, buyer assignments and the GP job/buyer writes.
 
 # One Clerk account as the app sees it. `roles` comes from Clerk publicMetadata, not from the session
 # token, so it is fetched rather than decoded.

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -549,7 +549,7 @@ type Query {
 type Mutation {
   createReceive(input: CreateReceiveInput!): ReceiveRecord!
   # Issue #427: the actor on every audit and history row is the Clerk-authenticated caller
-  # (require_user -> resolve_display_name), never an argument. The startedBy / enteredBy / pickedBy /
+  # (current_user -> resolve_display_name), never an argument. The startedBy / enteredBy / pickedBy /
   # fetchedBy / completedBy arguments below are accepted and IGNORED, and are nullable so they can
   # carry @deprecated; they exist only so a frontend from the previous deploy still validates, and
   # are dropped once none reference them.

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -16,7 +16,11 @@ _client = httpx.Client(base_url=CLERK_API_BASE, timeout=30.0)
 
 def _headers() -> dict[str, str]:
     if not CLERK_SECRET_KEY:
-        raise AppError("CLERK_SECRET_KEY is not configured")
+        # AppError takes a code, so the bare one-argument raise this used to be was a TypeError
+        # rather than the misconfiguration message it meant to be. Reachable from more paths since
+        # #423 - the gate now calls list_users() to authorize the roster-backed fields, so a backend
+        # deployed without the key answers those with a 500 traceback instead of a named error.
+        raise AppError("CLERK_SECRET_KEY is not configured", "CONFIGURATION_ERROR")
     return {
         "Authorization": f"Bearer {CLERK_SECRET_KEY}",
         "Content-Type": "application/json",

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -84,12 +84,16 @@ def list_users() -> list[dict]:
     return users
 
 
-def list_shop_assembly_members() -> list[dict]:
-    """Shop-assembly team members (#330): the subset of Clerk users holding a shop-assembly role,
-    for the manager assignment picker. Reuses list_users() and filters client-side to keep one
-    source of the user summary shape."""
+def shop_assembly_members(users: list[dict]) -> list[dict]:
+    """Shop-assembly team members (#330): the subset of a Clerk roster holding a shop-assembly role,
+    for the manager assignment picker. Clerk has no server-side filter on publicMetadata, so this is
+    a client-side filter over the whole roster either way.
+
+    Takes the roster rather than fetching it so the resolver can pass the request-scoped one the auth
+    gate already loaded (#423) - `shopAssemblyMembers` is role-gated, and that check and this answer
+    now come out of the same single call to Clerk."""
     members = set(SHOP_ASSEMBLY_ROLES)
-    return [u for u in list_users() if members.intersection(u["roles"])]
+    return [u for u in users if members.intersection(u["roles"])]
 
 
 def get_user(user_id: str) -> dict:

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -4,7 +4,6 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin
 from app.database import SessionLocal
 from app.repositories import admin_repository
 
@@ -19,7 +18,6 @@ class AdminQueries:
     ) -> list[OpeningHardwareStatus]:
         """Admin-gated (#415): only the admin Opening Status tab reads it, and it walks every opening
         in a project."""
-        require_admin(info)
         with SessionLocal() as session:
             rows = admin_repository.get_opening_hardware_status(
                 session, uuid.UUID(str(project_id)) if project_id else None

--- a/backend/app/schemas/buyer.py
+++ b/backend/app/schemas/buyer.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import strawberry
 
-from app.auth import require_admin, require_user
+from app.auth import current_user
 from app.database import SessionLocal
 from app.repositories import buyer_repository, user_repository
 
@@ -19,7 +19,7 @@ class BuyerQueries:
     def buyer_assignments(self, info: strawberry.Info) -> list[BuyerAssignment]:
         """Issue #216: which projects the CALLER's buyer identity may create POs for. The PO dialog
         reads this to filter its project options; the create/register mutations re-enforce it
-        server-side. require_user, not admin (#415), because that dialog is a PO-user screen.
+        server-side. Signed-in, not admin (#415), because that dialog is a PO-user screen.
 
         Scoped to the caller's own row as of #428. It used to return the whole table, so any signed-in
         account - Shop Assembly, Shipping Out, Warehouse Staff - could enumerate which buyer owns
@@ -29,7 +29,7 @@ class BuyerQueries:
         yet gets an empty list rather than an error - it simply cannot create project POs, which is
         the state the dialog already handles. `allBuyerAssignments` is the admin-gated whole-table
         read for the Buyers page."""
-        auth = require_user(info)
+        auth = current_user(info)
         # Same identity registerPoInGp enforces the PO against, so the dialog and the mutation can
         # never disagree about which assignment applies.
         buyer_id = user_repository.get_user_gp_buyer_id(auth["user_id"])
@@ -43,12 +43,11 @@ class BuyerQueries:
     def all_buyer_assignments(self, info: strawberry.Info) -> list[BuyerAssignment]:
         """Every buyer's assignment, for the Buyers admin page (#428).
 
-        This is what `buyerAssignments` used to be. It stayed a single require_user resolver because
+        This is what `buyerAssignments` used to be. It stayed a single signed-in resolver because
         one admin screen and one PO-user dialog happened to want the same shape - but the dialog only
         ever wants its own row, and the whole table is a map of which buyer owns which project. The
         page that genuinely needs all of them is admin-only anyway, so the whole-table read is gated
         to match."""
-        require_admin(info)
         with SessionLocal() as session:
             return [buyer_assignment_to_type(a) for a in buyer_repository.list_assignments(session)]
 
@@ -73,7 +72,6 @@ class BuyerMutations:
         ] = None,
     ) -> BuyerAssignment:
         """Issue #216: upsert a buyer's whole assignment (the projects they may order for). Admin."""
-        require_admin(info)
         with SessionLocal() as session:
             assignment = buyer_repository.save_assignment(
                 session,
@@ -86,7 +84,6 @@ class BuyerMutations:
 
     @strawberry.mutation
     def delete_buyer_assignment(self, info: strawberry.Info, buyer_id: str) -> bool:
-        require_admin(info)
         with SessionLocal() as session:
             buyer_repository.delete_assignment(session, buyer_id)
             session.commit()

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -2,9 +2,9 @@
 
 import strawberry
 
-from app.auth import require_admin, require_user
+from app.auth import user_roster
 from app.database import SessionLocal
-from app.repositories import dashboard_repository, user_repository
+from app.repositories import dashboard_repository
 
 from .types import AdminStats, HomeDashboardStats, ShopAssemblyStats
 
@@ -13,7 +13,6 @@ from .types import AdminStats, HomeDashboardStats, ShopAssemblyStats
 class DashboardQueries:
     @strawberry.field
     def home_dashboard_stats(self, info: strawberry.Info) -> HomeDashboardStats:
-        require_user(info)
         with SessionLocal() as session:
             d = dashboard_repository.get_home_dashboard_stats(session)
             return HomeDashboardStats(
@@ -25,7 +24,6 @@ class DashboardQueries:
 
     @strawberry.field
     def shop_assembly_stats(self, info: strawberry.Info) -> ShopAssemblyStats:
-        require_user(info)
         with SessionLocal() as session:
             d = dashboard_repository.get_shop_assembly_stats(session)
             return ShopAssemblyStats(
@@ -35,9 +33,14 @@ class DashboardQueries:
     @strawberry.field
     def admin_stats(self, info: strawberry.Info) -> AdminStats:
         """Admin-gated (#415): only the admin landing page reads it, and it enumerates Clerk users to
-        count them."""
-        require_admin(info)
-        users = user_repository.list_users()
+        count them.
+
+        That enumeration is also what authorized the caller. `user_roster` is the request-scoped
+        memo the gate resolved this field's Admin/Manager requirement from (ROSTER_BACKED in
+        app/auth_policy.py) - the roster carries roles per user, so one Clerk call answers both
+        questions. Calling `user_repository.list_users()` directly here would make it two, which is
+        what it was before #423."""
+        users = user_roster(info.context)
         with SessionLocal() as session:
             d = dashboard_repository.get_admin_stats(session, user_count=len(users))
             return AdminStats(

--- a/backend/app/schemas/gp_outbox.py
+++ b/backend/app/schemas/gp_outbox.py
@@ -7,7 +7,6 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.errors import NotFoundError
 from app.repositories import gp_outbox_repository
@@ -22,7 +21,6 @@ class GpOutboxQueries:
     @strawberry.field
     def gp_outbox_summary(self, info: strawberry.Info) -> GpOutboxSummary:
         """Counts behind the queue chip, polled by every open browser - scalar aggregates only."""
-        require_user(info)
         with SessionLocal() as session:
             return gp_outbox_summary_to_type(gp_outbox_repository.summary(session))
 
@@ -32,7 +30,6 @@ class GpOutboxQueries:
     ) -> list[GpOutboxEntry]:
         """The queue itself. Readable by any signed-in user because the PO and receiving lists join
         pending entries onto their rows client-side; only retry/cancel are admin-gated."""
-        require_user(info)
         with SessionLocal() as session:
             rows = gp_outbox_repository.list_entries(
                 session, status=status.value if status else None, limit=max(1, min(limit, 500))
@@ -49,7 +46,6 @@ class GpOutboxMutations:
         For `failureKind == 'ambiguous'` this is a genuinely dangerous button - GP may already hold
         the write - which is why the UI's confirm text says to check GP first. The backend cannot
         know, so it does not pretend to."""
-        require_admin(info)
         with SessionLocal() as session:
             row = gp_outbox_repository.retry_entry(session, uuid.UUID(str(id)))
             if row is None:
@@ -66,7 +62,6 @@ class GpOutboxMutations:
     def cancel_gp_outbox_entry(self, info: strawberry.Info, id: strawberry.ID) -> GpOutboxEntry:
         """Admin: abandon a queued write. Refused for an IN_FLIGHT row - cancelling one would leave
         the worker still writing to a row a human believes is dead."""
-        require_admin(info)
         with SessionLocal() as session:
             row = gp_outbox_repository.cancel_entry(session, uuid.UUID(str(id)))
             if row is None:

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -5,7 +5,6 @@ from dataclasses import replace
 
 import strawberry
 
-from app.auth import require_user
 from app.database import SessionLocal
 from app.errors import InventoryShortfallError
 from app.repositories import (
@@ -39,7 +38,6 @@ class ImportQueries:
     def project_hardware_schedule(
         self, info: strawberry.Info, project_id: strawberry.ID
     ) -> ProjectHardwareSchedule | None:
-        require_user(info)
         with SessionLocal() as session:
             data = import_repository.get_project_hardware_schedule(session, uuid.UUID(str(project_id)))
             if data is None:
@@ -50,7 +48,6 @@ class ImportQueries:
     def reconcile_schedule(
         self, info: strawberry.Info, project_id: strawberry.ID, items: list[ReconciliationItemInput]
     ) -> list[ReconciliationResult]:
-        require_user(info)
         from .enums import ReconciliationStatus
 
         items_data = [
@@ -77,7 +74,6 @@ class ImportQueries:
 
     @strawberry.field
     def project_excluded_items(self, info: strawberry.Info, project_id: strawberry.ID) -> list[ProjectExcludedItem]:
-        require_user(info)
         with SessionLocal() as session:
             rows = import_repository.list_excluded_items(session, uuid.UUID(str(project_id)))
             return [
@@ -93,7 +89,6 @@ class ImportQueries:
 class ImportMutations:
     @strawberry.mutation
     def finalize_import_session(self, info: strawberry.Info, input: FinalizeImportSessionInput) -> FinalizeImportResult:
-        require_user(info)
         # Convert Strawberry input to dict
         input_data = {
             "project_id": str(input.project_id),

--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -2,6 +2,13 @@
 
 Resolver implementations live in the domain modules (schemas/po.py, schemas/warehouse.py, ...),
 mirroring app/repositories/. DTO builders live in schemas/converters.py.
+
+Every field on this type is a ROOT field, and every root field is authorized from
+ROOT_FIELD_POLICY in app/auth_policy.py - checked by the schema extension in main.py before the
+resolver runs, not by a line in the body (#423). A field with no entry there, and no place on the
+OPEN_OPERATIONS allowlist, is refused. So adding a resolver below means adding its policy entry;
+forgetting breaks the field rather than opening it, and `tests/test_resolver_gate_completeness.py`
+fails on it either way.
 """
 
 import strawberry

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -4,7 +4,6 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user
 from app.database import SessionLocal
 from app.repositories import notification_repository
 
@@ -23,7 +22,6 @@ class NotificationQueries:
         unread_only: bool | None = None,
         limit: int = 5,
     ) -> list[Notification]:
-        require_user(info)
         with SessionLocal() as session:
             results = notification_repository.get_notifications(
                 session,
@@ -39,7 +37,6 @@ class NotificationQueries:
 class NotificationMutations:
     @strawberry.mutation
     def mark_notification_as_read(self, info: strawberry.Info, id: strawberry.ID) -> Notification:
-        require_user(info)
         with SessionLocal() as session:
             notification = notification_repository.mark_as_read(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -7,7 +7,7 @@ from datetime import date
 
 import strawberry
 
-from app.auth import require_admin, require_user
+from app.auth import current_user
 from app.database import SessionLocal
 from app.errors import (
     GpSetupInvalidError,
@@ -266,7 +266,6 @@ class POQueries:
     def purchase_orders(
         self, info: strawberry.Info, project_id: strawberry.ID | None = None, status: POStatus | None = None
     ) -> list[PurchaseOrder]:
-        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             pos = po_repository.get_purchase_orders(session, pid, status)
@@ -276,7 +275,6 @@ class POQueries:
     def po_document_download_url(self, info: strawberry.Info, document_id: strawberry.ID) -> str:
         """Mints a presigned S3 URL, so the gate is the only thing standing between an anonymous
         caller and a supplier PO document (#415)."""
-        require_user(info)
         from app.services import storage
 
         with SessionLocal() as session:
@@ -285,7 +283,6 @@ class POQueries:
 
     @strawberry.field
     def purchase_order(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder | None:
-        require_user(info)
         with SessionLocal() as session:
             po = po_repository.get_purchase_order(session, uuid.UUID(str(id)))
             if po is None:
@@ -299,7 +296,6 @@ class POQueries:
 
         Its own field rather than a list on PurchaseOrder: the PO list renders dozens of POs and must
         never pay for this join, and the detail modal is the only place it is read."""
-        require_user(info)
         with SessionLocal() as session:
             return [
                 POOpening(
@@ -327,14 +323,12 @@ class POQueries:
         vendor_id: strawberry.ID,
         product_codes: list[str],
     ) -> list[PriorOrderAsForProduct]:
-        require_user(info)
         with SessionLocal() as session:
             result = po_repository.get_prior_order_as_values(session, uuid.UUID(str(vendor_id)), product_codes)
             return [PriorOrderAsForProduct(product_code=pc, values=vals) for pc, vals in result.items()]
 
     @strawberry.field
     def po_statistics(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> POStatistics:
-        require_user(info)
         with SessionLocal() as session:
             stats = po_repository.get_po_statistics(session, uuid.UUID(str(project_id)) if project_id else None)
             return POStatistics(
@@ -349,17 +343,15 @@ class POQueries:
 
     @strawberry.field
     def open_p_os(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[PurchaseOrder]:
-        require_user(info)
         with SessionLocal() as session:
             pos = po_repository.get_open_pos(session, uuid.UUID(str(project_id)) if project_id else None)
             return [po_to_type(po) for po in pos]
 
     @strawberry.field
     def po_document_settings(self, info: strawberry.Info) -> PODocumentSettings:
-        """The admin boilerplate for the generated supplier PO document (issue #230). require_user, not
+        """The admin boilerplate for the generated supplier PO document (issue #230). Signed-in, not
         admin: the PO user's generate form reads it to render the document. Get-or-creates the singleton
         with guideline defaults on first read, so it never returns null."""
-        require_user(info)
         with SessionLocal() as session:
             settings = po_document_settings_repository.get_settings(session)
             session.commit()
@@ -374,7 +366,6 @@ class POMutations:
         no buyer involved. Registering the draft into GP (register_po_in_gp) is the separate,
         conscious user action where GP vendor / buyer identity / cost code are captured and the
         issue #216 assignment gating applies."""
-        require_user(info)
         line_items_data = [
             {
                 "hardware_category": li.hardware_category,
@@ -428,7 +419,7 @@ class POMutations:
         would trade a rare bad PO for a constantly unusable button - and the relay's own create_po
         pre-check (cost_code_account_invalid) is still there as the last line of defence, running
         inside GP's own transaction where it cannot be stale at all."""
-        auth = require_user(info)
+        auth = current_user(info)
         # Issue #216: the PO is registered as the caller's own GP buyer identity, never a free pick.
         caller_buyer = await asyncio.to_thread(user_repository.get_user_gp_buyer_id, auth["user_id"])
         _assert_buyer_identity(caller_buyer, input.buyer_id)
@@ -574,7 +565,6 @@ class POMutations:
         shipping_cost: float | None = strawberry.UNSET,
         tariff_amount: float | None = strawberry.UNSET,
     ) -> PurchaseOrder:
-        require_user(info)
         from app.repositories.po_repository import _UNSET
 
         pid = uuid.UUID(str(project_id)) if project_id else _UNSET
@@ -598,7 +588,6 @@ class POMutations:
 
     @strawberry.mutation
     def mark_po_as_ordered(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder:
-        require_user(info)
         with SessionLocal() as session:
             po = po_repository.mark_po_as_ordered(session, uuid.UUID(str(id)))
             session.commit()
@@ -607,7 +596,6 @@ class POMutations:
 
     @strawberry.mutation
     def cancel_po(self, info: strawberry.Info, id: strawberry.ID) -> PurchaseOrder:
-        require_user(info)
         with SessionLocal() as session:
             po = po_repository.cancel_po(session, uuid.UUID(str(id)))
             session.commit()
@@ -618,7 +606,6 @@ class POMutations:
     def update_po_line_item_order_as(
         self, info: strawberry.Info, id: strawberry.ID, order_as: str | None = None
     ) -> POLineItem:
-        require_user(info)
         with SessionLocal() as session:
             poli = po_repository.update_line_item_order_as(session, uuid.UUID(str(id)), order_as)
             session.commit()
@@ -627,7 +614,6 @@ class POMutations:
 
     @strawberry.mutation
     def update_po_line_item_unit_cost(self, info: strawberry.Info, id: strawberry.ID, unit_cost: float) -> POLineItem:
-        require_user(info)
         with SessionLocal() as session:
             poli = po_repository.update_line_item_unit_cost(session, uuid.UUID(str(id)), unit_cost)
             session.commit()
@@ -645,7 +631,6 @@ class POMutations:
         document_type: PODocumentType,
         file_data_base64: str,
     ) -> PODocumentInfo:
-        require_user(info)
         from app.models.enums import PODocumentType as PODocTypeDB
 
         with SessionLocal() as session:
@@ -663,7 +648,6 @@ class POMutations:
 
     @strawberry.mutation
     def delete_po_document(self, info: strawberry.Info, document_id: strawberry.ID) -> bool:
-        require_user(info)
         with SessionLocal() as session:
             po_repository.delete_po_document(session, uuid.UUID(str(document_id)))
             session.commit()
@@ -675,7 +659,6 @@ class POMutations:
     ) -> PODocumentSettings:
         """Patch the single-row PO-document boilerplate (issue #230). Admin-only. Only fields the client
         actually sent (not UNSET) are written, so a partial edit leaves the rest intact."""
-        require_admin(info)
         fields = {
             name: getattr(input, name)
             for name in (
@@ -706,8 +689,7 @@ class POMutations:
         self, info: strawberry.Info, po_id: strawberry.ID, input: SavePODocumentDataInput
     ) -> PurchaseOrder:
         """Persist the generate-dialog capture for a PO (issue #230) and return the PO with its now-saved
-        documentData, so a re-open of the dialog pre-fills. require_user (any PO user generates)."""
-        require_user(info)
+        documentData, so a re-open of the dialog pre-fills. Signed-in (any PO user generates)."""
         pid = uuid.UUID(str(po_id))
         with SessionLocal() as session:
             po_repository.upsert_po_document_data(

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -6,7 +6,6 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.errors import (
     ConflictError,
@@ -48,9 +47,8 @@ async def _adopt_existing(job_number: str) -> Project:
 class ProjectQueries:
     @strawberry.field
     def projects(self, info: strawberry.Info) -> list[Project]:
-        """The project picker every module reads, so require_user rather than the admin gate on
+        """The project picker every module reads, so signed-in rather than the admin requirement on
         `admin_projects` below - same rows, fewer fields."""
-        require_user(info)
         with SessionLocal() as session:
             rows = project_repository.list_projects_with_opening_counts(session)
             return [project_to_type(p, include_openings=False, opening_count=count) for p, count in rows]
@@ -58,14 +56,12 @@ class ProjectQueries:
     @strawberry.field
     def admin_projects(self, info: strawberry.Info) -> list[Project]:
         """Admin/Manager-only project list with all editable fields for the admin Projects page."""
-        require_admin(info)
         with SessionLocal() as session:
             rows = project_repository.list_projects_with_opening_counts(session)
             return [project_to_type(p, include_openings=False, opening_count=count) for p, count in rows]
 
     @strawberry.field
     def project_by_schedule_id(self, info: strawberry.Info, project_id: str) -> Project | None:
-        require_user(info)
         with SessionLocal() as session:
             p = project_repository.get_project_by_schedule_id(session, project_id)
             if p is None:
@@ -76,7 +72,6 @@ class ProjectQueries:
     def project_ship_to(self, info: strawberry.Info, project_id: strawberry.ID) -> ProjectShipTo | None:
         """The job-site address block for a project, by its UUID - the "deliver to site" ship-to option
         on the generated PO document (issue #230). A lean projection, kept off the PO list query."""
-        require_user(info)
         with SessionLocal() as session:
             p = project_repository.get_project(session, uuid.UUID(str(project_id)))
             if p is None:
@@ -112,7 +107,6 @@ class ProjectMutations:
 
         Admin-only. Creating a job writes to the accounting system of record.
         """
-        require_admin(info)
 
         company = relay_gateway.company
         if not company:
@@ -195,13 +189,11 @@ class ProjectMutations:
         The background service already does this on a timer and on every relay reconnect, so this is
         for the case where someone wants to see the result immediately - after creating a job directly
         in GP, or when checking whether the sync is working at all."""
-        require_admin(info)
         total, adopted = await gp_job_sync.run_once()
         return GpJobSyncResult(total=total, adopted=adopted)
 
     @strawberry.mutation
     def update_project(self, info: strawberry.Info, id: strawberry.ID, input: UpdateProjectInput) -> Project:
-        require_admin(info)
         with SessionLocal() as session:
             project = project_repository.update_project(
                 session,

--- a/backend/app/schemas/queries.py
+++ b/backend/app/schemas/queries.py
@@ -2,6 +2,13 @@
 
 Resolver implementations live in the domain modules (schemas/po.py, schemas/warehouse.py, ...),
 mirroring app/repositories/. DTO builders live in schemas/converters.py.
+
+Every field on this type is a ROOT field, and every root field is authorized from
+ROOT_FIELD_POLICY in app/auth_policy.py - checked by the schema extension in main.py before the
+resolver runs, not by a line in the body (#423). A field with no entry there, and no place on the
+OPEN_OPERATIONS allowlist, is refused. So adding a resolver below means adding its policy entry;
+forgetting breaks the field rather than opening it, and `tests/test_resolver_gate_completeness.py`
+fails on it either way.
 """
 
 import strawberry

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -5,7 +5,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin, require_user
+from app.auth import current_user
 from app.database import SessionLocal
 from app.errors import (
     ConflictError,
@@ -60,7 +60,6 @@ logger = logging.getLogger(__name__)
 class RelayQueries:
     @strawberry.field
     def relay_installs(self, info: strawberry.Info) -> list[RelayInstallInfo]:
-        require_admin(info)
         with SessionLocal() as session:
             return [relay_install_to_type(ri) for ri in relay_repository.list_installs(session)]
 
@@ -69,7 +68,6 @@ class RelayQueries:
         """The currently armed adopt window, or null. Admin-only, and polled by the Relay Installs page
         so the warning banner and its countdown reflect the real (single-replica, in-memory) state
         rather than what the browser that armed it happens to remember."""
-        require_admin(info)
         window = relay_adopt.peek()
         if window is None:
             return None
@@ -84,7 +82,6 @@ class RelayQueries:
     def relay_status(self, info: strawberry.Info) -> RelayStatus:
         """Whether the outbound relay WS channel is currently connected (and, if so, the GP company it is
         enrolled for), for the relay status chip and the company-aware PO/receive/adopt dialogs."""
-        require_user(info)
         live_install = relay_gateway.install_id
         return RelayStatus(
             connected=relay_gateway.connected,
@@ -96,21 +93,18 @@ class RelayQueries:
     @strawberry.field
     async def gp_jobs(self, info: strawberry.Info, company: str) -> list[GpJob]:
         """Live job master (JC00102) via the connected relay."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_jobs")
         return [gp_job_to_type(j) for j in result["jobs"]]
 
     @strawberry.field
     async def gp_vendors(self, info: strawberry.Info, company: str) -> list[GpVendor]:
         """Live active vendor list (PM00200) via the connected relay."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_vendors")
         return [gp_vendor_to_type(v) for v in result["vendors"]]
 
     @strawberry.field
     async def gp_buyers(self, info: strawberry.Info, company: str) -> list[str]:
         """Registered GP buyers (POP00101) via the connected relay, for the Create PO buyer dropdown."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_buyers")
         return result["buyers"]
 
@@ -123,14 +117,12 @@ class RelayQueries:
         list is ordinary working data every PO creator needs, but the descriptions are a staff roster
         by another name ('Don Roberton', and in the production company every buyer's email), and the
         only consumers are admin-only screens."""
-        require_admin(info)
         result = await relay_gateway.relay_call(company, "list_buyers_detailed")
         return [gp_buyer_to_type(b) for b in result["buyers"]]
 
     @strawberry.field
     async def gp_cost_codes(self, info: strawberry.Info, company: str, job: str) -> list[GpCostCode]:
         """Active per-job cost codes (JC00701) via the connected relay, for the Create PO cost-code dropdown."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_cost_codes", {"job": job})
         return [gp_cost_code_to_type(c) for c in result["cost_codes"]]
 
@@ -138,7 +130,6 @@ class RelayQueries:
     async def gp_tax_details(self, info: strawberry.Info, company: str) -> list[GpTaxDetail]:
         """Live GP purchase tax details (TX00201, TXDTLTYP=2) via the connected relay, for the
         register-PO tax-detail dropdown (issue #257)."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_tax_details")
         return [gp_tax_detail_to_type(t) for t in result["tax_details"]]
 
@@ -146,7 +137,6 @@ class RelayQueries:
     async def gp_customers(self, info: strawberry.Info, company: str) -> list[GpCustomer]:
         """Live customer master (RM00101) via the connected relay, for the create-job customer picker
         (#380)."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_customers")
         return [gp_customer_to_type(c) for c in result["customers"]]
 
@@ -157,7 +147,6 @@ class RelayQueries:
         """One customer's address codes (RM00102) via the connected relay, for the create-job job and
         bill-to address pickers (#380). Scoped to the customer because the job proc validates the codes
         against that customer's addresses."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_customer_addresses", {"customer": customer})
         return [gp_customer_address_to_type(a) for a in result["addresses"]]
 
@@ -169,9 +158,8 @@ class RelayQueries:
 
         Admin-gated, unlike the other gp_* reads. This one returns the payroll roster with names, and
         its only consumer is create_gp_job's dialog, which is already admin-only - so gating it at
-        require_user would hand the staff list to every signed-in warehouse and assembly user for no
+        merely signed-in would hand the staff list to every warehouse and assembly user for no
         benefit. A vendor or customer list is ordinary working data; a payroll master is not."""
-        require_admin(info)
         result = await relay_gateway.relay_call(company, "list_employees")
         return [gp_employee_to_type(e) for e in result["employees"]]
 
@@ -179,7 +167,6 @@ class RelayQueries:
     async def gp_tax_schedules(self, info: strawberry.Info, company: str) -> list[GpTaxSchedule]:
         """Live tax schedule master (TX00101) via the connected relay, for the create-job tax-schedule
         and use-tax-schedule pickers (#380). Not gpTaxDetails, which reads TX00201 details."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_tax_schedules")
         return [gp_tax_schedule_to_type(s) for s in result["tax_schedules"]]
 
@@ -188,7 +175,6 @@ class RelayQueries:
         """WennSoft divisions that have division accounts set up, via the connected relay, for the
         create-job division picker (#380). Bare strings, like gpBuyers: the division code is the only
         label GP has for it."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "list_divisions")
         return result["divisions"]
 
@@ -196,7 +182,6 @@ class RelayQueries:
     async def gp_po_totals(self, info: strawberry.Info, company: str, po_number: str) -> GpPoTotals | None:
         """GP-computed header totals (POP10100) for a PO, read live via the connected relay - auto-fills
         the generated PO document (issue #230). Returns null if the PO isn't found in GP."""
-        require_user(info)
         result = await relay_gateway.relay_call(company, "read_po_totals", {"po_number": po_number})
         if result is None or result.get("totals") is None:
             return None
@@ -218,7 +203,6 @@ class RelayQueries:
         live vendor list (PM00200 via the relay) is ranked by fuzzy score and the top candidates are
         returned (savedMapping false). The DB session is scoped to the mapping lookup only, so no
         session is held across the relay round-trip."""
-        require_user(info)
         from app.repositories import manufacturer_vendor_map_repository
         from app.services import manufacturer_match
 
@@ -276,7 +260,6 @@ class RelayMutations:
         Admin-only, and writing to the accounting system of record - the same bar create_gp_job sets.
         Note there is no delete counterpart: eConnect exposes no proc for it, and removing a buyer
         rows-deep in POP00101 by hand would bypass the business logic that rule exists to protect."""
-        require_admin(info)
 
         target = company or relay_gateway.company
         if not target:
@@ -321,7 +304,6 @@ class RelayMutations:
     def provision_relay_install(self, info: strawberry.Info, label: str, company: str) -> RelayInstallProvision:
         """Admin: create a relay install + a one-time enrollment token shown ONCE. The relay uses the
         token during setup to register its self-generated Bearer secret (which never comes back here)."""
-        require_admin(info)
         with SessionLocal() as session:
             install, token = relay_repository.provision_install(session, label=label, company=company)
             session.commit()
@@ -343,7 +325,7 @@ class RelayMutations:
         without physical access to the workstation - and the relay binds localhost, so there is no
         remote restart. Arm it only when a relay you own is dialling in, and disarm as soon as it
         reconnects."""
-        identity = require_admin(info)
+        identity = current_user(info)
         with SessionLocal() as session:
             install = session.get(RelayInstall, uuid.UUID(str(install_id)))
             if install is None:
@@ -370,7 +352,7 @@ class RelayMutations:
         Refuses the install currently holding the connection - revoking the credential under a live relay
         would take GP down. A merely switched-off relay deletes fine; that is the retire-a-workstation
         case, and the confirm dialog carries the warning."""
-        identity = require_admin(info)
+        identity = current_user(info)
         target = uuid.UUID(str(install_id))
         if relay_gateway.install_id == target:
             raise ConflictError("That relay is currently connected. Disconnect it before removing the install.")
@@ -395,7 +377,6 @@ class RelayMutations:
     @strawberry.mutation
     def disarm_relay_adopt(self, info: strawberry.Info) -> bool:
         """Admin: close an open adopt window early. Returns whether one was open."""
-        require_admin(info)
         return relay_adopt.disarm()
 
     @strawberry.mutation

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -4,7 +4,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user, resolve_display_name
+from app.auth import current_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import shipping_repository
 
@@ -30,7 +30,6 @@ from .types import (
 class ShippingQueries:
     @strawberry.field
     def ship_ready_items(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> ShipReadyItems:
-        require_user(info)
         with SessionLocal() as session:
             data = shipping_repository.get_ship_ready_items(session, uuid.UUID(str(project_id)) if project_id else None)
             return ShipReadyItems(
@@ -48,7 +47,6 @@ class ShippingQueries:
 
     @strawberry.field
     def packing_slips(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[PackingSlip]:
-        require_user(info)
         with SessionLocal() as session:
             slips = shipping_repository.list_packing_slips(session, uuid.UUID(str(project_id)) if project_id else None)
             return [packing_slip_to_type(ps) for ps in slips]
@@ -64,7 +62,6 @@ class ShippingQueries:
         """Accept UI (#293): shipping-out requests for a project, PENDING by default. reopenableOnly
         (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
         view uses it so it lists only requests Reopen can still act on."""
-        require_user(info)
         with SessionLocal() as session:
             reqs = shipping_repository.get_shipping_out_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
@@ -73,7 +70,6 @@ class ShippingQueries:
 
     @strawberry.field
     def returnable_lines(self, info: strawberry.Info, packing_slip_id: strawberry.ID) -> list[ReturnableLine]:
-        require_user(info)
         with SessionLocal() as session:
             lines = shipping_repository.get_returnable_lines(session, uuid.UUID(str(packing_slip_id)))
             return [
@@ -102,7 +98,7 @@ class ShippingMutations:
 
         The approval names the Clerk-authenticated caller (#427), and carries onto the minted pull's
         `requestedBy`."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
@@ -117,7 +113,7 @@ class ShippingMutations:
     ) -> ShippingOutRequest:
         """Reject a PENDING shipping-out request (#293). Open to any signed-in user. Recorded against
         the Clerk-authenticated caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
@@ -132,7 +128,6 @@ class ShippingMutations:
         hard-deletes the warehouse PullRequest the accept minted and flips the request to PENDING so it
         can be re-accepted or rejected. Refused if the warehouse has already worked the pull. Open to
         any signed-in user."""
-        require_user(info)
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
             shipping_repository.reopen_shipping_out_request(session, request_id)
@@ -147,7 +142,7 @@ class ShippingMutations:
         `shippedBy` is printed on the slip and shown in the shipments grid, so it is the record of
         who released the hardware. It is the Clerk-authenticated caller as of #427; the input field
         is still accepted and ignored."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         from app.models.enums import PullRequestItemType
 
@@ -184,7 +179,7 @@ class ShippingMutations:
     def create_shipment_return(self, info: strawberry.Info, input: CreateShipmentReturnInput) -> ShipmentReturn:
         """Book hardware back off a packing slip. `returnedBy` is the Clerk-authenticated caller
         (#427); the input field is still accepted and ignored."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         from app.models.enums import ReturnDisposition
 

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -4,7 +4,7 @@ import uuid
 
 import strawberry
 
-from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, require_role, require_user, resolve_display_name
+from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, current_user, require_role, resolve_display_name, user_roster
 from app.database import SessionLocal
 from app.repositories import shop_assembly_repository, user_repository
 from app.repositories import warehouse as warehouse_repository
@@ -44,7 +44,6 @@ class ShopAssemblyQueries:
         self, info: strawberry.Info, project_id: strawberry.ID | None = None
     ) -> list[ShopAssemblyOpening]:
         """Openings whose shop-assembly pull is complete (#222). Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_assemble_list(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -55,7 +54,6 @@ class ShopAssemblyQueries:
     def my_work(self, info: strawberry.Info, assigned_to_user_id: str) -> list[ShopAssemblyOpening]:
         """An assembler's claimed, unfinished openings - PENDING or IN_PROGRESS (#340), so a leaf with
         saved partial progress stays reachable. Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             saos = shop_assembly_repository.get_my_work(session, assigned_to_user_id)
             return [shop_assembly_opening_to_type(sao) for sao in saos]
@@ -75,7 +73,6 @@ class ShopAssemblyQueries:
         included deliberately: that replacement must stay visible rather than be stranded, and the
         caller can tell from openingItemState that it needs reallocation instead of an install. Open
         to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             rows = shop_assembly_repository.get_replacement_work(
                 session,
@@ -95,7 +92,6 @@ class ShopAssemblyQueries:
         """Accept UI (#293): shop-assembly requests for a project, PENDING by default. reopenableOnly
         (#325) keeps only requests whose minted pull request is still PENDING - the Approved/reopen
         view uses it so it lists only requests Reopen can still act on. Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             reqs = shop_assembly_repository.get_shop_assembly_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, status, reopenable_only
@@ -120,7 +116,6 @@ class ShopAssemblyQueries:
         runs a fixed five statements - the requests, their pulls, and three grouped aggregates -
         however many requests come back, so the cost of this resolver grows with rows returned and
         not with queries issued. Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             rows = shop_assembly_repository.get_assembly_pipeline_summaries(
                 session,
@@ -139,7 +134,6 @@ class ShopAssemblyQueries:
         same aggregates the list uses, so this screen and that one cannot disagree.
 
         Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             pipeline = shop_assembly_repository.get_assembly_pipeline(session, uuid.UUID(str(request_id)))
             return assembly_pipeline_to_type(pipeline)
@@ -147,9 +141,11 @@ class ShopAssemblyQueries:
     @strawberry.field
     def shop_assembly_members(self, info: strawberry.Info) -> list[ClerkUser]:
         """Shop-assembly team members for the manager assignment picker (#330). Manager-gated: only
-        a Shop Assembly Manager may enumerate members and assign pulled openings to them."""
-        require_role(info, SHOP_ASSEMBLY_MANAGER_ROLE)
-        return [clerk_user_to_type(u) for u in user_repository.list_shop_assembly_members()]
+        a Shop Assembly Manager may enumerate members and assign pulled openings to them.
+
+        Filters the request-scoped roster the gate loaded to check that role (ROSTER_BACKED in
+        app/auth_policy.py), so the check and the answer share one Clerk call."""
+        return [clerk_user_to_type(u) for u in user_repository.shop_assembly_members(user_roster(info.context))]
 
 
 @strawberry.type
@@ -168,7 +164,7 @@ class ShopAssemblyMutations:
         The approval is recorded against the Clerk-authenticated caller (#427). It is the whole
         content of the gate: an approval attributable to anyone the client names is not an approval.
         The name also becomes the minted pull's `requestedBy`."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
@@ -183,7 +179,7 @@ class ShopAssemblyMutations:
     ) -> ShopAssemblyRequest:
         """Reject a PENDING shop-assembly request (#293). Open to any signed-in user. Recorded
         against the Clerk-authenticated caller (#427), same reasoning as the accept."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
@@ -198,7 +194,6 @@ class ShopAssemblyMutations:
         hard-deletes the warehouse PullRequest the accept minted, re-points the request's openings off
         it, and flips the request to PENDING so it can be re-accepted or rejected. Refused if the
         warehouse has already worked the pull. Open to any signed-in user."""
-        require_user(info)
         request_id = uuid.UUID(str(id))
         with SessionLocal() as session:
             shop_assembly_repository.reopen_shop_assembly_request(session, request_id)
@@ -220,7 +215,7 @@ class ShopAssemblyMutations:
         also means a manager claiming work *for themselves* must unassign it first - the safer read of
         an ambiguous action, and one keystroke, not a hole.
         """
-        auth = require_user(info)
+        auth = current_user(info)
         is_self = input.assigned_to_user_id == auth["user_id"]
         if not is_self:
             require_role(info, SHOP_ASSEMBLY_MANAGER_ROLE)
@@ -242,7 +237,6 @@ class ShopAssemblyMutations:
         """Unassign an unfinished opening. Allowed while it is PENDING or IN_PROGRESS (#340) - saved
         progress lives on the item rows, so returning a half-built leaf to the pool loses nothing.
         Open to any signed-in user (the board's Unassign action)."""
-        require_user(info)
         with SessionLocal() as session:
             result = shop_assembly_repository.remove_opening_from_user(session, uuid.UUID(str(opening_id)))
             session.commit()
@@ -263,7 +257,7 @@ class ShopAssemblyMutations:
 
         The assembler on the progress rows and on any deficiency return is the Clerk-authenticated
         caller (#427), not the request's `performedBy`."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         updates = [
             shop_assembly_repository.AssemblyProgressUpdate(
@@ -296,7 +290,7 @@ class ShopAssemblyMutations:
         refuses a leaf that has already shipped. Open to any signed-in user - it changes what an
         assembled leaf is recorded as carrying, so it must not be reachable anonymously, and the
         person recorded as fitting it is the Clerk-authenticated caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = shop_assembly_repository.install_replacement(
@@ -322,7 +316,7 @@ class ShopAssemblyMutations:
         been persisting, and is refused while any unit is still unaccounted for. Open to any signed-in
         user - it writes inventory, so it must not be reachable anonymously. Who completed the leaf is
         the Clerk-authenticated caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = shop_assembly_repository.complete_opening(

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -1,7 +1,7 @@
 """Stock pool + deficiency queries and mutations.
 
 Every mutation here writes an audit row, and since #427 the actor on it is the Clerk-authenticated
-caller (`require_user` -> `resolve_display_name`), never the request's own `performedBy`/`reviewedBy`
+caller (`current_user` -> `resolve_display_name`), never the request's own `performedBy`/`reviewedBy`
 field. Those input fields are still accepted so a frontend from the previous deploy keeps working;
 they are ignored. Before the change these rows carried whatever the client sent, defaulting to the
 literal strings "Admin/Manager" or "Warehouse" - which is what most of them actually stored, because
@@ -12,7 +12,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_user, resolve_display_name
+from app.auth import current_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import stock as stock_repository
 
@@ -59,7 +59,6 @@ class StockQueries:
         only_deficient: bool = False,
         warehouse_id: strawberry.ID | None = None,
     ) -> list[StockItem]:
-        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_stock_items(
                 session,
@@ -73,7 +72,6 @@ class StockQueries:
 
     @strawberry.field
     def stock_item(self, info: strawberry.Info, id: strawberry.ID) -> StockItem | None:
-        require_user(info)
         with SessionLocal() as session:
             try:
                 row = stock_repository.get_stock_item(session, uuid.UUID(str(id)))
@@ -88,7 +86,6 @@ class StockQueries:
         project_id: strawberry.ID | None = None,
         source: DeficientItemSource | None = None,
     ) -> list[DeficientItemRow]:
-        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_deficient_items(
                 session,
@@ -105,7 +102,6 @@ class StockQueries:
         stock_item_id: strawberry.ID | None = None,
         project_id: strawberry.ID | None = None,
     ) -> list[DeficiencyReview]:
-        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_deficiency_reviews(
                 session,
@@ -117,7 +113,6 @@ class StockQueries:
 
     @strawberry.field
     def stock_matches_for_opening(self, info: strawberry.Info, opening_item_id: strawberry.ID) -> list[StockItem]:
-        require_user(info)
         with SessionLocal() as session:
             rows = stock_repository.get_stock_matches_for_opening(session, uuid.UUID(str(opening_item_id)))
             return [stock_item_to_type(r) for r in rows]
@@ -127,7 +122,7 @@ class StockQueries:
 class StockMutations:
     @strawberry.mutation
     def destock_inventory(self, info: strawberry.Info, input: DestockInventoryInput) -> StockItem:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.destock_inventory(
@@ -147,7 +142,7 @@ class StockMutations:
 
     @strawberry.mutation
     def transfer_inventory(self, info: strawberry.Info, input: TransferInventoryInput) -> TransferResult:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.transfer_inventory(
@@ -170,7 +165,7 @@ class StockMutations:
 
     @strawberry.mutation
     def allocate_stock_to_project(self, info: strawberry.Info, input: AllocateStockToProjectInput) -> InventoryLocation:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.allocate_stock_to_project(
@@ -191,7 +186,7 @@ class StockMutations:
 
     @strawberry.mutation
     def adjust_stock_quantity(self, info: strawberry.Info, input: AdjustStockQuantityInput) -> StockItem:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.adjust_stock_quantity(
@@ -207,7 +202,7 @@ class StockMutations:
 
     @strawberry.mutation
     def move_stock_location(self, info: strawberry.Info, input: MoveStockLocationInput) -> StockItem:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.move_stock_location(
@@ -231,7 +226,7 @@ class StockMutations:
         row: str,
         bay: str,
     ) -> StockItem:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.assign_stock_item_location(
@@ -248,7 +243,7 @@ class StockMutations:
 
     @strawberry.mutation
     def mark_stock_item_unlocated(self, info: strawberry.Info, stock_item_id: strawberry.ID) -> StockItem:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = stock_repository.mark_stock_item_unlocated(
@@ -262,7 +257,7 @@ class StockMutations:
 
     @strawberry.mutation
     def reclassify_stock_item(self, info: strawberry.Info, input: ReclassifyStockItemInput) -> ReclassifyStockResult:
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             new_row, original = stock_repository.reclassify_stock_item(
@@ -289,7 +284,7 @@ class StockMutations:
     ) -> InventoryLocation:
         """Condemn units on a project inventory row. Open to any signed-in user - it makes stock
         unavailable to every other request in the project, so it must not be reachable anonymously."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             il = stock_repository.report_inventory_deficiency(
@@ -307,7 +302,7 @@ class StockMutations:
     def report_stock_deficiency(self, info: strawberry.Info, input: ReportStockDeficiencyInput) -> StockItem:
         """Condemn units on a stock-pool row. Open to any signed-in user - same reasoning as
         reportInventoryDeficiency: it takes stock out of circulation."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             si = stock_repository.report_stock_deficiency(
@@ -327,7 +322,7 @@ class StockMutations:
     ) -> SAReplacementResult:
         """Flag a unit deficient at the bench. Open to any signed-in user - it writes project
         inventory and mints a replacement pull request, so it must not be reachable anonymously."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             il, pri = stock_repository.report_deficiency_at_assembly(
@@ -349,7 +344,7 @@ class StockMutations:
     def resolve_deficiency(self, info: strawberry.Info, input: ResolveDeficiencyInput) -> DeficiencyReview:
         """Disposition a condemned batch (scrap, repair, RMA, destock). Open to any signed-in user -
         it moves or writes off real stock, so it must not be reachable anonymously."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             review = stock_repository.resolve_deficiency(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -5,6 +5,9 @@ Every resolver here is Admin/Manager-gated (#415). `updateUserRoles` is the gran
 `createGpJob` and `createGpBuyer` - so an ungated copy let any caller mint the role that opens all of
 them. `users` is gated for the same reason a roster is not public: it returns every account's email,
 roles and GP buyer id. The three writes are only ever issued by the admin User Management page.
+
+The requirement itself lives in ROOT_FIELD_POLICY (app/auth_policy.py) since #423, not in these
+bodies - which is why nothing below opens with a gate call.
 """
 
 import strawberry

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -9,7 +9,7 @@ roles and GP buyer id. The three writes are only ever issued by the admin User M
 
 import strawberry
 
-from app.auth import invalidate_display_name, require_admin
+from app.auth import invalidate_display_name, user_roster
 from app.repositories import user_repository
 
 from .converters import clerk_user_to_type
@@ -20,8 +20,12 @@ from .types import ClerkUser
 class UserQueries:
     @strawberry.field
     def users(self, info: strawberry.Info) -> list[ClerkUser]:
-        require_admin(info)
-        return [clerk_user_to_type(u) for u in user_repository.list_users()]
+        """The whole Clerk roster, for the admin User Management page.
+
+        Reads the request-scoped roster the gate already fetched to check this caller holds
+        Admin/Manager (ROSTER_BACKED in app/auth_policy.py), so authorizing the call and answering
+        it share one trip to Clerk."""
+        return [clerk_user_to_type(u) for u in user_roster(info.context)]
 
 
 @strawberry.type
@@ -31,7 +35,6 @@ class UserMutations:
         """Set a user's roles outright, including granting Admin/Manager. Admin-gated: this is the
         privilege-escalation path, so the gate is the whole protection - nothing downstream re-checks
         who asked."""
-        require_admin(info)
         return clerk_user_to_type(user_repository.update_user_roles(user_id, roles))
 
     @strawberry.mutation
@@ -41,7 +44,6 @@ class UserMutations:
         Drops the cached display name too. Since #427 every audit and history row is stamped with
         `resolve_display_name`, which caches for a few minutes to keep a Clerk round-trip off hot
         write paths; without this the rows would keep naming the old spelling until that expired."""
-        require_admin(info)
         updated = clerk_user_to_type(user_repository.update_user_name(user_id, first_name, last_name))
         invalidate_display_name(user_id)
         return updated
@@ -50,5 +52,4 @@ class UserMutations:
     def update_user_gp_buyer_id(self, info: strawberry.Info, user_id: str, gp_buyer_id: str | None = None) -> ClerkUser:
         """Issue #216: link a UC Nexus account to the GP BUYERID it acts as (null clears). The PO
         dialog auto-uses the caller's identity and createPo/registerPoInGp enforce it."""
-        require_admin(info)
         return clerk_user_to_type(user_repository.update_user_gp_buyer_id(user_id, gp_buyer_id))

--- a/backend/app/schemas/vendor.py
+++ b/backend/app/schemas/vendor.py
@@ -4,7 +4,6 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin, require_user
 from app.database import SessionLocal
 from app.repositories import vendor_repository
 
@@ -17,15 +16,13 @@ from .types import Vendor
 class VendorQueries:
     @strawberry.field
     def vendors(self, info: strawberry.Info) -> list[Vendor]:
-        """require_user, not admin (#415): VendorSelect renders this list on the PO screens, so it is
+        """Signed-in, not admin (#415): VendorSelect renders this list on the PO screens, so it is
         not an admin-only read even though only an admin may write it."""
-        require_user(info)
         with SessionLocal() as session:
             return [vendor_to_type(v) for v in vendor_repository.list_vendors(session)]
 
     @strawberry.field
     def vendor(self, info: strawberry.Info, id: strawberry.ID) -> Vendor | None:
-        require_user(info)
         with SessionLocal() as session:
             v = vendor_repository.find_vendor(session, uuid.UUID(str(id)))
             return vendor_to_type(v) if v is not None else None
@@ -35,12 +32,11 @@ class VendorQueries:
 class VendorMutations:
     @strawberry.mutation
     def create_vendor(self, info: strawberry.Info, input: CreateVendorInput) -> Vendor:
-        """require_user, not admin. `VendorSelect` offers "+ Create new vendor" to every caller and
+        """Signed-in, not admin. `VendorSelect` offers "+ Create new vendor" to every caller and
         renders `VendorEditDialog` with `vendor={null}`, so a PO user adding a supplier mid-order goes
         through here. Editing or deleting an existing vendor is still admin - only the admin Vendors
         page reaches those. The dialog living under `modules/admin/` says nothing about who can open
         it, which is exactly the trap this comment exists to stop."""
-        require_user(info)
         with SessionLocal() as session:
             vendor = vendor_repository.create_vendor(
                 session,
@@ -56,7 +52,6 @@ class VendorMutations:
 
     @strawberry.mutation
     def update_vendor(self, info: strawberry.Info, id: strawberry.ID, input: UpdateVendorInput) -> Vendor:
-        require_admin(info)
         with SessionLocal() as session:
             vendor = vendor_repository.update_vendor(
                 session,
@@ -73,7 +68,6 @@ class VendorMutations:
 
     @strawberry.mutation
     def delete_vendor(self, info: strawberry.Info, id: strawberry.ID) -> bool:
-        require_admin(info)
         with SessionLocal() as session:
             vendor_repository.delete_vendor(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -5,7 +5,7 @@ import uuid
 
 import strawberry
 
-from app.auth import require_admin, require_user, resolve_display_name
+from app.auth import current_user, resolve_display_name
 from app.database import SessionLocal
 from app.errors import RelayUnavailableError
 from app.repositories import warehouse as warehouse_repository
@@ -162,7 +162,6 @@ def _persist_create_receive(*, key, po_id, received_by, line_items_data, warehou
 class WarehouseQueries:
     @strawberry.field
     def po_receiving_details(self, info: strawberry.Info, po_id: strawberry.ID) -> PurchaseOrder:
-        require_user(info)
         with SessionLocal() as session:
             po, receive_records = warehouse_repository.get_po_receiving_details(session, uuid.UUID(str(po_id)))
             return po_to_type(po, receive_records)
@@ -179,7 +178,6 @@ class WarehouseQueries:
         finalize. Deliberately distinct from `inventoryHierarchy`'s availability, which is on-hand
         minus deficient: that answers "what is physically unspoken-for in the building", this
         answers "what may I claim". Two grouped scalar aggregates, no per-row work."""
-        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_project_availability(session, uuid.UUID(str(project_id)))
             return [
@@ -201,7 +199,6 @@ class WarehouseQueries:
         project_id: strawberry.ID | None = None,
         warehouse_id: strawberry.ID | None = None,
     ) -> list[InventoryHierarchyNode]:
-        require_user(info)
         with SessionLocal() as session:
             hierarchy = warehouse_repository.get_inventory_hierarchy(
                 session,
@@ -236,7 +233,6 @@ class WarehouseQueries:
         category: str = "",
         product_code: str = "",
     ) -> list[InventoryItemDetail]:
-        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_inventory_items(
                 session, uuid.UUID(str(project_id)) if project_id else None, category, product_code
@@ -255,7 +251,6 @@ class WarehouseQueries:
     def unlocated_inventory(
         self, info: strawberry.Info, project_id: strawberry.ID | None = None
     ) -> list[InventoryItemDetail]:
-        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_unlocated_inventory(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -272,7 +267,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def recent_receive_records(self, info: strawberry.Info, limit: int = 10) -> list[RecentReceiveRecord]:
-        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_recent_receive_records(session, limit)
             return [
@@ -286,7 +280,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def opening_items(self, info: strawberry.Info, project_id: strawberry.ID | None = None) -> list[OpeningItem]:
-        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             ois = warehouse_repository.get_opening_items(session, pid)
@@ -318,7 +311,6 @@ class WarehouseQueries:
     ) -> list[OpeningLeafStatus]:
         """Per-opening door-leaf rollup (#313). project_id scopes to one project (shipping view);
         omit it for the global shop-assembly view (rows carry project identity to group by)."""
-        require_user(info)
         with SessionLocal() as session:
             pid = uuid.UUID(str(project_id)) if project_id else None
             rows = warehouse_repository.get_opening_leaf_status(session, pid)
@@ -335,7 +327,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def opening_item_details(self, info: strawberry.Info, id: strawberry.ID) -> OpeningItemDetail:
-        require_user(info)
         with SessionLocal() as session:
             from app.repositories import shop_assembly_repository
 
@@ -360,7 +351,6 @@ class WarehouseQueries:
         source: PullRequestSource | None = None,
         status: PullRequestStatus | None = None,
     ) -> list[PullRequest]:
-        require_user(info)
         with SessionLocal() as session:
             prs = warehouse_repository.get_pull_requests(
                 session, uuid.UUID(str(project_id)) if project_id else None, source, status
@@ -384,7 +374,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def pull_request_details(self, info: strawberry.Info, id: strawberry.ID) -> PullRequest:
-        require_user(info)
         with SessionLocal() as session:
             pr = warehouse_repository.get_pull_request_details(session, uuid.UUID(str(id)))
             staging = warehouse_repository.get_pull_staging_summaries(session, [pr.id])
@@ -405,7 +394,6 @@ class WarehouseQueries:
 
         Open to any signed-in user. It exposes real per-location inventory for one project, which is
         the same shape of information the warehouse inventory views already carry."""
-        require_user(info)
         with SessionLocal() as session:
             sheet = warehouse_repository.get_pick_sheet(session, uuid.UUID(str(pull_request_id)))
             pr = sheet.pull_request
@@ -426,7 +414,6 @@ class WarehouseQueries:
         run once per row of the pull-request queue, and the queue never needs it - only the detail
         view does. Returns an empty list for a shipping-out pull, a PR-REPL replacement pull, or a
         legacy pull, none of which have openings. Open to any signed-in user."""
-        require_user(info)
         with SessionLocal() as session:
             openings = warehouse_repository.get_pull_request_openings(session, uuid.UUID(str(pull_request_id)))
             return [shop_assembly_opening_to_type(o) for o in openings]
@@ -435,7 +422,6 @@ class WarehouseQueries:
     def back_ordered_items(
         self, info: strawberry.Info, project_id: strawberry.ID | None = None
     ) -> list[BackOrderedItem]:
-        require_user(info)
         with SessionLocal() as session:
             items = warehouse_repository.get_back_ordered_items(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -458,7 +444,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def warehouse_dashboard(self, info: strawberry.Info) -> WarehouseDashboard:
-        require_user(info)
         with SessionLocal() as session:
             d = warehouse_repository.get_warehouse_dashboard(session)
             return WarehouseDashboard(
@@ -476,7 +461,6 @@ class WarehouseQueries:
     def project_progress_by_product(
         self, info: strawberry.Info, project_id: strawberry.ID
     ) -> list[ProjectProgressByProduct]:
-        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_project_progress_by_product(session, uuid.UUID(str(project_id)))
             return [
@@ -497,7 +481,6 @@ class WarehouseQueries:
     def inventory_by_vendor(
         self, info: strawberry.Info, project_id: strawberry.ID | None = None
     ) -> list[VendorInventoryNode]:
-        require_user(info)
         with SessionLocal() as session:
             nodes = warehouse_repository.get_inventory_by_vendor(
                 session, uuid.UUID(str(project_id)) if project_id else None
@@ -529,7 +512,6 @@ class WarehouseQueries:
         bay: str | None = None,
         warehouse_id: strawberry.ID | None = None,
     ) -> LocationContents:
-        require_user(info)
         with SessionLocal() as session:
             data = warehouse_repository.get_location_contents(
                 session, aisle, row, bay, uuid.UUID(str(warehouse_id)) if warehouse_id else None
@@ -557,7 +539,6 @@ class WarehouseQueries:
         bay: str | None = None,
         limit: int = 10,
     ) -> list[AuditLogEntry]:
-        require_user(info)
         with SessionLocal() as session:
             entries = warehouse_repository.get_location_audit_history(session, aisle, row, bay, limit=limit)
             return [
@@ -576,7 +557,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def location_distinct_values(self, info: strawberry.Info) -> LocationDistinctValues:
-        require_user(info)
         with SessionLocal() as session:
             values = warehouse_repository.get_distinct_location_values(session)
             return LocationDistinctValues(
@@ -589,7 +569,6 @@ class WarehouseQueries:
     def location_duplicates(self, info: strawberry.Info) -> list[LocationDuplicateGroup]:
         """Admin-gated (#415): the admin Location Cleanup page is the only reader, and it is the
         list `mergeLocations` acts on."""
-        require_admin(info)
         with SessionLocal() as session:
             groups = warehouse_repository.get_location_duplicates(session)
             return [
@@ -606,7 +585,6 @@ class WarehouseQueries:
     def location_utilization(
         self, info: strawberry.Info, warehouse_id: strawberry.ID | None = None
     ) -> list[LocationUtilizationEntry]:
-        require_user(info)
         with SessionLocal() as session:
             rows = warehouse_repository.get_location_utilization(
                 session, uuid.UUID(str(warehouse_id)) if warehouse_id else None
@@ -632,7 +610,6 @@ class WarehouseQueries:
         project_id: strawberry.ID | None = None,
         limit: int = 50,
     ) -> list[AuditLogEntry]:
-        require_user(info)
         with SessionLocal() as session:
             entries = warehouse_repository.get_audit_log(
                 session,
@@ -657,9 +634,8 @@ class WarehouseQueries:
 
     @strawberry.field
     def warehouses(self, info: strawberry.Info, include_inactive: bool = True) -> list[Warehouse]:
-        """require_user, not admin (#415): the receive, transfer and return dialogs all read this
+        """Signed-in, not admin (#415): the receive, transfer and return dialogs all read this
         list to populate a warehouse picker, so it is not admin-only even though its writes are."""
-        require_user(info)
         with SessionLocal() as session:
             return [
                 warehouse_to_type(w)
@@ -668,7 +644,6 @@ class WarehouseQueries:
 
     @strawberry.field
     def warehouse(self, info: strawberry.Info, id: strawberry.ID) -> Warehouse | None:
-        require_user(info)
         with SessionLocal() as session:
             w = warehouse_admin_repository.find_warehouse(session, uuid.UUID(str(id)))
             return warehouse_to_type(w) if w is not None else None
@@ -687,7 +662,7 @@ class WarehouseMutations:
         gpReceiptPostedRef guard); eligibility (over-receive, PO status, location sums) is validated
         before the GP receipt is posted; the DB and Clerk work is offloaded so no Postgres connection is
         held across the relay round-trip and the /relay-link read loop is never blocked on a sync call."""
-        user = require_user(info)
+        user = current_user(info)
         key = gp_idempotency.validate_key(input.idempotency_key)
 
         po_id = uuid.UUID(str(input.po_id))
@@ -790,7 +765,7 @@ class WarehouseMutations:
         Open to any signed-in user - it assigns the pull to the caller, so it must not be reachable
         anonymously. The pull is assigned to the Clerk-authenticated caller (#427), not to whatever
         `startedBy` said - the assignment is what the whole pick is then attributed to."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             pr = warehouse_repository.start_pull_request_pick(session, uuid.UUID(str(id)), actor)
@@ -816,7 +791,7 @@ class WarehouseMutations:
 
         Open to any signed-in user - it attributes a user action, same rationale as
         `saveAssemblyProgress`. Who entered it is the Clerk-authenticated caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             sheet = warehouse_repository.save_pick_draft(
@@ -860,7 +835,7 @@ class WarehouseMutations:
         The deduction is stamped with the Clerk-authenticated caller (#427): this is the audit row
         that says who took the stock off the rack, and it is worth nothing if the client picks the
         name on it."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.confirm_pick(
@@ -916,7 +891,7 @@ class WarehouseMutations:
 
         Open to any signed-in user - it attributes a user action, and since #427 it attributes it to
         the Clerk-authenticated caller: the tick is a claim that a specific person has the leaf."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             item = warehouse_repository.set_pull_item_fetched(session, uuid.UUID(str(item_id)), fetched, actor)
@@ -935,7 +910,7 @@ class WarehouseMutations:
         That stamp is the Clerk-authenticated caller as of #427. It was the client's `completedBy`
         string, which made this the clearest example of the bug: one call could put any name on every
         opening the pull staged, and the staging panel shows exactly that name."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             pr = warehouse_repository.complete_pull_request(session, uuid.UUID(str(id)), completed_by=actor)
@@ -957,7 +932,7 @@ class WarehouseMutations:
 
         Open to any signed-in user - it makes hardware workable, so it must not be reachable
         anonymously. Each opening is stamped with the Clerk-authenticated caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.stage_pull_openings(
@@ -992,7 +967,7 @@ class WarehouseMutations:
         Open to any signed-in user - it writes inventory, so it must not be reachable anonymously.
         The cancellation and every restock audit row it writes name the Clerk-authenticated caller
         (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.cancel_pull_request(
@@ -1031,7 +1006,7 @@ class WarehouseMutations:
         the repository hardcoded it and there was no parameter to pass the truth through. `auditLog`,
         the location history panel and the recent-activity feed all read that column, so the one
         record of who altered a count was uniformly wrong."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.adjust_inventory_quantity(
@@ -1045,14 +1020,14 @@ class WarehouseMutations:
     def override_inventory_quantity(
         self, info: strawberry.Info, input: OverrideInventoryQuantityInput
     ) -> InventoryLocation:
-        """require_user, not admin. The Correction button on the warehouse Hardware Items tab is
+        """Signed-in, not admin. The Correction button on the warehouse Hardware Items tab is
         rendered for everyone ("available to all users, not just admins", HardwareItemsTab.tsx), and it
         opens `InventoryCorrectionModal`, which is what calls this. Admin-gating it would break the
         warehouse's own count-correction workflow.
 
         Gating it would also buy nothing while `adjustInventoryQuantity` next door stays open to any
         signed-in user: the same end quantity is reachable by passing the delta instead."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.override_inventory_quantity(
@@ -1080,7 +1055,7 @@ class WarehouseMutations:
     ) -> InventoryLocation:
         """Relocate a project inventory row, writing a MOVE audit row naming the caller (#427); it
         used to name "Admin/Manager" regardless of who moved the stock."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.move_inventory_location(
@@ -1096,7 +1071,7 @@ class WarehouseMutations:
     ) -> InventoryLocation:
         """Clear a project inventory row's location, writing an UNLOCATE audit row naming the
         caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.mark_inventory_unlocated(
@@ -1116,7 +1091,7 @@ class WarehouseMutations:
         bay: str,
     ) -> InventoryLocation:
         """Put a project inventory row away, writing a PUT_AWAY audit row naming the caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.assign_inventory_location(
@@ -1137,7 +1112,7 @@ class WarehouseMutations:
         warehouse_id: strawberry.ID | None = None,
     ) -> OpeningItem:
         """Relocate an assembled leaf, writing a MOVE audit row naming the caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.move_opening_item_location(
@@ -1156,7 +1131,7 @@ class WarehouseMutations:
     @strawberry.mutation
     def mark_opening_item_unlocated(self, info: strawberry.Info, opening_item_id: strawberry.ID) -> OpeningItem:
         """Clear an assembled leaf's location, writing an UNLOCATE audit row naming the caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.mark_opening_item_unlocated(
@@ -1176,7 +1151,7 @@ class WarehouseMutations:
         bay: str,
     ) -> OpeningItem:
         """Put an assembled leaf away, writing a PUT_AWAY audit row naming the caller (#427)."""
-        auth = require_user(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.assign_opening_item_location(
@@ -1201,7 +1176,7 @@ class WarehouseMutations:
         item at the source location. Its audit rows name the admin who ran it (#427) rather than the
         literal "Admin/Manager" - the gate already proves the role, so the row may as well say which
         admin, given a merge can touch hundreds of rows at once."""
-        auth = require_admin(info)
+        auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             counts = warehouse_repository.merge_locations(
@@ -1224,7 +1199,6 @@ class WarehouseMutations:
     # Warehouses (admin)
     @strawberry.mutation
     def create_warehouse(self, info: strawberry.Info, input: CreateWarehouseInput) -> Warehouse:
-        require_admin(info)
         with SessionLocal() as session:
             wh = warehouse_admin_repository.create_warehouse(
                 session,
@@ -1243,7 +1217,6 @@ class WarehouseMutations:
 
     @strawberry.mutation
     def update_warehouse(self, info: strawberry.Info, id: strawberry.ID, input: UpdateWarehouseInput) -> Warehouse:
-        require_admin(info)
         with SessionLocal() as session:
             wh = warehouse_admin_repository.update_warehouse(
                 session,
@@ -1263,7 +1236,6 @@ class WarehouseMutations:
 
     @strawberry.mutation
     def delete_warehouse(self, info: strawberry.Info, id: strawberry.ID) -> bool:
-        require_admin(info)
         with SessionLocal() as session:
             warehouse_admin_repository.delete_warehouse(session, uuid.UUID(str(id)))
             session.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 
 from app.auth import get_context, require_admin_request
+from app.auth_policy import enforce_root_field
 from app.database import SessionLocal
 from app.errors import AppError
 from app.repositories import relay_repository
@@ -32,7 +33,30 @@ logger = logging.getLogger(__name__)
 ADOPT_HELLO_TIMEOUT_SECONDS = 5.0
 
 
-class ErrorHandlerExtension(SchemaExtension):
+class ResolverGuardExtension(SchemaExtension):
+    """The one hook every GraphQL field resolution passes through. It does two jobs.
+
+    1. **Authorizes root fields** against ROOT_FIELD_POLICY (app/auth_policy.py), before the resolver
+       runs. Deny-by-default: a field with no policy entry and no place on the open-operations
+       allowlist is refused, so #415's "a resolver that forgets its gate is public" cannot recur.
+       Only root fields are checked (`info.path.prev is None`) - a nested field is reachable only
+       through a root field that already passed, and checking every one would put a Clerk decision on
+       every node of every response.
+    2. **Maps AppError to GraphQLError**, publishing `extensions.code` (and `relayError` where the
+       error carries a detail body).
+
+    Both live in one extension rather than two on purpose:
+
+      - The gate's own refusals are AppErrors, and they MUST reach the browser as
+        `extensions.code = UNAUTHENTICATED` / `FORBIDDEN`; the frontend's Apollo link keys its token
+        re-mint and replay off exactly that (#429). Sharing one try/except makes that structural. As
+        two extensions it would depend on their order in the `extensions=[...]` list, which nothing
+        would fail on if someone swapped it.
+      - `resolve` is graphql-core middleware: it runs per FIELD, not per operation, including every
+        scalar of every row in a list of hundreds. A second extension would double that wrapper cost
+        for no functional gain.
+    """
+
     @staticmethod
     def _to_graphql_error(e: Exception) -> GraphQLError:
         if isinstance(e, AppError):
@@ -50,12 +74,28 @@ class ErrorHandlerExtension(SchemaExtension):
             return GraphQLError(message=e.message, extensions=extensions)
         return GraphQLError(message=str(e), extensions={"code": "NOT_IMPLEMENTED"})
 
+    @staticmethod
+    def _is_root_field(info: GraphQLResolveInfo) -> bool:
+        """A field selected directly on Query/Mutation, and ours rather than graphql-core's.
+
+        The `__`-prefixed introspection fields (`__schema`, `__type`, `__typename`) are root fields
+        too, and they are resolved by graphql-core's own resolvers, which this middleware also wraps.
+        They expose the schema's shape, never any data, and they were reachable before #423 - gating
+        them would break GraphiQL and every introspection-driven tool for no security gain.
+        """
+        return info.path.prev is None and not info.field_name.startswith("__")
+
     def resolve(self, _next: Callable, root: Any, info: GraphQLResolveInfo, *args, **kwargs):
         # For async resolvers _next() returns a coroutine that strawberry awaits *after* this method
         # returns, so a synchronous try/except here would never see the exception - the AppError -> code
         # mapping would be silently dropped. Handle the awaitable case in an async wrapper so both sync
         # and async resolvers get the extension pattern.
         try:
+            # Inside the try so a refusal is mapped by the same code path as any other AppError, and
+            # ahead of _next so the resolver body never starts for a caller who is about to be
+            # refused - the ordering #415's gates could only achieve by convention.
+            if self._is_root_field(info):
+                enforce_root_field(info.field_name, info.context)
             result = _next(root, info, *args, **kwargs)
         except (AppError, NotImplementedError) as e:
             raise self._to_graphql_error(e) from e
@@ -73,7 +113,7 @@ class ErrorHandlerExtension(SchemaExtension):
 schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
-    extensions=[ErrorHandlerExtension],
+    extensions=[ResolverGuardExtension],
 )
 
 graphql_app = GraphQLRouter(schema, context_getter=get_context)

--- a/backend/tests/test_create_gp_buyer.py
+++ b/backend/tests/test_create_gp_buyer.py
@@ -11,7 +11,8 @@ import asyncio
 
 import pytest
 
-from app.auth import AuthError
+from app.auth import ADMIN_ROLE
+from app.auth_policy import ROOT_FIELD_POLICY
 from app.errors import RelayCallError, RelayUnavailableError, ValidationError
 from app.schemas import relay as relay_module
 from app.schemas.relay import RelayMutations
@@ -19,10 +20,6 @@ from app.schemas.relay import RelayMutations
 
 class _FakeInfo:
     context = {"request": None}
-
-
-def _as_admin(monkeypatch):
-    monkeypatch.setattr(relay_module, "require_admin", lambda info: {"user_id": "user_1", "roles": ["Admin"]})
 
 
 def _relay(monkeypatch, *, company="TUBC", result=None, raises=None):
@@ -45,25 +42,18 @@ def _create(**kwargs):
     return asyncio.run(RelayMutations().create_gp_buyer(_FakeInfo(), **fields))
 
 
-def test_requires_an_admin(monkeypatch):
-    # Registering a buyer writes to the accounting system of record.
-    def _deny(info):
-        raise AuthError("Admin role required")
+def test_requires_an_admin():
+    """Registering a buyer writes to the accounting system of record.
 
-    monkeypatch.setattr(relay_module, "require_admin", _deny)
-
-    async def _never(*a, **k):
-        raise AssertionError("the relay must not be called for a non-admin")
-
-    monkeypatch.setattr(relay_module.relay_gateway, "relay_call", _never)
-
-    with pytest.raises(AuthError):
-        _create()
+    Since #423 the gate is the policy table, applied by the schema extension before the resolver, so
+    the requirement is asserted where it is now decided; `test_resolver_auth_gates.py` covers that the
+    extension enforces the table and refuses before the body runs. The tests below therefore call the
+    resolver directly with no auth setup at all - what they are about is the guard order INSIDE the
+    body, which is unchanged."""
+    assert ROOT_FIELD_POLICY["createGpBuyer"] == ADMIN_ROLE
 
 
 def test_no_relay_stops_before_gp(monkeypatch):
-    _as_admin(monkeypatch)
-
     async def _never(*a, **k):
         raise AssertionError("the relay must not be called when none is connected")
 
@@ -75,7 +65,6 @@ def test_no_relay_stops_before_gp(monkeypatch):
 
 
 def test_sends_the_trimmed_buyer_to_the_relay(monkeypatch):
-    _as_admin(monkeypatch)
     calls = _relay(monkeypatch)
 
     _create(buyer_id="  newbuyer  ", description="  New Buyer  ")
@@ -85,7 +74,6 @@ def test_sends_the_trimmed_buyer_to_the_relay(monkeypatch):
 
 def test_company_defaults_to_the_connected_relays(monkeypatch):
     # The connected relay is enrolled for exactly one company, which is the only one it could write to.
-    _as_admin(monkeypatch)
     calls = _relay(monkeypatch, company="TUCSH")
 
     _create(company=None)
@@ -97,7 +85,6 @@ def test_answers_with_gps_stored_row_not_the_request(monkeypatch):
     # The relay reads POP00101 back after the write, and that row is what the dropdown will show on
     # its next refetch - so answering with the request echoed back could hand the dialog a buyer that
     # differs from the one everything else is about to see.
-    _as_admin(monkeypatch)
     _relay(monkeypatch, result={"buyer_id": "newbuyer", "description": "What GP Actually Kept"})
 
     buyer = _create(description="What Was Asked For")
@@ -107,7 +94,6 @@ def test_answers_with_gps_stored_row_not_the_request(monkeypatch):
 
 
 def test_blank_buyer_id_is_rejected_before_the_relay(monkeypatch):
-    _as_admin(monkeypatch)
     calls = _relay(monkeypatch)
 
     with pytest.raises(ValidationError) as exc:
@@ -119,7 +105,6 @@ def test_blank_buyer_id_is_rejected_before_the_relay(monkeypatch):
 
 def test_over_length_buyer_id_is_rejected_against_gps_own_width(monkeypatch):
     # BUYERID is char(15). Caught here rather than after a full round-trip returning invalid_payload.
-    _as_admin(monkeypatch)
     calls = _relay(monkeypatch)
 
     with pytest.raises(ValidationError) as exc:
@@ -130,7 +115,6 @@ def test_over_length_buyer_id_is_rejected_against_gps_own_width(monkeypatch):
 
 
 def test_over_length_description_is_rejected(monkeypatch):
-    _as_admin(monkeypatch)
     calls = _relay(monkeypatch)
 
     with pytest.raises(ValidationError) as exc:
@@ -141,7 +125,6 @@ def test_over_length_description_is_rejected(monkeypatch):
 
 
 def test_an_already_registered_buyer_surfaces_the_relays_own_message(monkeypatch):
-    _as_admin(monkeypatch)
     # Shaped as relay/errors.py error_body() builds it: {error, message, context}, always all three.
     detail = {
         "error": "buyer_already_exists",
@@ -160,7 +143,6 @@ def test_an_already_registered_buyer_surfaces_the_relays_own_message(monkeypatch
 
 
 def test_a_gp_refusal_surfaces_with_its_detail_intact(monkeypatch):
-    _as_admin(monkeypatch)
     # relay/errors.py econnect_error_body() nests the proc, the numeric state and its taErrorCode
     # description under `context` - that is the shape GpErrorAlert reads (error.relay.context.proc),
     # so asserting against a flattened one would prove nothing about what the alert renders.

--- a/backend/tests/test_create_gp_job.py
+++ b/backend/tests/test_create_gp_job.py
@@ -11,7 +11,8 @@ from datetime import date
 
 import pytest
 
-from app.auth import AuthError
+from app.auth import ADMIN_ROLE
+from app.auth_policy import ROOT_FIELD_POLICY
 from app.database import SessionLocal
 from app.errors import ConflictError, RelayCallError, RelayUnavailableError, ValidationError
 from app.models.project import Project as ProjectModel
@@ -34,10 +35,6 @@ def _clean_up_test_projects(_migrate_database):
         for project in session.query(ProjectModel).filter(ProjectModel.project_id.like("NEXUS-380-%")).all():
             session.delete(project)
         session.commit()
-
-
-def _as_admin(monkeypatch):
-    monkeypatch.setattr(project_module, "require_admin", lambda info: {"user_id": "user_1", "roles": ["Admin"]})
 
 
 def _input(**overrides):
@@ -95,24 +92,17 @@ def _create(**overrides):
     return asyncio.run(ProjectMutations().create_gp_job(_FakeInfo(), _input(**overrides)))
 
 
-def test_requires_an_admin(monkeypatch):
-    # Creating a job writes to the accounting system of record, so this is not an any-user mutation.
-    def _deny(info):
-        raise AuthError("Admin role required")
+def test_requires_an_admin():
+    """Creating a job writes to the accounting system of record, so this is not an any-user mutation.
 
-    monkeypatch.setattr(project_module, "require_admin", _deny)
-
-    async def _never(*a, **k):
-        raise AssertionError("the relay must not be called for a non-admin")
-
-    monkeypatch.setattr(project_module.relay_gateway, "relay_call", _never)
-
-    with pytest.raises(AuthError):
-        _create()
+    Since #423 the gate is the policy table, applied by the schema extension before the resolver runs,
+    so the requirement is asserted where it is decided. `test_resolver_auth_gates.py` covers that the
+    extension enforces the table. The tests below call the resolver directly with no auth setup -
+    what they pin is the guard order INSIDE the body, which is unchanged."""
+    assert ROOT_FIELD_POLICY["createGpJob"] == ADMIN_ROLE
 
 
 def test_refuses_when_no_relay_is_connected(monkeypatch):
-    _as_admin(monkeypatch)
     _relay(monkeypatch, company=None)
 
     with pytest.raises(RelayUnavailableError):
@@ -121,7 +111,6 @@ def test_refuses_when_no_relay_is_connected(monkeypatch):
 
 def test_gp_rejection_surfaces_the_procs_own_message(monkeypatch):
     # The whole point of the OnlyValidate pass: GP words the objection better than we can.
-    _as_admin(monkeypatch)
     _relay(
         monkeypatch,
         raises=RelayCallError("Job cannot be created within a closed period", detail={}),
@@ -136,7 +125,6 @@ def test_gp_rejection_keeps_the_relay_detail_for_the_error_alert(monkeypatch):
     # main.py publishes extensions.relayError from the raised error's .detail. A plain ValidationError
     # has no such field, so converting without carrying it over would empty the dialog's GP detail
     # table - the proc, the error state and the taErrorCode description all gone (#187).
-    _as_admin(monkeypatch)
     detail = {
         "error": "econnect_error",
         "message": "Job cannot be created within a closed period",
@@ -156,7 +144,6 @@ def test_a_job_already_in_gp_is_adopted_rather_than_dead_ending(monkeypatch):
     user pressed Create again. The relay's job_exists pre-check now answers job_already_exists, which
     no amount of retrying can clear - and the sync would have created the project a few minutes later
     anyway, so there is nothing to refuse."""
-    _as_admin(monkeypatch)
     _relay(
         monkeypatch,
         raises=RelayCallError("job 'NEXUS-380-T1' already exists in GP", detail={"error": "job_already_exists"}),
@@ -179,7 +166,6 @@ def test_a_job_already_in_gp_is_adopted_rather_than_dead_ending(monkeypatch):
 
 
 def test_sends_every_required_field_and_omits_unset_optionals(monkeypatch):
-    _as_admin(monkeypatch)
     _no_persist(monkeypatch)
     calls = _relay(monkeypatch)
 
@@ -196,7 +182,6 @@ def test_sends_every_required_field_and_omits_unset_optionals(monkeypatch):
 
 
 def test_sends_the_optional_fields_that_were_filled_in(monkeypatch):
-    _as_admin(monkeypatch)
     _no_persist(monkeypatch)
     calls = _relay(monkeypatch)
 
@@ -211,7 +196,6 @@ def test_sends_the_optional_fields_that_were_filled_in(monkeypatch):
 def test_the_sync_winning_the_race_is_not_an_error(monkeypatch):
     # GP committed, then gp_job_sync adopted the job before this resolver's persist ran. The row we
     # wanted exists; failing here would report a failure for a create that fully succeeded.
-    _as_admin(monkeypatch)
     _relay(monkeypatch)
     _no_persist(monkeypatch)
 
@@ -228,7 +212,6 @@ def test_the_sync_winning_the_race_is_not_an_error(monkeypatch):
 
 
 def test_persists_the_project_from_gps_own_answer(monkeypatch, _clean_up_test_projects):
-    _as_admin(monkeypatch)
     # GP's reply, not the input, is what the project is built from
     _relay(monkeypatch, result={"job_number": "NEXUS-380-T9", "job_name": "Name GP Kept"})
 

--- a/backend/tests/test_error_extension.py
+++ b/backend/tests/test_error_extension.py
@@ -1,9 +1,9 @@
-"""ErrorHandlerExtension: a RelayCallError's detail (the relay's eConnect proc / error_state /
+"""ResolverGuardExtension error mapping: a RelayCallError's detail (the relay's eConnect proc / error_state /
 description) must survive into the GraphQL error extensions so the frontend can show the full GP
 failure to the end user (issue #187), not just the generic RELAY_CALL_FAILED code."""
 
 from app.errors import RelayCallError, ValidationError
-from main import ErrorHandlerExtension
+from main import ResolverGuardExtension
 
 
 def test_relay_call_error_detail_surfaces_under_relay_error():
@@ -12,7 +12,7 @@ def test_relay_call_error_detail_surfaces_under_relay_error():
         "message": "Duplicate Order",
         "context": {"proc": "taPoLine", "error_state": 9127, "error_description": "Duplicate Order"},
     }
-    err = ErrorHandlerExtension._to_graphql_error(RelayCallError("Duplicate Order", detail=detail))
+    err = ResolverGuardExtension._to_graphql_error(RelayCallError("Duplicate Order", detail=detail))
     assert err.message == "Duplicate Order"
     assert err.extensions["code"] == "RELAY_CALL_FAILED"
     assert err.extensions["relayError"] == detail
@@ -20,13 +20,13 @@ def test_relay_call_error_detail_surfaces_under_relay_error():
 
 
 def test_relay_call_error_with_empty_detail_omits_relay_error():
-    err = ErrorHandlerExtension._to_graphql_error(RelayCallError("something failed"))
+    err = ResolverGuardExtension._to_graphql_error(RelayCallError("something failed"))
     assert err.extensions["code"] == "RELAY_CALL_FAILED"
     assert "relayError" not in err.extensions
 
 
 def test_plain_app_error_is_unchanged():
-    err = ErrorHandlerExtension._to_graphql_error(ValidationError("bad thing", field="vendor"))
+    err = ResolverGuardExtension._to_graphql_error(ValidationError("bad thing", field="vendor"))
     assert err.message == "bad thing"
     assert err.extensions["code"] == "VALIDATION_ERROR"
     assert err.extensions["field"] == "vendor"

--- a/backend/tests/test_gp_relay_reads.py
+++ b/backend/tests/test_gp_relay_reads.py
@@ -1,13 +1,15 @@
 """Query.gp_jobs/gp_vendors/gp_buyers/gp_cost_codes/relay_status: relay_call wiring + dict->type mapping.
 
 Plain `def test_...(): asyncio.run(...)` (matches test_relay_gateway.py) - resolvers are exercised
-directly against a Query instance with require_user monkeypatched out; Clerk auth itself needs no
-coverage here (no resolver-level auth test exists anywhere in this codebase yet)."""
+directly against a Query instance. Since #423 that needs no auth setup at all: the gate is a schema
+extension in front of the resolver, not a line inside it, so calling the body directly never touches
+Clerk. What each gp_* read REQUIRES is asserted against the policy table instead, below.
+"""
 
 import asyncio
 
-import pytest
-
+from app.auth import ADMIN_ROLE
+from app.auth_policy import ROOT_FIELD_POLICY, SIGNED_IN
 from app.schemas import relay as relay_module
 from app.schemas.queries import Query
 from app.services.relay_gateway import RelayGateway
@@ -15,13 +17,6 @@ from app.services.relay_gateway import RelayGateway
 
 class FakeInfo:
     context = {"request": None}
-
-
-@pytest.fixture(autouse=True)
-def _bypass_require_user(monkeypatch):
-    monkeypatch.setattr(relay_module, "require_user", lambda info: {"user_id": "test-user"})
-    # gp_employees is admin-gated (#392): the payroll roster is not ordinary working data.
-    monkeypatch.setattr(relay_module, "require_admin", lambda info: {"user_id": "test-admin", "roles": ["Admin"]})
 
 
 class FakeGateway:
@@ -134,25 +129,13 @@ def test_gp_buyers_detailed_maps_relay_result_to_type(monkeypatch):
     assert fake.calls == [("TUBC", "list_buyers_detailed", None)]
 
 
-def test_gp_buyers_detailed_requires_an_admin(monkeypatch):
-    # gp_buyers (bare ids) stays require_user; the descriptions are a staff roster by another name.
-    from app.auth import AuthError
-
-    def _deny(info):
-        raise AuthError("Admin role required")
-
-    monkeypatch.setattr(relay_module, "require_admin", _deny)
-
-    async def _never(*a, **k):
-        raise AssertionError("the relay must not be called for a non-admin")
-
-    monkeypatch.setattr(relay_module, "relay_gateway", type("G", (), {"relay_call": staticmethod(_never)})())
-
-    async def run():
-        return await Query().gp_buyers_detailed(FakeInfo(), company="TUBC")
-
-    with pytest.raises(AuthError):
-        asyncio.run(run())
+def test_gp_buyers_detailed_requires_an_admin():
+    """The bare-id `gpBuyers` backs the Create PO dropdown and stays open to any signed-in user; the
+    descriptions turn the same list into a staff roster, so that one is admin. Asserted against the
+    policy table because that is what decides it now - `test_resolver_auth_gates.py` covers that the
+    extension actually enforces the table."""
+    assert ROOT_FIELD_POLICY["gpBuyersDetailed"] == ADMIN_ROLE
+    assert ROOT_FIELD_POLICY["gpBuyers"] == SIGNED_IN
 
 
 def test_gp_cost_codes_maps_relay_result_to_type(monkeypatch):
@@ -240,26 +223,11 @@ def test_gp_employees_maps_relay_result_to_type(monkeypatch):
     assert fake.calls == [("TUBC", "list_employees", None)]
 
 
-def test_gp_employees_requires_an_admin(monkeypatch):
-    # Every other gp_* read is require_user; this one returns staff names, and its only consumer is
-    # the admin-only create-job dialog.
-    from app.auth import AuthError
-
-    def _deny(info):
-        raise AuthError("Admin role required")
-
-    monkeypatch.setattr(relay_module, "require_admin", _deny)
-
-    async def _never(*a, **k):
-        raise AssertionError("the relay must not be called for a non-admin")
-
-    monkeypatch.setattr(relay_module, "relay_gateway", type("G", (), {"relay_call": staticmethod(_never)})())
-
-    async def run():
-        return await Query().gp_employees(FakeInfo(), company="TUBC")
-
-    with pytest.raises(AuthError):
-        asyncio.run(run())
+def test_gp_employees_requires_an_admin():
+    """Every other gp_* read is open to any signed-in user; this one returns the payroll master with
+    staff names, and its only consumer is the admin-only create-job dialog."""
+    assert ROOT_FIELD_POLICY["gpEmployees"] == ADMIN_ROLE
+    assert ROOT_FIELD_POLICY["gpDivisions"] == SIGNED_IN
 
 
 def test_gp_divisions_passes_through_the_relay_list(monkeypatch):

--- a/backend/tests/test_relay_link_route.py
+++ b/backend/tests/test_relay_link_route.py
@@ -23,6 +23,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 import main  # noqa: E402
+from app.auth import ADMIN_ROLE  # noqa: E402
 from app.database import SessionLocal  # noqa: E402
 from app.models.relay_install import RelayInstall  # noqa: E402
 from app.repositories import relay_repository  # noqa: E402
@@ -397,27 +398,26 @@ def test_read_loop_records_the_relay_hello_frame(monkeypatch):
 
 
 class _FakeInfo:
-    """A resolver `info` with no real request. require_admin is patched out per test - what is under
-    test here is the connected-install guard, not the auth gate (that lives in
-    test_resolver_auth_gates)."""
+    """A resolver `info` for a caller the gate has already admitted.
 
-    context = {"request": None}
+    These tests call the resolver directly, so no schema extension runs - and since #423 the gate is
+    the extension, not a line in the body. The body still reads the caller's identity through
+    `current_user`, which returns the identity `enforce_root_field` verified and memoised on the
+    request context. Seeding that memo is exactly the state a resolver runs in, and it needs no real
+    request. What is under test here is the connected-install guard; the authorization itself lives
+    in test_resolver_auth_gates."""
+
+    def __init__(self, user_id: str = "user_admin"):
+        self.context = {"request": None, "_auth_user_id": user_id, "_auth_roles": [ADMIN_ROLE]}
 
 
-def _as_admin(monkeypatch):
-    from app.schemas import relay as relay_module
-
-    monkeypatch.setattr(relay_module, "require_admin", lambda info: {"user_id": "user_admin", "roles": ["Admin"]})
-
-
-def test_delete_refuses_the_install_holding_the_live_connection(_migrate_database, monkeypatch):
+def test_delete_refuses_the_install_holding_the_live_connection(_migrate_database):
     """Revoking the secret under a running relay would take GP down mid-write, so the resolver refuses
     it. This drives the real route because the id it compares against is set by the route - reading
     install.id in the same pre-commit block as install.company, per the DetachedInstanceError rule."""
     from app.errors import ConflictError
     from app.schemas.relay import RelayMutations
 
-    _as_admin(monkeypatch)
     secret = "relay-link-delete-guard-secret"
     install_id = _enroll_committed("WS-DELETE-GUARD", "TUBC", secret)
     try:
@@ -438,11 +438,10 @@ def test_delete_refuses_the_install_holding_the_live_connection(_migrate_databas
         _delete_install(install_id)
 
 
-def test_delete_allows_a_different_disconnected_install_while_one_is_live(_migrate_database, monkeypatch):
+def test_delete_allows_a_different_disconnected_install_while_one_is_live(_migrate_database):
     # Retiring a workstation is the normal case and must not be blocked by an unrelated relay being up.
     from app.schemas.relay import RelayMutations
 
-    _as_admin(monkeypatch)
     live_secret = "relay-link-delete-live-secret"
     live_id = _enroll_committed("WS-DELETE-LIVE", "TUBC", live_secret)
     other_id = _enroll_committed("WS-DELETE-OTHER", "TUBC", "relay-link-delete-other-secret")

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -173,6 +173,65 @@ def test_a_root_field_with_no_policy_entry_is_refused():
     assert "someFieldNobodyGatedYet" in str(excinfo.value)
 
 
+# --- per-field pins ------------------------------------------------------------------------------
+#
+# The #415 shape had one pin per resolver, each asserting that body called its gate. These are the
+# replacement, and they are strictly stronger: they exercise the decision the caller actually gets
+# rather than the presence of a line, and they still fail by field name, which is what made the old
+# ones useful in review. Driven off ROOT_FIELD_POLICY so a field added to the table is covered the
+# moment it is added, and one removed stops being asserted about - neither needs a list here.
+
+_ROLE_GATED = sorted(f for f, requirement in ROOT_FIELD_POLICY.items() if requirement != SIGNED_IN)
+
+
+@pytest.mark.parametrize("field", sorted(ROOT_FIELD_POLICY), ids=sorted(ROOT_FIELD_POLICY))
+def test_every_gated_field_refuses_an_anonymous_caller(field):
+    """No session, no field. This is the property #415 established and #423 had to preserve while
+    moving where it is decided - a refactor that dropped a policy entry, or made SIGNED_IN mean
+    "anyone", fails here on the field it broke."""
+    with pytest.raises(AppError) as excinfo:
+        enforce_root_field(field, {"request": _FakeRequest()})
+
+    assert excinfo.value.code == "UNAUTHENTICATED", f"{field} let an anonymous caller through with {excinfo.value.code}"
+
+
+@pytest.mark.parametrize("field", _ROLE_GATED, ids=_ROLE_GATED)
+def test_every_role_gated_field_refuses_a_caller_without_the_role(field, monkeypatch):
+    """A signed-in session is not a role. Everything in this list guards something a plain warehouse
+    or assembly account has no business reaching - relay credentials, the Clerk roster, warehouse
+    and vendor writes, the GP job and buyer writes, and `updateUserRoles`, which grants the role the
+    rest of them are gated on."""
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: {"sub": "u_caller"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: ["Warehouse Staff"])
+    monkeypatch.setattr(user_repository, "list_users", lambda: [{"id": "u_caller", "roles": ["Warehouse Staff"]}])
+
+    with pytest.raises(AppError) as excinfo:
+        enforce_root_field(field, {"request": _FakeRequest("tok")})
+
+    assert excinfo.value.code == "FORBIDDEN", f"{field} admitted a caller holding only Warehouse Staff"
+    assert excinfo.value.message == f"{ROOT_FIELD_POLICY[field]} role required"
+
+
+@pytest.mark.parametrize("field", _ROLE_GATED, ids=_ROLE_GATED)
+def test_every_role_gated_field_admits_a_caller_holding_the_role(field, monkeypatch):
+    """The other direction, per field. A gate nobody can pass is the failure mode a deny-by-default
+    refactor invites: a typo in a role name, or a policy entry pointing at a role Clerk never grants,
+    locks the field for everyone and looks like working security until someone reports it."""
+    role = ROOT_FIELD_POLICY[field]
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: {"sub": "u_caller"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [role])
+    monkeypatch.setattr(user_repository, "list_users", lambda: [{"id": "u_caller", "roles": [role]}])
+
+    enforce_root_field(field, {"request": _FakeRequest("tok")})
+
+
+@pytest.mark.parametrize("field", sorted(OPEN_OPERATIONS), ids=sorted(OPEN_OPERATIONS))
+def test_every_open_operation_is_reachable_without_a_session(field):
+    """The allowlist has to actually allow. `enrollRelayInstall` is the relay's only way in during
+    setup, before it holds any credential - gating it strands every new install."""
+    enforce_root_field(field, {"request": _FakeRequest()})
+
+
 def test_nested_fields_are_not_re_checked(monkeypatch, signed_in):
     """Only root fields are gated (`info.path.prev is None`). A nested field is reachable only through
     a root field that already passed, and checking each one would put a Clerk decision on every node

--- a/backend/tests/test_resolver_auth_gates.py
+++ b/backend/tests/test_resolver_auth_gates.py
@@ -1,382 +1,309 @@
-"""Gated resolvers call their gate before they act (#345, extended to the admin surface by #415).
+"""The schema extension refuses an unauthorized caller before the resolver runs (#345, #415, #423).
 
-Auth in this codebase is **opt-in per resolver** (CLAUDE.md): there is no middleware to catch a
-resolver that forgets, and `get_context` only stashes the request. That makes a dropped
-`require_user(info)` invisible - the resolver keeps working, it just works for anonymous callers
-too, which is exactly how `reportDeficiencyAtAssembly` came to mint replacement pull requests and
-write project inventory with no session at all.
+These were pin tests: one per resolver, each monkeypatching that resolver's gate with something that
+raised a sentinel, proving the body asked before it acted. They had to be written one at a time
+because the gate was a line inside each body, and a body that dropped its line failed here by name.
 
-These are pin tests, not behaviour tests. Each one replaces the gate with something that raises a
-sentinel and asserts the sentinel comes back out: if the gate runs, the call cannot proceed, so no
-database is needed and nothing about the resolver body is asserted. A refactor that drops a gate
-makes the resolver return (or fail differently) and the test goes red on that resolver by name.
+#423 moved the decision into `enforce_root_field` (app/auth_policy.py), called from
+ResolverGuardExtension before `_next`. Ordering is structural now: there is no body-level line left
+to drop, and no resolver-by-resolver list to keep in step with 161 of them. What is worth testing is
+the mechanism, once - so these run real operations through the real schema and assert what a caller
+gets back.
 
-`shopAssemblyMembers` and the manager branch of `assignOpenings` are role-gated rather than
-user-gated; both gates are pinned.
+The sentinel idea survives, inverted. Instead of stubbing the gate and watching it fire, each test
+stubs the thing the RESOLVER would touch first (`SessionLocal`, a repository call) so that if the
+body ever starts, it says so loudly. A refusal that arrives with the sentinel un-fired is a refusal
+that happened first.
 
-This file pins gates one at a time and proves the gate runs *first*, which is what a monkeypatched
-sentinel can show and a source scan cannot. It says nothing about resolvers nobody thought to list -
-that is `test_resolver_gate_completeness.py`, which walks every resolver in `app/schemas/` and fails
-on any that never asks. The two are complements: this one is depth, that one is coverage.
+`test_resolver_gate_completeness.py` is the complement: this file is behaviour, that one is coverage.
 """
 
-import uuid
+import asyncio
 
 import pytest
 
-from app.schemas import admin as admin_module
-from app.schemas import dashboard as dashboard_module
-from app.schemas import gp_outbox as gp_outbox_module
+from app import auth
+from app.auth import ADMIN_ROLE, SHOP_ASSEMBLY_MANAGER_ROLE
+from app.auth_policy import OPEN_OPERATIONS, ROOT_FIELD_POLICY, SIGNED_IN, enforce_root_field
+from app.errors import AppError
+from app.repositories import user_repository
 from app.schemas import relay as relay_module
 from app.schemas import shop_assembly as shop_assembly_module
-from app.schemas import stock as stock_module
-from app.schemas import user as user_module
-from app.schemas import vendor as vendor_module
 from app.schemas import warehouse as warehouse_module
-from app.schemas.admin import AdminQueries
-from app.schemas.dashboard import DashboardQueries
-from app.schemas.enums import DeficiencyResolution
-from app.schemas.gp_outbox import GpOutboxMutations, GpOutboxQueries
-from app.schemas.inputs import (
-    AssignOpeningsInput,
-    CompleteOpeningInput,
-    CreateVendorInput,
-    CreateWarehouseInput,
-    InstallReplacementInput,
-    OverrideInventoryQuantityInput,
-    PickLineInput,
-    RecordAssemblyProgressInput,
-    ReportDeficiencyAtAssemblyInput,
-    ReportInventoryDeficiencyInput,
-    ReportStockDeficiencyInput,
-    ResolveDeficiencyInput,
-    UpdateVendorInput,
-    UpdateWarehouseInput,
-)
-from app.schemas.relay import RelayMutations, RelayQueries
-from app.schemas.shop_assembly import ShopAssemblyMutations, ShopAssemblyQueries
-from app.schemas.stock import StockMutations
-from app.schemas.user import UserMutations, UserQueries
-from app.schemas.vendor import VendorMutations
-from app.schemas.warehouse import WarehouseMutations, WarehouseQueries
+from main import schema
 
 
-class _GateReached(Exception):
-    """Raised by the stubbed gate. Seeing it means the resolver asked before it acted."""
+class _ResolverRan(Exception):
+    """Raised by whatever the resolver body reaches for first. Seeing it means the gate let the call
+    through; never seeing it, on a query that was refused, means the gate ran first."""
 
 
-class FakeInfo:
-    def __init__(self, request=None):
-        self.context = {"request": request}
+class _FakeRequest:
+    def __init__(self, token: str | None = None):
+        self.headers = {"authorization": f"Bearer {token}"} if token else {}
 
 
-def _id() -> str:
-    return str(uuid.uuid4())
+def _execute(query: str, token: str | None = None, context: dict | None = None):
+    """Run an operation through the real schema, with a request that carries the given bearer token.
+
+    The context dict is the same one `get_context` builds per request, and the same one the gate
+    memoises on - so passing one in lets a test watch what a single request costs."""
+    ctx = context if context is not None else {"request": _FakeRequest(token)}
+    return asyncio.run(schema.execute(query, context_value=ctx))
 
 
-# (label, module the resolver resolves its gate from, callable taking no args)
-_USER_GATED = [
-    ("assembleList", shop_assembly_module, lambda: ShopAssemblyQueries().assemble_list(FakeInfo())),
-    ("myWork", shop_assembly_module, lambda: ShopAssemblyQueries().my_work(FakeInfo(), "user_1")),
-    ("replacementWork", shop_assembly_module, lambda: ShopAssemblyQueries().replacement_work(FakeInfo())),
-    (
-        "shopAssemblyRequests",
-        shop_assembly_module,
-        lambda: ShopAssemblyQueries().shop_assembly_requests(FakeInfo()),
-    ),
-    (
-        "assemblyPipelineSummaries",
-        shop_assembly_module,
-        lambda: ShopAssemblyQueries().assembly_pipeline_summaries(FakeInfo()),
-    ),
-    (
-        "assemblyPipeline",
-        shop_assembly_module,
-        lambda: ShopAssemblyQueries().assembly_pipeline(FakeInfo(), _id()),
-    ),
-    (
-        "acceptShopAssemblyRequest",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().accept_shop_assembly_request(FakeInfo(), _id(), "acceptor"),
-    ),
-    (
-        "rejectShopAssemblyRequest",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().reject_shop_assembly_request(FakeInfo(), _id(), "rejector"),
-    ),
-    (
-        "reopenShopAssemblyRequest",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().reopen_shop_assembly_request(FakeInfo(), _id()),
-    ),
-    (
-        "assignOpenings",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().assign_openings(
-            FakeInfo(),
-            AssignOpeningsInput(opening_ids=[_id()], assigned_to_user_id="user_1", assigned_to="Someone"),
-        ),
-    ),
-    (
-        "removeOpeningFromUser",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().remove_opening_from_user(FakeInfo(), _id()),
-    ),
-    (
-        "recordAssemblyProgress",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().record_assembly_progress(
-            FakeInfo(), RecordAssemblyProgressInput(opening_id=_id(), items=[])
-        ),
-    ),
-    (
-        "installReplacement",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().install_replacement(
-            FakeInfo(), InstallReplacementInput(shop_assembly_opening_item_id=_id(), quantity=1)
-        ),
-    ),
-    (
-        "completeOpening",
-        shop_assembly_module,
-        lambda: ShopAssemblyMutations().complete_opening(FakeInfo(), CompleteOpeningInput(opening_id=_id())),
-    ),
-    (
-        "reportInventoryDeficiency",
-        stock_module,
-        lambda: StockMutations().report_inventory_deficiency(
-            FakeInfo(), ReportInventoryDeficiencyInput(inventory_location_id=_id(), quantity=1)
-        ),
-    ),
-    (
-        "reportStockDeficiency",
-        stock_module,
-        lambda: StockMutations().report_stock_deficiency(
-            FakeInfo(), ReportStockDeficiencyInput(stock_item_id=_id(), quantity=1)
-        ),
-    ),
-    (
-        "reportDeficiencyAtAssembly",
-        stock_module,
-        lambda: StockMutations().report_deficiency_at_assembly(
-            FakeInfo(), ReportDeficiencyAtAssemblyInput(shop_assembly_opening_item_id=_id(), quantity=1)
-        ),
-    ),
-    (
-        "resolveDeficiency",
-        stock_module,
-        lambda: StockMutations().resolve_deficiency(
-            FakeInfo(),
-            ResolveDeficiencyInput(
-                inventory_location_id=_id(),
-                resolution=DeficiencyResolution.REPAIR,
-                quantity=1,
-                reviewed_by="reviewer",
-            ),
-        ),
-    ),
-    # The pick (#367). confirmPick writes inventory; the other three attribute a user action or
-    # expose one project's per-location stock, so all four are gated for the same reasons the
-    # staging and cancel mutations next to them are.
-    (
-        "pullPickSheet",
-        warehouse_module,
-        lambda: WarehouseQueries().pull_pick_sheet(FakeInfo(), _id()),
-    ),
-    (
-        "startPullRequestPick",
-        warehouse_module,
-        lambda: WarehouseMutations().start_pull_request_pick(FakeInfo(), _id(), "picker"),
-    ),
-    (
-        "savePickDraft",
-        warehouse_module,
-        lambda: WarehouseMutations().save_pick_draft(
-            FakeInfo(),
-            _id(),
-            [PickLineInput(hardware_category="HINGE", product_code="HG-100", inventory_location_id=_id(), quantity=1)],
-            "picker",
-        ),
-    ),
-    (
-        "confirmPick",
-        warehouse_module,
-        lambda: WarehouseMutations().confirm_pick(
-            FakeInfo(),
-            _id(),
-            [PickLineInput(hardware_category="HINGE", product_code="HG-100", inventory_location_id=_id(), quantity=1)],
-            "picker",
-        ),
-    ),
-    (
-        "setPullItemFetched",
-        warehouse_module,
-        lambda: WarehouseMutations().set_pull_item_fetched(FakeInfo(), _id(), True, "picker"),
-    ),
-    # Both of these are reached from non-admin screens through a component that happens to live under
-    # modules/admin/, so they are user-gated and pinned here rather than in _ADMIN_GATED. Pinning the
-    # gate they actually use is what stops a future "tidy-up" from promoting them to require_admin and
-    # silently breaking a PO user's vendor add or the warehouse's count correction.
-    (
-        "createVendor",
-        vendor_module,
-        lambda: VendorMutations().create_vendor(FakeInfo(), CreateVendorInput(name="V")),
-    ),
-    (
-        "overrideInventoryQuantity",
-        warehouse_module,
-        lambda: WarehouseMutations().override_inventory_quantity(
-            FakeInfo(),
-            OverrideInventoryQuantityInput(inventory_location_id=_id(), new_quantity=1, reason_text="r"),
-        ),
-    ),
-]
+def _codes(result) -> set[str | None]:
+    return {(e.extensions or {}).get("code") for e in (result.errors or [])}
 
 
-# Admin-only resolvers. The adopt window (#353 PR B) deliberately weakens the /relay-link auth
-# boundary while it is open, so "is this actually admin-gated" is a security property, not a nicety.
-_ADMIN_GATED = [
-    ("relayAdoptWindow", relay_module, lambda: RelayQueries().relay_adopt_window(FakeInfo())),
-    ("armRelayAdopt", relay_module, lambda: RelayMutations().arm_relay_adopt(FakeInfo(), _id())),
-    ("disarmRelayAdopt", relay_module, lambda: RelayMutations().disarm_relay_adopt(FakeInfo())),
-    # #366: deleting an install revokes a relay credential outright, so the gate is the whole
-    # protection - there is nothing downstream to catch a non-admin caller.
-    ("deleteRelayInstall", relay_module, lambda: RelayMutations().delete_relay_install(FakeInfo(), _id())),
-    # #353 PR E: retrying an `ambiguous` queued write can duplicate a GP posting, and cancelling one
-    # abandons work somebody has already done. Both are admin-only.
-    (
-        "retryGpOutboxEntry",
-        gp_outbox_module,
-        lambda: GpOutboxMutations().retry_gp_outbox_entry(FakeInfo(), _id()),
-    ),
-    (
-        "cancelGpOutboxEntry",
-        gp_outbox_module,
-        lambda: GpOutboxMutations().cancel_gp_outbox_entry(FakeInfo(), _id()),
-    ),
-    # #415. All four user.py resolvers shipped with no gate at all. `updateUserRoles` is the one that
-    # matters most: it grants Admin/Manager, the role every other entry in this list is gated on, so
-    # an ungated copy is a self-service escalation into all of them. `users` returns every account's
-    # email, roles and GP buyer id.
-    ("users", user_module, lambda: UserQueries().users(FakeInfo())),
-    (
-        "updateUserRoles",
-        user_module,
-        lambda: UserMutations().update_user_roles(FakeInfo(), "user_1", ["Admin/Manager"]),
-    ),
-    (
-        "updateUserName",
-        user_module,
-        lambda: UserMutations().update_user_name(FakeInfo(), "user_1", "First", "Last"),
-    ),
-    (
-        "updateUserGpBuyerId",
-        user_module,
-        lambda: UserMutations().update_user_gp_buyer_id(FakeInfo(), "user_1", "donr"),
-    ),
-    # #415 sweep: the rest of the admin-only surface, all of it previously ungated. The warehouse and
-    # vendor writes are the ones with teeth - an anonymous caller could delete a warehouse, rewrite an
-    # inventory row's quantity outright, or merge every item at one location into another.
-    (
-        "openingHardwareStatus",
-        admin_module,
-        lambda: AdminQueries().opening_hardware_status(FakeInfo()),
-    ),
-    ("adminStats", dashboard_module, lambda: DashboardQueries().admin_stats(FakeInfo())),
-    (
-        "updateVendor",
-        vendor_module,
-        lambda: VendorMutations().update_vendor(FakeInfo(), _id(), UpdateVendorInput(name="V")),
-    ),
-    ("deleteVendor", vendor_module, lambda: VendorMutations().delete_vendor(FakeInfo(), _id())),
-    (
-        "locationDuplicates",
-        warehouse_module,
-        lambda: WarehouseQueries().location_duplicates(FakeInfo()),
-    ),
-    (
-        "mergeLocations",
-        warehouse_module,
-        lambda: WarehouseMutations().merge_locations(FakeInfo(), "A", "1", "1", "B", "2", "2"),
-    ),
-    (
-        "createWarehouse",
-        warehouse_module,
-        lambda: WarehouseMutations().create_warehouse(FakeInfo(), CreateWarehouseInput(name="W", code="W1")),
-    ),
-    (
-        "updateWarehouse",
-        warehouse_module,
-        lambda: WarehouseMutations().update_warehouse(FakeInfo(), _id(), UpdateWarehouseInput(name="W")),
-    ),
-    (
-        "deleteWarehouse",
-        warehouse_module,
-        lambda: WarehouseMutations().delete_warehouse(FakeInfo(), _id()),
-    ),
-]
-
-# Any signed-in user; the PO and receiving lists read the queue to show pending chips.
-_OUTBOX_USER_GATED = [
-    ("gpOutboxSummary", gp_outbox_module, lambda: GpOutboxQueries().gp_outbox_summary(FakeInfo())),
-    ("gpOutbox", gp_outbox_module, lambda: GpOutboxQueries().gp_outbox(FakeInfo())),
-]
+def _messages(result) -> set[str]:
+    return {e.message for e in (result.errors or [])}
 
 
-@pytest.mark.parametrize("label, module, call", _USER_GATED, ids=[row[0] for row in _USER_GATED])
-def test_resolver_requires_a_signed_in_user(label, module, call, monkeypatch):
-    def _gate(info):
-        raise _GateReached(label)
+@pytest.fixture
+def signed_in(monkeypatch):
+    """A verifiable token for user `u_caller`, with no roles unless a test grants some.
 
-    monkeypatch.setattr(module, "require_user", _gate)
-
-    with pytest.raises(_GateReached):
-        call()
-
-
-@pytest.mark.parametrize("label, module, call", _ADMIN_GATED, ids=[row[0] for row in _ADMIN_GATED])
-def test_resolver_requires_an_admin(label, module, call, monkeypatch):
-    def _gate(info):
-        raise _GateReached(label)
-
-    monkeypatch.setattr(module, "require_admin", _gate)
-
-    with pytest.raises(_GateReached):
-        call()
+    Patches `verify_clerk_token` rather than minting a real JWT: what is under test is the gate's
+    decision, not RS256, and the alternative is a JWKS round trip in a unit test."""
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: {"sub": "u_caller"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [])
+    return "tok"
 
 
-@pytest.mark.parametrize("label, module, call", _OUTBOX_USER_GATED, ids=[row[0] for row in _OUTBOX_USER_GATED])
-def test_outbox_read_requires_a_signed_in_user(label, module, call, monkeypatch):
-    def _gate(info):
-        raise _GateReached(label)
+def _explodes(monkeypatch, module, attr="SessionLocal"):
+    """Make the resolver body's first move raise, so a body that runs cannot do so quietly."""
 
-    monkeypatch.setattr(module, "require_user", _gate)
+    def _boom(*args, **kwargs):
+        raise _ResolverRan(f"{module.__name__}.{attr}")
 
-    with pytest.raises(_GateReached):
-        call()
+    monkeypatch.setattr(module, attr, _boom)
 
 
-def test_shop_assembly_members_requires_the_manager_role(monkeypatch):
-    def _gate(info, role):
-        raise _GateReached(role)
+def test_anonymous_caller_is_refused_before_the_resolver_body_runs(monkeypatch):
+    """The #415 defect, restated as behaviour: no session, no work. `warehouses` is a plain
+    signed-in read, so the only thing standing between an anonymous POST and the database is this."""
+    _explodes(monkeypatch, warehouse_module)
 
-    monkeypatch.setattr(shop_assembly_module, "require_role", _gate)
+    result = _execute("{ warehouses { id } }")
 
-    with pytest.raises(_GateReached):
-        ShopAssemblyQueries().shop_assembly_members(FakeInfo())
+    assert _codes(result) == {"UNAUTHENTICATED"}
+    assert not any("SessionLocal" in m for m in _messages(result)), (
+        "the resolver body started before the caller was refused - the gate is no longer running first"
+    )
 
 
-def test_assigning_to_another_user_requires_the_manager_role(monkeypatch):
-    """The one gate that is conditional: self-assignment is open, assigning somebody else is not."""
+def test_the_refusal_carries_the_code_the_frontend_recovers_on():
+    """UNAUTHENTICATED is not decoration. The Apollo link re-mints the Clerk token and replays the
+    operation once on exactly this code (#429); FORBIDDEN it leaves alone. The extension raises these
+    inside the same try/except that maps AppError -> extensions.code, so the two cannot drift."""
+    result = _execute("{ warehouses { id } }")
 
-    def _role_gate(info, role):
-        raise _GateReached(role)
+    assert _codes(result) == {"UNAUTHENTICATED"}
+    assert _messages(result) == {"Authentication required"}
 
-    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
-    monkeypatch.setattr(shop_assembly_module, "require_role", _role_gate)
 
-    with pytest.raises(_GateReached):
-        ShopAssemblyMutations().assign_openings(
-            FakeInfo(),
-            AssignOpeningsInput(opening_ids=[_id()], assigned_to_user_id="somebody_else", assigned_to="Other"),
-        )
+def test_an_open_operation_is_reachable_without_a_session(monkeypatch):
+    """`enrollRelayInstall` is the whole allowlist. The relay calls it during setup, before it holds
+    any credential, so there is no Clerk session to gate on - it is authenticated by the single-use
+    enrollment token instead. Reaching the body is the assertion."""
+    assert set(OPEN_OPERATIONS) == {"enrollRelayInstall"}, (
+        "the open-operations allowlist changed; the new entry needs its own reachability test and a "
+        "reason that survives review"
+    )
+    _explodes(monkeypatch, relay_module)
+
+    result = _execute(
+        'mutation { enrollRelayInstall(input: {enrollmentToken: "t", hostname: "h", secret: "s"}) { ok } }'
+    )
+
+    assert any("SessionLocal" in m for m in _messages(result)), (
+        f"enrollRelayInstall did not reach its body: {_messages(result)}. The relay cannot enrol if "
+        f"this is gated on a Clerk session it does not have."
+    )
+
+
+def test_an_admin_field_refuses_a_signed_in_non_admin(monkeypatch, signed_in):
+    """`relayInstalls` lists relay credentials. A valid session is not enough for it, and the caller
+    must not get as far as the query."""
+    _explodes(monkeypatch, relay_module)
+
+    result = _execute("{ relayInstalls { id } }", token=signed_in)
+
+    assert _codes(result) == {"FORBIDDEN"}
+    assert _messages(result) == {f"{ADMIN_ROLE} role required"}
+    assert not any("SessionLocal" in m for m in _messages(result))
+
+
+def test_an_admin_field_admits_an_admin(monkeypatch, signed_in):
+    """The other half of the same check - a gate that refuses everyone is not a gate either."""
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [ADMIN_ROLE])
+    _explodes(monkeypatch, relay_module)
+
+    result = _execute("{ relayInstalls { id } }", token=signed_in)
+
+    assert any("SessionLocal" in m for m in _messages(result)), (
+        f"an Admin/Manager was refused relayInstalls: {_messages(result)}"
+    )
+
+
+def test_a_role_gated_field_refuses_someone_without_that_role(monkeypatch, signed_in):
+    """`shopAssemblyMembers` is Shop Assembly Manager-gated (#330), not admin - the one requirement in
+    the table that is neither SIGNED_IN nor Admin/Manager, so it is the one that proves the table can
+    express an arbitrary role."""
+    assert ROOT_FIELD_POLICY["shopAssemblyMembers"] == SHOP_ASSEMBLY_MANAGER_ROLE
+    # Roster-backed, so the roles come out of list_users rather than a per-user lookup.
+    monkeypatch.setattr(user_repository, "list_users", lambda: [{"id": "u_caller", "roles": ["Shop Assembly User"]}])
+    _explodes(monkeypatch, shop_assembly_module, "user_repository")
+
+    result = _execute("{ shopAssemblyMembers { id } }", token=signed_in)
+
+    assert _codes(result) == {"FORBIDDEN"}
+    assert _messages(result) == {f"{SHOP_ASSEMBLY_MANAGER_ROLE} role required"}
+
+
+def test_a_root_field_with_no_policy_entry_is_refused():
+    """Deny by default, which is the entire difference between #415's shape and this one. An operation
+    nobody wrote a policy for fails closed - the alternative default is what let `updateUserRoles`
+    ship reachable with no session at all."""
+    with pytest.raises(AppError) as excinfo:
+        enforce_root_field("someFieldNobodyGatedYet", {"request": _FakeRequest("tok")})
+
+    assert excinfo.value.code == "FORBIDDEN"
+    assert "someFieldNobodyGatedYet" in str(excinfo.value)
+
+
+def test_nested_fields_are_not_re_checked(monkeypatch, signed_in):
+    """Only root fields are gated (`info.path.prev is None`). A nested field is reachable only through
+    a root field that already passed, and checking each one would put a Clerk decision on every node
+    of every response - the reason the per-resolver shape was expensive in the first place."""
+    verifications = []
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: (verifications.append(token), {"sub": "u_caller"})[1])
+    _explodes(monkeypatch, warehouse_module)
+
+    # `warehouses` selects several sub-fields; only the root one may be gated.
+    _execute("{ warehouses { id name code isActive } }", token=signed_in)
+
+    assert len(verifications) == 1
+
+
+def test_the_jwt_is_verified_once_for_a_query_hitting_several_root_fields(monkeypatch, signed_in):
+    """#415 verified per gate, so a page firing one query over five root fields paid five times. The
+    identity is a property of the request, so it is resolved once and memoised on the request's own
+    context."""
+    verifications = []
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: (verifications.append(token), {"sub": "u_caller"})[1])
+    _explodes(monkeypatch, warehouse_module)
+    _explodes(monkeypatch, shop_assembly_module, "SessionLocal")
+
+    _execute(
+        "{ warehouses { id } pullRequests { id } vendors { id } assembleList { id } }",
+        token=signed_in,
+    )
+
+    assert len(verifications) == 1, f"the token was verified {len(verifications)} times for one request"
+
+
+def test_the_role_lookup_is_not_repeated_across_root_fields(monkeypatch, signed_in):
+    """Same argument, and the expensive half: roles live in Clerk publicMetadata rather than the
+    session token, so each `require_admin` was its own Clerk Backend API round trip. The admin
+    dashboard fires several admin queries; they now share one."""
+    role_lookups = []
+    monkeypatch.setattr(
+        user_repository, "get_user_roles", lambda user_id: (role_lookups.append(user_id), [ADMIN_ROLE])[1]
+    )
+    _explodes(monkeypatch, relay_module)
+
+    _execute("{ relayInstalls { id } relayAdoptWindow { label } }", token=signed_in)
+
+    assert len(role_lookups) == 1, f"roles were fetched {len(role_lookups)} times for one request"
+
+
+def test_two_requests_do_not_share_an_identity(monkeypatch):
+    """The memo lives on the context dict `get_context` builds per request, so it cannot outlive one.
+    A process-global cache would be the same optimisation and a much worse bug: one user's roles
+    served to another."""
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: {"sub": f"u_{token}"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [ADMIN_ROLE] if user_id == "u_a" else [])
+    _explodes(monkeypatch, relay_module)
+
+    admitted = _execute("{ relayInstalls { id } }", token="a")
+    refused = _execute("{ relayInstalls { id } }", token="b")
+
+    assert any("SessionLocal" in m for m in _messages(admitted))
+    assert _codes(refused) == {"FORBIDDEN"}
+
+
+def test_admin_stats_authorizes_and_answers_with_one_clerk_call(monkeypatch, signed_in):
+    """The double round trip #423 called out. `adminStats` counts Clerk users, so it calls
+    `list_users` - which returns roles per user, the caller's included - and then paid for a separate
+    `get_user_roles` to authorize the very same caller. The gate now takes the roles out of that one
+    roster call (ROSTER_BACKED in app/auth_policy.py)."""
+    rosters = []
+    role_lookups = []
+    monkeypatch.setattr(
+        user_repository,
+        "list_users",
+        lambda: (rosters.append(1), [{"id": "u_caller", "roles": [ADMIN_ROLE]}])[1],
+    )
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: (role_lookups.append(user_id), [])[1])
+    from app.schemas import dashboard as dashboard_module
+
+    _explodes(monkeypatch, dashboard_module)
+
+    result = _execute("{ adminStats { userCount } }", token=signed_in)
+
+    assert any("SessionLocal" in m for m in _messages(result)), (
+        f"adminStats was refused for an Admin/Manager: {_messages(result)}"
+    )
+    assert len(rosters) == 1, f"the Clerk roster was fetched {len(rosters)} times"
+    assert role_lookups == [], "adminStats still pays a separate per-user role lookup on top of the roster"
+
+
+def test_the_roster_is_not_fetched_for_a_field_that_does_not_need_it(monkeypatch, signed_in):
+    """The roster is the cheaper answer only where the body wanted it anyway. Every other admin field
+    stays on the single-user lookup rather than pulling every Clerk account to authorize one."""
+    rosters = []
+    monkeypatch.setattr(user_repository, "list_users", lambda: (rosters.append(1), [])[1])
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [ADMIN_ROLE])
+    _explodes(monkeypatch, relay_module)
+
+    _execute("{ relayInstalls { id } }", token=signed_in)
+
+    assert rosters == []
+
+
+def test_a_signed_in_field_costs_no_role_lookup(monkeypatch, signed_in):
+    """SIGNED_IN means identity only. Reading roles for it would put a Clerk round trip on every
+    warehouse and assembly screen in the app to learn something the gate does not use."""
+    assert ROOT_FIELD_POLICY["warehouses"] == SIGNED_IN
+    role_lookups = []
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: (role_lookups.append(user_id), [])[1])
+    _explodes(monkeypatch, warehouse_module)
+
+    _execute("{ warehouses { id } }", token=signed_in)
+
+    assert role_lookups == []
+
+
+def test_the_user_management_page_reads_the_roster_it_was_authorized_from(monkeypatch, signed_in):
+    """`users` is the other roster-backed field: an admin-only read whose answer IS the roster the
+    gate checked the caller against."""
+    caller = {
+        "id": "u_caller",
+        "first_name": "A",
+        "last_name": "B",
+        "email": "a@b.c",
+        "roles": [ADMIN_ROLE],
+        "gp_buyer_id": None,
+        "image_url": "",
+    }
+    rosters = []
+    monkeypatch.setattr(user_repository, "list_users", lambda: (rosters.append(1), [caller])[1])
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: pytest.fail("roster should answer this"))
+
+    result = _execute("{ users { id email } }", token=signed_in)
+
+    assert result.errors is None, f"users failed: {_messages(result)}"
+    assert result.data == {"users": [{"id": "u_caller", "email": "a@b.c"}]}
+    assert len(rosters) == 1

--- a/backend/tests/test_resolver_gate_completeness.py
+++ b/backend/tests/test_resolver_gate_completeness.py
@@ -1,24 +1,25 @@
-"""Every GraphQL resolver calls an auth gate, or is on the exemption list below (#415).
+"""Every GraphQL root field has an authorization policy, and every plain route has a gate (#415, #423).
 
-Auth here is opt-in per resolver: `get_context` only stashes the request, and there is no middleware
-to catch a resolver that never asks. That makes "ungated" the silent default - the resolver works, it
-just also works for anonymous callers. `test_resolver_auth_gates.py` pins the gates we knew about;
-this test is the one that finds the ones nobody knew about.
+The property is the same one #415 established: no operation is reachable unauthenticated by accident.
+What changed with #423 is where it is decided and therefore what this file has to check.
 
-That gap was not hypothetical. All four resolvers in `app/schemas/user.py` shipped ungated, including
-`updateUserRoles`, which grants `Admin/Manager` - the role gating relay provisioning, relay deletion,
-buyer assignments and the GP job/buyer writes. An unauthenticated POST returned the full Clerk roster
-with emails, roles and GP buyer ids. It was found by accident while correcting an unrelated comment,
-and the sweep that followed turned up 91 more.
+Under #415 auth was opt-in per resolver - `require_user(info)` as the first line of 161 bodies - so
+"ungated" was the silent default and this test's job was to catch a body that forgot. It parsed the
+source of every resolver and asserted the line was there. That worked, and it could only ever detect
+an omission after somebody wrote it.
 
-This test parses the source rather than the schema, so it needs no database and no Strawberry
-introspection: for every function under `app/schemas/` decorated `@strawberry.field` or
-`@strawberry.mutation`, assert the body mentions one of the gates. It cannot prove the gate runs
-*first* or that the right gate was chosen - that is what the pin tests are for - only that asking was
-not forgotten entirely.
+Since #423 the default is refusal. `enforce_root_field` (app/auth_policy.py) runs in the schema
+extension before any resolver, and a field with no entry in ROOT_FIELD_POLICY and no place on the
+OPEN_OPERATIONS allowlist is REFUSED. So a forgotten policy is no longer a hole - it is a broken
+field. This test's job is now the other direction: prove the table still describes the whole schema,
+so nobody discovers a missing entry from a production 403.
 
-To deliberately leave a resolver open, add it to `_EXEMPT` with a reason. That makes an open resolver
-a reviewed decision instead of an oversight, which is the whole point.
+It asks the built Strawberry schema rather than the source, which is the authority on what a root
+field is actually called - `open_p_os` is `openPOs` to a caller, and a table keyed on the wrong one
+would fail closed on a field that looks covered.
+
+`test_resolver_auth_gates.py` is the complement: this file is coverage, that one is behaviour - that
+the extension actually refuses, first, and with the right code.
 """
 
 import ast
@@ -26,156 +27,106 @@ from pathlib import Path
 
 import pytest
 
-_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "app" / "schemas"
+from app.auth import ADMIN_ROLE, SHOP_ASSEMBLY_MANAGER_ROLE
+from app.auth_policy import OPEN_OPERATIONS, ROOT_FIELD_POLICY, ROSTER_BACKED, SIGNED_IN
+from main import schema
 
-# `require_admin_request` is deliberately absent: it takes a FastAPI Request, not a Strawberry Info,
-# so it is the gate for the plain HTTP routes in main.py and can never be a valid resolver gate.
-# Accepting it here would green-light `require_admin_request(info)`, which type-checks to nothing and
-# blows up at runtime on `info.headers`.
-_GATES = {"require_user", "require_admin", "require_role"}
+# The requirements a policy entry may name. A typo'd role - "Admin/Manger" - would otherwise be a
+# field nobody can call, since the check is a membership test against what Clerk returns.
+_VALID_REQUIREMENTS = {SIGNED_IN, ADMIN_ROLE, SHOP_ASSEMBLY_MANAGER_ROLE}
 
-# (module stem, resolver function name) -> why it is deliberately reachable without a gate.
-# Anything added here needs a reason that survives review, not a note that gating was inconvenient.
-_EXEMPT: dict[tuple[str, str], str] = {
-    # The relay calls this during one-time setup, before it holds any credential, so there is no
-    # Clerk session to gate on. It is not unauthenticated: `relay_repository.enroll_install` matches
-    # the enrollment token by hash, rejects an expired one, and rejects a reused one via the
-    # `enrolled_at` guard. The admin who minted the token is the authorization.
-    ("relay", "enroll_relay_install"): "authenticated by the single-use enrollment token, not Clerk",
-}
+_graphql_schema = schema._schema
+_ROOT_FIELDS = set(_graphql_schema.query_type.fields) | set(_graphql_schema.mutation_type.fields)
 
 
-def _resolver_functions(tree: ast.Module):
-    """Yield every function decorated @strawberry.field / @strawberry.mutation, at any nesting."""
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
-        for dec in node.decorator_list:
-            # Bare `@strawberry.field` is an Attribute; `@strawberry.field(...)` is a Call.
-            target = dec.func if isinstance(dec, ast.Call) else dec
-            if isinstance(target, ast.Attribute) and target.attr in {"field", "mutation"}:
-                yield node
-                break
-
-
-def _calls_a_gate(fn, gates=frozenset(_GATES)) -> bool:
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Call):
-            f = node.func
-            name = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
-            if name in gates:
-                return True
-    return False
-
-
-def _leading_call_name(stmt) -> str | None:
-    """The function called by a bare-expression or plain-assignment statement, if it is one.
-
-    Assignment counts because several resolvers legitimately keep the result:
-    ``auth = require_user(info)`` then read ``auth["user_id"]``.
-    """
-    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
-        call = stmt.value
-    elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
-        call = stmt.value
-    else:
-        return None
-    f = call.func
-    return f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
-
-
-def _gates_before_acting(fn) -> bool:
-    """The gate must be the first thing the body does, after any docstring."""
-    body = list(fn.body)
-    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
-        body = body[1:]
-    return bool(body) and _leading_call_name(body[0]) in _GATES
-
-
-def _all_resolvers():
-    # rglob, not glob: a resolver moved into a sub-package (app/schemas/gp/queries.py) must not fall
-    # out of the sweep just by moving.
-    rows = []
-    for path in sorted(_SCHEMAS_DIR.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for fn in _resolver_functions(tree):
-            rows.append((path.stem, fn))
-    return rows
-
-
-_RESOLVERS = _all_resolvers()
-
-# Every file that *looks* like it defines resolvers, decided by plain text rather than by the AST
-# walk this file is trying to police - so the two can disagree and be caught at it.
-_MODULES_WITH_DECORATORS = {
-    path.stem
-    for path in _SCHEMAS_DIR.rglob("*.py")
-    if "@strawberry.field" in (text := path.read_text(encoding="utf-8")) or "@strawberry.mutation" in text
-}
-
-
-def test_every_module_that_declares_resolvers_was_collected():
-    """Guard the guard. A bare count threshold is too weak: if the decorator predicate regressed and
-    warehouse.py's 46 resolvers stopped being collected, a `> 100` assertion would still pass with 115.
-    Comparing against a text scan catches a whole module dropping out, which is the realistic failure.
-    """
-    collected = {module for module, _ in _RESOLVERS}
-    missing = _MODULES_WITH_DECORATORS - collected
-    assert not missing, f"modules declare resolver decorators but none were collected from them: {sorted(missing)}"
-    assert len(_RESOLVERS) >= 155, f"only {len(_RESOLVERS)} resolvers collected; the AST walk likely regressed"
-
-
-@pytest.mark.parametrize(
-    "module, fn",
-    _RESOLVERS,
-    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
-)
-def test_resolver_calls_an_auth_gate(module, fn):
-    if (module, fn.name) in _EXEMPT:
-        pytest.skip(f"deliberately ungated: {_EXEMPT[(module, fn.name)]}")
-
-    assert _calls_a_gate(fn), (
-        f"{module}.{fn.name} (line {fn.lineno}) is a GraphQL resolver with no "
-        f"require_user/require_admin/require_role call. Nothing else enforces auth - add a gate, or "
-        f"add it to _EXEMPT in this file with a reason."
+def test_the_schema_still_has_the_root_fields_this_file_is_policing():
+    """Guard the guard. Every assertion below is a set comparison against the schema, so a schema that
+    came back empty - a renamed private attribute, a composition that stopped picking up the domain
+    query classes - would make all of them pass vacuously."""
+    assert len(_ROOT_FIELDS) >= 155, (
+        f"only {len(_ROOT_FIELDS)} root fields found on the schema; the introspection below likely "
+        f"regressed rather than the schema shrinking by a hundred fields"
+    )
+    assert _graphql_schema.subscription_type is None, (
+        "the schema grew a subscription type. Subscriptions do not go through the resolve hook the "
+        "same way; decide how they are gated before adding one, and extend this file to cover them."
     )
 
 
-@pytest.mark.parametrize(
-    "module, fn",
-    _RESOLVERS,
-    ids=[f"{module}.{fn.name}" for module, fn in _RESOLVERS],
-)
-def test_resolver_gates_before_it_acts(module, fn):
-    """A gate that runs after the work has already happened is not a gate.
+def test_every_root_field_has_a_policy_or_is_explicitly_open():
+    """The whole point of #423. A field in neither table is refused at runtime, so this failing means
+    a real operation is broken, not merely unguarded - but it is the same omission either way."""
+    uncovered = sorted(_ROOT_FIELDS - set(ROOT_FIELD_POLICY) - set(OPEN_OPERATIONS))
+    assert not uncovered, (
+        f"root fields with no authorization policy: {uncovered}. Add each to ROOT_FIELD_POLICY in "
+        f"app/auth_policy.py with what it requires, or - if it is genuinely reachable without a Clerk "
+        f"session - to OPEN_OPERATIONS with the reason. Until then the extension refuses them."
+    )
 
-    The pin tests in `test_resolver_auth_gates.py` prove ordering by monkeypatching a sentinel, but
-    only for the resolvers somebody listed. This covers every one of them, so a refactor that drops
-    `require_user(info)` below the `with SessionLocal()` block - letting an anonymous caller's write
-    land and only then rejecting them - fails here by name.
-    """
-    if (module, fn.name) in _EXEMPT:
-        pytest.skip(f"deliberately ungated: {_EXEMPT[(module, fn.name)]}")
 
-    assert _gates_before_acting(fn), (
-        f"{module}.{fn.name} (line {fn.lineno}) calls a gate, but not as its first statement. "
-        f"Move the gate above everything else in the body - work done before it runs is work done "
-        f"for an unauthenticated caller."
+def test_no_policy_entry_names_a_field_that_does_not_exist():
+    """A stale entry is dead weight that reads like coverage. It also hides the reverse mistake: a
+    renamed field leaves its old name behind in the table and the new one uncovered, and only the
+    check above would notice."""
+    stale = sorted((set(ROOT_FIELD_POLICY) | set(OPEN_OPERATIONS)) - _ROOT_FIELDS)
+    assert not stale, (
+        f"app/auth_policy.py names root fields the schema does not have: {stale}. Either they were "
+        f"renamed (update the entry) or removed (delete it)."
+    )
+
+
+def test_no_field_is_both_gated_and_open():
+    """OPEN_OPERATIONS is checked first, so an overlap would silently un-gate a field whose policy
+    entry says otherwise - the most expensive kind of duplicate."""
+    overlap = sorted(set(ROOT_FIELD_POLICY) & set(OPEN_OPERATIONS))
+    assert not overlap, (
+        f"{overlap} appear in both ROOT_FIELD_POLICY and OPEN_OPERATIONS. OPEN_OPERATIONS wins, so "
+        f"the policy entry is doing nothing. Delete whichever one is wrong."
+    )
+
+
+@pytest.mark.parametrize("field", sorted(ROOT_FIELD_POLICY), ids=sorted(ROOT_FIELD_POLICY))
+def test_policy_requirement_is_one_the_gate_understands(field):
+    requirement = ROOT_FIELD_POLICY[field]
+    assert requirement in _VALID_REQUIREMENTS, (
+        f"{field} requires {requirement!r}, which is neither SIGNED_IN nor a role this codebase "
+        f"grants ({sorted(_VALID_REQUIREMENTS - {SIGNED_IN})}). The gate tests membership against "
+        f"what Clerk returns, so a requirement nobody can hold locks the field for everyone."
+    )
+
+
+def test_every_open_operation_carries_its_reason():
+    """OPEN_OPERATIONS maps a field to why it is safe without a Clerk session. An empty reason makes
+    it an entry nobody has to defend, which is how the list stops meaning anything."""
+    unexplained = sorted(f for f, reason in OPEN_OPERATIONS.items() if not (reason or "").strip())
+    assert not unexplained, f"open operations with no stated reason: {unexplained}"
+
+
+def test_roster_backed_fields_are_role_gated():
+    """ROSTER_BACKED only picks which Clerk call answers a role requirement. A field that requires
+    nothing but SIGNED_IN has no role to look up, so listing it there buys a roster fetch for
+    nothing - and would suggest it is gated harder than it is."""
+    wrong = sorted(f for f in ROSTER_BACKED if ROOT_FIELD_POLICY.get(f, SIGNED_IN) == SIGNED_IN)
+    assert not wrong, (
+        f"{wrong} are in ROSTER_BACKED but require no role. Remove them: the roster is fetched to "
+        f"answer a role check, and these have none."
     )
 
 
 # --- plain FastAPI routes in main.py (#422) -------------------------------------------------------
 #
-# The sweep above walks app/schemas/ only, so /testing/clerk-sign-in - a plain @app.get route that
-# mints a real Clerk session for any staff email - sat outside it with no auth at all. Routes get the
-# same treatment as resolvers: call a gate or appear below with a reason. There is no ordering check
-# here, and that is deliberate - the gated routes check TESTING_ENABLED before auth so a production
-# deployment refuses outright rather than leaking whether the credential would have been good enough.
+# Untouched by #423, and deliberately so. The schema extension only runs for GraphQL; a plain
+# @app.get route like /testing/clerk-sign-in - which mints a real Clerk session for any staff email -
+# has nothing in front of it, which is exactly how it sat with no auth at all until #422. Routes get
+# the same treatment as root fields did: call a gate or appear below with a reason. There is no
+# ordering check here, and that is deliberate - the gated routes check TESTING_ENABLED before auth so
+# a production deployment refuses outright rather than leaking whether the credential would have been
+# good enough.
 
 _MAIN_PY = Path(__file__).resolve().parent.parent / "main.py"
 
-# The only gate that fits a bare FastAPI Request. require_user/require_admin/require_role unwrap a
-# Strawberry Info and can never appear in a route, mirroring the exclusion note on _GATES above.
+# The only gate that fits a bare FastAPI Request. The GraphQL path's helpers unwrap a Strawberry Info
+# or a Strawberry context and can never appear in a route.
 _ROUTE_GATES = frozenset({"require_admin_request"})
 
 # route function name -> why it is deliberately reachable without require_admin_request.
@@ -202,11 +153,21 @@ def _route_functions(tree: ast.Module):
                 break
 
 
+def _calls_a_gate(fn, gates) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            f = node.func
+            name = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if name in gates:
+                return True
+    return False
+
+
 _ROUTES = list(_route_functions(ast.parse(_MAIN_PY.read_text(encoding="utf-8"))))
 
 
 def test_every_main_py_route_was_collected():
-    """Guard the guard, same shape as the module-collection test above: if the decorator predicate
+    """Guard the guard, same shape as the root-field count above: if the decorator predicate
     regressed, the parametrized test below would silently shrink instead of failing."""
     collected = {fn.name for fn in _ROUTES}
     expected = {"health", "relay_link", "reset_data", "get_clerk_sign_in_token"}
@@ -221,6 +182,7 @@ def test_route_calls_an_auth_gate(fn):
 
     assert _calls_a_gate(fn, _ROUTE_GATES), (
         f"main.py route {fn.name} (line {fn.lineno}) has no require_admin_request call. Nothing else "
-        f"enforces auth on a plain FastAPI route - add the gate (or an equivalent explicit credential "
-        f"check alongside it), or add it to _ROUTE_EXEMPT in this file with a reason."
+        f"enforces auth on a plain FastAPI route - the GraphQL policy table does not cover them - so "
+        f"add the gate (or an equivalent explicit credential check alongside it), or add it to "
+        f"_ROUTE_EXEMPT in this file with a reason."
     )

--- a/backend/tests/test_shop_assembly_members.py
+++ b/backend/tests/test_shop_assembly_members.py
@@ -1,14 +1,19 @@
 """shopAssemblyMembers query (#330): the manager assignment picker.
 
-Covers the repository role filter, the resolver's dict->ClerkUser mapping, and the require_role gate
-that restricts the query to a Shop Assembly Manager. Resolver is exercised directly against a
-ShopAssemblyQueries instance (matches test_gp_relay_reads.py)."""
+Covers the repository role filter, the resolver's dict->ClerkUser mapping, and `require_role` - which
+since #423 is no longer the field's gate (that is the policy table, applied by the schema extension)
+but is still what `assignOpenings` calls in its body for the one requirement a field-level table
+cannot express: anyone may self-assign, only a manager may assign somebody else.
+
+Resolvers are exercised directly against a ShopAssemblyQueries / ShopAssemblyMutations instance
+(matches test_gp_relay_reads.py)."""
 
 import uuid
 
 import pytest
 
 from app.auth import SHOP_ASSEMBLY_MANAGER_ROLE, ForbiddenError, require_role
+from app.auth_policy import ROOT_FIELD_POLICY
 from app.repositories import shop_assembly_repository, user_repository
 from app.schemas import shop_assembly as shop_assembly_module
 from app.schemas.inputs import AssignOpeningsInput
@@ -37,7 +42,7 @@ class FakeInfo:
         self.context = {"request": request}
 
 
-def test_list_shop_assembly_members_filters_by_role(monkeypatch):
+def test_shop_assembly_members_filters_by_role():
     users = [
         _summary("mgr", ["Shop Assembly Manager"]),
         _summary("worker", ["Shop Assembly User"]),
@@ -46,30 +51,29 @@ def test_list_shop_assembly_members_filters_by_role(monkeypatch):
         _summary("admin", ["Admin/Manager"]),
         _summary("none", []),
     ]
-    monkeypatch.setattr(user_repository, "list_users", lambda: users)
 
-    members = user_repository.list_shop_assembly_members()
+    members = user_repository.shop_assembly_members(users)
 
     assert {m["id"] for m in members} == {"mgr", "worker", "both"}
 
 
-def test_resolver_gates_on_manager_role_and_maps_to_type(monkeypatch):
-    calls = []
-    monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: calls.append(role))
-    monkeypatch.setattr(
-        user_repository,
-        "list_shop_assembly_members",
-        lambda: [_summary("mgr", ["Shop Assembly Manager"]), _summary("worker", ["Shop Assembly User"])],
-    )
+def test_resolver_maps_the_request_roster_to_type(monkeypatch):
+    """The roster comes from the request context - the same one the gate checked this caller's
+    Shop Assembly Manager role against (ROSTER_BACKED in app/auth_policy.py), so authorizing the
+    query and answering it are one Clerk call."""
+    roster = [_summary("mgr", ["Shop Assembly Manager"]), _summary("worker", ["Shop Assembly User"])]
+    monkeypatch.setattr(shop_assembly_module, "user_roster", lambda context: roster)
 
     result = ShopAssemblyQueries().shop_assembly_members(FakeInfo())
 
-    assert calls == [SHOP_ASSEMBLY_MANAGER_ROLE]
+    assert ROOT_FIELD_POLICY["shopAssemblyMembers"] == SHOP_ASSEMBLY_MANAGER_ROLE
     assert [u.id for u in result] == ["mgr", "worker"]
     assert result[0].email == "mgr@example.com"
 
 
 def test_require_role_forbids_when_role_absent(monkeypatch):
+    """`require_role` is the in-body check, not the field gate. It reads the request-scoped role memo,
+    so verify_clerk_token and get_user_roles are what it ends up calling on a cold context."""
     monkeypatch.setattr("app.auth.verify_clerk_token", lambda token: {"sub": "u1"})
     monkeypatch.setattr(user_repository, "get_user_roles", lambda uid: ["Shop Assembly User"])
 
@@ -115,7 +119,7 @@ def _assign_input(assigned_to_user_id):
 
 def test_assign_openings_self_assign_skips_manager_gate(monkeypatch):
     role_calls = []
-    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
+    monkeypatch.setattr(shop_assembly_module, "current_user", lambda info: {"user_id": "caller"})
     monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: role_calls.append(role))
     _bypass_assign_db(monkeypatch)
 
@@ -126,7 +130,7 @@ def test_assign_openings_self_assign_skips_manager_gate(monkeypatch):
 
 def test_assign_openings_to_other_requires_manager_role(monkeypatch):
     role_calls = []
-    monkeypatch.setattr(shop_assembly_module, "require_user", lambda info: {"user_id": "caller"})
+    monkeypatch.setattr(shop_assembly_module, "current_user", lambda info: {"user_id": "caller"})
     monkeypatch.setattr(shop_assembly_module, "require_role", lambda info, role: role_calls.append(role))
     _bypass_assign_db(monkeypatch)
 

--- a/backend/tests/test_suggest_vendor_for_manufacturer.py
+++ b/backend/tests/test_suggest_vendor_for_manufacturer.py
@@ -1,12 +1,11 @@
 """Query.suggest_vendor_for_manufacturer (issue #232): saved-mapping hit vs ranked live vendors.
 
-Follows test_gp_relay_reads.py: resolvers exercised directly with require_user monkeypatched out. The
-mapping lookup is patched so these run without a DB - the resolver only opens a session to call lookup,
-which never issues a query here."""
+Follows test_gp_relay_reads.py: the resolver is exercised directly, which since #423 needs no auth
+setup - the gate is a schema extension in front of it, not a line inside it. The mapping lookup is
+patched so these run without a DB; the resolver only opens a session to call lookup, which never
+issues a query here."""
 
 import asyncio
-
-import pytest
 
 from app.repositories import manufacturer_vendor_map_repository as map_repo
 from app.schemas import relay as relay_module
@@ -15,11 +14,6 @@ from app.schemas.queries import Query
 
 class FakeInfo:
     context = {"request": None}
-
-
-@pytest.fixture(autouse=True)
-def _bypass_require_user(monkeypatch):
-    monkeypatch.setattr(relay_module, "require_user", lambda info: {"user_id": "test-user"})
 
 
 class FakeGateway:


### PR DESCRIPTION
Closes #423.

#415's 161 hand-written gates worked but stayed opt-in: a new resolver is public until someone remembers a line, the rule was spread across 15 modules, and require_admin cost a Clerk round trip per root field. this inverts the default.

new backend/app/auth_policy.py
- ROOT_FIELD_POLICY, 160 entries, field -> SIGNED_IN sentinel or a Clerk role name, grouped by defining module. lifted from the gate each body called, not re-derived.
- OPEN_OPERATIONS, field -> why it is safe without Clerk. currently only enrollRelayInstall, carrying the old _EXEMPT reasoning verbatim.
- enforce_root_field: a field in neither table is REFUSED, with an error log. refused as FORBIDDEN, not UNAUTHENTICATED, so the #429 Apollo link does not re-mint and replay in a loop against a field that will never be callable.

extension: ErrorHandlerExtension renamed ResolverGuardExtension, gate added inside its existing try so a refusal is mapped by the same path as any other AppError - the frontend keys its #429 re-mint off extensions.code, and as two extensions that would depend on list order with nothing failing if swapped. resolve() is graphql-core middleware running per FIELD, so a second extension would double that wrapper cost on every scalar of every row. only root fields are checked (info.path.prev is None); introspection (__schema/__type/__typename) is skipped explicitly, it exposes shape not data and was reachable before.

bodies: require_user/require_admin deleted from app/auth.py, 117 bare gate calls removed - there is no line left to forget. 43 sites that needed the identity now call current_user(info), documented as a read of the already-verified identity rather than a gate. require_role kept for the one requirement that is not a property of the field: assignOpenings lets anyone self-assign and only a Shop Assembly Manager assign someone else (#330), so its table entry is SIGNED_IN and the conditional check stays in the body unchanged. #427's actor resolution and #428's caller scoping are intact.

per-request caching on the context dict get_context builds per request (_auth_user_id, _auth_roles, _auth_user_roster). cannot leak across requests: Strawberry wraps get_context as a FastAPI dependency, so it runs once per request and returns a new dict; there is no process-global keyed cache. refusals are memoised too, so an expired token costs one verify for the request rather than one per root field. measured: 3 root fields -> 1 JWT verification, 3 admin fields -> 1 role lookup.

adminStats: ROSTER_BACKED = {adminStats, users, shopAssemblyMembers} - the three fields whose bodies enumerate the whole roster anyway. for those the gate takes the caller's roles out of that one list_users() call instead of adding its own GET /users/{id}. 2 Clerk round trips -> 1. explicitly a performance hint, never an authorization input; every other admin field stays on the single-user lookup, pinned by a test.

also fixes a latent bug in the same path: user_repository._headers raised AppError with one argument, but AppError requires a code, so a backend without CLERK_SECRET_KEY got a TypeError instead of the misconfiguration message. more reachable now that the gate calls list_users() for roster-backed fields.

tests reshaped, property preserved. completeness now introspects the built schema (the authority on names - open_p_os is openPOs) and asserts every root field is in the table or the allowlist, no stale entry, nothing in both (the allowlist would silently win), every requirement is one the gate understands (a typo'd role locks a field for everyone), every open operation states a reason, subscription_type is None so adding one forces a decision. the #422 main.py route sweep is unchanged. auth_gates is now behaviour through the real schema, with the sentinel idea inverted: each test stubs what the RESOLVER touches first (SessionLocal), so a refusal arriving with the sentinel un-fired proves the gate ran first. plus per-field pins driven off the table - all 160 gated fields refuse an anonymous caller, all 34 role-gated fields refuse a caller without the role and admit one with it.

independent cross-check before merge: AST-extracted every resolver's gate from master and diffed against the new table. 161 resolvers = 160 policy entries + 1 allowlisted, every requirement matches exactly, 32 admin fields preserved, no downgrades. the only apparent difference was assignOpenings, where master's require_role is conditional inside `if not is_self` - preserved verbatim.

ruff clean. pytest 888 passed / 537 skipped, against a measured master baseline of 849/539 - the suite grew. frontend 390 passed / 39 files, lint 0 errors, build OK. end-to-end through the real router: anonymous `{ warehouses { id } }` -> data null with extensions.code UNAUTHENTICATED; introspection still reachable.

note: the project CLAUDE.md's resolver-gate convention is now wrong in every particular (resolvers call no gate, require_user/require_admin no longer exist, the exemption list is OPEN_OPERATIONS). it is gitignored so it cannot be updated here; updated separately.