### PR TITLE
chore(graphql): drop the deprecated client-supplied actor arguments (#438)

### DIFF
--- a/backend/app/graphql/import.graphql
+++ b/backend/app/graphql/import.graphql
@@ -86,7 +86,6 @@ input ClassificationInput {
 
 input ShippingOutPRDraftInput {
   request_number: String!
-  requested_by: String!
   items: [ShippingOutPRDraftItemInput!]!
 }
 

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -80,10 +80,10 @@ type Mutation {
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
   # Accept gate (#293). Any signed-in user. Accept mints the warehouse PullRequest;
   # the warehouse approve handles shortfalls. The approval is recorded against the
-  # Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED, kept only so
-  # a frontend from the previous deploy still validates.
-  acceptShippingOutRequest(id: ID!, acceptedBy: String @deprecated(reason: "ignored; actor is the caller")): ShippingOutRequest!
-  rejectShippingOutRequest(id: ID!, rejectedBy: String @deprecated(reason: "ignored; actor is the caller"), reason: String): ShippingOutRequest!
+  # Clerk-authenticated caller (#427). The acceptedBy/rejectedBy arguments lingered as ignored
+  # @deprecated no-ops for one deploy so stale tabs still validated, and came out in #438.
+  acceptShippingOutRequest(id: ID!): ShippingOutRequest!
+  rejectShippingOutRequest(id: ID!, reason: String): ShippingOutRequest!
   # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
   # PullRequest. Refused if the warehouse has already worked the pull.
   reopenShippingOutRequest(id: ID!): ShippingOutRequest!

--- a/backend/app/graphql/shop_assembly.graphql
+++ b/backend/app/graphql/shop_assembly.graphql
@@ -123,7 +123,6 @@ input InstallReplacementInput {
   shop_assembly_opening_item_id: ID!
   # Bounded by replacement_pending_quantity, so this can never inflate a leaf.
   quantity: Int!
-  performed_by: String
 }
 
 input AssignOpeningsInput {
@@ -147,7 +146,6 @@ input AssemblyProgressItemInput {
 input RecordAssemblyProgressInput {
   opening_id: ID!
   items: [AssemblyProgressItemInput!]!
-  performed_by: String
 }
 
 # --- Pipeline observability (#344) ---
@@ -266,7 +264,6 @@ input CompleteOpeningInput {
   aisle: String
   row: String
   bay: String
-  completed_by: String
 }
 
 # Every field below is gated on an authenticated caller (#339) except where a stronger role
@@ -319,10 +316,10 @@ type Mutation {
   # Accept gate (#293). Any signed-in user. Accept mints the warehouse PullRequest and
   # is a **pure human gate** since #342: the hardware was reserved when the request was created, so
   # nothing is re-checked here. Reject is what releases that reservation. The approval is recorded
-  # against the Clerk-authenticated caller (#427) - acceptedBy/rejectedBy are accepted and IGNORED,
-  # kept only so a frontend from the previous deploy still validates.
-  acceptShopAssemblyRequest(id: ID!, acceptedBy: String @deprecated(reason: "ignored; actor is the caller")): ShopAssemblyRequest!
-  rejectShopAssemblyRequest(id: ID!, rejectedBy: String @deprecated(reason: "ignored; actor is the caller"), reason: String): ShopAssemblyRequest!
+  # against the Clerk-authenticated caller (#427). The acceptedBy/rejectedBy arguments lingered as
+  # ignored @deprecated no-ops for one deploy so stale tabs still validated, and came out in #438.
+  acceptShopAssemblyRequest(id: ID!): ShopAssemblyRequest!
+  rejectShopAssemblyRequest(id: ID!, reason: String): ShopAssemblyRequest!
   # Reopen (#325). Undoes an erroneous accept: APPROVED -> PENDING, hard-deletes the minted
   # PullRequest and re-points the openings off it. Refused if the warehouse has already worked the pull.
   reopenShopAssemblyRequest(id: ID!): ShopAssemblyRequest!

--- a/backend/app/graphql/warehouse.graphql
+++ b/backend/app/graphql/warehouse.graphql
@@ -270,7 +270,6 @@ type ConfirmPickResult {
 input StagePullOpeningsInput {
   pull_request_id: ID!
   opening_ids: [ID!]!
-  staged_by: String!
 }
 
 type StagePullOpeningsResult {
@@ -284,7 +283,6 @@ type StagePullOpeningsResult {
 
 input CancelPullRequestInput {
   id: ID!
-  cancelled_by: String!
   reason: String
 }
 
@@ -471,7 +469,6 @@ input LocationInput {
 input ConfirmShipmentInput {
   project_id: ID!
   packing_slip_number: String!
-  shipped_by: String!
   items: [ShipmentItemInput!]!
 }
 
@@ -487,7 +484,6 @@ input ShipmentItemInput {
 input CreateShipmentReturnInput {
   packing_slip_id: ID!
   warehouse_id: ID!
-  returned_by: String!
   reference: String
   items: [ShipmentReturnItemInput!]!
 }
@@ -550,27 +546,26 @@ type Mutation {
   createReceive(input: CreateReceiveInput!): ReceiveRecord!
   # Issue #427: the actor on every audit and history row is the Clerk-authenticated caller
   # (current_user -> resolve_display_name), never an argument. The startedBy / enteredBy / pickedBy /
-  # fetchedBy / completedBy arguments below are accepted and IGNORED, and are nullable so they can
-  # carry @deprecated; they exist only so a frontend from the previous deploy still validates, and
-  # are dropped once none reference them.
+  # fetchedBy / completedBy arguments these mutations used to take were left in as ignored
+  # @deprecated no-ops so a frontend from the previous deploy still validated; #438 dropped them.
   # Claim a pending pull and open it for picking (#367). Nothing moves in inventory - this is what
   # approvePullRequest was, minus everything that touched stock. The pull is assigned to the caller.
-  startPullRequestPick(id: ID!, startedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequest!
+  startPullRequestPick(id: ID!): PullRequest!
   # Save the half-keyed pick sheet (#367). Replace-all, not merge: the paper is the authority.
   # Shape is validated, availability deliberately is not - a draft is a note, not a claim.
-  savePickDraft(pullRequestId: ID!, lines: [PickLineInput!]!, enteredBy: String @deprecated(reason: "ignored; actor is the caller")): PickSheet!
+  savePickDraft(pullRequestId: ID!, lines: [PickLineInput!]!): PickSheet!
   # Deduct exactly the rows the picker dictated and consume the claim behind them (#367). Three hard
   # ceilings: the row's available units, what the pull asked for, and what is free once other
   # requests' reservations are counted (CONFLICT when that one is hit, so #342 holds). A
   # confirmation that does not cover everything returns SHORT and is resumable.
-  confirmPick(pullRequestId: ID!, lines: [PickLineInput!]!, pickedBy: String @deprecated(reason: "ignored; actor is the caller")): ConfirmPickResult!
+  confirmPick(pullRequestId: ID!, lines: [PickLineInput!]!): ConfirmPickResult!
   # Tick (or untick) one assembled leaf off a shipping pull's fetch list (#367). Nothing moves in
   # inventory - the leaf's hardware left it at assembly.
-  setPullItemFetched(itemId: ID!, fetched: Boolean!, fetchedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequestItem!
+  setPullItemFetched(itemId: ID!, fetched: Boolean!): PullRequestItem!
   # Close the whole pull. Since #343 this reads as "stage everything still outstanding and finish":
   # any opening not yet confirmed individually is flipped to PULLED and stamped with the caller.
   # Refused until the pick is confirmed (#367).
-  completePullRequest(id: ID!, completedBy: String @deprecated(reason: "ignored; actor is the caller")): PullRequest!
+  completePullRequest(id: ID!): PullRequest!
   # Confirm that the carts for these openings of a picked shop-assembly pull are built (#343).
   # Each one becomes assignable and workable immediately; staging the last completes the pull.
   # Nothing moves in inventory - the deduction and the source request's reservation were both spent

--- a/backend/app/schemas/buyer.py
+++ b/backend/app/schemas/buyer.py
@@ -1,7 +1,6 @@
 """Buyer assignment queries + mutations (issue #216: per-buyer project authorization)."""
 
 import uuid
-from typing import Annotated
 
 import strawberry
 
@@ -60,16 +59,6 @@ class BuyerMutations:
         info: strawberry.Info,
         buyer_id: str,
         project_ids: list[strawberry.ID],
-        # Accepted and ignored: cost-code designation was removed, but an admin tab loaded before that
-        # deploy still sends this argument, and an unknown argument fails GraphQL validation outright.
-        # (The current frontend keeps sending a defaulted [] too, so a frontend deployed ahead of a
-        # pre-removal backend still satisfies the old required argument.) Dropped once deployed
-        # frontends stop sending it, together with the field on BuyerAssignment. deprecation_reason
-        # makes the no-op visible in introspection/GraphiQL, not just in this comment.
-        cost_codes: Annotated[
-            list[str] | None,
-            strawberry.argument(deprecation_reason="cost-code designation removed; ignored"),
-        ] = None,
     ) -> BuyerAssignment:
         """Issue #216: upsert a buyer's whole assignment (the projects they may order for). Admin."""
         with SessionLocal() as session:

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -189,7 +189,6 @@ class ImportMutations:
             "shipping_out_pr_drafts": [
                 {
                     "request_number": pr.request_number,
-                    "requested_by": pr.requested_by,
                     "items": [
                         {
                             "item_type": item.item_type.value,

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -1,5 +1,4 @@
 from datetime import date
-from typing import Annotated
 
 import strawberry
 
@@ -11,19 +10,6 @@ from .enums import (
     ReturnDisposition,
     TransferSourceType,
 )
-
-# Issue #427: every mutation that stamps an actor on an audit or history row now takes that actor
-# from the Clerk token the gate verified, never from its arguments - the old way let any signed-in
-# user file their work under someone else's name.
-#
-# The arguments themselves stay in the schema, accepted and ignored, for the same reason #430 kept
-# `saveBuyerAssignment(costCodes:)`: a tab loaded against the previous deploy still sends them, and
-# an unknown argument fails GraphQL validation outright, so removing them would break every open
-# session at once. They also became nullable, because a required argument cannot carry @deprecated -
-# and widening required to optional is safe in the other direction, since old clients still send a
-# value. Dropped once no deployed frontend references them.
-ACTOR_IGNORED = "the actor is taken from the authenticated caller (#427); this value is ignored"
-IgnoredActorArg = Annotated[str | None, strawberry.argument(deprecation_reason=ACTOR_IGNORED)]
 
 
 @strawberry.input
@@ -170,7 +156,6 @@ class ShippingOutPRDraftItemInput:
 @strawberry.input
 class ShippingOutPRDraftInput:
     request_number: str
-    requested_by: str
     items: list[ShippingOutPRDraftItemInput] = strawberry.field(default_factory=list)
 
 
@@ -338,7 +323,6 @@ class TransferInventoryInput:
     dest_aisle: str
     dest_row: str
     dest_bay: str
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -458,7 +442,6 @@ class ShipmentItemInput:
 class ConfirmShipmentInput:
     project_id: strawberry.ID
     packing_slip_number: str
-    shipped_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     items: list[ShipmentItemInput] = strawberry.field(default_factory=list)
 
 
@@ -475,7 +458,6 @@ class ShipmentReturnItemInput:
 class CreateShipmentReturnInput:
     packing_slip_id: strawberry.ID
     warehouse_id: strawberry.ID
-    returned_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     reference: str | None = None
     items: list[ShipmentReturnItemInput] = strawberry.field(default_factory=list)
 
@@ -512,7 +494,6 @@ class AssemblyProgressItemInput:
 class RecordAssemblyProgressInput:
     opening_id: strawberry.ID
     items: list[AssemblyProgressItemInput] = strawberry.field(default_factory=list)
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -522,7 +503,6 @@ class InstallReplacementInput:
 
     shop_assembly_opening_item_id: strawberry.ID
     quantity: int
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -548,7 +528,6 @@ class StagePullOpeningsInput:
 
     pull_request_id: strawberry.ID
     opening_ids: list[strawberry.ID]
-    staged_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -559,7 +538,6 @@ class CancelPullRequestInput:
     and the refusal names them. `reason` is optional but shown to whoever raised the pull."""
 
     id: strawberry.ID
-    cancelled_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
     reason: str | None = None
 
 
@@ -569,7 +547,6 @@ class CompleteOpeningInput:
     aisle: str | None = None
     row: str | None = None
     bay: str | None = None
-    completed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 # ---------------------------------------------------------------------------
@@ -586,7 +563,6 @@ class DestockInventoryInput:
     target_aisle: str | None = None
     target_row: str | None = None
     target_bay: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -599,7 +575,6 @@ class AllocateStockToProjectInput:
     target_aisle: str | None = None
     target_row: str | None = None
     target_bay: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -607,7 +582,6 @@ class AdjustStockQuantityInput:
     stock_item_id: strawberry.ID
     new_quantity: int
     reason_text: str
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -616,7 +590,6 @@ class MoveStockLocationInput:
     new_aisle: str
     new_row: str
     new_bay: str
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -626,7 +599,6 @@ class ReclassifyStockItemInput:
     new_product_code: str
     quantity: int
     reason_text: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -634,7 +606,6 @@ class ReportInventoryDeficiencyInput:
     inventory_location_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -654,7 +625,6 @@ class OverrideInventoryQuantityInput:
     reason_text: str
     # required when new_quantity increases the row; ignored on a decrease. quantities must sum to the delta.
     destinations: list[OverrideDestinationInput] = strawberry.field(default_factory=list)
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -662,7 +632,6 @@ class ReportStockDeficiencyInput:
     stock_item_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -670,7 +639,6 @@ class ReportDeficiencyAtAssemblyInput:
     shop_assembly_opening_item_id: strawberry.ID
     quantity: int
     reason_text: str | None = None
-    performed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)
 
 
 @strawberry.input
@@ -683,4 +651,3 @@ class ResolveDeficiencyInput:
     reason_text: str | None = None
     rma_reference: str | None = None
     destock_source: DestockSource | None = None
-    reviewed_by: str | None = strawberry.field(default=None, deprecation_reason=ACTOR_IGNORED)

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -15,7 +15,7 @@ from .converters import (
     shipping_out_request_to_type,
 )
 from .enums import ShippingOutRequestStatus
-from .inputs import ConfirmShipmentInput, CreateShipmentReturnInput, IgnoredActorArg
+from .inputs import ConfirmShipmentInput, CreateShipmentReturnInput
 from .types import (
     PackingSlip,
     ReturnableLine,
@@ -89,9 +89,7 @@ class ShippingQueries:
 @strawberry.type
 class ShippingMutations:
     @strawberry.mutation
-    def accept_shipping_out_request(
-        self, info: strawberry.Info, id: strawberry.ID, accepted_by: IgnoredActorArg = None
-    ) -> ShippingOutRequest:
+    def accept_shipping_out_request(self, info: strawberry.Info, id: strawberry.ID) -> ShippingOutRequest:
         """Accept a PENDING shipping-out request (#293). Open to any signed-in user. Mints the
         warehouse PullRequest (SHIPPING_OUT, PENDING) from the request's items; the warehouse
         approve handles any inventory shortfall (no gate here).
@@ -109,7 +107,7 @@ class ShippingMutations:
 
     @strawberry.mutation
     def reject_shipping_out_request(
-        self, info: strawberry.Info, id: strawberry.ID, rejected_by: IgnoredActorArg = None, reason: str | None = None
+        self, info: strawberry.Info, id: strawberry.ID, reason: str | None = None
     ) -> ShippingOutRequest:
         """Reject a PENDING shipping-out request (#293). Open to any signed-in user. Recorded against
         the Clerk-authenticated caller (#427)."""
@@ -141,7 +139,7 @@ class ShippingMutations:
 
         `shippedBy` is printed on the slip and shown in the shipments grid, so it is the record of
         who released the hardware. It is the Clerk-authenticated caller as of #427; the input field
-        is still accepted and ignored."""
+        that used to name it was dropped in #438."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         from app.models.enums import PullRequestItemType
@@ -178,7 +176,7 @@ class ShippingMutations:
     @strawberry.mutation
     def create_shipment_return(self, info: strawberry.Info, input: CreateShipmentReturnInput) -> ShipmentReturn:
         """Book hardware back off a packing slip. `returnedBy` is the Clerk-authenticated caller
-        (#427); the input field is still accepted and ignored."""
+        (#427); the input field that used to name it was dropped in #438."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         from app.models.enums import ReturnDisposition

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -22,7 +22,6 @@ from .enums import ShopAssemblyRequestStatus
 from .inputs import (
     AssignOpeningsInput,
     CompleteOpeningInput,
-    IgnoredActorArg,
     InstallReplacementInput,
     RecordAssemblyProgressInput,
 )
@@ -151,9 +150,7 @@ class ShopAssemblyQueries:
 @strawberry.type
 class ShopAssemblyMutations:
     @strawberry.mutation
-    def accept_shop_assembly_request(
-        self, info: strawberry.Info, id: strawberry.ID, accepted_by: IgnoredActorArg = None
-    ) -> ShopAssemblyRequest:
+    def accept_shop_assembly_request(self, info: strawberry.Info, id: strawberry.ID) -> ShopAssemblyRequest:
         """Accept a PENDING shop-assembly request (#293). Open to any signed-in user.
 
         A pure human approval gate since #342: it mints the warehouse PullRequest and approves the
@@ -175,7 +172,7 @@ class ShopAssemblyMutations:
 
     @strawberry.mutation
     def reject_shop_assembly_request(
-        self, info: strawberry.Info, id: strawberry.ID, rejected_by: IgnoredActorArg = None, reason: str | None = None
+        self, info: strawberry.Info, id: strawberry.ID, reason: str | None = None
     ) -> ShopAssemblyRequest:
         """Reject a PENDING shop-assembly request (#293). Open to any signed-in user. Recorded
         against the Clerk-authenticated caller (#427), same reasoning as the accept."""

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -2,10 +2,10 @@
 
 Every mutation here writes an audit row, and since #427 the actor on it is the Clerk-authenticated
 caller (`current_user` -> `resolve_display_name`), never the request's own `performedBy`/`reviewedBy`
-field. Those input fields are still accepted so a frontend from the previous deploy keeps working;
-they are ignored. Before the change these rows carried whatever the client sent, defaulting to the
-literal strings "Admin/Manager" or "Warehouse" - which is what most of them actually stored, because
-the stock modals hardcoded exactly those two.
+field. Those input fields survived #427 as ignored no-ops so a frontend from the previous deploy kept
+validating, and came out of the schema entirely in #438. Before the change these rows carried
+whatever the client sent, defaulting to the literal strings "Admin/Manager" or "Warehouse" - which is
+what most of them actually stored, because the stock modals hardcoded exactly those two.
 """
 
 import uuid

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1524,16 +1524,6 @@ class BuyerAssignment:
 
     buyer_id: str
     projects: list[BuyerAssignmentProject]
-    # Always []. Per-buyer cost-code designation was removed (every code GP reports active for the job
-    # is selectable), but a browser tab loaded before that deploy still asks for this field, and an
-    # unknown field is a GraphQL validation error the frontend's chunk-error boundary cannot catch.
-    # Kept until deployed frontends no longer request it, then dropped with the field on the mutation.
-    # Known limit of the shim: it preserves schema validity, not the old behavior - a stale PO tab
-    # filters the job's GP codes against this empty list, so its cost-code dropdown reads empty
-    # ("No cost codes defined for this job in GP") until the tab is reloaded.
-    cost_codes: list[str] = strawberry.field(
-        default_factory=list, deprecation_reason="cost-code designation removed; always empty"
-    )
 
 
 @strawberry.type

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -32,7 +32,6 @@ from .inputs import (
     CancelPullRequestInput,
     CreateReceiveInput,
     CreateWarehouseInput,
-    IgnoredActorArg,
     OverrideInventoryQuantityInput,
     PickLineInput,
     StagePullOpeningsInput,
@@ -752,9 +751,7 @@ class WarehouseMutations:
 
     # Pull Requests - the pick (#367)
     @strawberry.mutation
-    def start_pull_request_pick(
-        self, info: strawberry.Info, id: strawberry.ID, started_by: IgnoredActorArg = None
-    ) -> PullRequest:
+    def start_pull_request_pick(self, info: strawberry.Info, id: strawberry.ID) -> PullRequest:
         """Claim a pending pull and open it for picking (#367). Nothing moves in inventory.
 
         This is what `approvePullRequest` used to be, minus everything that touched stock. The
@@ -763,8 +760,9 @@ class WarehouseMutations:
         was picked or from where.
 
         Open to any signed-in user - it assigns the pull to the caller, so it must not be reachable
-        anonymously. The pull is assigned to the Clerk-authenticated caller (#427), not to whatever
-        `startedBy` said - the assignment is what the whole pick is then attributed to."""
+        anonymously. The pull is assigned to the Clerk-authenticated caller (#427), never to a name
+        the client picks - the assignment is what the whole pick is then attributed to. The old
+        `startedBy` argument that let it be picked came out in #438."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
@@ -780,7 +778,6 @@ class WarehouseMutations:
         info: strawberry.Info,
         pull_request_id: strawberry.ID,
         lines: list[PickLineInput],
-        entered_by: IgnoredActorArg = None,
     ) -> PickSheet:
         """Save the half-keyed pick sheet without moving anything (#367).
 
@@ -817,7 +814,6 @@ class WarehouseMutations:
         info: strawberry.Info,
         pull_request_id: strawberry.ID,
         lines: list[PickLineInput],
-        picked_by: IgnoredActorArg = None,
     ) -> ConfirmPickResult:
         """Deduct exactly the rows the picker dictated, and consume the claim behind them (#367).
 
@@ -881,7 +877,6 @@ class WarehouseMutations:
         info: strawberry.Info,
         item_id: strawberry.ID,
         fetched: bool,
-        fetched_by: IgnoredActorArg = None,
     ) -> PullRequestItem:
         """Tick (or untick) one assembled leaf off a shipping pull's fetch list (#367).
 
@@ -900,16 +895,15 @@ class WarehouseMutations:
             return pull_request_item_to_type(item)
 
     @strawberry.mutation
-    def complete_pull_request(
-        self, info: strawberry.Info, id: strawberry.ID, completed_by: IgnoredActorArg = None
-    ) -> PullRequest:
+    def complete_pull_request(self, info: strawberry.Info, id: strawberry.ID) -> PullRequest:
         """Close the whole pull in one go. Since #343 this reads as "stage everything still
         outstanding and finish": any opening not yet confirmed individually is flipped to PULLED and
         stamped here.
 
         That stamp is the Clerk-authenticated caller as of #427. It was the client's `completedBy`
         string, which made this the clearest example of the bug: one call could put any name on every
-        opening the pull staged, and the staging panel shows exactly that name."""
+        opening the pull staged, and the staging panel shows exactly that name. The argument was
+        removed outright in #438."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:

--- a/backend/tests/test_resolver_actor_provenance.py
+++ b/backend/tests/test_resolver_actor_provenance.py
@@ -174,8 +174,9 @@ def test_resolver_does_not_take_its_actor_from_the_client(module, fn):
         f"name. Take it from the gate instead:\n"
         f"    auth = require_user(info)\n"
         f"    actor = resolve_display_name(auth['user_id'])\n"
-        f"The argument may stay in the GraphQL schema, accepted and ignored, so a frontend from the "
-        f"previous deploy keeps working - it just must not reach the repository."
+        f"Do not add the argument back to the GraphQL schema either. #427 left the old ones in as "
+        f"ignored @deprecated no-ops purely so a tab from the previous deploy still validated, and "
+        f"#438 removed them once that window closed - a new one has no such window to earn."
     )
 
 

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -397,13 +397,11 @@ export const CREATE_GP_BUYER = gql`
   }
 `;
 
-// costCodes is dead weight both ways (the new backend ignores it, nothing reads it back), but the
-// OLD backend still declares it as a required [String!]! - so keep sending the defaulted empty list
-// or a frontend that deploys ahead of the backend fails GraphQL validation on every save. The
-// follow-up PR that drops the argument from the schema drops it here first.
+// costCodes came out of the schema in #438: per-buyer cost-code designation was removed in #430,
+// which left the argument as an ignored no-op only so a tab from the previous deploy still validated.
 export const SAVE_BUYER_ASSIGNMENT = gql`
-  mutation SaveBuyerAssignment($buyerId: String!, $projectIds: [ID!]!, $costCodes: [String!] = []) {
-    saveBuyerAssignment(buyerId: $buyerId, projectIds: $projectIds, costCodes: $costCodes) {
+  mutation SaveBuyerAssignment($buyerId: String!, $projectIds: [ID!]!) {
+    saveBuyerAssignment(buyerId: $buyerId, projectIds: $projectIds) {
       buyerId
       projects {
         id

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -925,21 +925,18 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
 
   // Shipping PR management
   const addShippingPR = useCallback(() => {
-    setShippingPRDrafts((prev) => [...prev, { requestNumber: '', requestedBy: '', items: [] }]);
+    setShippingPRDrafts((prev) => [...prev, { requestNumber: '', items: [] }]);
   }, []);
 
   const removeShippingPR = useCallback((index: number) => {
     setShippingPRDrafts((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
-  const updateShippingPR = useCallback(
-    (index: number, field: 'requestNumber' | 'requestedBy', value: string) => {
-      setShippingPRDrafts((prev) =>
-        prev.map((draft, i) => (i === index ? { ...draft, [field]: value } : draft)),
-      );
-    },
-    [],
-  );
+  const updateShippingPR = useCallback((index: number, requestNumber: string) => {
+    setShippingPRDrafts((prev) =>
+      prev.map((draft, i) => (i === index ? { ...draft, requestNumber } : draft)),
+    );
+  }, []);
 
   // Add or remove one already-built line on a draft (#335). The step decides what kind of line it
   // is - an assembled leaf or loose hardware - so this no longer hard-codes LOOSE.
@@ -1085,7 +1082,6 @@ export default function ImportWizard({ open, project, onClose }: ImportWizardPro
       shippingOutPrDrafts: purpose === 'shipping'
         ? effectiveShippingPRDrafts.map((pr) => ({
             requestNumber: pr.requestNumber,
-            requestedBy: pr.requestedBy,
             items: pr.items.map((item) => ({
               itemType: item.itemType,
               openingNumber: item.openingNumber,

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -58,7 +58,7 @@ interface ShippingPRsStepProps {
   leavesError: boolean;
   onAddPR: () => void;
   onRemovePR: (index: number) => void;
-  onUpdatePR: (index: number, field: 'requestNumber' | 'requestedBy', value: string) => void;
+  onUpdatePR: (index: number, requestNumber: string) => void;
   onTogglePRItem: (prIndex: number, item: ShippingPRItem) => void;
   /**
    * Reservation-aware availability per (category|product) for this project (#342). A LOOSE line
@@ -261,22 +261,17 @@ export default function ShippingPRsStep({
               </IconButton>
             </Box>
 
+            {/* No requester box: the import stamps every request it creates as "Hardware Schedule
+                Import", so the one that used to sit here was collected and thrown away (#438). */}
             <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
               <TextField
                 label="PR Number"
                 size="small"
                 required
                 value={draft.requestNumber}
-                onChange={(e) => onUpdatePR(prIdx, 'requestNumber', e.target.value)}
+                onChange={(e) => onUpdatePR(prIdx, e.target.value)}
                 sx={{ flex: 1 }}
                 slotProps={{ input: { sx: monoSx } }}
-              />
-              <TextField
-                label="Requested By"
-                size="small"
-                value={draft.requestedBy}
-                onChange={(e) => onUpdatePR(prIdx, 'requestedBy', e.target.value)}
-                sx={{ flex: 1 }}
               />
             </Box>
 

--- a/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
+++ b/frontend/src/modules/import/__tests__/ShippingPRsStep.test.tsx
@@ -21,7 +21,7 @@ function leaf(overrides: Partial<AssembledLeafCandidate> = {}): AssembledLeafCan
   };
 }
 
-const EMPTY_DRAFT: ShippingPRDraft = { requestNumber: 'SOR-1', requestedBy: 'ada', items: [] };
+const EMPTY_DRAFT: ShippingPRDraft = { requestNumber: 'SOR-1', items: [] };
 
 function renderStep(leaves: AssembledLeafCandidate[], overrides: Record<string, unknown> = {}) {
   const onTogglePRItem = vi.fn();
@@ -129,7 +129,6 @@ it('leaves the flagged leaf off the request on cancel', async () => {
 it('removes an already-selected flagged leaf without asking', () => {
   const selected: ShippingPRDraft = {
     requestNumber: 'SOR-1',
-    requestedBy: 'ada',
     items: [
       { itemType: 'OPENING_ITEM', openingNumber: '0019-EX', openingItemId: 'oi-1', leaf: 1, requestedQuantity: 1 },
     ],

--- a/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
+++ b/frontend/src/modules/import/__tests__/availabilityGating.test.tsx
@@ -253,7 +253,6 @@ function looseItem(overrides: Partial<AggregatedHardwareItem> = {}): AggregatedH
 
 const SHIP_DRAFT: ShippingPRDraft = {
   requestNumber: 'SOR-1',
-  requestedBy: 'ada',
   items: [
     {
       itemType: 'LOOSE',

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -34,9 +34,13 @@ export function shippingPRItemKey(item: ShippingPRItem): string {
     : `LOOSE|${item.openingNumber}|${item.hardwareCategory}|${item.productCode}`;
 }
 
+/**
+ * One shipping-out request the wizard will create on finalize. There is deliberately no requester
+ * field: the import path stamps every request it creates as "Hardware Schedule Import", so the
+ * "Requested By" box the step used to show was never read (#438).
+ */
 export interface ShippingPRDraft {
   requestNumber: string;
-  requestedBy: string;
   items: ShippingPRItem[];
 }
 


### PR DESCRIPTION
Closes #438.

#427 stopped every audit-writing resolver reading a client-supplied actor; the arguments stayed in the schema nullable and deprecated so a tab loaded before that deploy would not fail validation. #430 left saveBuyerAssignment(costCodes:) the same way. that window has passed - removing them.

removed: 9 mutation arguments via the IgnoredActorArg alias (startPullRequestPick.startedBy, savePickDraft.enteredBy, confirmPick.pickedBy, setPullItemFetched.fetchedBy, completePullRequest.completedBy, accept/rejectShopAssemblyRequest.acceptedBy/rejectedBy, accept/rejectShippingOutRequest.acceptedBy/rejectedBy) and 18 ACTOR_IGNORED input fields, plus BuyerAssignment.costCodes and saveBuyerAssignment(costCodes:).

enumerated from deprecation_reason across app/schemas/ rather than from the issue text - the grep matched the issue list exactly, nothing extra, nothing missing.

IgnoredActorArg, the ACTOR_IGNORED reason string and the 20-line comment block explaining the compatibility window are gone from inputs.py, along with the now-unused Annotated imports there and in buyer.py.

#427 missed nothing: no frontend mutation sent any of the 27. the pickedBy/shippedBy/stagedBy hits under frontend/src/graphql/ are output fields being read back, untouched. the one frontend caller still sending a removed argument was saveBuyerAssignment(costCodes:) in admin.ts, which #430 deliberately left for this PR. removed.

ShippingOutPRDraftInput.requestedBy dropped as dead code - confirmed end to end first: finalize_import_session destructures shipping_out_pr_drafts and never reads requested_by, created_by is hardcoded "Hardware Schedule Import". removed the input field, the imports.py forward, the wizard's "Requested By" TextField, and narrowed onUpdatePR from (index, field, value) to (index, requestNumber). types.ts carries a docstring saying why there is no requester field.

backend/app/graphql/ SDL reference files updated in 4 places. worth knowing: they had already drifted before this change, still declaring staged_by/shipped_by as required, pre-dating #427 making them nullable. nothing enforces those files.

test_resolver_actor_provenance.py passed unchanged, but its failure message advised that an argument "may stay in the GraphQL schema, accepted and ignored" - wrong guidance for a new resolver now, so it points at #438 instead. its ACTOR_NAMES vocabulary guard is unaffected, all 18 names still appear via output types.

deploy note: the currently deployed backend declares cost_codes with a None default, so a frontend that omits it is already satisfied - there is no frontend-ahead-of-backend hazard. the real and intended breakage is the other direction: a tab loaded before this deploy that fires one of these mutations now gets a validation error instead of a silent no-op. merging before the workday rather than into it.

backend ruff clean, 888 passed / 537 skipped - identical to master. frontend lint 0 errors, 390 passed / 39 files, build clean. schema builds, zero deprecation markers left.