### PR TITLE
feat(gp): provision the new job's cost codes from GP's master and division setup

### DIFF
--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -131,12 +131,14 @@ ROOT_FIELD_POLICY: dict[str, str] = {
     "syncGpJobs": ADMIN_ROLE,
     "updateProject": ADMIN_ROLE,
     # --- relay.py -------------------------------------------------------------------------
-    # The gp_* reads are signed-in because every PO screen needs them. The two exceptions are the
-    # ones that return staff rosters by another name: `gpBuyersDetailed` (buyer ids with names) and
-    # `gpEmployees`. Everything that provisions, adopts or deletes a relay install is admin - those
-    # are relay credentials.
+    # The gp_* reads are signed-in because every PO screen needs them. Three exceptions: two return
+    # staff rosters by another name (`gpBuyersDetailed`, buyer ids with names, and `gpEmployees`), and
+    # `gpCostCodeMaster` has exactly one consumer, the admin-only create-job dialog, so it sits at the
+    # bar the `createGpJob` it feeds already sets. Everything that provisions, adopts or deletes a
+    # relay install is admin - those are relay credentials.
     "gpBuyers": SIGNED_IN,
     "gpBuyersDetailed": ADMIN_ROLE,
+    "gpCostCodeMaster": ADMIN_ROLE,
     "gpCostCodes": SIGNED_IN,
     "gpCustomerAddresses": SIGNED_IN,
     "gpCustomers": SIGNED_IN,

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -20,6 +20,7 @@ from .types import (
     DeficientItemRow,
     GpBuyer,
     GpCostCode,
+    GpCostCodeMasterEntry,
     GpCustomer,
     GpCustomerAddress,
     GpEmployee,
@@ -191,6 +192,18 @@ def gp_buyer_to_type(b: dict) -> GpBuyer:
 
 def gp_cost_code_to_type(c: dict) -> GpCostCode:
     return GpCostCode(cost_code=c["cost_code"], description=c.get("description"), cost_element=c["cost_element"])
+
+
+def gp_cost_code_master_entry_to_type(c: dict) -> GpCostCodeMasterEntry:
+    # The master row carries more than the picker needs (alias, profit type, transaction type, the
+    # account index itself). Only what the dialog shows and sends back is mapped: the account is GP's
+    # to resolve at create time, so handing it to the client would invite it being sent back.
+    return GpCostCodeMasterEntry(
+        cost_code=c["cost_code"],
+        description=c.get("description"),
+        cost_element=c["cost_element"],
+        mapped=bool(c["mapped"]),
+    )
 
 
 def gp_tax_detail_to_type(t: dict) -> GpTaxDetail:

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -13,6 +13,23 @@ from .enums import (
 
 
 @strawberry.input
+class CostCodeSelectionInput:
+    """One cost code to provision on a job at the moment it is created (#448).
+
+    This names WHICH code out of GP's own master (JC40202) to put on the job, and nothing else. Every
+    value that lands in JC00701 - the alias, the description, and above all the GL account index -
+    is read from GP's config at create time: the account comes from JC40302's (division, cost element)
+    mapping, never from Nexus configuration and never from anything the user typed. That is the same
+    provenance principle #427 and #430 settled for everything Nexus writes into GP.
+
+    The cost element travels with the number because the master is keyed on both - the same code
+    number exists once per element, and the account mapping is per element too."""
+
+    cost_code: str
+    cost_element: int
+
+
+@strawberry.input
 class CreateGpJobInput:
     """Originate a job in GP through the WennSoft job proc, which then becomes a UC Nexus project
     (#380).
@@ -22,7 +39,13 @@ class CreateGpJobInput:
     defaulted) is left alone, except the eight below that the issue asks to expose.
 
     None on an optional field means "not sent", so GP keeps its own default. That is deliberately
-    different from sending a blank string, which would overwrite it."""
+    different from sending a blank string, which would overwrite it.
+
+    `cost_codes` is the one thing here that is not a wsiJCJobMaster parameter: the proc creates a job
+    with zero JC00701 rows, so the codes are provisioned alongside it (#448). An empty list is
+    accepted and means exactly that - a job with no cost structure, which leaves the register-PO
+    cost-code dropdown empty and quarantines the project on the next gp_job_sync stamp (rule one of
+    the #425 setup check) until somebody adds codes in GP."""
 
     job_number: str
     job_name: str
@@ -43,6 +66,8 @@ class CreateGpJobInput:
     schedule_start_date: date | None = None
     scheduled_completion_date: date | None = None
     bid_due_date: date | None = None
+
+    cost_codes: list[CostCodeSelectionInput] = strawberry.field(default_factory=list)
 
 
 @strawberry.input

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -105,6 +105,11 @@ class ProjectMutations:
         nothing to retry from the still-open dialog. Queuing would buy latency tolerance nobody needs
         and add an ambiguous-write class that does not otherwise exist here.
 
+        The selected cost codes are provisioned in the SAME GP transaction as the job (#448), because
+        the proc alone leaves JC00701 empty - a job with no cost codes has an empty register-PO
+        dropdown and is quarantined by the #425 setup check on the next sync stamp. Splitting them
+        into a second call would make that broken state reachable through a partial failure.
+
         Admin-only. Creating a job writes to the accounting system of record.
         """
 
@@ -133,6 +138,12 @@ class ProjectMutations:
                 input.scheduled_completion_date.isoformat() if input.scheduled_completion_date else None
             ),
             "bid_due_date": input.bid_due_date.isoformat() if input.bid_due_date else None,
+            # Only the code number and its element travel (#448). Everything else the JC00701 row
+            # needs - alias, description, and the GL account index above all - the relay reads out of
+            # GP's own master inside the same transaction, so nothing here can dictate an account.
+            "cost_codes": [
+                {"cost_code": c.cost_code.strip(), "cost_element": c.cost_element} for c in input.cost_codes
+            ],
         }
 
         try:

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -110,6 +110,11 @@ class ProjectMutations:
         dropdown and is quarantined by the #425 setup check on the next sync stamp. Splitting them
         into a second call would make that broken state reachable through a partial failure.
 
+        `cost_codes_provisioned` carries how many of them GP actually kept, so the dialog can be honest
+        about a selection that did not land. On the adopt path it is zero and means it: an already
+        existing job is left exactly as GP has it, the picked codes are NOT applied to it, and
+        created=false plus the zero count is how the client is told that.
+
         Admin-only. Creating a job writes to the accounting system of record.
         """
 
@@ -157,7 +162,9 @@ class ProjectMutations:
                 # amount of retrying can clear.
                 logger.info("create_gp_job: %s already in GP; adopting instead", input.job_number)
                 project = await _adopt_existing(input.job_number)
-                return CreateGpJobResult(project=project, created=False)
+                # Nothing was provisioned: the create never ran, and this path deliberately does not
+                # go on to write cost codes onto a job somebody else's setup already owns.
+                return CreateGpJobResult(project=project, created=False, cost_codes_provisioned=0)
             # GP said no - a closed fiscal period, an address code that isn't on the customer, a
             # division without accounts. The proc words those better than we could, so the message is
             # passed through to the dialog rather than replaced with a generic failure.
@@ -167,6 +174,11 @@ class ProjectMutations:
         # echoed back (see ops.create_job_op).
         job_number = str((result or {}).get("job_number") or input.job_number).strip()
         job_name = str((result or {}).get("job_name") or input.job_name).strip() or None
+        # The relay's verified read-back of JC00701, not len(payload["cost_codes"]). A relay older than
+        # #448 ignores the unknown cost_codes key entirely and answers without this field, so it reads
+        # as 0 - which is exactly what happened in GP, and how a silently dropped selection surfaces to
+        # the dialog instead of being reported as a provisioned job.
+        cost_codes_provisioned = int((result or {}).get("cost_codes_provisioned") or 0)
 
         def _persist() -> Project:
             with SessionLocal() as session:
@@ -177,14 +189,22 @@ class ProjectMutations:
 
         try:
             # Off the event loop: the /relay-link read loop runs on it and must not block on Postgres.
-            return CreateGpJobResult(project=await asyncio.to_thread(_persist), created=True)
+            return CreateGpJobResult(
+                project=await asyncio.to_thread(_persist),
+                created=True,
+                cost_codes_provisioned=cost_codes_provisioned,
+            )
         except ConflictError:
             # The sync adopted this job between GP committing and us persisting. Benign race, same as
             # the one _persist_missing swallows from the other side - the row we wanted exists.
             # GP still created the job on this call, so this is a real creation - only the Nexus row
             # was written by someone else first.
             logger.info("create_gp_job: %s was adopted by the sync first", job_number)
-            return CreateGpJobResult(project=await asyncio.to_thread(_load_project, job_number), created=True)
+            return CreateGpJobResult(
+                project=await asyncio.to_thread(_load_project, job_number),
+                created=True,
+                cost_codes_provisioned=cost_codes_provisioned,
+            )
         except Exception:
             # The job EXISTS in GP at this point - that call already committed. Losing the Nexus row is
             # recoverable rather than fatal: the sync adopts it on its next pass, and retrying the

--- a/backend/app/schemas/relay.py
+++ b/backend/app/schemas/relay.py
@@ -22,6 +22,7 @@ from app.services.relay_gateway import gateway as relay_gateway
 
 from .converters import (
     gp_buyer_to_type,
+    gp_cost_code_master_entry_to_type,
     gp_cost_code_to_type,
     gp_customer_address_to_type,
     gp_customer_to_type,
@@ -36,6 +37,7 @@ from .inputs import CreateGpCustomerAddressInput, EnrollRelayInstallInput
 from .types import (
     GpBuyer,
     GpCostCode,
+    GpCostCodeMasterEntry,
     GpCustomer,
     GpCustomerAddress,
     GpEmployee,
@@ -144,6 +146,25 @@ class RelayQueries:
         """Active per-job cost codes (JC00701) via the connected relay, for the Create PO cost-code dropdown."""
         result = await relay_gateway.relay_call(company, "list_cost_codes", {"job": job})
         return [gp_cost_code_to_type(c) for c in result["cost_codes"]]
+
+    @strawberry.field
+    async def gp_cost_code_master(
+        self, info: strawberry.Info, company: str, division: str
+    ) -> list[GpCostCodeMasterEntry]:
+        """GP's cost code master (JC40202) for one division, via the connected relay - the create-job
+        dialog's cost-code picker (#448).
+
+        Not gpCostCodes, which reads the codes already on a job (JC00701). wsiJCJobMaster creates a job
+        with none of those at all, so this is the list a new job's codes are chosen FROM, and the pick
+        is provisioned in the same GP transaction as the job.
+
+        Scoped to a division because that is what decides whether a code is usable at all: the GL
+        account comes from JC40302's (division, cost element) mapping, and a code the division has no
+        usable account for comes back mapped=false for the picker to render disabled rather than hide.
+        Hiding it would leave the user hunting for a code they can see in GP; disabling it says the
+        division is what needs fixing."""
+        result = await relay_gateway.relay_call(company, "list_cost_code_master", {"division": division})
+        return [gp_cost_code_master_entry_to_type(c) for c in result["cost_codes"]]
 
     @strawberry.field
     async def gp_tax_details(self, info: strawberry.Info, company: str) -> list[GpTaxDetail]:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -279,10 +279,17 @@ class CreateGpJobResult:
     `created` distinguishes the two ways this mutation succeeds. Normally GP creates the job and
     `created` is true. But when GP already holds that job number the mutation adopts it instead of
     dead-ending (the retry-after-ambiguous-failure path), and the caller has to be able to tell -
-    otherwise the UI reports a creation that never happened."""
+    otherwise the UI reports a creation that never happened.
+
+    `cost_codes_provisioned` is how many JC00701 rows GP really ended up with, read back by the relay
+    rather than counted from the request (#448). It exists because a relay older than #448 ignores the
+    unknown `cost_codes` key and creates the bare, quarantined job this feature exists to prevent -
+    silently, and with an otherwise perfectly successful reply. A zero against a non-empty selection is
+    the only signal of that, so the dialog can say the codes did not land instead of claiming they did."""
 
     project: "Project"
     created: bool
+    cost_codes_provisioned: int
 
 
 @strawberry.type

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -209,6 +209,25 @@ class GpCostCode:
 
 
 @strawberry.type
+class GpCostCodeMasterEntry:
+    """One code from GP's cost code MASTER (JC40202), for the create-job cost-code picker (#448).
+
+    Not GpCostCode above, which is a code already on a job (JC00701). This is the catalogue those rows
+    are provisioned from, so it carries the one thing the per-job read has no use for: whether the
+    division the job is being created under actually has a GL account for this code's cost element.
+
+    `mapped` false means it does not - either JC40302 has no row for that (division, cost element), or
+    the row it has points at an account index that is not in GL00105. The second case is the stale
+    sandbox defence: a dangling index is exactly what #425 quarantines a job for, so provisioning a
+    code with one would create the broken job this picker exists to prevent."""
+
+    cost_code: str  # two-segment number 'cc1-cc2' e.g. '210-200'
+    description: str | None
+    cost_element: int
+    mapped: bool
+
+
+@strawberry.type
 class GpCustomer:
     """A GP customer (RM00101) read live via the relay, for the create-job customer picker (#380)."""
 

--- a/backend/tests/test_create_gp_job.py
+++ b/backend/tests/test_create_gp_job.py
@@ -162,6 +162,9 @@ def test_a_job_already_in_gp_is_adopted_rather_than_dead_ending(monkeypatch):
     assert result.project == "project:NEXUS-380-T1"
     # created=False is what stops the UI reporting a creation that never happened (#392)
     assert result.created is False
+    # and nothing was provisioned: the job GP already has keeps its own cost codes, so the dialog has
+    # to tell the user the selection was not applied rather than let it look like it was (#448)
+    assert result.cost_codes_provisioned == 0
     assert synced == [True]  # the sync pass is what gives the project GP's own job name
 
 
@@ -227,6 +230,44 @@ def test_a_job_with_no_cost_codes_sends_an_empty_list(monkeypatch):
     _create()
 
     assert calls[0][2]["cost_codes"] == []
+
+
+def test_the_created_job_reports_gps_own_provisioned_count(monkeypatch):
+    """What GP kept, read back out of JC00701 by the relay - not len(the selection) echoed back.
+
+    The relay writes the rows and then counts them, so this is the only number that has been anywhere
+    near GP. Sending back the request's own length would make the field agree with the client by
+    construction and therefore worth nothing."""
+    _no_persist(monkeypatch)
+    _relay(
+        monkeypatch,
+        result={"job_number": "NEXUS-380-T1", "job_name": "Test job", "cost_codes_provisioned": 2},
+    )
+
+    result = _create(
+        cost_codes=[
+            CostCodeSelectionInput(cost_code="310-000", cost_element=3),
+            CostCodeSelectionInput(cost_code="520-000", cost_element=2),
+        ]
+    )
+
+    assert result.created is True
+    assert result.cost_codes_provisioned == 2
+
+
+def test_a_relay_too_old_to_provision_reports_zero(monkeypatch):
+    """A pre-#448 relay ignores the unknown cost_codes key and answers a plain, successful create with
+    no such field - having made the bare, quarantined job this feature exists to prevent.
+
+    Zero is both the honest count and the only signal of that, since nothing else about the reply says
+    the selection was dropped. The dialog turns it into a warning rather than a success toast."""
+    _no_persist(monkeypatch)
+    _relay(monkeypatch, result={"job_number": "NEXUS-380-T1", "job_name": "Test job"})
+
+    result = _create(cost_codes=[CostCodeSelectionInput(cost_code="310-000", cost_element=3)])
+
+    assert result.created is True
+    assert result.cost_codes_provisioned == 0
 
 
 def test_the_sync_winning_the_race_is_not_an_error(monkeypatch):

--- a/backend/tests/test_create_gp_job.py
+++ b/backend/tests/test_create_gp_job.py
@@ -17,7 +17,7 @@ from app.database import SessionLocal
 from app.errors import ConflictError, RelayCallError, RelayUnavailableError, ValidationError
 from app.models.project import Project as ProjectModel
 from app.schemas import project as project_module
-from app.schemas.inputs import CreateGpJobInput
+from app.schemas.inputs import CostCodeSelectionInput, CreateGpJobInput
 from app.schemas.project import ProjectMutations
 
 
@@ -191,6 +191,42 @@ def test_sends_the_optional_fields_that_were_filled_in(monkeypatch):
     assert payload["estimator_id"] == "EST1"
     assert payload["use_tax_schedule"] == "GST 5%"
     assert payload["schedule_start_date"] == "2025-09-20"
+
+
+def test_sends_the_selected_cost_codes_for_provisioning(monkeypatch):
+    """The picked codes ride on the same create_job call as the job (#448), so GP provisions JC00701
+    in the transaction that creates JC00102 rather than in a second one that can fail on its own.
+
+    Only the number and the element go: the account index the row needs is GP's to resolve from
+    JC40302 at create time, and a client that could name it could name a wrong one."""
+    _no_persist(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    _create(
+        cost_codes=[
+            CostCodeSelectionInput(cost_code=" 210-200 ", cost_element=2),
+            CostCodeSelectionInput(cost_code="310-000", cost_element=3),
+        ]
+    )
+
+    assert calls[0][2]["cost_codes"] == [
+        # stripped: GP's own code numbers are fixed-width and space-padded, and a picker value that
+        # arrived with the padding still on would be provisioned as a code nothing else matches
+        {"cost_code": "210-200", "cost_element": 2},
+        {"cost_code": "310-000", "cost_element": 3},
+    ]
+
+
+def test_a_job_with_no_cost_codes_sends_an_empty_list(monkeypatch):
+    """Not an omitted key. Empty is the honest payload for "no cost structure", which GP accepts and
+    the #425 setup check then quarantines the project for on the next sync stamp - a real state, and
+    one the dialog warns about rather than prevents."""
+    _no_persist(monkeypatch)
+    calls = _relay(monkeypatch)
+
+    _create()
+
+    assert calls[0][2]["cost_codes"] == []
 
 
 def test_the_sync_winning_the_race_is_not_an_error(monkeypatch):

--- a/backend/tests/test_gp_relay_reads.py
+++ b/backend/tests/test_gp_relay_reads.py
@@ -155,6 +155,62 @@ def test_gp_cost_codes_maps_relay_result_to_type(monkeypatch):
     assert fake.calls == [("TUBC", "list_cost_codes", {"job": "1001"})]
 
 
+def test_gp_cost_code_master_scopes_the_call_to_the_division(monkeypatch):
+    """The master is read per division because the division is what decides whether a code is usable:
+    the GL account comes from JC40302's (division, cost element) mapping, so the same code number is
+    provisionable under one division and not another."""
+    fake = _install_fake_gateway(
+        monkeypatch,
+        {
+            "company": "TUBC",
+            "division": "VANCOUVER",
+            "cost_codes": [
+                {
+                    "cost_code": "210-200",
+                    "alias": "210-200-2",
+                    "description": "Supply Hardware",
+                    "cost_element": 2,
+                    "profit_type_number": 2,
+                    "type_of_transaction": 1,
+                    "account_index": 96,
+                    "mapped": True,
+                },
+                {
+                    "cost_code": "310-000",
+                    "alias": "310-000-3",
+                    "description": None,
+                    "cost_element": 3,
+                    "profit_type_number": 2,
+                    "type_of_transaction": 1,
+                    "account_index": 0,
+                    "mapped": False,
+                },
+            ],
+        },
+    )
+
+    async def run():
+        return await Query().gp_cost_code_master(FakeInfo(), company="TUBC", division="VANCOUVER")
+
+    codes = asyncio.run(run())
+    # mapped=False survives rather than being filtered out - the picker disables it, and a code that
+    # simply vanished would send the user hunting for one they can see in GP (#448)
+    assert [(c.cost_code, c.description, c.cost_element, c.mapped) for c in codes] == [
+        ("210-200", "Supply Hardware", 2, True),
+        ("310-000", None, 3, False),
+    ]
+    # list_cost_code_master (JC40202, the catalogue), not list_cost_codes (JC00701, one job's rows)
+    assert fake.calls == [("TUBC", "list_cost_code_master", {"division": "VANCOUVER"})]
+
+
+def test_gp_cost_code_master_requires_an_admin():
+    """Its only consumer is the admin-only create-job dialog, so it sits at the bar the createGpJob it
+    feeds already sets. `gpCostCodes` - the per-job read behind the register-PO dropdown - stays open
+    to any signed-in user, because every PO screen needs it."""
+    assert ROOT_FIELD_POLICY["gpCostCodeMaster"] == ADMIN_ROLE
+    assert ROOT_FIELD_POLICY["gpCostCodes"] == SIGNED_IN
+
+
 def test_relay_status_resolver_reads_gateway_connected(monkeypatch):
     gateway = RelayGateway()
     monkeypatch.setattr(relay_module, "relay_gateway", gateway)

--- a/frontend/src/graphql/import.ts
+++ b/frontend/src/graphql/import.ts
@@ -213,6 +213,10 @@ export const CREATE_GP_JOB = gql`
   mutation CreateGpJob($input: CreateGpJobInput!) {
     createGpJob(input: $input) {
       created
+      # Issue #448: GP's own read-back count of what landed in JC00701. A relay older than #448 drops
+      # the unknown costCodes key without a word and answers a perfectly successful create, so a zero
+      # against a non-empty selection is the only way to detect the bare, quarantined job it just made.
+      costCodesProvisioned
       # id only: the dialog reads created, and the list is refreshed by refetchQueries, so the rest
       # of the project would be fetched and thrown away.
       project {

--- a/frontend/src/graphql/import.ts
+++ b/frontend/src/graphql/import.ts
@@ -192,6 +192,21 @@ export const GET_GP_DIVISIONS = gql`
   }
 `;
 
+// Issue #448: the company's cost-code master, read per division because `mapped` is a property of the
+// pair - it says whether THIS division has a GL account for that code's cost element. A job created
+// with no cost codes has an empty register-PO dropdown and is quarantined by the GP-setup check on the
+// next sync, so the create form provisions them up front rather than leaving it to accounting.
+export const GET_GP_COST_CODE_MASTER = gql`
+  query GpCostCodeMaster($company: String!, $division: String!) {
+    gpCostCodeMaster(company: $company, division: $division) {
+      costCode
+      description
+      costElement
+      mapped
+    }
+  }
+`;
+
 // Issue #392: `created` distinguishes GP actually creating the job from the mutation adopting one GP
 // already held, so the toast can stop claiming a creation that did not happen.
 export const CREATE_GP_JOB = gql`

--- a/frontend/src/modules/import/CreateGpJobDialog.tsx
+++ b/frontend/src/modules/import/CreateGpJobDialog.tsx
@@ -376,6 +376,10 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     () => new Set(selectedCostCodeEntries.map(costCodeKey)),
     [selectedCostCodeEntries],
   );
+  // The denominator of the counter. Mapped rows, not every row: an unmapped one can never be checked,
+  // so counting it made an untouched form - which has everything it is allowed to have selected -
+  // read as though the user had already deselected something.
+  const mappedCostCodeCount = useMemo(() => costCodeMaster.filter((c) => c.mapped).length, [costCodeMaster]);
 
   const toggleCostCode = useCallback((key: string) => {
     setDeselectedCostCodes((prev) => {
@@ -415,6 +419,11 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   ].some((e) => isRelayOpUnsupported(e));
   // The optional section degrades on its own instead: pickers become free-text entry.
   const employeesUnavailable = Boolean(employeesError);
+  // #448: deliberately NOT folded into readsUnsupported. A relay too old for list_cost_code_master
+  // still creates jobs, and a job with no cost codes is a legal create - blocking the form would take
+  // away something #380 allowed. What it changes is the wording: the raw "does not support
+  // list_cost_code_master" says nothing a user can act on, whereas "update the relay" does.
+  const costCodeMasterUnsupported = isRelayOpUnsupported(costCodeMasterError);
 
   const refreshReads = useCallback(() => {
     void refetchCustomers();
@@ -440,15 +449,21 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     billScopedToOwnCustomer,
   ]);
 
-  const [createGpJob, { loading }] = useMutation<{ createGpJob: { created: boolean; project: Pick<Project, 'id'> } }>(
-    CREATE_GP_JOB,
-    { refetchQueries: [{ query: GET_PROJECTS }] },
-  );
+  const [createGpJob, { loading }] = useMutation<{
+    createGpJob: { created: boolean; costCodesProvisioned: number; project: Pick<Project, 'id'> };
+  }>(CREATE_GP_JOB, { refetchQueries: [{ query: GET_PROJECTS }] });
+
+  // #448: the selection is derived from a master that is not there yet while the read is in flight, so
+  // a submit fired in that window sends costCodes: [] and creates exactly the bare, quarantined job
+  // this feature exists to prevent - and it looks like a normal success. Folded into requiredComplete
+  // rather than into `disabled` so it also stops handleSubmit, which re-checks the same flag.
+  const costCodesPending = division !== '' && costCodeMasterLoading;
 
   const requiredComplete =
     jobNumber.trim() !== '' &&
     jobName.trim() !== '' &&
     division !== '' &&
+    !costCodesPending &&
     customer !== null &&
     addressCodeOrBlank(jobAddressCode) !== '' &&
     addressCodeOrBlank(billtoAddressCode) !== '' &&
@@ -628,12 +643,32 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
       // `=== true`, not `!== false`: an absent or partial payload must not be read as a creation,
       // which is the very claim this branch exists to stop making.
       const created = response.data?.createGpJob?.created === true;
-      showToast(
-        created
-          ? `Job ${jobNumber.trim()} created in GP.`
-          : `Job ${jobNumber.trim()} already existed in GP and is now a project.`,
-        'success',
-      );
+      // #448: and the same rule one level down. GP's read-back count is what says the selection
+      // actually landed - a relay older than #448 drops the codes without a word and still answers a
+      // perfectly ordinary success, so a job that reports "created" can be the bare, quarantined one
+      // this feature exists to prevent. Both silent cases are told rather than dressed as a success:
+      // nobody would otherwise find out until the register-PO dropdown came up empty.
+      const provisioned = response.data?.createGpJob?.costCodesProvisioned ?? 0;
+      const asked = selectedCostCodeEntries.length;
+      const job = jobNumber.trim();
+      if (!created) {
+        // The job is somebody else's setup, left exactly as GP has it - the picked codes were not
+        // added to it, so the selection the user made here has gone nowhere.
+        showToast(
+          asked === 0
+            ? `Job ${job} already existed in GP and is now a project.`
+            : `Job ${job} already existed in GP and is now a project. The cost codes selected here were not applied to it.`,
+          asked === 0 ? 'success' : 'warning',
+        );
+      } else if (asked > 0 && provisioned === 0) {
+        showToast(
+          `Job ${job} was created in GP, but its cost codes were not provisioned - the relay on that workstation is ` +
+            `too old to add them. Add them in GP, and update the relay before creating another job.`,
+          'warning',
+        );
+      } else {
+        showToast(`Job ${job} created in GP.`, 'success');
+      }
       handleClose();
     } catch (err) {
       // GP's own words - a closed fiscal period, an address code not on the customer, a division with
@@ -674,7 +709,9 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
       : costCodeMasterLoading
         ? 'Reading the cost-code master from GP…'
         : costCodeMaster.length === 0 && !costCodeMasterError
-          ? 'GP reports no cost codes for this division.'
+          ? // The master is company-wide - the division only decides which of its codes have a GL
+            // account - so an empty one is not a fact about the division that was picked.
+            "GP's cost-code master is empty for this company, so there is nothing to provision."
           : null;
 
   return (
@@ -880,17 +917,18 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
           <Stack spacing={0.75}>
             <Stack direction="row" spacing={2} alignItems="baseline" justifyContent="space-between">
               <Typography sx={microLabelSx}>Cost codes</Typography>
-              {costCodeMaster.length > 0 && (
+              {mappedCostCodeCount > 0 && (
                 <Typography variant="caption" color="text.secondary" sx={tabularSx}>
-                  {`${selectedCostCodeEntries.length} of ${costCodeMaster.length} selected`}
+                  {`${selectedCostCodeEntries.length} of ${mappedCostCodeCount} selected`}
                 </Typography>
               )}
             </Stack>
 
             {costCodeMasterError && (
               <Alert severity="warning">
-                Could not read the cost codes from GP. The job can still be created, but it will have none until they
-                are added in GP. {costCodeMasterError.message}
+                {costCodeMasterUnsupported
+                  ? 'The connected relay is too old to offer cost codes. Update the relay on that workstation to pick them here. The job can still be created, but it will have none until they are added in GP.'
+                  : `Could not read the cost codes from GP. The job can still be created, but it will have none until they are added in GP. ${costCodeMasterError.message}`}
               </Alert>
             )}
 

--- a/frontend/src/modules/import/CreateGpJobDialog.tsx
+++ b/frontend/src/modules/import/CreateGpJobDialog.tsx
@@ -6,7 +6,10 @@ import {
   DialogActions,
   TextField,
   Autocomplete,
+  Box,
   Button,
+  Checkbox,
+  FormControlLabel,
   Stack,
   Alert,
   MenuItem,
@@ -19,6 +22,7 @@ import { RefreshCw } from 'lucide-react';
 import { useApolloClient, useMutation, useQuery } from '@apollo/client/react';
 import {
   CREATE_GP_JOB,
+  GET_GP_COST_CODE_MASTER,
   GET_GP_CUSTOMERS,
   GET_GP_CUSTOMER_ADDRESSES,
   GET_GP_DIVISIONS,
@@ -32,7 +36,7 @@ import { extractGpError, isRelayOpUnsupported, type GpError } from '../../graphq
 import RelayStatusChip from '../../relay/RelayStatusChip';
 import { useRelayStatus } from '../../relay/useRelayStatus';
 import type { Project } from '../../types/project';
-import { monoSx, microLabelSx } from '../../theme';
+import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import AddCustomerAddressDialog, { type CreatedGpCustomerAddress } from './AddCustomerAddressDialog';
 
 interface GpCustomerOption {
@@ -56,6 +60,25 @@ interface GpEmployeeOption {
   employeeId: string;
   firstName: string | null;
   lastName: string | null;
+}
+
+/**
+ * #448: one row of the company's cost-code master, as it applies to the chosen division.
+ *
+ * `mapped` is not a property of the code on its own - it says the division has a GL account for this
+ * code's cost element. An unmapped code provisioned onto the job is exactly what the GP-setup health
+ * check quarantines the project for, so those rows are offered as facts and never as choices.
+ */
+interface GpCostCodeMasterEntry {
+  costCode: string; // two-segment number 'cc1-cc2', e.g. '310-000'
+  description: string | null;
+  costElement: number; // GP Cost_Element; the trailing digit of the register-PO cost code
+  mapped: boolean;
+}
+
+/** GP's own 'phase-step-element' spelling, and the row identity the selection is keyed on. */
+function costCodeKey(c: GpCostCodeMasterEntry): string {
+  return `${c.costCode}-${c.costElement}`;
 }
 
 function employeeLabel(e: GpEmployeeOption): string {
@@ -203,6 +226,9 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   const [billtoAddressCode, setBilltoAddressCode] = useState('');
   const [taxScheduleId, setTaxScheduleId] = useState('');
   const [createdDate, setCreatedDate] = useState(todayIso);
+  // #448: the cost codes the user took OUT of the division's master, as costCodeKey() values. The
+  // selection itself is derived from this - see selectedCostCodeEntries for why it is stored this way.
+  const [deselectedCostCodes, setDeselectedCostCodes] = useState<Set<string>>(() => new Set());
 
   const [optionalOpen, setOptionalOpen] = useState(false);
   // #392: both hold a GP payroll EMPLOYID, picked via EmployeeField. wsProjectNumber stays free
@@ -248,6 +274,19 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   } = useQuery<{ gpDivisions: string[] }>(GET_GP_DIVISIONS, {
     variables: { company },
     skip: readsSkipped,
+    fetchPolicy: 'cache-first',
+  });
+  // #448: the cost-code master, scoped to the division - `mapped` is a fact about the pair, so this
+  // cannot be read until a division is picked and re-reads on its own when one changes (Apollo keys
+  // the cache entry on the variables, same as the per-customer address reads below).
+  const {
+    data: costCodeMasterData,
+    loading: costCodeMasterLoading,
+    error: costCodeMasterError,
+    refetch: refetchCostCodeMaster,
+  } = useQuery<{ gpCostCodeMaster: GpCostCodeMasterEntry[] }>(GET_GP_COST_CODE_MASTER, {
+    variables: { company, division },
+    skip: readsSkipped || division === '',
     fetchPolicy: 'cache-first',
   });
   const {
@@ -309,6 +348,7 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   const customers = useMemo(() => customersData?.gpCustomers ?? [], [customersData]);
   const divisions = useMemo(() => divisionsData?.gpDivisions ?? [], [divisionsData]);
   const taxSchedules = useMemo(() => taxSchedulesData?.gpTaxSchedules ?? [], [taxSchedulesData]);
+  const costCodeMaster = useMemo(() => costCodeMasterData?.gpCostCodeMaster ?? [], [costCodeMasterData]);
   const addresses = useMemo(() => addressesData?.gpCustomerAddresses ?? [], [addressesData]);
   // Bill-to address options follow whichever customer will actually be billed.
   const billAddresses = useMemo(
@@ -317,6 +357,40 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   );
   // #444: and so does an address created FROM that picker - same rule, same reason.
   const billPickerCustomer = billScopedToOwnCustomer ? billCustomer : customer;
+
+  /**
+   * #448: the selection is DERIVED - every mapped code in the master, minus what the user took out.
+   *
+   * Accounting provisions a job with the whole master rather than a hand-picked subset, so select-all
+   * is the default and unchecking is the exception; holding only the exceptions is what makes the
+   * default apply to whatever master is currently loaded without an effect to re-seed it. It also
+   * settles the awkward cases for free: nothing is selected while the read is in flight (the master is
+   * empty, so the derivation is), and an unmapped code can never end up selected however the state is
+   * manipulated - provisioning one is exactly what the GP-setup check quarantines a project for.
+   */
+  const selectedCostCodeEntries = useMemo(
+    () => costCodeMaster.filter((c) => c.mapped && !deselectedCostCodes.has(costCodeKey(c))),
+    [costCodeMaster, deselectedCostCodes],
+  );
+  const selectedCostCodeKeys = useMemo(
+    () => new Set(selectedCostCodeEntries.map(costCodeKey)),
+    [selectedCostCodeEntries],
+  );
+
+  const toggleCostCode = useCallback((key: string) => {
+    setDeselectedCostCodes((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(key)) next.add(key);
+      return next;
+    });
+  }, []);
+
+  const handleDivisionChange = useCallback((value: string) => {
+    setDivision(value);
+    // Mapping is a property of the (code, division) pair, so a deselection made against the previous
+    // division says nothing about this one - the new master comes up fully selected, as it should.
+    setDeselectedCostCodes(new Set());
+  }, []);
 
   // A failed read is NOT an empty list. Without this the deploy-before-relay-rebuild window (the ops
   // are not in an older relay's advertised op-set) renders a green relay chip over empty required
@@ -347,6 +421,8 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     void refetchDivisions();
     void refetchTaxSchedules();
     void refetchEmployees();
+    // #448: only readable once a division is chosen, so there is nothing to re-read before then.
+    if (division) void refetchCostCodeMaster();
     if (customer) void refetchAddresses();
     // The bill-to picker reads a second customer's addresses whenever one is set, and it is the only
     // view of that list - skipping it here left the one picker most likely to be stale unrefreshed.
@@ -356,8 +432,10 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     refetchDivisions,
     refetchTaxSchedules,
     refetchEmployees,
+    refetchCostCodeMaster,
     refetchAddresses,
     refetchBillAddresses,
+    division,
     customer,
     billScopedToOwnCustomer,
   ]);
@@ -386,6 +464,7 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     setBilltoAddressCode('');
     setTaxScheduleId('');
     setCreatedDate(todayIso());
+    setDeselectedCostCodes(new Set());
     setOptionalOpen(false);
     setEstimatorId('');
     setWsManagerId('');
@@ -530,6 +609,9 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
             billtoAddressCode: addressCodeOrBlank(billtoAddressCode),
             taxScheduleId,
             createdDate,
+            // #448: what the job is provisioned with. An empty list is a legal create - it just makes
+            // a job that cannot take a PO until accounting adds cost codes in GP.
+            costCodes: selectedCostCodeEntries.map((c) => ({ costCode: c.costCode, costElement: c.costElement })),
             estimatorId: blankToNull(estimatorId),
             wsManagerId: blankToNull(wsManagerId),
             wsProjectNumber: blankToNull(wsProjectNumber),
@@ -569,6 +651,7 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
     billtoAddressCode,
     taxScheduleId,
     createdDate,
+    selectedCostCodeEntries,
     estimatorId,
     wsManagerId,
     wsProjectNumber,
@@ -582,6 +665,17 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
   ]);
 
   const disabled = !relayConnected || loading;
+
+  // #448: why there is no list to tick, when there isn't one. A failed read is handled separately -
+  // it is the one case where the section has to say the job will go out unprovisioned.
+  const costCodesNote =
+    division === ''
+      ? 'Pick a division first - whether a code has a GP account depends on it.'
+      : costCodeMasterLoading
+        ? 'Reading the cost-code master from GP…'
+        : costCodeMaster.length === 0 && !costCodeMasterError
+          ? 'GP reports no cost codes for this division.'
+          : null;
 
   return (
     <Dialog open={open} onClose={loading ? undefined : handleClose} maxWidth="sm" fullWidth>
@@ -607,7 +701,7 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
               aria-label="Refresh GP data"
               onClick={refreshReads}
               disabled={!relayConnected || loading}
-              title="Re-read customers, addresses, divisions, tax schedules and employees from GP"
+              title="Re-read customers, addresses, divisions, cost codes, tax schedules and employees from GP"
             >
               <RefreshCw size={16} strokeWidth={1.75} />
             </IconButton>
@@ -663,7 +757,7 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
             select
             label="Division"
             value={division}
-            onChange={(e) => setDivision(e.target.value)}
+            onChange={(e) => handleDivisionChange(e.target.value)}
             required
             disabled={disabled || divisionsLoading}
             size="small"
@@ -778,6 +872,90 @@ export default function CreateGpJobDialog({ open, onClose }: CreateGpJobDialogPr
               slotProps={{ inputLabel: { shrink: true } }}
               helperText="Must fall inside an open GP fiscal period."
             />
+          </Stack>
+
+          {/* #448: a job created with no cost codes has an empty register-PO dropdown and is
+              quarantined by the GP-setup check on the next sync, so they are provisioned here rather
+              than left for accounting to notice. */}
+          <Stack spacing={0.75}>
+            <Stack direction="row" spacing={2} alignItems="baseline" justifyContent="space-between">
+              <Typography sx={microLabelSx}>Cost codes</Typography>
+              {costCodeMaster.length > 0 && (
+                <Typography variant="caption" color="text.secondary" sx={tabularSx}>
+                  {`${selectedCostCodeEntries.length} of ${costCodeMaster.length} selected`}
+                </Typography>
+              )}
+            </Stack>
+
+            {costCodeMasterError && (
+              <Alert severity="warning">
+                Could not read the cost codes from GP. The job can still be created, but it will have none until they
+                are added in GP. {costCodeMasterError.message}
+              </Alert>
+            )}
+
+            {costCodesNote && (
+              <Typography variant="caption" color="text.secondary">
+                {costCodesNote}
+              </Typography>
+            )}
+
+            {costCodeMaster.length > 0 && (
+              <Box
+                sx={{
+                  maxHeight: 200,
+                  overflowY: 'auto',
+                  border: 1,
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  px: 1,
+                  py: 0.5,
+                }}
+              >
+                {costCodeMaster.map((c) => {
+                  const key = costCodeKey(c);
+                  return (
+                    <FormControlLabel
+                      key={key}
+                      // An unmapped code is not a choice: provisioning it is what breaks the job.
+                      disabled={disabled || !c.mapped}
+                      sx={{ display: 'flex', alignItems: 'flex-start', ml: 0, mb: 0.25 }}
+                      control={
+                        <Checkbox
+                          size="small"
+                          checked={selectedCostCodeKeys.has(key)}
+                          onChange={() => toggleCostCode(key)}
+                          sx={{ py: 0.25 }}
+                        />
+                      }
+                      label={
+                        <Box>
+                          <Typography variant="body2" component="span" sx={monoSx}>
+                            {key}
+                          </Typography>
+                          {c.description && (
+                            <Typography variant="body2" component="span" color="text.secondary">
+                              {` ${c.description}`}
+                            </Typography>
+                          )}
+                          {!c.mapped && (
+                            <Typography variant="caption" display="block" color="text.secondary">
+                              {`No GP account for cost element ${c.costElement} in this division`}
+                            </Typography>
+                          )}
+                        </Box>
+                      }
+                    />
+                  );
+                })}
+              </Box>
+            )}
+
+            {costCodeMaster.length > 0 && selectedCostCodeEntries.length === 0 && (
+              <Typography variant="caption" color="warning.main">
+                With no cost codes the job is blocked from GP purchasing until they are added in GP.
+              </Typography>
+            )}
           </Stack>
 
           <Link

--- a/frontend/src/modules/import/__tests__/CreateGpJobDialog.test.tsx
+++ b/frontend/src/modules/import/__tests__/CreateGpJobDialog.test.tsx
@@ -6,6 +6,7 @@ import CreateGpJobDialog from '../CreateGpJobDialog';
 import {
   CREATE_GP_CUSTOMER_ADDRESS,
   CREATE_GP_JOB,
+  GET_GP_COST_CODE_MASTER,
   GET_GP_CUSTOMERS,
   GET_GP_CUSTOMER_ADDRESSES,
   GET_GP_DIVISIONS,
@@ -66,6 +67,37 @@ const employeesReadMock: MockedResponse = {
   },
 };
 
+function costCodeEntry(costCode: string, description: string, costElement: number, mapped: boolean) {
+  return { costCode, description, costElement, mapped, __typename: 'GpCostCodeMasterEntry' };
+}
+
+/**
+ * #448: the cost-code master as it applies to VANCOUVER. 210-200 is unmapped - the division has no GL
+ * account for that code's cost element - and provisioning it is exactly what the GP-setup check
+ * quarantines a project for, so it is the row the picker has to refuse to send.
+ *
+ * Named like employeesReadMock so a test needing a different master can swap it out by identity.
+ */
+const costCodeMasterReadMock: MockedResponse = {
+  request: { query: GET_GP_COST_CODE_MASTER, variables: { company: COMPANY, division: 'VANCOUVER' } },
+  maxUsageCount: INFINITE,
+  result: {
+    data: {
+      gpCostCodeMaster: [
+        costCodeEntry('310-000', 'Hardware', 3, true),
+        costCodeEntry('520-000', 'Electrical', 2, true),
+        costCodeEntry('210-200', 'Site labour', 2, false),
+      ],
+    },
+  },
+};
+
+/** What the form defaults to sending: every mapped code in the master, in master order. */
+const MAPPED_COST_CODES = [
+  { costCode: '310-000', costElement: 3 },
+  { costCode: '520-000', costElement: 2 },
+];
+
 const readMocks: MockedResponse[] = [
   {
     request: { query: GET_GP_CUSTOMERS, variables: { company: COMPANY } },
@@ -98,6 +130,7 @@ const readMocks: MockedResponse[] = [
     },
   },
   addressesReadMock,
+  costCodeMasterReadMock,
 ];
 
 const projectsMock: MockedResponse = {
@@ -171,6 +204,14 @@ async function fillRequired() {
   await pickFromSelect(/^Bill-to address/, /MAIN/);
   await pickFromSelect(/^Tax schedule/, /Federal GST 5%/);
   typeInto(/^Created date/, '2025-09-15');
+  // #448: the cost-code master is read off the division and its mapped codes default to checked, and
+  // they ride along on the create - so a submit fired before that lands carries a different payload.
+  await screen.findByText('2 of 3 selected');
+}
+
+/** The row's own checkbox: its accessible name is the label, which leads with GP's own spelling. */
+function costCodeBox(code: RegExp) {
+  return screen.getByRole('checkbox', { name: code });
 }
 
 function createButton() {
@@ -265,6 +306,7 @@ test('an adopted job does not claim it was created', async () => {
           billtoAddressCode: 'MAIN',
           taxScheduleId: 'GST 5%',
           createdDate: '2025-09-15',
+          costCodes: MAPPED_COST_CODES,
           estimatorId: null,
           wsManagerId: null,
           wsProjectNumber: null,
@@ -382,6 +424,7 @@ test("a GP rejection is shown in the proc's own words and the dialog stays open"
           billtoAddressCode: 'MAIN',
           taxScheduleId: 'GST 5%',
           createdDate: '2025-09-15',
+          costCodes: MAPPED_COST_CODES,
           estimatorId: null,
           wsManagerId: null,
           wsProjectNumber: null,
@@ -432,6 +475,7 @@ test('a successful submit sends only the optional fields that were filled in', a
           billtoAddressCode: 'MAIN',
           taxScheduleId: 'GST 5%',
           createdDate: '2025-09-15',
+          costCodes: MAPPED_COST_CODES,
           estimatorId: 'IANB',
           scheduleStartDate: '2025-09-20',
           wsManagerId: null,
@@ -834,4 +878,104 @@ test('a duplicate address code shows the relay detail, stays open, and re-reads 
   // Closing here would throw away a whole address over one wrong code, so it stays open and typed in.
   expect(screen.getByLabelText(/^Address code/)).toHaveValue('MAIN');
   expect(screen.getByLabelText(/^Address 1/)).toHaveValue('77 New Rd');
+});
+
+// --- #448: provisioning the new job's cost codes -------------------------------------------------
+
+/** The create, with whatever cost codes the form settled on. Everything else is the fillRequired run. */
+function createJobMock(costCodes: { costCode: string; costElement: number }[]): MockedResponse {
+  return {
+    request: {
+      query: CREATE_GP_JOB,
+      variables: {
+        input: {
+          jobNumber: 'NEXUS-380-T1',
+          jobName: 'Test job',
+          division: 'VANCOUVER',
+          customerNumber: 'ELL100',
+          jobAddressCode: 'MAIN',
+          billtoAddressCode: 'MAIN',
+          taxScheduleId: 'GST 5%',
+          createdDate: '2025-09-15',
+          costCodes,
+          estimatorId: null,
+          wsManagerId: null,
+          wsProjectNumber: null,
+          billCustomerNumber: null,
+          useTaxSchedule: null,
+          scheduleStartDate: null,
+          scheduledCompletionDate: null,
+          bidDueDate: null,
+        },
+      },
+    },
+    result: {
+      data: {
+        createGpJob: {
+          created: true,
+          project: { id: 'project-1', __typename: 'Project' },
+          __typename: 'CreateGpJobResult',
+        },
+      },
+    },
+  };
+}
+
+test('the division cost-code master arrives with the mapped codes checked and the unmapped one unusable', async () => {
+  // Accounting provisions a job wholesale, so select-all is the default. The unmapped code is the
+  // exception, and not because it is unwanted: the division has no GL account for its cost element, so
+  // putting it on the job is what the GP-setup check quarantines the project for.
+  renderDialog();
+  await waitFor(() => expect(screen.getByLabelText(/^Job number/)).toBeEnabled());
+
+  // whether a code has an account is a fact about the division, so there is nothing to show yet
+  expect(screen.getByText(/Pick a division first/)).toBeInTheDocument();
+
+  await pickFromSelect(/^Division/, /VANCOUVER/);
+
+  await waitFor(() => expect(costCodeBox(/310-000-3/)).toBeChecked());
+  expect(costCodeBox(/520-000-2/)).toBeChecked();
+  expect(costCodeBox(/210-200-2/)).toBeDisabled();
+  expect(costCodeBox(/210-200-2/)).not.toBeChecked();
+  expect(screen.getByText(/No GP account for cost element 2 in this division/)).toBeInTheDocument();
+  expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+});
+
+test('a cost code unchecked before the submit is left out of the create', async () => {
+  // The mock matches on exact variables, so this IS the assertion on the payload: the code that was
+  // unchecked is gone, and the one that stayed travels as GP's own pair rather than the display key.
+  const success = createJobMock([{ costCode: '520-000', costElement: 2 }]);
+
+  renderDialog([success]);
+  await fillRequired();
+
+  fireEvent.click(costCodeBox(/310-000-3/));
+  await waitFor(() => expect(costCodeBox(/310-000-3/)).not.toBeChecked());
+  expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+
+  await waitFor(() => expect(createButton()).toBeEnabled());
+  fireEvent.click(createButton());
+
+  expect(await screen.findByText(/Job NEXUS-380-T1 created in GP/)).toBeInTheDocument();
+});
+
+test('a job with no cost codes can still be created, with a warning that it cannot buy', async () => {
+  // An unprovisioned job is a legal create - it is what GP does on its own - so the button stays
+  // usable. What it must not be is silent: nothing else in Nexus explains an empty register-PO
+  // cost-code dropdown until purchasing hits it.
+  const success = createJobMock([]);
+
+  renderDialog([success]);
+  await fillRequired();
+
+  fireEvent.click(costCodeBox(/310-000-3/));
+  fireEvent.click(costCodeBox(/520-000-2/));
+  await waitFor(() => expect(screen.getByText('0 of 3 selected')).toBeInTheDocument());
+
+  expect(screen.getByText(/blocked from GP purchasing until they are added in GP/)).toBeInTheDocument();
+  expect(createButton()).toBeEnabled();
+
+  fireEvent.click(createButton());
+
+  expect(await screen.findByText(/Job NEXUS-380-T1 created in GP/)).toBeInTheDocument();
 });

--- a/frontend/src/modules/import/__tests__/CreateGpJobDialog.test.tsx
+++ b/frontend/src/modules/import/__tests__/CreateGpJobDialog.test.tsx
@@ -191,7 +191,7 @@ function typeInto(label: RegExp, value: string) {
 }
 
 /** Everything the proc requires, in the order the form asks for it. */
-async function fillRequired() {
+async function fillRequiredFields() {
   // Nothing is editable until the relay status resolves - the company it carries is what the GP
   // reads are keyed on.
   await waitFor(() => expect(screen.getByLabelText(/^Job number/)).toBeEnabled());
@@ -204,9 +204,15 @@ async function fillRequired() {
   await pickFromSelect(/^Bill-to address/, /MAIN/);
   await pickFromSelect(/^Tax schedule/, /Federal GST 5%/);
   typeInto(/^Created date/, '2025-09-15');
+}
+
+/** The above, plus the cost-code master the create waits on. What most tests want. */
+async function fillRequired() {
+  await fillRequiredFields();
   // #448: the cost-code master is read off the division and its mapped codes default to checked, and
   // they ride along on the create - so a submit fired before that lands carries a different payload.
-  await screen.findByText('2 of 3 selected');
+  // The counter is the master having landed, and the button stays disabled until it has.
+  await screen.findByText('2 of 2 selected');
 }
 
 /** The row's own checkbox: its accessible name is the label, which leads with GP's own spelling. */
@@ -322,6 +328,8 @@ test('an adopted job does not claim it was created', async () => {
       data: {
         createGpJob: {
           created: false,
+          // #448: an already-existing job is left as GP has it, so nothing was provisioned onto it.
+          costCodesProvisioned: 0,
           project: { id: 'project-1', __typename: 'Project' },
           __typename: 'CreateGpJobResult',
         },
@@ -491,6 +499,7 @@ test('a successful submit sends only the optional fields that were filled in', a
       data: {
         createGpJob: {
           created: true,
+          costCodesProvisioned: MAPPED_COST_CODES.length,
           project: { id: 'project-1', __typename: 'Project' },
           __typename: 'CreateGpJobResult',
         },
@@ -882,8 +891,16 @@ test('a duplicate address code shows the relay detail, stays open, and re-reads 
 
 // --- #448: provisioning the new job's cost codes -------------------------------------------------
 
-/** The create, with whatever cost codes the form settled on. Everything else is the fillRequired run. */
-function createJobMock(costCodes: { costCode: string; costElement: number }[]): MockedResponse {
+/**
+ * The create, with whatever cost codes the form settled on. Everything else is the fillRequired run.
+ *
+ * `costCodesProvisioned` defaults to agreeing with the request, which is the healthy relay. The whole
+ * point of the field is that it need not: a relay older than #448 drops the codes and answers zero.
+ */
+function createJobMock(
+  costCodes: { costCode: string; costElement: number }[],
+  { created = true, costCodesProvisioned = costCodes.length } = {},
+): MockedResponse {
   return {
     request: {
       query: CREATE_GP_JOB,
@@ -912,7 +929,8 @@ function createJobMock(costCodes: { costCode: string; costElement: number }[]): 
     result: {
       data: {
         createGpJob: {
-          created: true,
+          created,
+          costCodesProvisioned,
           project: { id: 'project-1', __typename: 'Project' },
           __typename: 'CreateGpJobResult',
         },
@@ -938,7 +956,9 @@ test('the division cost-code master arrives with the mapped codes checked and th
   expect(costCodeBox(/210-200-2/)).toBeDisabled();
   expect(costCodeBox(/210-200-2/)).not.toBeChecked();
   expect(screen.getByText(/No GP account for cost element 2 in this division/)).toBeInTheDocument();
-  expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
+  // Mapped rows are the denominator: the unmapped one can never be ticked, so counting it would make
+  // an untouched form - which has everything it is allowed to have - read as partly deselected.
+  expect(screen.getByText('2 of 2 selected')).toBeInTheDocument();
 });
 
 test('a cost code unchecked before the submit is left out of the create', async () => {
@@ -951,7 +971,7 @@ test('a cost code unchecked before the submit is left out of the create', async 
 
   fireEvent.click(costCodeBox(/310-000-3/));
   await waitFor(() => expect(costCodeBox(/310-000-3/)).not.toBeChecked());
-  expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+  expect(screen.getByText('1 of 2 selected')).toBeInTheDocument();
 
   await waitFor(() => expect(createButton()).toBeEnabled());
   fireEvent.click(createButton());
@@ -970,7 +990,7 @@ test('a job with no cost codes can still be created, with a warning that it cann
 
   fireEvent.click(costCodeBox(/310-000-3/));
   fireEvent.click(costCodeBox(/520-000-2/));
-  await waitFor(() => expect(screen.getByText('0 of 3 selected')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText('0 of 2 selected')).toBeInTheDocument());
 
   expect(screen.getByText(/blocked from GP purchasing until they are added in GP/)).toBeInTheDocument();
   expect(createButton()).toBeEnabled();
@@ -978,4 +998,110 @@ test('a job with no cost codes can still be created, with a warning that it cann
   fireEvent.click(createButton());
 
   expect(await screen.findByText(/Job NEXUS-380-T1 created in GP/)).toBeInTheDocument();
+});
+
+test('the create is held while the cost-code master is still in flight, so an empty selection cannot be sent', async () => {
+  // The selection is DERIVED from the master, so while that read is in flight there is nothing to
+  // derive and the form would send costCodes: [] - creating exactly the bare, quarantined job this
+  // feature exists to prevent, and reporting it as an ordinary success.
+  //
+  // The read is pinned open rather than merely slowed: a delay is a race against however long the
+  // other reads take under a loaded test run, and this has to be the read that holds the button. The
+  // other direction - it enables once the master lands - is what every fillRequired() test proves.
+  const masterInFlight: MockedResponse = { ...costCodeMasterReadMock, delay: INFINITE };
+
+  render(
+    <MockedProvider
+      mocks={[
+        relayStatusMock(true),
+        ...readMocks.filter((m) => m !== costCodeMasterReadMock),
+        masterInFlight,
+        projectsMock,
+        // servable on purpose: a button that stopped holding would then reach a toast the assertion
+        // below catches, rather than dying on an unmatched operation that looks the same as passing
+        createJobMock(MAPPED_COST_CODES),
+      ]}
+    >
+      <ToastProvider>
+        <CreateGpJobDialog open onClose={() => {}} />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+
+  // every other required field is filled, so the disabled button is down to this read and nothing else
+  await fillRequiredFields();
+
+  expect(screen.getByText(/Reading the cost-code master from GP/)).toBeInTheDocument();
+  expect(createButton()).toBeDisabled();
+  // and a click in that window does nothing at all - no create, no toast
+  fireEvent.click(createButton());
+  await waitFor(() => expect(screen.queryByText(/created in GP/)).not.toBeInTheDocument());
+});
+
+test('a relay too old for the cost-code master says to update it rather than showing the raw op error', async () => {
+  // Deliberately NOT the hard readsUnsupported gate: a relay without list_cost_code_master still
+  // creates jobs, and an unprovisioned job is a legal create. Only the wording changes - "does not
+  // support list_cost_code_master" tells the user nothing they can act on.
+  const unsupportedMaster: MockedResponse = {
+    request: { query: GET_GP_COST_CODE_MASTER, variables: { company: COMPANY, division: 'VANCOUVER' } },
+    maxUsageCount: INFINITE,
+    result: {
+      errors: [
+        new GraphQLError('The connected relay does not support list_cost_code_master', {
+          extensions: { code: 'RELAY_OP_UNSUPPORTED' },
+        }),
+      ],
+    },
+  };
+
+  render(
+    <MockedProvider
+      mocks={[
+        relayStatusMock(true),
+        ...readMocks.filter((m) => m !== costCodeMasterReadMock),
+        unsupportedMaster,
+        projectsMock,
+      ]}
+    >
+      <ToastProvider>
+        <CreateGpJobDialog open onClose={() => {}} />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+
+  await fillRequiredFields();
+
+  expect(await screen.findByText(/relay is too old to offer cost codes/i)).toBeInTheDocument();
+  expect(screen.queryByText(/does not support list_cost_code_master/)).not.toBeInTheDocument();
+  // the job itself is still creatable, so neither the hard banner nor a dead button appears
+  expect(screen.queryByText(/relay is too old to create jobs/i)).not.toBeInTheDocument();
+  await waitFor(() => expect(createButton()).toBeEnabled());
+});
+
+test('a create whose cost codes did not land warns instead of reporting a clean success', async () => {
+  // A relay older than #448 ignores the unknown costCodes key without a word and answers a perfectly
+  // ordinary success, having made the bare job the GP-setup check quarantines. GP's own read-back
+  // count is the only evidence of it, so a zero against a non-empty selection has to be said out loud.
+  const droppedByAnOldRelay = createJobMock(MAPPED_COST_CODES, { costCodesProvisioned: 0 });
+
+  renderDialog([droppedByAnOldRelay]);
+  await fillRequired();
+  await waitFor(() => expect(createButton()).toBeEnabled());
+  fireEvent.click(createButton());
+
+  expect(await screen.findByText(/cost codes were not provisioned/i)).toBeInTheDocument();
+  expect(screen.queryByText('Job NEXUS-380-T1 created in GP.')).not.toBeInTheDocument();
+});
+
+test('an adopted job says the cost codes picked here were not applied to it', async () => {
+  // The adopt path leaves the job exactly as GP has it - the selection is not applied to somebody
+  // else's setup. Saying only "already existed" would let the user believe their codes went on it.
+  const adopted = createJobMock(MAPPED_COST_CODES, { created: false, costCodesProvisioned: 0 });
+
+  renderDialog([adopted]);
+  await fillRequired();
+  await waitFor(() => expect(createButton()).toBeEnabled());
+  fireEvent.click(createButton());
+
+  expect(await screen.findByText(/were not applied to it/i)).toBeInTheDocument();
 });

--- a/relay/README.md
+++ b/relay/README.md
@@ -94,9 +94,15 @@ running the same eConnect logic the HTTP routes use (`ops.py` holds the shared `
 blank to run HTTP-only, as before. op dispatch (`_OPS` in `channel.py`, which is also what the relay
 advertises to the backend on connect so an out-of-date relay is caught before the round-trip):
 - reads: `list_vendors`, `list_buyers`, `list_buyers_detailed`, `list_tax_details`, `list_cost_codes`,
-  `list_jobs`, `list_customers`, `list_customer_addresses`, `list_tax_schedules`, `list_divisions`,
-  `list_employees`, `read_po_totals`
+  `list_cost_code_master`, `list_jobs`, `list_customers`, `list_customer_addresses`,
+  `list_tax_schedules`, `list_divisions`, `list_employees`, `read_po_totals`
 - writes: `create_po`, `create_receipt`, `create_job`, `create_buyer`
+
+`create_job` also provisions the job's cost codes (#448): `wsiJCJobMaster` writes only the `JC00102`
+row, so a job created without them has no `JC00701` cost structure at all - an empty register-PO
+dropdown and an instant #425 quarantine - and the codes named in the request's `cost_codes` are written
+with `wsiJCJobDetailMSTR` in the same transaction, every value taken from the company master
+(`JC40202`, account index from `JC40302` for the job's division) rather than from the request.
 
 reconnects with exponential backoff on drop; the `websockets` client's default 20s ping/pong keeps the
 channel alive through a corporate proxy's idle timeout.

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -205,6 +205,24 @@ def _run_list_cost_codes(company: str, payload: dict) -> dict:
     return {"company": company, "job": job, "cost_codes": rows}
 
 
+def _run_list_cost_code_master(company: str, payload: dict) -> dict:
+    """The company's cost-code master, scoped to one division (#448) - what the create-project dialog
+    offers when it asks which cost codes the new job should get.
+
+    Division-scoped for the same reason _run_list_cost_codes is job-scoped: it is not a filter on the
+    list, it is what decides the GL account each code would be provisioned with (JC40302 maps
+    (Divisions, Cost_Element) -> ACTINDX), so answering without one would return codes with no account
+    at all. A missing or blank division answers missing_division, exactly as the job read answers
+    missing_job."""
+    ops.check_company_allowed(company)
+    division = (payload.get("division") or "").strip()
+    if not division:
+        raise ops.RelayOpError("missing_division", "division is required")
+    with db.get_read_connection(company) as conn:
+        rows = econnect.list_cost_code_master(conn, division)
+    return {"company": company, "division": division, "cost_codes": rows}
+
+
 def _run_list_jobs(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     with db.get_read_connection(company) as conn:
@@ -359,6 +377,9 @@ _OPS = {
     "list_buyers": _run_list_buyers,
     "list_tax_details": _run_list_tax_details,
     "list_cost_codes": _run_list_cost_codes,
+    # issue #448 - the company cost-code master, so a job created from Nexus can be provisioned with a
+    # cost structure instead of arriving with none (which #425 quarantines on sight).
+    "list_cost_code_master": _run_list_cost_code_master,
     "list_jobs": _run_list_jobs,
     "read_po_totals": _run_read_po_totals,
     "create_po": _run_create_po,

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -1106,6 +1106,164 @@ def create_job(conn, *, only_validate: bool = False, **fields) -> None:
         )
 
 
+# --- provision a job's cost codes (issue #448) ------------------------------
+# wsiJCJobMaster creates the JC00102 row and NOTHING else: a job born from create_job above has zero
+# JC00701 cost codes. Everything downstream that matters runs off JC00701 - the register-PO cost-code
+# dropdown (list_cost_codes) is empty, and job_setup_health's first rule ("has at least one active cost
+# code") fails, so #425's quarantine holds the project the moment it is created. Until now the fix was
+# to open GP and add the codes by hand, which is most of what creating the job from Nexus was meant to
+# avoid. These two functions are the read that offers the company's cost codes and the write that puts
+# the chosen ones on the job.
+
+
+def list_cost_code_master(conn, division: str) -> list[dict]:
+    """Read-only: the company's cost-code master JC40202, each row carrying the GL account index it
+    would be provisioned with FOR THIS DIVISION.
+
+    JC40202 is the company-wide template - the same list GP's own Job Cost setup offers when somebody
+    adds cost codes to a job by hand. It holds the code segments, the alias, the description, the cost
+    element, the profit type and the transaction type, and every one of those is copied onto the
+    JC00701 row verbatim. What it does NOT hold is the account: JC40202 has an ACTINDX column, it is 0
+    on every row in this company, and treating it as the mapping would provision an entire job's cost
+    structure with no accounts at all.
+
+    The account comes from JC40302, which maps (Divisions, Cost_Element) -> ACTINDX. That is the only
+    legitimate source of it, and it is the same provenance rule #427 and #430 settled everywhere else:
+    GP's own configuration decides, never Nexus config and never something the user typed. The job's
+    division is therefore an input to this read, not a display detail - the same cost element resolves
+    to a different account in a different division.
+
+    The GL00105 join is the defence one level up from #425. That issue is JC00701 rows pointing at
+    account indexes this company does not have; here the same thing can be true of the DIVISION mapping
+    itself in a sandbox cloned from another company, and provisioning off it would manufacture fresh
+    dangling rows rather than inherit them.
+
+    `mapped` is the verdict the caller filters on: the JC40302 row exists AND its index is either 0 or
+    present in GL00105. That is exactly account_index_exists' rule and exactly what list_cost_codes
+    already applies to the register-PO dropdown, so a code this read calls mapped provisions into a
+    JC00701 row those guards accept by construction - the job cannot be created into the quarantine the
+    provisioning exists to prevent. Index 0 passes deliberately: it means "GP picks the account at
+    posting time", not "unmapped".
+
+    Returns one dict per code: cost_code ('cc1-cc2', the shape list_cost_codes and the /po cost_code
+    use), alias, description, cost_element, profit_type_number, type_of_transaction, account_index (None
+    when the element has no JC40302 row at all) and mapped. Unmapped codes are returned rather than
+    filtered out, so the picker can show them greyed with a reason instead of silently offering a
+    shorter list than GP does."""
+    rows = conn.cursor().execute(
+        "SELECT RTRIM(m.Cost_Code_Number_1) AS cc1, RTRIM(m.Cost_Code_Number_2) AS cc2, "
+        "RTRIM(m.Cost_Code_Alias) AS alias, RTRIM(m.Cost_Code_Description) AS descr, "
+        "m.Cost_Element AS elem, m.Profit_Type_Number AS ptype, m.Type_of_Transaction AS ttype, "
+        "a.ACTINDX AS account_index, g.ACTINDX AS resolved "
+        "FROM dbo.JC40202 m "
+        "LEFT JOIN dbo.JC40302 a ON RTRIM(a.Divisions) = ? AND a.Cost_Element = m.Cost_Element "
+        "LEFT JOIN dbo.GL00105 g ON g.ACTINDX = a.ACTINDX "
+        "ORDER BY m.Cost_Code_Number_1, m.Cost_Code_Number_2, m.Cost_Element",
+        division.strip(),
+    ).fetchall()
+    out = []
+    for r in rows:
+        account_index = None if r.account_index is None else int(r.account_index)
+        out.append(
+            {
+                "cost_code": f"{r.cc1}-{r.cc2}",
+                "alias": r.alias or None,
+                "description": r.descr or None,
+                "cost_element": int(r.elem),
+                "profit_type_number": int(r.ptype),
+                "type_of_transaction": int(r.ttype),
+                "account_index": account_index,
+                # No JC40302 row -> nothing to provision with. A row whose index is non-zero but absent
+                # from GL00105 is the stale-sandbox case above and is just as unusable.
+                "mapped": account_index is not None and (account_index == 0 or r.resolved is not None),
+            }
+        )
+    return out
+
+
+def create_job_cost_code(
+    conn,
+    *,
+    only_validate: bool = False,
+    job_number: str,
+    cost_code_number_1: str,
+    cost_code_number_2: str,
+    alias: str,
+    description: str,
+    cost_element: int,
+    account_index: int,
+    profit_type_number: int,
+    type_of_transaction: int,
+) -> None:
+    """Put ONE cost code on a GP job through the WennSoft cost-code proc wsiJCJobDetailMSTR - the
+    JC00701 write, and the missing half of create_job above (see this section's header for why a job
+    with no cost codes is a job nobody can raise a PO against).
+
+    Nine inputs are sent; the proc's remaining ones are left defaulted, the same treatment create_job
+    gives wsiJCJobMaster's 215 - an unset optional is absent from the EXEC, not an explicit NULL. The
+    row this produces was compared field for field against one added through GP's own Job Cost Code
+    Maintenance window and is identical, which is what makes provisioning from Nexus equivalent to
+    doing it by hand rather than merely similar to it.
+
+    JC00102 is deliberately untouched: cost-code provisioning writes no estimate, no committed cost and
+    no rollup, so there is nothing on the job header for it to update. Those totals accrue later, from
+    the PO and receipt path.
+
+    only_validate drives @I_vOnlyValidate for the same reason create_job takes it: the dry run has to
+    exercise the exact statement the real call will make, or it validates something else. The caller
+    runs the whole selection through validation before writing any of it, so a job cannot end up with
+    half its cost structure.
+
+    @I_vReturnErrorText=1 makes the proc fill @oErrString, and that text rides out on proc_message - the
+    WennSoft procs number their error states independently of DYNAMICS.taErrorCode, so a lookup there
+    returns an unrelated GP description (see EConnectError)."""
+    sql = """
+    DECLARE @err int = 0;
+    DECLARE @err_str varchar(255) = '';
+    EXEC dbo.wsiJCJobDetailMSTR
+        @I_vWSJobNumber         = ?,
+        @I_vWSCostCodeNumber1   = ?,
+        @I_vWSCostCodeNumber2   = ?,
+        @I_vCostCodeAlias       = ?,
+        @I_vCostCodeDescription = ?,
+        @I_vCostElement         = ?,
+        @I_vWSAccountIndex1     = ?,
+        @I_vProfitTypeNumber    = ?,
+        @I_vTypeofTransaction   = ?,
+        -- literal, not a caller parameter: every value written here comes from JC40202/JC40302, so a
+        -- retry after a lost reply rewrites the identical row instead of failing on a duplicate.
+        @I_vUpdateIfExists      = 1,
+        @I_vOnlyValidate        = ?,
+        @I_vReturnErrorText     = 1,
+        @O_iErrorState          = @err OUTPUT,
+        @oErrString             = @err_str OUTPUT;
+    SELECT @err AS error_state, @err_str AS err_string;
+    """
+    row = conn.cursor().execute(
+        sql,
+        job_number,
+        cost_code_number_1,
+        cost_code_number_2,
+        alias,
+        description,
+        cost_element,
+        account_index,
+        profit_type_number,
+        type_of_transaction,
+        1 if only_validate else 0,
+    ).fetchone()
+    if row.error_state != 0:
+        message = (row.err_string or "").strip()
+        pass_label = "validation" if only_validate else "create"
+        raise EConnectError(
+            f"wsiJCJobDetailMSTR {pass_label} failed for job {job_number} cost code "
+            f"{cost_code_number_1}-{cost_code_number_2}-{cost_element}: {message}",
+            proc="wsiJCJobDetailMSTR",
+            error_state=row.error_state,
+            proc_message=message or None,
+        )
+
+
 # --- create a GP customer address (issue #444) ------------------------------
 # The create-job form picks its job address and bill-to address out of RM00102 (list_customer_addresses
 # above), so a site that was never entered in GP meant stopping the job creation, opening GP, adding the

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -755,6 +755,19 @@ def list_cost_codes(conn, job_number: str) -> list[dict]:
 
 _ACTIVE_COST_CODE = "WS_Inactive = 0"
 
+# The "usable account index" rule (index 0, or an index present in GL00105) is spelled in FOUR places,
+# and they have to agree or a code one of them offers is a code another refuses:
+#   - account_index_exists            - the Python short-circuit on 0, then a GL00105 probe.
+#   - list_cost_codes' WHERE          - `WS_Account_Index_1 = 0 OR a.ACTINDX IS NOT NULL`, positive form.
+#   - job_setup_health's predicates   - the verdict's SUM(CASE ... <> 0 AND a.ACTINDX IS NULL) and the
+#                                       detail query's WHERE, both the NEGATED form (count the broken).
+#   - list_cost_code_master's `mapped` - the same rule one level up, against the DIVISION mapping.
+# Consolidating them into one shared SQL fragment (the way _ACTIVE_COST_CODE consolidates the active
+# rule) was considered and deliberately deferred: the four live in differently shaped queries - one is
+# Python, one a positive WHERE, one a negated aggregate inside a GROUP BY - so a single fragment would
+# fit none of them without contortion, and each is pinned by its own tests. This note is the link
+# between them; change one and change the others.
+
 
 def job_setup_health(conn, job_number: str | None = None) -> list[dict]:
     """Read-only: the per-job GP setup verdict for EVERY job in the company (#425), or for one job
@@ -1145,11 +1158,21 @@ def list_cost_code_master(conn, division: str) -> list[dict]:
     provisioning exists to prevent. Index 0 passes deliberately: it means "GP picks the account at
     posting time", not "unmapped".
 
+    JC40202 carries no inactive/retired flag of any kind (verified against the live column list
+    2026-07-30), so unlike list_cost_codes there is deliberately no WS_Inactive-style filter here -
+    there is nothing to filter. The company master is the whole company master.
+
     Returns one dict per code: cost_code ('cc1-cc2', the shape list_cost_codes and the /po cost_code
-    use), alias, description, cost_element, profit_type_number, type_of_transaction, account_index (None
-    when the element has no JC40302 row at all) and mapped. Unmapped codes are returned rather than
-    filtered out, so the picker can show them greyed with a reason instead of silently offering a
-    shorter list than GP does."""
+    use), cost_code_number_1 / cost_code_number_2 (the RAW segments, so the provisioning write binds
+    what GP stores rather than re-splitting the joined form), alias, description, cost_element,
+    profit_type_number, type_of_transaction, account_index (None when the element has no JC40302 row at
+    all) and mapped. Unmapped codes are returned rather than filtered out, so the picker can show them
+    greyed with a reason instead of silently offering a shorter list than GP does."""
+    # The cc3/cc4 filter: the provisioning write (create_job_cost_code) sends segments 1 and 2 only, so
+    # a four-segment master code cannot be provisioned faithfully and must not be offered - the picker
+    # would show a code that provisions into a DIFFERENT JC00701 row than the one it names. Zero rows in
+    # this company have a non-blank segment 3 or 4 (verified live 2026-07-30), so this changes nothing
+    # here and refuses to guess anywhere it would.
     rows = conn.cursor().execute(
         "SELECT RTRIM(m.Cost_Code_Number_1) AS cc1, RTRIM(m.Cost_Code_Number_2) AS cc2, "
         "RTRIM(m.Cost_Code_Alias) AS alias, RTRIM(m.Cost_Code_Description) AS descr, "
@@ -1158,20 +1181,41 @@ def list_cost_code_master(conn, division: str) -> list[dict]:
         "FROM dbo.JC40202 m "
         "LEFT JOIN dbo.JC40302 a ON RTRIM(a.Divisions) = ? AND a.Cost_Element = m.Cost_Element "
         "LEFT JOIN dbo.GL00105 g ON g.ACTINDX = a.ACTINDX "
+        "WHERE RTRIM(m.Cost_Code_Number_3) = '' AND RTRIM(m.Cost_Code_Number_4) = '' "
         "ORDER BY m.Cost_Code_Number_1, m.Cost_Code_Number_2, m.Cost_Element",
         division.strip(),
     ).fetchall()
     out = []
+    seen: set[tuple[str, int]] = set()
     for r in rows:
+        cost_code = f"{r.cc1}-{r.cc2}"
+        cost_element = int(r.elem)
+        # Defensive dedupe on the key the caller selects by, keeping the FIRST row so the answer is
+        # deterministic. No duplicate (code, element) pair exists in JC40202 at this customer (verified
+        # live 2026-07-30), but a single duplicated pair would cause three separate failures at once:
+        # duplicate keys in the picker, an account that depends on SQL row order, and both copies
+        # rejected by CreateJobRequest's duplicate-selection validator if the user ticked either.
+        key = (cost_code, cost_element)
+        if key in seen:
+            continue
+        seen.add(key)
         account_index = None if r.account_index is None else int(r.account_index)
         out.append(
             {
-                "cost_code": f"{r.cc1}-{r.cc2}",
+                "cost_code": cost_code,
+                # The raw segments ride along beside the joined form: the write binds these, so a
+                # segment containing a '-' provisions the row GP actually holds rather than whatever
+                # re-splitting 'cc1-cc2' would produce.
+                "cost_code_number_1": r.cc1,
+                "cost_code_number_2": r.cc2,
                 "alias": r.alias or None,
                 "description": r.descr or None,
-                "cost_element": int(r.elem),
-                "profit_type_number": int(r.ptype),
-                "type_of_transaction": int(r.ttype),
+                "cost_element": cost_element,
+                # No Profit_Type_Number / Type_of_Transaction is NULL in this company (verified live
+                # 2026-07-30). If one ever is, it degrades to the proc's own default rather than killing
+                # the whole company's picker with a TypeError on int(None).
+                "profit_type_number": int(r.ptype or 0),
+                "type_of_transaction": int(r.ttype or 0),
                 "account_index": account_index,
                 # No JC40302 row -> nothing to provision with. A row whose index is non-zero but absent
                 # from GL00105 is the stale-sandbox case above and is just as unusable.
@@ -1199,11 +1243,20 @@ def create_job_cost_code(
     JC00701 write, and the missing half of create_job above (see this section's header for why a job
     with no cost codes is a job nobody can raise a PO against).
 
-    Nine inputs are sent; the proc's remaining ones are left defaulted, the same treatment create_job
-    gives wsiJCJobMaster's 215 - an unset optional is absent from the EXEC, not an explicit NULL. The
-    row this produces was compared field for field against one added through GP's own Job Cost Code
+    Nine inputs are sent and ALL NINE are bound on every call - none of them is conditional, and a
+    blank alias or description arrives as '' from the caller rather than being dropped, the same way
+    create_customer_address sends its unset optionals as blanks. create_job's rule that an unset
+    optional is absent from the EXEC rather than an explicit NULL is about the proc's ~120 OTHER
+    inputs: those are what stay defaulted here, and none of them is reachable through this signature.
+    The row this produces was compared field for field against one added through GP's own Job Cost Code
     Maintenance window and is identical, which is what makes provisioning from Nexus equivalent to
     doing it by hand rather than merely similar to it.
+
+    UpdateIfExists=1 cannot clobber a row somebody hand-edited in GP, because nothing reaches this
+    function on a job that already existed: create_job_op refuses one outright at its job_exists
+    pre-check. Every code written here goes onto a job created moments earlier in the same transaction,
+    so the rewrite-on-retry the flag enables is only ever rewriting values read out of the same master
+    seconds before.
 
     JC00102 is deliberately untouched: cost-code provisioning writes no estimate, no committed cost and
     no rollup, so there is nothing on the job header for it to update. Those totals accrue later, from

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -416,8 +416,9 @@ class CreateJobResponse(BaseModel):
     job_number: str
     job_name: str
     company: str
-    # Issue #448: how many JC00701 cost codes were written onto the new job, verified by a read-back
-    # rather than counted off the request. 0 for a caller that sent none.
+    # Issue #448: how many JC00701 cost codes were written onto the new job. Each one is read back
+    # individually through the same lookup a PO uses, so this is not the request counted back at the
+    # caller. 0 for a caller that sent none.
     cost_codes_provisioned: int = 0
 
 

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -317,6 +317,31 @@ _JOB_OPTIONAL_STRINGS = (
 )
 
 
+class JobCostCodeSelection(BaseModel):
+    """One cost code to put on the job being created (issue #448).
+
+    Only the two identifying fields are sent. Everything else the JC00701 row needs - the alias, the
+    description, the profit and transaction types, and above all the GL account index - is read out of
+    the company master (JC40202/JC40302) by the relay at provisioning time. That is the #427/#430
+    provenance rule: the caller names WHICH cost codes the job gets, GP's own configuration decides what
+    they mean. A client that could send an account index could put a job's costs on any account in the
+    chart, and nothing downstream would ever question it.
+
+    cost_code is the 'cc1-cc2' shape list_cost_code_master returns and the register-PO dropdown already
+    speaks; cost_element is the code's own element, which varies by code and is part of its identity -
+    the same 'cc1-cc2' can exist under more than one element."""
+
+    cost_code: str = Field(..., max_length=15)
+    cost_element: int
+
+    @model_validator(mode="after")
+    def normalize(self):
+        self.cost_code = (self.cost_code or "").strip()
+        if not self.cost_code:
+            raise ValueError("cost_code is required")
+        return self
+
+
 class CreateJobRequest(BaseModel):
     """The 8 fields wsiJCJobMaster actually requires, plus the 8 it accepts but does not demand.
 
@@ -349,13 +374,24 @@ class CreateJobRequest(BaseModel):
     scheduled_completion_date: date | None = None
     bid_due_date: date | None = None
 
+    # Issue #448: the cost codes to provision onto the new job, in the order they should be written.
+    # Empty is valid and is what every caller before #448 sends - the job is then created exactly as it
+    # was, with no JC00701 rows - so nothing about the create path changes for a caller that ignores it.
+    cost_codes: list[JobCostCodeSelection] = Field(default_factory=list)
+
     @model_validator(mode="after")
     def normalize(self):
         """Trim every string, then reject a required one that trimmed to nothing. A whitespace-only job
         number would otherwise reach GP as blank and fail deep inside the proc; an untrimmed one would
         not match the job_exists pre-check that makes a retry safe. Optional fields that trim to blank
         become None, i.e. not sent - a user who opened the optional section and typed nothing must not
-        thereby overwrite a GP default with an empty string."""
+        thereby overwrite a GP default with an empty string.
+
+        A cost code selected twice is refused rather than de-duplicated. wsiJCJobDetailMSTR writes with
+        UpdateIfExists=1, so the second write would land on the same JC00701 row and succeed, and the
+        job would come back reporting one more code provisioned than it has - the read-back count in
+        create_job_op would then fail a create that actually worked. It is also not a request anyone
+        means to make."""
         for name in _JOB_REQUIRED_STRINGS:
             value = (getattr(self, name) or "").strip()
             if not value:
@@ -364,6 +400,15 @@ class CreateJobRequest(BaseModel):
         for name in _JOB_OPTIONAL_STRINGS:
             value = (getattr(self, name) or "").strip()
             setattr(self, name, value or None)
+        seen: set[tuple[str, int]] = set()
+        for selection in self.cost_codes:
+            key = (selection.cost_code, selection.cost_element)
+            if key in seen:
+                raise ValueError(
+                    f"cost code '{selection.cost_code}' element {selection.cost_element} is selected "
+                    f"more than once"
+                )
+            seen.add(key)
         return self
 
 
@@ -371,6 +416,9 @@ class CreateJobResponse(BaseModel):
     job_number: str
     job_name: str
     company: str
+    # Issue #448: how many JC00701 cost codes were written onto the new job, verified by a read-back
+    # rather than counted off the request. 0 for a caller that sent none.
+    cost_codes_provisioned: int = 0
 
 
 # --- create a GP customer address (issue #444) ---

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -235,6 +235,96 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
     )
 
 
+def _provision_cost_codes(conn, *, company: str, request: models.CreateJobRequest) -> int:
+    """Write the requested cost codes onto the job just created (issue #448), and return how many
+    landed. Runs inside the caller's transaction, so the job and its cost structure commit together or
+    neither does - a job that exists with half its codes is the state this whole feature exists to
+    avoid, since #425's quarantine would hold it and nobody would know why.
+
+    Every value written comes from the company master, never from the request. The selection names
+    which codes the job gets; the alias, description, profit type, transaction type and above all the
+    GL account index are read out of JC40202/JC40302 here. That is the same provenance rule #427 and
+    #430 settled for actors and accounts elsewhere: GP's configuration decides, and a caller that could
+    send an account index could post a job's costs anywhere in the chart.
+
+    Two refusals, both before anything is written:
+      - a code that is not in JC40202 at all. The picker is fed from that table, so this is a stale
+        client or a made-up code, and the proc would take it and create a cost code the company's own
+        setup has never heard of.
+      - a code JC40302 has no usable account for in this job's division. Provisioning it would
+        manufacture exactly the dangling JC00701 row #425 is about - the job would register POs and
+        then fail forever at receipt with eConnect 4612.
+
+    Then validate ALL of them before writing ANY of them, the same reason create_job_op dry-runs the
+    job proc: the eleventh code failing after ten were written leaves a partially provisioned job that
+    only a rollback saves, and the rollback is what the dry run makes unnecessary.
+
+    Finally count the active JC00701 rows back. taPoLine has a known err=0-but-no-row silent-failure
+    mode and this is the same class of proc, so a success report is not evidence a row landed. Counting
+    the job's whole active set works because the job was created seconds ago by wsiJCJobMaster, which
+    writes no cost codes at all - every row there is one of these."""
+    master = {
+        (row["cost_code"], row["cost_element"]): row
+        for row in econnect.list_cost_code_master(conn, request.division)
+    }
+
+    chosen = []
+    for selection in request.cost_codes:
+        row = master.get((selection.cost_code, selection.cost_element))
+        if row is None:
+            raise RelayOpError(
+                "cost_code_not_in_master",
+                f"cost code '{selection.cost_code}' element {selection.cost_element} is not in the "
+                f"cost-code master (JC40202) for GP company {company}",
+                cost_code=selection.cost_code,
+                cost_element=selection.cost_element,
+            )
+        if not row["mapped"]:
+            raise RelayOpError(
+                "cost_code_unmapped",
+                f"cost code '{selection.cost_code}' element {selection.cost_element} has no usable GL "
+                f"account for division '{request.division}' in {company}: JC40302 maps no account index "
+                f"for that cost element, or the one it maps does not exist in the chart (GL00105). A job "
+                f"provisioned with it could register POs and never receive them.",
+                cost_code=selection.cost_code,
+                cost_element=selection.cost_element,
+                division=request.division,
+            )
+        chosen.append(row)
+
+    for only_validate in (True, False):
+        for row in chosen:
+            # split_cost_code is what the PO path splits with, so the segments provisioned here and the
+            # segments a PO later looks the code up by cannot drift.
+            cc1, cc2, _cc3, _cc4, _element = econnect.split_cost_code(row["cost_code"])
+            econnect.create_job_cost_code(
+                conn,
+                only_validate=only_validate,
+                job_number=request.job_number,
+                cost_code_number_1=cc1,
+                cost_code_number_2=cc2,
+                alias=row["alias"] or "",
+                description=row["description"] or "",
+                cost_element=row["cost_element"],
+                account_index=row["account_index"],
+                profit_type_number=row["profit_type_number"],
+                type_of_transaction=row["type_of_transaction"],
+            )
+
+    landed = conn.cursor().execute(
+        "SELECT COUNT(*) AS n FROM dbo.JC00701 WHERE RTRIM(WS_Job_Number) = ? AND WS_Inactive = 0",
+        request.job_number,
+    ).fetchone()
+    expected = len(chosen)
+    if landed.n != expected:
+        raise econnect.EConnectError(
+            f"wsiJCJobDetailMSTR reported success but job {request.job_number} has {landed.n} active "
+            f"cost codes in JC00701, expected {expected}",
+            proc="wsiJCJobDetailMSTR",
+        )
+    return expected
+
+
 def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> models.CreateJobResponse:
     """Create a GP job (issue #380): pre-check, dry run, real call. The caller commits.
 
@@ -251,9 +341,16 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
        echoed back. The backend snapshots that name onto the project, and what GP kept is the honest
        thing to snapshot - WS_Job_Name is char(31), so a longer name is truncated on write and the
        request no longer describes the job. It also proves the row landed.
+    5. Provision the requested cost codes (issue #448, see _provision_cost_codes). wsiJCJobMaster
+       writes the JC00102 row and nothing else, so without this the job is created into #425's
+       quarantine - no active cost codes - and its register-PO dropdown is empty. Inside the SAME
+       transaction the caller commits, so the job and its cost structure land together or not at all.
+       Skipped entirely when no cost codes were selected, which is what every pre-#448 caller sends.
 
     Both passes raise econnect.EConnectError carrying the proc's message (see econnect.create_job)."""
-    fields = request.model_dump(exclude={"company"})
+    # cost_codes is a provisioning instruction for step 5, not a wsiJCJobMaster field - leaving it in
+    # would trip create_job's unknown-field guard on every call (#448).
+    fields = request.model_dump(exclude={"company", "cost_codes"})
 
     if econnect.job_exists(conn, request.job_number):
         raise RelayOpError(
@@ -272,10 +369,15 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
             proc="wsiJCJobMaster",
         )
 
+    provisioned = 0
+    if request.cost_codes:
+        provisioned = _provision_cost_codes(conn, company=company, request=request)
+
     return models.CreateJobResponse(
         job_number=created["job_number"],
         job_name=created["job_name"] or request.job_name,
         company=company,
+        cost_codes_provisioned=provisioned,
     )
 
 

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -235,19 +235,23 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
     )
 
 
-def _provision_cost_codes(conn, *, company: str, request: models.CreateJobRequest) -> int:
-    """Write the requested cost codes onto the job just created (issue #448), and return how many
-    landed. Runs inside the caller's transaction, so the job and its cost structure commit together or
-    neither does - a job that exists with half its codes is the state this whole feature exists to
-    avoid, since #425's quarantine would hold it and nobody would know why.
+def _resolve_cost_code_selection(conn, *, company: str, request: models.CreateJobRequest) -> list[dict]:
+    """Resolve the requested cost codes against the company master (issue #448) and return the master
+    rows the write step will provision from. Writes nothing.
 
-    Every value written comes from the company master, never from the request. The selection names
+    Runs BEFORE the job proc, not after it. The selection is checked against GP's own tables, so a
+    stale picker or a made-up code is a refusal that must cost nothing - and it only costs nothing if
+    it happens before wsiJCJobMaster has created anything. Rolling the job back afterwards would work,
+    but "the create failed and nothing was written" is a promise the ordering keeps rather than one the
+    transaction has to rescue.
+
+    Every value provisioned comes from the company master, never from the request. The selection names
     which codes the job gets; the alias, description, profit type, transaction type and above all the
     GL account index are read out of JC40202/JC40302 here. That is the same provenance rule #427 and
     #430 settled for actors and accounts elsewhere: GP's configuration decides, and a caller that could
     send an account index could post a job's costs anywhere in the chart.
 
-    Two refusals, both before anything is written:
+    Two refusals:
       - a code that is not in JC40202 at all. The picker is fed from that table, so this is a stale
         client or a made-up code, and the proc would take it and create a cost code the company's own
         setup has never heard of.
@@ -255,14 +259,11 @@ def _provision_cost_codes(conn, *, company: str, request: models.CreateJobReques
         manufacture exactly the dangling JC00701 row #425 is about - the job would register POs and
         then fail forever at receipt with eConnect 4612.
 
-    Then validate ALL of them before writing ANY of them, the same reason create_job_op dry-runs the
-    job proc: the eleventh code failing after ten were written leaves a partially provisioned job that
-    only a rollback saves, and the rollback is what the dry run makes unnecessary.
+    An empty selection short-circuits without reading the master at all: that is what every pre-#448
+    caller sends, and for them the create path has to be exactly what it was."""
+    if not request.cost_codes:
+        return []
 
-    Finally count the active JC00701 rows back. taPoLine has a known err=0-but-no-row silent-failure
-    mode and this is the same class of proc, so a success report is not evidence a row landed. Counting
-    the job's whole active set works because the job was created seconds ago by wsiJCJobMaster, which
-    writes no cost codes at all - every row there is one of these."""
     master = {
         (row["cost_code"], row["cost_element"]): row
         for row in econnect.list_cost_code_master(conn, request.division)
@@ -291,18 +292,46 @@ def _provision_cost_codes(conn, *, company: str, request: models.CreateJobReques
                 division=request.division,
             )
         chosen.append(row)
+    return chosen
+
+
+def _write_cost_codes(conn, *, request: models.CreateJobRequest, chosen: list[dict]) -> int:
+    """Write the resolved cost codes onto the job just created (issue #448) and return how many landed.
+    Runs inside the caller's transaction, so the job and its cost structure commit together or neither
+    does - a job that exists with half its codes is the state this whole feature exists to avoid, since
+    #425's quarantine would hold it and nobody would know why.
+
+    The rows come from _resolve_cost_code_selection, which already refused anything the master does not
+    know or cannot account for, so by here there is nothing left to reject on our side.
+
+    Validate ALL of them before writing ANY of them, the same reason create_job_op dry-runs the job
+    proc: the eleventh code failing after ten were written leaves a partially provisioned job that only
+    a rollback saves, and the rollback is what the dry run makes unnecessary.
+
+    The segments are bound straight off the master row (cost_code_number_1 / _2) rather than re-split
+    out of the joined 'cc1-cc2' form. Re-splitting a segment that itself contains a '-' would provision
+    a different row than the one the picker named, and the master already hands over exactly what GP
+    stores.
+
+    Then verify EACH code through econnect.cost_code_on_job - the same lookup /po runs before it lets a
+    line reference a cost code. taPoLine has a known err=0-but-no-row silent-failure mode and this is
+    the same class of proc, so a success report is not evidence a row landed. Checking per code through
+    the PO path's own lookup means "provisioned" and "reachable by a PO" cannot drift apart: a row that
+    landed but that lookup cannot find is a row no PO could ever use, and that is a failure whether or
+    not JC00701 has something in it. It also needs no assumption about rows this call did not write,
+    which a COUNT of the job's whole active set does - that count is only correct while nothing else
+    ever seeds JC00701 for a new job."""
+    if not chosen:
+        return 0
 
     for only_validate in (True, False):
         for row in chosen:
-            # split_cost_code is what the PO path splits with, so the segments provisioned here and the
-            # segments a PO later looks the code up by cannot drift.
-            cc1, cc2, _cc3, _cc4, _element = econnect.split_cost_code(row["cost_code"])
             econnect.create_job_cost_code(
                 conn,
                 only_validate=only_validate,
                 job_number=request.job_number,
-                cost_code_number_1=cc1,
-                cost_code_number_2=cc2,
+                cost_code_number_1=row["cost_code_number_1"],
+                cost_code_number_2=row["cost_code_number_2"],
                 alias=row["alias"] or "",
                 description=row["description"] or "",
                 cost_element=row["cost_element"],
@@ -311,18 +340,17 @@ def _provision_cost_codes(conn, *, company: str, request: models.CreateJobReques
                 type_of_transaction=row["type_of_transaction"],
             )
 
-    landed = conn.cursor().execute(
-        "SELECT COUNT(*) AS n FROM dbo.JC00701 WHERE RTRIM(WS_Job_Number) = ? AND WS_Inactive = 0",
-        request.job_number,
-    ).fetchone()
-    expected = len(chosen)
-    if landed.n != expected:
-        raise econnect.EConnectError(
-            f"wsiJCJobDetailMSTR reported success but job {request.job_number} has {landed.n} active "
-            f"cost codes in JC00701, expected {expected}",
-            proc="wsiJCJobDetailMSTR",
-        )
-    return expected
+    for row in chosen:
+        # 'phase-step-element', the shape the register-PO dropdown (list_cost_codes) and the /po
+        # cost_code speak, so this asks the question a PO will ask, in the words a PO will ask it in.
+        cost_code = f"{row['cost_code']}-{row['cost_element']}"
+        if not econnect.cost_code_on_job(conn, request.job_number, cost_code):
+            raise econnect.EConnectError(
+                f"wsiJCJobDetailMSTR reported success but cost code {cost_code} is not on job "
+                f"{request.job_number} in JC00701",
+                proc="wsiJCJobDetailMSTR",
+            )
+    return len(chosen)
 
 
 def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> models.CreateJobResponse:
@@ -332,24 +360,29 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
        the proc, and this turns that into a clean job_already_exists the dialog can show. It also makes a
        retry after an ambiguous failure safe: if the first attempt actually committed and the reply was
        lost, the retry says "already exists" instead of attempting a second create.
-    2. OnlyValidate=1. The proc validates everything - division accounts, customer, both address codes,
+    2. Resolve the cost-code selection against JC40202/JC40302 (issue #448, see
+       _resolve_cost_code_selection). Read-only, and deliberately ahead of the job proc: a selection GP's
+       own master does not recognise is a stale picker, and refusing it here means the create fails
+       having written nothing at all - which is what step 3's dry run promises for the job's own fields
+       and what the selection deserves for the same reason. A no-op when no cost codes were selected,
+       which is what every pre-#448 caller sends.
+    3. OnlyValidate=1. The proc validates everything - division accounts, customer, both address codes,
        tax schedule, open fiscal period - and reports the FIRST problem in its own words. Running it
        first means a rejected create fails having written nothing, and the user reads GP's actual
        objection rather than a generic failure.
-    3. The real call, same parameters.
-    4. Read the row back from JC00102 and answer with GP's stored job number and name, NOT the request
+    4. The real call, same parameters.
+    5. Read the row back from JC00102 and answer with GP's stored job number and name, NOT the request
        echoed back. The backend snapshots that name onto the project, and what GP kept is the honest
        thing to snapshot - WS_Job_Name is char(31), so a longer name is truncated on write and the
        request no longer describes the job. It also proves the row landed.
-    5. Provision the requested cost codes (issue #448, see _provision_cost_codes). wsiJCJobMaster
-       writes the JC00102 row and nothing else, so without this the job is created into #425's
-       quarantine - no active cost codes - and its register-PO dropdown is empty. Inside the SAME
-       transaction the caller commits, so the job and its cost structure land together or not at all.
-       Skipped entirely when no cost codes were selected, which is what every pre-#448 caller sends.
+    6. Write the resolved cost codes onto it (see _write_cost_codes). wsiJCJobMaster writes the JC00102
+       row and nothing else, so without this the job is created into #425's quarantine - no active cost
+       codes - and its register-PO dropdown is empty. Inside the SAME transaction the caller commits, so
+       the job and its cost structure land together or not at all.
 
     Both passes raise econnect.EConnectError carrying the proc's message (see econnect.create_job)."""
-    # cost_codes is a provisioning instruction for step 5, not a wsiJCJobMaster field - leaving it in
-    # would trip create_job's unknown-field guard on every call (#448).
+    # cost_codes is a provisioning instruction for steps 2 and 6, not a wsiJCJobMaster field - leaving
+    # it in would trip create_job's unknown-field guard on every call (#448).
     fields = request.model_dump(exclude={"company", "cost_codes"})
 
     if econnect.job_exists(conn, request.job_number):
@@ -357,6 +390,8 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
             "job_already_exists",
             f"job '{request.job_number}' already exists in GP company {company} (JC00102)",
         )
+
+    chosen_cost_codes = _resolve_cost_code_selection(conn, company=company, request=request)
 
     econnect.create_job(conn, only_validate=True, **fields)
     econnect.create_job(conn, only_validate=False, **fields)
@@ -369,9 +404,7 @@ def create_job_op(conn, *, company: str, request: models.CreateJobRequest) -> mo
             proc="wsiJCJobMaster",
         )
 
-    provisioned = 0
-    if request.cost_codes:
-        provisioned = _provision_cost_codes(conn, company=company, request=request)
+    provisioned = _write_cost_codes(conn, request=request, chosen=chosen_cost_codes)
 
     return models.CreateJobResponse(
         job_number=created["job_number"],

--- a/relay/tests/test_channel.py
+++ b/relay/tests/test_channel.py
@@ -70,6 +70,34 @@ def test_list_cost_codes_routes_to_econnect_and_strips_job(monkeypatch):
     }
 
 
+def test_list_cost_code_master_requires_division():
+    # The division is not a filter on the list - it is what decides the GL account each code would be
+    # provisioned with (JC40302), so there is no sensible answer without one.
+    reply = channel._dispatch("list_cost_code_master", "TUBC", {})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "missing_division"
+
+
+def test_list_cost_code_master_routes_to_econnect_and_strips_division(monkeypatch):
+    seen = {}
+
+    def _fake(conn, division):
+        seen["division"] = division
+        return [{"cost_code": "210-200", "cost_element": 2, "mapped": True}]
+
+    monkeypatch.setattr(econnect, "list_cost_code_master", _fake)
+    reply = channel._dispatch("list_cost_code_master", "TUBC", {"division": " VANCOUVER "})
+    assert seen["division"] == "VANCOUVER"
+    assert reply == {
+        "ok": True,
+        "result": {
+            "company": "TUBC",
+            "division": "VANCOUVER",
+            "cost_codes": [{"cost_code": "210-200", "cost_element": 2, "mapped": True}],
+        },
+    }
+
+
 def test_list_jobs_routes_to_econnect(monkeypatch):
     monkeypatch.setattr(econnect, "list_jobs", lambda conn: [{"job_number": "80003", "job_name": "Test"}])
     reply = channel._dispatch("list_jobs", "TUBC", {})
@@ -268,7 +296,13 @@ def test_create_job_success_returns_the_response_body(monkeypatch):
     monkeypatch.setattr(ops, "create_job_op", _fake)
     reply = channel._dispatch("create_job", "TUBC", _JOB_PAYLOAD)
     assert reply["ok"] is True
-    assert reply["result"] == {"job_number": "NEXUS-380-T1", "job_name": "Test job", "company": "TUBC"}
+    # cost_codes_provisioned rides along on every create_job reply (#448); 0 when none were selected.
+    assert reply["result"] == {
+        "job_number": "NEXUS-380-T1",
+        "job_name": "Test job",
+        "company": "TUBC",
+        "cost_codes_provisioned": 0,
+    }
 
 
 def test_create_job_already_exists_translates_cleanly(monkeypatch):

--- a/relay/tests/test_cost_code_provisioning.py
+++ b/relay/tests/test_cost_code_provisioning.py
@@ -23,7 +23,6 @@ from ucnexus_relay.ops import RelayOpError
 
 _MasterRow = namedtuple("_MasterRow", "cc1 cc2 alias descr elem ptype ttype account_index resolved")
 _ExecRow = namedtuple("_ExecRow", "error_state err_string")
-_CountRow = namedtuple("_CountRow", "n")
 
 REQUIRED = {
     "job_number": "NEXUS-448-T1",
@@ -51,20 +50,17 @@ class _FakeCursor:
         return self._conn.rows
 
     def fetchone(self):
-        if "JC00701" in self._sql:
-            return _CountRow(self._conn.active_cost_codes)  # the provisioning read-back
         return _ExecRow(self._conn.error_state, self._conn.err_string)
 
 
 class _FakeConn:
-    """Answers the master read from `rows`, any proc EXEC with (error_state, err_string) and the
-    JC00701 read-back with `active_cost_codes`. Keeps every (sql, params) for assertions."""
+    """Answers the master read from `rows` and any proc EXEC with (error_state, err_string). Keeps
+    every (sql, params) for assertions."""
 
-    def __init__(self, *rows, error_state=0, err_string="", active_cost_codes=0):
+    def __init__(self, *rows, error_state=0, err_string=""):
         self.rows = list(rows)
         self.error_state = error_state
         self.err_string = err_string
-        self.active_cost_codes = active_cost_codes
         self.calls: list[tuple[str, tuple]] = []
 
     def cursor(self):
@@ -105,6 +101,15 @@ def test_the_master_read_joins_the_division_mapping_and_the_chart():
     assert "LEFT JOIN dbo.GL00105 g ON g.ACTINDX = a.ACTINDX" in sql
 
 
+def test_four_segment_master_codes_are_filtered_out_in_sql():
+    """The write sends segments 1 and 2 only, so a code with a third or fourth segment cannot be
+    provisioned faithfully - offering it would provision a DIFFERENT JC00701 row than the picker named.
+    No row in this company has one, which is why the filter costs nothing and refuses to guess."""
+    conn = _FakeConn(_master_row())
+    list_cost_code_master(conn, "VANCOUVER")
+    assert "WHERE RTRIM(m.Cost_Code_Number_3) = '' AND RTRIM(m.Cost_Code_Number_4) = ''" in conn.sql()
+
+
 def test_the_division_is_bound_stripped():
     # Same normalization list_divisions applies, so a division read out of that picker matches here.
     conn = _FakeConn(_master_row())
@@ -117,6 +122,9 @@ def test_a_row_assembles_the_shape_the_picker_and_the_write_both_need():
     assert list_cost_code_master(conn, "VANCOUVER") == [
         {
             "cost_code": "210-200",
+            # The raw segments ride along beside the joined form so the write never has to re-split it.
+            "cost_code_number_1": "210",
+            "cost_code_number_2": "200",
             "alias": "HOLLOW MTL",
             "description": "Hollow metal",
             "cost_element": 2,
@@ -126,6 +134,33 @@ def test_a_row_assembles_the_shape_the_picker_and_the_write_both_need():
             "mapped": True,
         }
     ]
+
+
+def test_a_duplicate_code_and_element_pair_keeps_the_first_row():
+    """No duplicate pair exists in JC40202 at this customer, but one would break three things at once:
+    duplicate keys in the picker, an account that depends on SQL row order, and both copies rejected by
+    the duplicate-selection validator. Keeping the first row makes the answer deterministic."""
+    conn = _FakeConn(_master_row(account_index=96), _master_row(account_index=1401, alias="SECOND"))
+    rows = list_cost_code_master(conn, "VANCOUVER")
+    assert len(rows) == 1
+    assert rows[0]["account_index"] == 96
+    assert rows[0]["alias"] == "HOLLOW MTL"
+
+
+def test_the_dedupe_key_includes_the_cost_element():
+    # cost_element is part of the key, so 210-200 element 2 and element 5 are two separate codes and
+    # the dedupe must not collapse them.
+    conn = _FakeConn(_master_row(elem=2), _master_row(elem=5))
+    assert [r["cost_element"] for r in list_cost_code_master(conn, "VANCOUVER")] == [2, 5]
+
+
+def test_a_null_profit_or_transaction_type_degrades_to_the_procs_default():
+    """None are NULL live. If one ever is, it has to become the proc's own default rather than kill the
+    whole company's picker with a TypeError on int(None)."""
+    conn = _FakeConn(_master_row(ptype=None, ttype=None))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["profit_type_number"] == 0
+    assert row["type_of_transaction"] == 0
 
 
 def test_a_blank_alias_or_description_comes_back_as_none():
@@ -255,12 +290,15 @@ def _request(cost_codes=None, **overrides):
 
 
 def _stub_job_create(monkeypatch):
-    """Everything create_job_op does before provisioning, stubbed to succeed."""
+    """Everything create_job_op does around provisioning, stubbed to succeed. Returns the list each
+    econnect.create_job call is recorded into, so a test can assert the job proc never ran."""
+    job_calls: list[dict] = []
     monkeypatch.setattr(econnect, "job_exists", lambda c, j: False)
-    monkeypatch.setattr(econnect, "create_job", lambda c, **k: None)
+    monkeypatch.setattr(econnect, "create_job", lambda c, **k: job_calls.append(k))
     monkeypatch.setattr(
         econnect, "get_job", lambda c, j: {"job_number": REQUIRED["job_number"], "job_name": "Test job"}
     )
+    return job_calls
 
 
 def _stub_master(monkeypatch, *rows):
@@ -284,9 +322,27 @@ def _stub_writes(monkeypatch):
     return written
 
 
+def _stub_on_job(monkeypatch, *, missing=()):
+    """The per-code verification read, recorded. `missing` names the 'cc1-cc2-element' strings the
+    lookup answers False for - a code the proc claimed to write that no PO could then reference."""
+    verified: list[tuple[str, str]] = []
+
+    def _fake(conn, job_number, cost_code):
+        verified.append((job_number, cost_code))
+        return cost_code not in missing
+
+    monkeypatch.setattr(econnect, "cost_code_on_job", _fake)
+    return verified
+
+
 def _mapped(cost_code="210-200", element=2, **overrides):
+    # The segments default to the joined form split at its FIRST '-', which is how GP's own two-segment
+    # codes decompose; a fixture whose second segment contains a '-' overrides them explicitly.
+    cc1, _, cc2 = cost_code.partition("-")
     base = {
         "cost_code": cost_code,
+        "cost_code_number_1": cc1,
+        "cost_code_number_2": cc2,
         "alias": "HOLLOW MTL",
         "description": "Hollow metal",
         "cost_element": element,
@@ -304,22 +360,58 @@ def test_no_cost_codes_provisions_nothing(monkeypatch):
     _stub_job_create(monkeypatch)
     seen = _stub_master(monkeypatch)
     written = _stub_writes(monkeypatch)
+    verified = _stub_on_job(monkeypatch)
 
     response = ops.create_job_op(conn, company="TUBC", request=_request())
 
     assert response.cost_codes_provisioned == 0
     assert seen == []  # the master is not even read
     assert written == []
-    assert conn.calls == []  # and no read-back either
+    assert verified == []  # and nothing to verify afterwards
+    assert conn.calls == []
+
+
+def test_the_selection_is_resolved_before_the_job_proc_runs(monkeypatch):
+    """A stale picker selection has to refuse the create having written NOTHING, which is only true
+    while the master read and its refusals sit ahead of wsiJCJobMaster's dry run."""
+    order: list[str] = []
+    conn = _FakeConn()
+
+    def _job_exists(c, j):
+        order.append("job_exists")
+        return False
+
+    def _master(c, division):
+        order.append("master")
+        return [_mapped()]
+
+    def _create_job(c, **k):
+        order.append("create_job")
+
+    monkeypatch.setattr(econnect, "job_exists", _job_exists)
+    monkeypatch.setattr(econnect, "list_cost_code_master", _master)
+    monkeypatch.setattr(econnect, "create_job", _create_job)
+    monkeypatch.setattr(
+        econnect, "get_job", lambda c, j: {"job_number": REQUIRED["job_number"], "job_name": "Test job"}
+    )
+    _stub_writes(monkeypatch)
+    _stub_on_job(monkeypatch)
+
+    ops.create_job_op(
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+    )
+
+    assert order == ["job_exists", "master", "create_job", "create_job"]
 
 
 def test_every_validation_pass_precedes_the_first_real_write(monkeypatch):
     """The eleventh code failing after ten were written leaves a half-provisioned job that only a
     rollback saves; validating the whole selection first is what makes the rollback unnecessary."""
-    conn = _FakeConn(active_cost_codes=2)
+    conn = _FakeConn()
     _stub_job_create(monkeypatch)
     _stub_master(monkeypatch, _mapped(), _mapped(cost_code="310-000", element=3))
     written = _stub_writes(monkeypatch)
+    _stub_on_job(monkeypatch)
 
     request = _request(
         cost_codes=[
@@ -337,10 +429,11 @@ def test_every_validation_pass_precedes_the_first_real_write(monkeypatch):
 def test_the_master_is_read_for_the_jobs_own_division(monkeypatch):
     # The same cost element resolves to a different account in a different division, so the division
     # is what decides the account, not a filter on the list.
-    conn = _FakeConn(active_cost_codes=1)
+    conn = _FakeConn()
     _stub_job_create(monkeypatch)
     seen = _stub_master(monkeypatch, _mapped())
     _stub_writes(monkeypatch)
+    _stub_on_job(monkeypatch)
 
     ops.create_job_op(
         conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
@@ -351,12 +444,17 @@ def test_the_master_is_read_for_the_jobs_own_division(monkeypatch):
 
 def test_every_written_value_comes_from_the_master(monkeypatch):
     """Provenance (#427/#430): the request names which codes, GP's configuration says what they mean.
-    The account index especially - a caller that could send one could post a job's costs anywhere."""
-    conn = _FakeConn(active_cost_codes=1)
+    The account index especially - a caller that could send one could post a job's costs anywhere.
+
+    The segments included: this fixture's second segment contains a '-', so re-splitting the joined
+    'cc1-cc2' form the way econnect.split_cost_code does would write '2' where GP holds '2-00'. The
+    master row's own segment keys are what the write binds, so they win."""
+    conn = _FakeConn()
     _stub_job_create(monkeypatch)
     _stub_master(
         monkeypatch,
         _mapped(
+            cost_code="210-2-00",
             alias="FROM GP",
             description="What GP has on file",
             account_index=1401,
@@ -365,16 +463,19 @@ def test_every_written_value_comes_from_the_master(monkeypatch):
         ),
     )
     written = _stub_writes(monkeypatch)
+    _stub_on_job(monkeypatch)
 
     ops.create_job_op(
-        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-2-00", "cost_element": 2}])
     )
 
+    # what a re-split would have produced, and did not
+    assert econnect.split_cost_code("210-2-00")[:2] == ("210", "2")
     assert written[0] == {
         "only_validate": True,
         "job_number": "NEXUS-448-T1",
         "cost_code_number_1": "210",
-        "cost_code_number_2": "200",
+        "cost_code_number_2": "2-00",
         "alias": "FROM GP",
         "description": "What GP has on file",
         "cost_element": 2,
@@ -386,7 +487,7 @@ def test_every_written_value_comes_from_the_master(monkeypatch):
 
 def test_a_code_that_is_not_in_the_master_is_refused(monkeypatch):
     conn = _FakeConn()
-    _stub_job_create(monkeypatch)
+    job_calls = _stub_job_create(monkeypatch)
     _stub_master(monkeypatch, _mapped())
     written = _stub_writes(monkeypatch)
 
@@ -400,6 +501,7 @@ def test_a_code_that_is_not_in_the_master_is_refused(monkeypatch):
     assert "JC40202" in exc.value.message
     assert "TUBC" in exc.value.message
     assert written == []
+    assert job_calls == []  # not even the dry run: the refusal costs the job nothing
 
 
 def test_the_same_code_under_a_different_element_is_a_different_code(monkeypatch):
@@ -422,7 +524,7 @@ def test_a_code_with_no_usable_account_is_refused(monkeypatch):
     """Provisioning it would manufacture the dangling JC00701 row #425 is about: the job would register
     POs and then fail forever at receipt with eConnect 4612."""
     conn = _FakeConn()
-    _stub_job_create(monkeypatch)
+    job_calls = _stub_job_create(monkeypatch)
     _stub_master(monkeypatch, _mapped(account_index=1617, mapped=False))
     written = _stub_writes(monkeypatch)
 
@@ -436,13 +538,14 @@ def test_a_code_with_no_usable_account_is_refused(monkeypatch):
     assert "VANCOUVER" in exc.value.message
     assert "JC40302" in exc.value.message
     assert written == []
+    assert job_calls == []
 
 
 def test_nothing_is_written_when_a_later_selection_is_bad(monkeypatch):
     # The whole selection is checked against the master before any pass runs, so one bad code cannot
     # get ten good ones written first.
     conn = _FakeConn()
-    _stub_job_create(monkeypatch)
+    job_calls = _stub_job_create(monkeypatch)
     _stub_master(monkeypatch, _mapped())
     written = _stub_writes(monkeypatch)
 
@@ -459,31 +562,39 @@ def test_nothing_is_written_when_a_later_selection_is_bad(monkeypatch):
         )
 
     assert written == []
+    assert job_calls == []
 
 
-def test_the_read_back_counts_the_rows_that_actually_landed(monkeypatch):
-    conn = _FakeConn(active_cost_codes=1)
-    _stub_job_create(monkeypatch)
-    _stub_master(monkeypatch, _mapped())
-    _stub_writes(monkeypatch)
-
-    ops.create_job_op(
-        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
-    )
-
-    sql, params = conn.calls[-1]
-    assert "SELECT COUNT(*) AS n FROM dbo.JC00701" in sql
-    assert "WS_Inactive = 0" in sql
-    assert params == ("NEXUS-448-T1",)
-
-
-def test_a_short_read_back_raises_naming_both_counts(monkeypatch):
-    """taPoLine has a known err=0-but-no-row mode and this is the same class of proc, so a success
-    report is not evidence a row landed."""
-    conn = _FakeConn(active_cost_codes=1)
+def test_each_provisioned_code_is_verified_through_the_po_paths_own_lookup(monkeypatch):
+    """cost_code_on_job is the lookup /po runs before it lets a line name a cost code, so asking it is
+    what keeps "provisioned" and "reachable by a PO" from drifting apart. The three-segment string is
+    the shape the register-PO dropdown and /po both speak."""
+    conn = _FakeConn()
     _stub_job_create(monkeypatch)
     _stub_master(monkeypatch, _mapped(), _mapped(cost_code="310-000", element=3))
     _stub_writes(monkeypatch)
+    verified = _stub_on_job(monkeypatch)
+
+    request = _request(
+        cost_codes=[
+            {"cost_code": "210-200", "cost_element": 2},
+            {"cost_code": "310-000", "cost_element": 3},
+        ]
+    )
+    response = ops.create_job_op(conn, company="TUBC", request=request)
+
+    assert verified == [("NEXUS-448-T1", "210-200-2"), ("NEXUS-448-T1", "310-000-3")]
+    assert response.cost_codes_provisioned == 2
+
+
+def test_a_code_that_did_not_land_raises_naming_it(monkeypatch):
+    """taPoLine has a known err=0-but-no-row mode and this is the same class of proc, so a success
+    report is not evidence a row landed. Naming the code beats naming a count."""
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped(), _mapped(cost_code="310-000", element=3))
+    _stub_writes(monkeypatch)
+    _stub_on_job(monkeypatch, missing=("310-000-3",))
 
     request = _request(
         cost_codes=[
@@ -495,8 +606,8 @@ def test_a_short_read_back_raises_naming_both_counts(monkeypatch):
         ops.create_job_op(conn, company="TUBC", request=request)
 
     assert exc.value.proc == "wsiJCJobDetailMSTR"
-    assert "has 1 active" in str(exc.value)
-    assert "expected 2" in str(exc.value)
+    assert "310-000-3" in str(exc.value)
+    assert "NEXUS-448-T1" in str(exc.value)
 
 
 def test_provisioning_runs_only_after_the_job_itself_landed(monkeypatch):
@@ -518,10 +629,10 @@ def test_provisioning_runs_only_after_the_job_itself_landed(monkeypatch):
 
 
 def test_the_job_proc_never_receives_the_cost_code_selection(monkeypatch):
-    """cost_codes is a provisioning instruction for step 5, not a wsiJCJobMaster field. If it leaks
-    into the kwargs create_job_op builds for econnect.create_job, that function's unknown-field guard
-    refuses EVERY create - and the permissive `lambda c, **k` stubs in the other tests would never
-    notice, which is exactly how the bug shipped once already."""
+    """cost_codes is a provisioning instruction for steps 2 and 6, not a wsiJCJobMaster field. If it
+    leaks into the kwargs create_job_op builds for econnect.create_job, that function's unknown-field
+    guard refuses EVERY create - and the permissive `lambda c, **k` stubs in the other tests would
+    never notice, which is exactly how the bug shipped once already."""
     received: list[set] = []
     monkeypatch.setattr(econnect, "job_exists", lambda c, j: False)
     monkeypatch.setattr(econnect, "create_job", lambda c, **k: received.append(set(k)))
@@ -530,7 +641,8 @@ def test_the_job_proc_never_receives_the_cost_code_selection(monkeypatch):
     )
     _stub_master(monkeypatch, _mapped())
     _stub_writes(monkeypatch)
-    conn = _FakeConn(active_cost_codes=1)
+    _stub_on_job(monkeypatch)
+    conn = _FakeConn()
 
     ops.create_job_op(
         conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])

--- a/relay/tests/test_cost_code_provisioning.py
+++ b/relay/tests/test_cost_code_provisioning.py
@@ -1,0 +1,580 @@
+"""Cost-code provisioning for a job created from Nexus (issue #448): the JC40202/JC40302 master read,
+the wsiJCJobDetailMSTR write, and the create_job_op step that ties them together.
+
+The failure being fixed is that wsiJCJobMaster writes the JC00102 row and nothing else, so a job
+created from Nexus had zero JC00701 cost codes - an empty register-PO dropdown, and job_setup_health's
+first rule ("has at least one active cost code") failing, which quarantines the project on sight
+(#425). No real GP here: a fake cursor records the SQL and answers each query in turn.
+
+The rule these pin hardest is provenance (#427/#430): the request names WHICH cost codes the job gets,
+and every value actually written - alias, description, profit/transaction type, and above all the GL
+account index - is read out of GP's own master. A caller that could send an account index could post a
+job's costs anywhere in the chart.
+"""
+
+from collections import namedtuple
+from datetime import date
+
+import pytest
+
+from ucnexus_relay import econnect, models, ops
+from ucnexus_relay.econnect import EConnectError, create_job_cost_code, list_cost_code_master
+from ucnexus_relay.ops import RelayOpError
+
+_MasterRow = namedtuple("_MasterRow", "cc1 cc2 alias descr elem ptype ttype account_index resolved")
+_ExecRow = namedtuple("_ExecRow", "error_state err_string")
+_CountRow = namedtuple("_CountRow", "n")
+
+REQUIRED = {
+    "job_number": "NEXUS-448-T1",
+    "job_name": "Test job",
+    "division": "VANCOUVER",
+    "customer_number": "ELL100",
+    "job_address_code": "MAIN",
+    "billto_address_code": "MAIN",
+    "tax_schedule_id": "GST 5%",
+    "created_date": date(2026, 7, 30),
+}
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self._sql = ""
+
+    def execute(self, sql, *params):
+        self._sql = sql
+        self._conn.calls.append((sql, params))
+        return self
+
+    def fetchall(self):
+        return self._conn.rows
+
+    def fetchone(self):
+        if "JC00701" in self._sql:
+            return _CountRow(self._conn.active_cost_codes)  # the provisioning read-back
+        return _ExecRow(self._conn.error_state, self._conn.err_string)
+
+
+class _FakeConn:
+    """Answers the master read from `rows`, any proc EXEC with (error_state, err_string) and the
+    JC00701 read-back with `active_cost_codes`. Keeps every (sql, params) for assertions."""
+
+    def __init__(self, *rows, error_state=0, err_string="", active_cost_codes=0):
+        self.rows = list(rows)
+        self.error_state = error_state
+        self.err_string = err_string
+        self.active_cost_codes = active_cost_codes
+        self.calls: list[tuple[str, tuple]] = []
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def sql(self, i=0):
+        return self.calls[i][0]
+
+
+def _master_row(**overrides):
+    base = {
+        "cc1": "210",
+        "cc2": "200",
+        "alias": "HOLLOW MTL",
+        "descr": "Hollow metal",
+        "elem": 2,
+        "ptype": 1,
+        "ttype": 3,
+        "account_index": 96,
+        "resolved": 96,
+    }
+    return _MasterRow(**{**base, **overrides})
+
+
+# --- econnect.list_cost_code_master: the read ---
+
+
+def test_the_master_read_joins_the_division_mapping_and_the_chart():
+    conn = _FakeConn(_master_row())
+    list_cost_code_master(conn, "VANCOUVER")
+    sql = conn.sql()
+    assert "dbo.JC40202" in sql
+    # JC40302 is the ONLY legitimate source of the account index; JC40202's own ACTINDX is 0 on every
+    # row in this company and is not the mapping.
+    assert "LEFT JOIN dbo.JC40302 a ON RTRIM(a.Divisions) = ? AND a.Cost_Element = m.Cost_Element" in sql
+    # ... and the chart join is what stops a sandbox whose division mapping itself dangles from
+    # provisioning fresh #425 rows.
+    assert "LEFT JOIN dbo.GL00105 g ON g.ACTINDX = a.ACTINDX" in sql
+
+
+def test_the_division_is_bound_stripped():
+    # Same normalization list_divisions applies, so a division read out of that picker matches here.
+    conn = _FakeConn(_master_row())
+    list_cost_code_master(conn, "  VANCOUVER ")
+    assert conn.calls[0][1] == ("VANCOUVER",)
+
+
+def test_a_row_assembles_the_shape_the_picker_and_the_write_both_need():
+    conn = _FakeConn(_master_row())
+    assert list_cost_code_master(conn, "VANCOUVER") == [
+        {
+            "cost_code": "210-200",
+            "alias": "HOLLOW MTL",
+            "description": "Hollow metal",
+            "cost_element": 2,
+            "profit_type_number": 1,
+            "type_of_transaction": 3,
+            "account_index": 96,
+            "mapped": True,
+        }
+    ]
+
+
+def test_a_blank_alias_or_description_comes_back_as_none():
+    conn = _FakeConn(_master_row(alias="", descr=""))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["alias"] is None
+    assert row["description"] is None
+
+
+def test_a_cost_element_with_no_division_mapping_is_unmapped():
+    """No JC40302 row for the element: there is nothing to provision the code with, so the picker must
+    not offer it. account_index None distinguishes this from a mapping that exists and says 0."""
+    conn = _FakeConn(_master_row(account_index=None, resolved=None))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["account_index"] is None
+    assert row["mapped"] is False
+
+
+def test_a_mapped_account_index_of_zero_is_usable():
+    # 0 is "GP picks the account at posting time", which eConnect honours - the same rule
+    # account_index_exists applies. Treating it as unmapped would hide most of the master.
+    conn = _FakeConn(_master_row(account_index=0, resolved=None))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["account_index"] == 0
+    assert row["mapped"] is True
+
+
+def test_an_index_that_resolves_in_the_chart_is_mapped():
+    conn = _FakeConn(_master_row(account_index=1401, resolved=1401))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["account_index"] == 1401
+    assert row["mapped"] is True
+
+
+def test_a_non_zero_index_absent_from_the_chart_is_unmapped():
+    """The stale-sandbox defence: the division mapping itself points at an account this company does
+    not have. Provisioning off it would manufacture exactly the dangling JC00701 rows #425 is about."""
+    conn = _FakeConn(_master_row(account_index=1617, resolved=None))
+    row = list_cost_code_master(conn, "VANCOUVER")[0]
+    assert row["account_index"] == 1617
+    assert row["mapped"] is False
+
+
+def test_unmapped_codes_are_returned_not_filtered_out():
+    # The picker greys them with a reason; a shorter list than GP's own would just look wrong.
+    conn = _FakeConn(_master_row(), _master_row(cc2="300", account_index=None, resolved=None))
+    assert [r["mapped"] for r in list_cost_code_master(conn, "VANCOUVER")] == [True, False]
+
+
+# --- econnect.create_job_cost_code: the write ---
+
+
+def _write_kwargs(**overrides):
+    base = {
+        "job_number": "NEXUS-448-T1",
+        "cost_code_number_1": "210",
+        "cost_code_number_2": "200",
+        "alias": "HOLLOW MTL",
+        "description": "Hollow metal",
+        "cost_element": 2,
+        "account_index": 96,
+        "profit_type_number": 1,
+        "type_of_transaction": 3,
+    }
+    return {**base, **overrides}
+
+
+def test_update_if_exists_is_a_literal_one():
+    """Not a caller parameter: every value written comes from the master, so a retry after a lost reply
+    rewrites the identical row instead of failing on a duplicate."""
+    conn = _FakeConn()
+    create_job_cost_code(conn, **_write_kwargs())
+    assert "@I_vUpdateIfExists      = 1," in conn.sql()
+
+
+def test_the_error_text_is_always_requested():
+    conn = _FakeConn()
+    create_job_cost_code(conn, **_write_kwargs())
+    assert "@I_vReturnErrorText     = 1," in conn.sql()
+
+
+def test_only_validate_is_bound_and_defaults_to_a_real_write():
+    conn = _FakeConn()
+    create_job_cost_code(conn, **_write_kwargs())
+    assert "@I_vOnlyValidate        = ?," in conn.sql()
+    assert conn.calls[0][1][-1] == 0
+
+    dry = _FakeConn()
+    create_job_cost_code(dry, only_validate=True, **_write_kwargs())
+    assert dry.calls[0][1][-1] == 1
+
+
+def test_the_nine_inputs_are_bound_in_the_procs_parameter_order():
+    conn = _FakeConn()
+    create_job_cost_code(conn, **_write_kwargs())
+    sql, params = conn.calls[0]
+    assert "dbo.wsiJCJobDetailMSTR" in sql
+    assert params == ("NEXUS-448-T1", "210", "200", "HOLLOW MTL", "Hollow metal", 2, 96, 1, 3, 0)
+
+
+def test_a_proc_error_raises_with_the_procs_own_message():
+    conn = _FakeConn(error_state=51000, err_string="The cost code already exists on this job.")
+    with pytest.raises(EConnectError) as exc:
+        create_job_cost_code(conn, **_write_kwargs())
+    assert exc.value.proc == "wsiJCJobDetailMSTR"
+    assert exc.value.error_state == 51000
+    # The WennSoft procs number their states independently of taErrorCode, so the proc's own text is
+    # what has to survive to the user (see EConnectError).
+    assert exc.value.proc_message == "The cost code already exists on this job."
+    assert "NEXUS-448-T1" in str(exc.value)
+    assert "210-200-2" in str(exc.value)
+
+
+def test_a_validation_pass_failure_says_validation():
+    conn = _FakeConn(error_state=1, err_string="Invalid account index.")
+    with pytest.raises(EConnectError, match="validation failed"):
+        create_job_cost_code(conn, only_validate=True, **_write_kwargs())
+
+
+# --- ops.create_job_op: provisioning ---
+
+
+def _request(cost_codes=None, **overrides):
+    return models.CreateJobRequest(
+        company="TUBC", **{**REQUIRED, **overrides}, cost_codes=cost_codes or []
+    )
+
+
+def _stub_job_create(monkeypatch):
+    """Everything create_job_op does before provisioning, stubbed to succeed."""
+    monkeypatch.setattr(econnect, "job_exists", lambda c, j: False)
+    monkeypatch.setattr(econnect, "create_job", lambda c, **k: None)
+    monkeypatch.setattr(
+        econnect, "get_job", lambda c, j: {"job_number": REQUIRED["job_number"], "job_name": "Test job"}
+    )
+
+
+def _stub_master(monkeypatch, *rows):
+    seen: list = []
+
+    def _fake(conn, division):
+        seen.append(division)
+        return list(rows)
+
+    monkeypatch.setattr(econnect, "list_cost_code_master", _fake)
+    return seen
+
+
+def _stub_writes(monkeypatch):
+    written: list[dict] = []
+    monkeypatch.setattr(
+        econnect,
+        "create_job_cost_code",
+        lambda c, *, only_validate=False, **kw: written.append({"only_validate": only_validate, **kw}),
+    )
+    return written
+
+
+def _mapped(cost_code="210-200", element=2, **overrides):
+    base = {
+        "cost_code": cost_code,
+        "alias": "HOLLOW MTL",
+        "description": "Hollow metal",
+        "cost_element": element,
+        "profit_type_number": 1,
+        "type_of_transaction": 3,
+        "account_index": 96,
+        "mapped": True,
+    }
+    return {**base, **overrides}
+
+
+def test_no_cost_codes_provisions_nothing(monkeypatch):
+    """Every pre-#448 caller sends none, and for them the create path must be exactly what it was."""
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    seen = _stub_master(monkeypatch)
+    written = _stub_writes(monkeypatch)
+
+    response = ops.create_job_op(conn, company="TUBC", request=_request())
+
+    assert response.cost_codes_provisioned == 0
+    assert seen == []  # the master is not even read
+    assert written == []
+    assert conn.calls == []  # and no read-back either
+
+
+def test_every_validation_pass_precedes_the_first_real_write(monkeypatch):
+    """The eleventh code failing after ten were written leaves a half-provisioned job that only a
+    rollback saves; validating the whole selection first is what makes the rollback unnecessary."""
+    conn = _FakeConn(active_cost_codes=2)
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped(), _mapped(cost_code="310-000", element=3))
+    written = _stub_writes(monkeypatch)
+
+    request = _request(
+        cost_codes=[
+            {"cost_code": "210-200", "cost_element": 2},
+            {"cost_code": "310-000", "cost_element": 3},
+        ]
+    )
+    response = ops.create_job_op(conn, company="TUBC", request=request)
+
+    assert [w["only_validate"] for w in written] == [True, True, False, False]
+    assert [w["cost_code_number_2"] for w in written] == ["200", "000", "200", "000"]
+    assert response.cost_codes_provisioned == 2
+
+
+def test_the_master_is_read_for_the_jobs_own_division(monkeypatch):
+    # The same cost element resolves to a different account in a different division, so the division
+    # is what decides the account, not a filter on the list.
+    conn = _FakeConn(active_cost_codes=1)
+    _stub_job_create(monkeypatch)
+    seen = _stub_master(monkeypatch, _mapped())
+    _stub_writes(monkeypatch)
+
+    ops.create_job_op(
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+    )
+
+    assert seen == ["VANCOUVER"]
+
+
+def test_every_written_value_comes_from_the_master(monkeypatch):
+    """Provenance (#427/#430): the request names which codes, GP's configuration says what they mean.
+    The account index especially - a caller that could send one could post a job's costs anywhere."""
+    conn = _FakeConn(active_cost_codes=1)
+    _stub_job_create(monkeypatch)
+    _stub_master(
+        monkeypatch,
+        _mapped(
+            alias="FROM GP",
+            description="What GP has on file",
+            account_index=1401,
+            profit_type_number=2,
+            type_of_transaction=4,
+        ),
+    )
+    written = _stub_writes(monkeypatch)
+
+    ops.create_job_op(
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+    )
+
+    assert written[0] == {
+        "only_validate": True,
+        "job_number": "NEXUS-448-T1",
+        "cost_code_number_1": "210",
+        "cost_code_number_2": "200",
+        "alias": "FROM GP",
+        "description": "What GP has on file",
+        "cost_element": 2,
+        "account_index": 1401,
+        "profit_type_number": 2,
+        "type_of_transaction": 4,
+    }
+
+
+def test_a_code_that_is_not_in_the_master_is_refused(monkeypatch):
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped())
+    written = _stub_writes(monkeypatch)
+
+    with pytest.raises(RelayOpError) as exc:
+        ops.create_job_op(
+            conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "999-999", "cost_element": 9}])
+        )
+
+    assert exc.value.code == "cost_code_not_in_master"
+    assert "999-999" in exc.value.message
+    assert "JC40202" in exc.value.message
+    assert "TUBC" in exc.value.message
+    assert written == []
+
+
+def test_the_same_code_under_a_different_element_is_a_different_code(monkeypatch):
+    # cost_element is part of the identity, not a detail: 210-200 element 2 and element 5 are separate
+    # JC00701 rows with separate accounts.
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped(element=2))
+    _stub_writes(monkeypatch)
+
+    with pytest.raises(RelayOpError) as exc:
+        ops.create_job_op(
+            conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 5}])
+        )
+
+    assert exc.value.code == "cost_code_not_in_master"
+
+
+def test_a_code_with_no_usable_account_is_refused(monkeypatch):
+    """Provisioning it would manufacture the dangling JC00701 row #425 is about: the job would register
+    POs and then fail forever at receipt with eConnect 4612."""
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped(account_index=1617, mapped=False))
+    written = _stub_writes(monkeypatch)
+
+    with pytest.raises(RelayOpError) as exc:
+        ops.create_job_op(
+            conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+        )
+
+    assert exc.value.code == "cost_code_unmapped"
+    assert "210-200" in exc.value.message
+    assert "VANCOUVER" in exc.value.message
+    assert "JC40302" in exc.value.message
+    assert written == []
+
+
+def test_nothing_is_written_when_a_later_selection_is_bad(monkeypatch):
+    # The whole selection is checked against the master before any pass runs, so one bad code cannot
+    # get ten good ones written first.
+    conn = _FakeConn()
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped())
+    written = _stub_writes(monkeypatch)
+
+    with pytest.raises(RelayOpError):
+        ops.create_job_op(
+            conn,
+            company="TUBC",
+            request=_request(
+                cost_codes=[
+                    {"cost_code": "210-200", "cost_element": 2},
+                    {"cost_code": "999-999", "cost_element": 9},
+                ]
+            ),
+        )
+
+    assert written == []
+
+
+def test_the_read_back_counts_the_rows_that_actually_landed(monkeypatch):
+    conn = _FakeConn(active_cost_codes=1)
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped())
+    _stub_writes(monkeypatch)
+
+    ops.create_job_op(
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+    )
+
+    sql, params = conn.calls[-1]
+    assert "SELECT COUNT(*) AS n FROM dbo.JC00701" in sql
+    assert "WS_Inactive = 0" in sql
+    assert params == ("NEXUS-448-T1",)
+
+
+def test_a_short_read_back_raises_naming_both_counts(monkeypatch):
+    """taPoLine has a known err=0-but-no-row mode and this is the same class of proc, so a success
+    report is not evidence a row landed."""
+    conn = _FakeConn(active_cost_codes=1)
+    _stub_job_create(monkeypatch)
+    _stub_master(monkeypatch, _mapped(), _mapped(cost_code="310-000", element=3))
+    _stub_writes(monkeypatch)
+
+    request = _request(
+        cost_codes=[
+            {"cost_code": "210-200", "cost_element": 2},
+            {"cost_code": "310-000", "cost_element": 3},
+        ]
+    )
+    with pytest.raises(EConnectError) as exc:
+        ops.create_job_op(conn, company="TUBC", request=request)
+
+    assert exc.value.proc == "wsiJCJobDetailMSTR"
+    assert "has 1 active" in str(exc.value)
+    assert "expected 2" in str(exc.value)
+
+
+def test_provisioning_runs_only_after_the_job_itself_landed(monkeypatch):
+    """A cost code on a job that is not in JC00102 is not a thing GP can hold, and the read-back is
+    what proves the job landed at all."""
+    conn = _FakeConn()
+    monkeypatch.setattr(econnect, "job_exists", lambda c, j: False)
+    monkeypatch.setattr(econnect, "create_job", lambda c, **k: None)
+    monkeypatch.setattr(econnect, "get_job", lambda c, j: None)
+    _stub_master(monkeypatch, _mapped())
+    written = _stub_writes(monkeypatch)
+
+    with pytest.raises(EConnectError, match="not in JC00102"):
+        ops.create_job_op(
+            conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+        )
+
+    assert written == []
+
+
+def test_the_job_proc_never_receives_the_cost_code_selection(monkeypatch):
+    """cost_codes is a provisioning instruction for step 5, not a wsiJCJobMaster field. If it leaks
+    into the kwargs create_job_op builds for econnect.create_job, that function's unknown-field guard
+    refuses EVERY create - and the permissive `lambda c, **k` stubs in the other tests would never
+    notice, which is exactly how the bug shipped once already."""
+    received: list[set] = []
+    monkeypatch.setattr(econnect, "job_exists", lambda c, j: False)
+    monkeypatch.setattr(econnect, "create_job", lambda c, **k: received.append(set(k)))
+    monkeypatch.setattr(
+        econnect, "get_job", lambda c, j: {"job_number": REQUIRED["job_number"], "job_name": "Test job"}
+    )
+    _stub_master(monkeypatch, _mapped())
+    _stub_writes(monkeypatch)
+    conn = _FakeConn(active_cost_codes=1)
+
+    ops.create_job_op(
+        conn, company="TUBC", request=_request(cost_codes=[{"cost_code": "210-200", "cost_element": 2}])
+    )
+
+    assert len(received) == 2  # the dry run and the real call
+    for kwargs in received:
+        assert "cost_codes" not in kwargs
+
+
+# --- CreateJobRequest / JobCostCodeSelection validation ---
+
+
+def test_a_cost_code_selected_twice_is_rejected():
+    # UpdateIfExists=1 means the second write would land on the same JC00701 row and succeed, and the
+    # read-back would then fail a create that actually worked.
+    with pytest.raises(ValueError, match="more than once"):
+        _request(
+            cost_codes=[
+                {"cost_code": "210-200", "cost_element": 2},
+                {"cost_code": "210-200", "cost_element": 2},
+            ]
+        )
+
+
+def test_the_same_code_under_two_elements_is_not_a_duplicate():
+    request = _request(
+        cost_codes=[
+            {"cost_code": "210-200", "cost_element": 2},
+            {"cost_code": "210-200", "cost_element": 5},
+        ]
+    )
+    assert len(request.cost_codes) == 2
+
+
+def test_a_blank_cost_code_is_rejected():
+    with pytest.raises(ValueError, match="cost_code is required"):
+        _request(cost_codes=[{"cost_code": "   ", "cost_element": 2}])
+
+
+def test_a_cost_code_is_trimmed():
+    request = _request(cost_codes=[{"cost_code": "  210-200 ", "cost_element": 2}])
+    assert request.cost_codes[0].cost_code == "210-200"
+
+
+def test_cost_codes_default_to_none_selected():
+    assert _request().cost_codes == []


### PR DESCRIPTION
closes #448.

Nexus-created job (wsiJCJobMaster) lands with zero JC00701 cost codes -> register-PO cost-code dropdown empty -> #439 health rule one quarantines the project at the next gp_job_sync stamp. relay-created TUBC test jobs in that state:
NEXUS-380-T1/T2
NEXUS-392-T1
NEXUS-444-T1

create flow now provisions the job's cost codes in the same GP transaction as the job. #439 rules unchanged.

every written value comes from GP config, never Nexus or the user (#427/#430 provenance). the request names WHICH codes only. alias, description, profit type, transaction type, GL account index read at create time from:
JC40202 cost-code master
JC40302 (division, cost element) -> account index

relay
- new read op list_cost_code_master - JC40202 joined division-scoped to JC40302 and GL00105
- mapped = JC40302 row exists and its index is 0 or in GL00105, same rule as account_index_exists and #446's dropdown filter. the GL00105 join defends against a stale sandbox where the division mapping itself dangles
- unmapped codes returned, not filtered
- create_job - CreateJobRequest gains cost_codes (code + element only, duplicates rejected)
- after the job lands: refuse cost_code_not_in_master / cost_code_unmapped before any write -> OnlyValidate=1 for ALL codes -> real wsiJCJobDetailMSTR calls with UpdateIfExists=1 -> JC00701 count read-back, fails loudly on a silent no-op
- one transaction, job + codes commit together or neither
- wsiJCJobDetailMSTR call shape (9 params, others defaulted) validated live in TUBC under jayp's supervision 2026-07-30. proc-created row field-for-field identical to a GP-UI-created row, JC00102 carries no rollups at provisioning time (details in #448's comment)
- review fix - cost_codes leaked into the wsiJCJobMaster kwargs via model_dump and tripped create_job's unknown-field guard. now excluded, regression test pins that the job proc never receives the selection

backend
- CreateGpJobInput gains costCodes (CostCodeSelectionInput, costCode + costElement). empty list = unprovisioned job
- create_gp_job passes them through stripped
- new gpCostCodeMaster(company, division) -> GpCostCodeMasterEntry (costCode, description, costElement, mapped). account index not exposed to the client
- ROOT_FIELD_POLICY entry ADMIN_ROLE

frontend
- CreateGpJobDialog gains a Cost codes section, the division's master as a checkbox list, mapped codes pre-checked, unmapped disabled with "No GP account for cost element N in this division"
- selection is derived, state holds only deselections. division change re-defaults, an unmapped code can never enter the payload
- zero selection stays submittable with a warning that the job cannot buy until codes are added in GP
- a failed master read degrades locally (warning inside the section), not folded into the relay-down gate

relay 454 passed (32 new), ruff clean. backend ruff + format clean, suite verified in CI (local run 925 passed, 2 pre-existing environmental failures from missing local rapidfuzz, untouched by this change). frontend 399 passed (3 new), 0 lint errors, build clean.

deployed relays pick up the relay half on their next build/install, same build train as #446.
