### PR TITLE
feat(relay): reconcile backend channels from config.toml without a restart

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -150,12 +150,19 @@ that environment's own backend service as well (verified 2026-07-30: pr-430 pred
 could not read GP until it had its own copy). seeding runs at backend startup, so either way the change
 lands on that service's next deploy.
 
-the URL list is read once at `serve` start, so adding or removing a test backend needs a relay restart
-(the app's Restart Relay button). the enrolled secret is still re-read on every reconnect, unchanged,
-and a config.toml that fails to parse mid-edit no longer kills the channel - it retries with the last
-good settings. the setup wizard preserves a hand-added `[channel]` block, so re-running it will not
-silently drop the URL. remove the URL when the PR closes - a torn-down environment retries forever
-otherwise (quietly: a non-production channel logs a repeated failure once, then at DEBUG).
+**adding or removing a URL takes effect on its own, within about ten seconds (#456).** the supervisor
+re-reads config.toml on a tick and reconciles its channel set against it: a URL that appears gets a
+channel, a URL that disappears has its channel cancelled and its `/health` row dropped. no restart, and
+production's channel is never touched either way. it used to need the app's Restart Relay button, which
+is a click nobody could automate - and since a preview environment's database is empty, nothing at all
+is testable there until the channel is up, because the project list comes from GP.
+
+still remove the URL when the PR closes: the channel goes away when you do, and until then a torn-down
+environment retries forever (quietly - a non-production channel logs a repeated failure once, then at
+DEBUG). the enrolled secret is re-read on every reconnect as before, and a config.toml caught mid-write
+kills neither: the channels keep dialling with the last good settings and the finished edit lands on the
+next tick. the setup wizard preserves a hand-added `[channel]` block, so re-running it will not silently
+drop the URL.
 
 the ops newer than `create_po` / `create_receipt` are channel-only - they have no HTTP route, because
 the browser hop is no longer the live path.

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -769,7 +769,14 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
                     # tick - and an operator grepping relay.log sees the edit they just made.
                     logger.info(
                         "backend channels configured" if known is None else "backend channels changed",
-                        extra={"urls": urls, "added": sorted(set(urls) - (known or set()))},
+                        extra={
+                            "urls": urls,
+                            "added": sorted(set(urls) - (known or set())),
+                            # Named as well as added: a removal otherwise logs `added: []` and leaves
+                            # the operator to diff the URL list against the previous line to see what
+                            # they just took out.
+                            "removed": sorted((known or set()) - set(urls)),
+                        },
                     )
                     _warn_if_no_primary(urls)
                     known = set(urls)

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -11,6 +11,10 @@ now supervises one independent reconnecting channel per configured URL, and prod
 never dropped to test a PR. The same enrolled secret authenticates on all of them (the backend matches
 on its hash, and a PR environment is seeded with that hash rather than issued a credential of its own).
 
+That set is reconciled against config.toml on a tick rather than read once (issue #456), so adding or
+removing a preview environment needs no restart - see `run_forever` for why that mattered enough to
+build.
+
 Which backend a channel points at decides what it may reach: the production URL is unrestricted, every
 other URL is pinned to the sandbox company (config.NON_PRIMARY_ALLOWED_COMPANIES). Reads and writes
 are both served on a test channel - a PR that touches GP has to be verifiable before it merges - and
@@ -100,6 +104,15 @@ def register_channels(urls: list[str]) -> None:
     the key set stops changing under channel_state_snapshot once startup is done."""
     for url in urls:
         _STATES.setdefault(url, dict(_UNKNOWN_STATE))
+
+
+def forget_channel(url: str) -> None:
+    """Drop a channel's state row, once its URL has left config.toml and its task is reaped (#456).
+
+    Without this a torn-down PR environment would keep its row on /health forever, so the desktop
+    app's channel panel would go on listing a backend nobody is dialling any more - which reads as a
+    broken connection rather than a removed one."""
+    _STATES.pop(url, None)
 
 
 def _mark_connected(url: str) -> None:
@@ -651,26 +664,40 @@ async def _run_channel(url: str, stop_event: asyncio.Event | None = None) -> Non
         await asyncio.sleep(backoff)
 
 
-async def run_forever(stop_event: asyncio.Event | None = None) -> None:
-    """Supervise one reconnecting channel per configured backend URL. Intended to run as a single
-    background asyncio task alongside the relay's existing HTTP server (see cli.py); an empty
-    [channel].backend_url disables it entirely - the relay just runs the HTTP server, as before.
+# How often the supervisor re-reads config.toml to see which backends it should be dialling (#456).
+# The cost of a tick is one small TOML parse - the same one _run_channel already pays on every
+# reconnect attempt - so this is set by how long somebody should have to wait for a channel to come
+# up, not by what the parse costs. Ten seconds is under the time it takes to alt-tab back to the
+# browser, which is the point: adding a PR environment stops being a thing you wait on.
+CHANNEL_RECONCILE_SECONDS = 10.0
 
-    The URL LIST is read once, here, and a change to it takes effect on the next serve restart (the
-    desktop app's Restart Relay button). That is deliberately unlike the secret, which is re-read on
-    every reconnect: a re-enrolment has to self-heal a relay nobody can walk over to, whereas adding a
-    PR environment is something the person editing config.toml is already standing at the machine for.
-    Spawning and reaping channel tasks on every retry to avoid one restart is not worth the machinery."""
-    urls = get_settings().channel.backend_urls
-    if not urls:
-        logger.info("channel disabled (no [channel] backend_url configured)")
-        return
 
-    if not any(is_primary_backend_url(url) for url in urls):
-        # Loud, because the likeliest cause is a typo in a hand-added backend_url list rather than a
-        # deliberate choice: production is then just another restricted channel and every real UBC/UCSH
-        # job is refused with company_not_allowed_on_channel. A dev checkout pointed at localhost hits
-        # this legitimately, which is why it warns rather than refusing to start.
+def _configured_urls() -> list[str] | None:
+    """The backend URLs config.toml currently names, or None if it could not be read.
+
+    Guarded and returning None rather than raising, for the reason _run_channel re-reads the secret
+    the same way: hand-editing config.toml on a running relay is the documented way to add a test
+    backend (#414), so catching a save mid-write or a missing bracket is a live possibility. Letting
+    that propagate would kill the supervisor, taking production's channel with it - and no amount of
+    fixing the file afterwards would bring it back without a serve restart, which is the thing #456
+    exists to stop needing. None means "keep whatever is running"."""
+    try:
+        get_settings.cache_clear()
+        return get_settings().channel.backend_urls
+    except Exception as e:
+        logger.warning(
+            "could not re-read config.toml; leaving the current channels alone",
+            extra={"category": "config_unreadable", "error": str(e)},
+        )
+        return None
+
+
+def _warn_if_no_primary(urls: list[str]) -> None:
+    """Loud, because the likeliest cause is a typo in a hand-added backend_url list rather than a
+    deliberate choice: production is then just another restricted channel and every real UBC/UCSH job
+    is refused with company_not_allowed_on_channel. A dev checkout pointed at localhost hits this
+    legitimately, which is why it warns rather than refusing to start."""
+    if urls and not any(is_primary_backend_url(url) for url in urls):
         logger.warning(
             "no production channel configured - EVERY channel is restricted to the sandbox company. "
             "if this is a workstation, check [channel] backend_url matches the production URL exactly, "
@@ -678,15 +705,35 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
             extra={"category": "no_primary_channel", "urls": urls, "expected": PRODUCTION_BACKEND_URL},
         )
 
-    logger.info("starting backend channels", extra={"urls": urls})
-    register_channels(urls)  # so /health lists every channel from the first poll, before any dials
+
+async def run_forever(stop_event: asyncio.Event | None = None) -> None:
+    """Hold up one reconnecting channel per configured backend URL, and keep that set in step with
+    config.toml. Intended to run as a single background asyncio task alongside the relay's existing
+    HTTP server (see cli.py); with no [channel] backend_url configured it simply runs no channels.
+
+    The URL list used to be read once, so adding or removing a backend took a serve restart - the
+    desktop app's Restart Relay button. That was the wrong shape for the thing it was blocking (#456).
+    Testing a change against a Railway PR environment means adding its URL, and on an empty preview
+    database nothing is testable at all until the channel is up: the project list itself comes from
+    GP. An agent can edit config.toml and read relay.log; it cannot click a button in a tray app. So
+    the one manual step sat in the middle of an otherwise unattended loop, and a session on #455 spent
+    thirty minutes idle waiting for that click.
+
+    Now the URL set is reconciled on a tick, the way the secret is already re-read on every reconnect:
+    a URL that appears gets a channel, a URL that disappears has its channel cancelled and its /health
+    row dropped. Teardown matters as much as setup - a closed PR's environment otherwise retries
+    forever against a backend that no longer exists.
+
+    What is deliberately NOT reconciled is a channel that died: the task set is diffed against the URL
+    set, not against liveness. `_run_channel` catches per attempt and is not supposed to exit, so one
+    that does is a bug worth seeing in the log rather than papering over with a respawn loop."""
+    tasks: dict[str, asyncio.Task] = {}
+    known: set[str] | None = None
 
     async def _supervised(url: str) -> None:
         """Log a channel that escapes its own retry loop. _run_channel is not supposed to - it catches
-        Exception per attempt - but if it ever does, the log has to happen HERE. Doing it from the
-        gather() below cannot work: gather returns only once EVERY awaitable is done, and the siblings
-        loop forever, so an aggregated result is never reached and a dead channel would be visible
-        only as a stale 'disconnected' on /health with nothing in relay.log."""
+        Exception per attempt - but if it ever does, the log has to happen HERE, because nothing else
+        awaits these tasks while they are healthy."""
         try:
             await _run_channel(url, stop_event)
         except asyncio.CancelledError:
@@ -698,13 +745,52 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
             )
             _mark_disconnected(url, "failed")
 
-    tasks = [asyncio.create_task(_supervised(url), name=f"channel:{url}") for url in urls]
+    async def _reconcile(urls: list[str]) -> None:
+        for url in urls:
+            if url not in tasks:
+                register_channels([url])  # so /health lists it from the next poll, before any dial
+                tasks[url] = asyncio.create_task(_supervised(url), name=f"channel:{url}")
+        retired = [(url, tasks.pop(url)) for url in list(tasks) if url not in urls]
+        for _, task in retired:
+            task.cancel()
+        if retired:
+            # Await the cancellations before dropping the state rows, so a task still unwinding cannot
+            # re-insert its own key through _mark_disconnected and leave a ghost channel on /health.
+            await asyncio.gather(*(task for _, task in retired), return_exceptions=True)
+            for url, _ in retired:
+                forget_channel(url)
+
     try:
-        await asyncio.gather(*tasks, return_exceptions=True)
+        while True:
+            urls = _configured_urls()
+            if urls is not None:
+                if known != set(urls):
+                    # Only on a change, so a steady relay logs this once at startup rather than every
+                    # tick - and an operator grepping relay.log sees the edit they just made.
+                    logger.info(
+                        "backend channels configured" if known is None else "backend channels changed",
+                        extra={"urls": urls, "added": sorted(set(urls) - (known or set()))},
+                    )
+                    _warn_if_no_primary(urls)
+                    known = set(urls)
+                await _reconcile(urls)
+            if stop_event is not None and stop_event.is_set():
+                return
+            if stop_event is None:
+                await asyncio.sleep(CHANNEL_RECONCILE_SECONDS)
+            else:
+                # Wait on the event rather than sleeping through it, so shutdown is not held up for
+                # most of a tick.
+                try:
+                    await asyncio.wait_for(stop_event.wait(), CHANNEL_RECONCILE_SECONDS)
+                except asyncio.TimeoutError:
+                    pass
+                if stop_event.is_set():
+                    return
     finally:
         # Reap them rather than just cancelling: cli.py cancels THIS task on shutdown, and a bare
         # cancel() would leave the children pending as the loop closes ("Task was destroyed but it is
         # pending"). CancelledError is a BaseException, so a cancelled child is not logged above.
-        for task in tasks:
+        for task in tasks.values():
             task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.gather(*tasks.values(), return_exceptions=True)

--- a/relay/src/ucnexus_relay/cli.py
+++ b/relay/src/ucnexus_relay/cli.py
@@ -107,8 +107,9 @@ def _serve(argv: list[str]) -> int:
 
     async def _run() -> None:
         # the outbound channel is additive to the existing inbound HTTP server - a blank
-        # [channel].backend_url makes channel.run_forever() a no-op, so this is safe on a relay that
-        # hasn't been reconfigured for it yet.
+        # [channel].backend_url leaves channel.run_forever() supervising nothing, so this is safe on a
+        # relay that hasn't been reconfigured for it yet. it keeps watching config.toml either way
+        # (#456), so a URL added later comes up without a restart.
         #
         # Skip the channel entirely when unenrolled (no secret): the backend refuses it pre-accept, so
         # running it would just spam secret-rejected retries. serve still binds the local HTTP server so

--- a/relay/tests/test_channel_multi_backend.py
+++ b/relay/tests/test_channel_multi_backend.py
@@ -10,8 +10,10 @@ thing standing between a PR environment and a live GP company is `_dispatch` ref
 """
 
 import asyncio
+import contextlib
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -162,22 +164,24 @@ def test_run_forever_starts_one_channel_per_configured_url(monkeypatch, tmp_path
 
     async def fake_run_channel(url, stop_event=None):
         started.append(url)
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
-    asyncio.run(channel.run_forever())
+    asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert started == [PRODUCTION_BACKEND_URL, PR_URL]
 
 
-def test_run_forever_is_a_no_op_when_no_backend_is_configured(monkeypatch, tmp_path):
+def test_run_forever_starts_nothing_when_no_backend_is_configured(monkeypatch, tmp_path):
     started: list[str] = []
 
     async def fake_run_channel(url, stop_event=None):
         started.append(url)
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [])
-    asyncio.run(channel.run_forever())
+    asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert started == []
 
 
@@ -189,10 +193,11 @@ def test_one_channel_raising_does_not_take_the_others_down(monkeypatch, tmp_path
             raise RuntimeError("PR environment went away mid-run")
         await asyncio.sleep(0)
         finished.append(url)
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
-    asyncio.run(channel.run_forever())  # must not raise
+    asyncio.run(_supervise_for_one_tick(monkeypatch))  # must not raise
     assert finished == [PRODUCTION_BACKEND_URL]
 
 
@@ -200,29 +205,178 @@ def test_a_stop_event_reaches_every_channel(monkeypatch, tmp_path):
     seen: list[tuple[str, bool]] = []
 
     async def fake_run_channel(url, stop_event=None):
-        seen.append((url, stop_event is not None and stop_event.is_set()))
+        seen.append((url, stop_event is not None))
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
-
-    async def run():
-        stop = asyncio.Event()
-        stop.set()
-        await channel.run_forever(stop)
-
-    asyncio.run(run())
+    asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert seen == [(PRODUCTION_BACKEND_URL, True), (PR_URL, True)]
 
 
-def _use_backend_urls(monkeypatch, tmp_path, urls: list[str]) -> None:
+# --- reconcile (#456) -------------------------------------------------------------------------------
+# The supervisor keeps its channel set in step with config.toml, so adding or removing a Railway
+# preview environment takes effect on its own. What used to be needed instead was a click on the
+# desktop app's Restart Relay button, which an agent editing config.toml cannot do - and on an empty
+# preview database nothing is testable until the channel is up, because the project list itself comes
+# from GP.
+
+
+def test_a_url_added_to_config_gets_a_channel_without_a_restart(monkeypatch, tmp_path):
+    started: list[str] = []
+
+    async def fake_run_channel(url, stop_event=None):
+        started.append(url)
+        await _forever()
+
+    monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
+    cfg = _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL])
+
+    async def run():
+        stop, task = _start_supervisor(monkeypatch)
+        await _tick()
+        assert started == [PRODUCTION_BACKEND_URL]  # the PR environment is not in config.toml yet
+
+        _write_backend_urls(cfg, [PRODUCTION_BACKEND_URL, PR_URL])
+        await _tick()
+        await _stop(stop, task)
+
+    asyncio.run(run())
+    assert started == [PRODUCTION_BACKEND_URL, PR_URL]
+    # And production was never dropped to pick the new one up - it is still the same one channel.
+    assert started.count(PRODUCTION_BACKEND_URL) == 1
+
+
+def test_a_url_removed_from_config_has_its_channel_cancelled(monkeypatch, tmp_path, clean_channel_states):
+    """A closed PR's environment is torn down, and its URL then retries forever against a backend
+    that no longer exists. Removing the line has to be enough to stop it."""
+    cancelled: list[str] = []
+
+    async def fake_run_channel(url, stop_event=None):
+        try:
+            await _forever()
+        except asyncio.CancelledError:
+            cancelled.append(url)
+            raise
+
+    monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
+    cfg = _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
+
+    async def run():
+        stop, task = _start_supervisor(monkeypatch)
+        await _tick()
+        assert PR_URL in channel._STATES
+
+        _write_backend_urls(cfg, [PRODUCTION_BACKEND_URL])
+        await _tick()
+        # Read the state HERE, before shutting the supervisor down: shutting down cancels every
+        # remaining channel, which would make production look retired too.
+        observed = (list(cancelled), dict(channel._STATES))
+        await _stop(stop, task)
+        return observed
+
+    cancelled_by_reconcile, states = asyncio.run(run())
+    assert cancelled_by_reconcile == [PR_URL]
+    # Its /health row goes with it, or the desktop app keeps listing a backend nobody is dialling.
+    assert PR_URL not in states
+    assert PRODUCTION_BACKEND_URL in states
+
+
+def test_a_config_that_will_not_parse_leaves_the_running_channels_alone(
+    monkeypatch, tmp_path, clean_channel_states
+):
+    """Hand-editing config.toml on a running relay is the documented way to add a test backend, so a
+    save caught mid-write is a live possibility. It must not take production's channel down - there
+    would then be no way back without the restart this whole change exists to remove."""
+    cancelled: list[str] = []
+
+    async def fake_run_channel(url, stop_event=None):
+        try:
+            await _forever()
+        except asyncio.CancelledError:
+            cancelled.append(url)
+            raise
+
+    monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
+    cfg = _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL])
+
+    async def run():
+        stop, task = _start_supervisor(monkeypatch)
+        await _tick()
+
+        cfg.write_text('[channel]\nbackend_url = ["wss://half-writ', encoding="utf-8")
+        await _tick()
+        survived_the_bad_parse = list(cancelled)
+
+        _write_backend_urls(cfg, [PRODUCTION_BACKEND_URL, PR_URL])
+        await _tick()
+        observed = (survived_the_bad_parse, dict(channel._STATES))
+        await _stop(stop, task)
+        return observed
+
+    cancelled_by_reconcile, states = asyncio.run(run())
+    assert cancelled_by_reconcile == []  # still up, still dialling production
+    # And the finished edit is picked up once it parses, so a mid-write save costs one interval and
+    # not the channel.
+    assert PR_URL in states
+
+
+async def _forever() -> None:
+    """Stand in for a healthy channel: _run_channel never returns on its own."""
+    await asyncio.Event().wait()
+
+
+async def _tick() -> None:
+    """Let the supervisor run one reconcile pass. The interval is patched to 0, so yielding to the
+    loop a few times is enough for it to come round again and for the tasks it spawns to start."""
+    for _ in range(6):
+        await asyncio.sleep(0)
+
+
+def _start_supervisor(monkeypatch) -> tuple[asyncio.Event, asyncio.Task]:
+    monkeypatch.setattr(channel, "CHANNEL_RECONCILE_SECONDS", 0)
+    stop = asyncio.Event()
+    return stop, asyncio.create_task(channel.run_forever(stop))
+
+
+async def _stop(stop: asyncio.Event, task: asyncio.Task) -> None:
+    stop.set()
+    await _tick()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+async def _supervise_for_one_tick(monkeypatch) -> None:
+    stop, task = _start_supervisor(monkeypatch)
+    await _tick()
+    await _stop(stop, task)
+
+
+def _write_backend_urls(cfg: Path, urls: list[str]) -> None:
+    rendered = ", ".join(f'"{u}"' for u in urls)
+    cfg.write_text(f'[auth]\nshared_secret = "s3cret"\n\n[channel]\nbackend_url = [{rendered}]\n', encoding="utf-8")
+
+
+def _use_backend_urls(monkeypatch, tmp_path, urls: list[str]) -> Path:
     """Point get_settings at a config.toml carrying exactly these backend URLs. Writing a real file
     rather than stubbing get_settings keeps the TOML round-trip (which is where a list would break)
-    inside the test."""
-    rendered = ", ".join(f'"{u}"' for u in urls)
+    inside the test - and since #456 it is also what lets a test EDIT the file under a running
+    supervisor, which is the whole behaviour being checked.
+
+    The stub carries `cache_clear` because the supervisor drops the lru_cache before every read, for
+    exactly the reason these tests rely on: without it a re-read returns the file as it was the first
+    time it was parsed."""
     cfg = tmp_path / "config.toml"
-    cfg.write_text(f'[auth]\nshared_secret = "s3cret"\n\n[channel]\nbackend_url = [{rendered}]\n', encoding="utf-8")
+    _write_backend_urls(cfg, urls)
     get_settings.cache_clear()
-    monkeypatch.setattr(channel, "get_settings", lambda *a, **k: get_settings(str(cfg)))
+
+    def stub(*a, **k):
+        return get_settings(str(cfg))
+
+    stub.cache_clear = get_settings.cache_clear
+    monkeypatch.setattr(channel, "get_settings", stub)
+    return cfg
 
 
 # --- /health snapshot ------------------------------------------------------------------------------
@@ -375,38 +529,59 @@ def test_run_forever_warns_when_no_channel_is_production(monkeypatch, tmp_path, 
     # URL. Every channel is then sandbox-pinned and all real GP work is refused, which is otherwise
     # visible only as an INFO field.
     async def fake_run_channel(url, stop_event=None):
-        return
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PR_URL])
     with caplog.at_level(logging.WARNING):
-        asyncio.run(channel.run_forever())
+        asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert any("no production channel configured" in r.message for r in caplog.records)
 
 
 def test_run_forever_is_quiet_when_production_is_present(monkeypatch, tmp_path, caplog):
     async def fake_run_channel(url, stop_event=None):
-        return
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
     with caplog.at_level(logging.WARNING):
-        asyncio.run(channel.run_forever())
+        asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert not any("no production channel configured" in r.message for r in caplog.records)
 
 
+def test_the_no_production_warning_is_not_repeated_on_every_tick(monkeypatch, tmp_path, caplog):
+    """The supervisor re-reads config.toml every few seconds since #456. A warning that fired on each
+    pass would bury relay.log within a day, so it is tied to the URL SET changing, not to the read."""
+
+    async def fake_run_channel(url, stop_event=None):
+        await _forever()
+
+    monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
+    _use_backend_urls(monkeypatch, tmp_path, [PR_URL])
+
+    async def run():
+        stop, task = _start_supervisor(monkeypatch)
+        for _ in range(5):
+            await _tick()
+        await _stop(stop, task)
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(run())
+    assert len([r for r in caplog.records if "no production channel configured" in r.message]) == 1
+
+
 def test_a_channel_that_escapes_its_retry_loop_is_logged_and_marked_failed(monkeypatch, tmp_path, caplog):
-    # asyncio.gather returns only once EVERY awaitable finishes, and the siblings loop forever - so an
-    # aggregated result is never reached. The log has to come from the per-channel wrapper or a dead
-    # channel is invisible.
+    # Nothing awaits these tasks while they are healthy, so the log has to come from the per-channel
+    # wrapper or a dead channel is invisible.
     async def fake_run_channel(url, stop_event=None):
         if url == PR_URL:
             raise RuntimeError("boom")
+        await _forever()
 
     monkeypatch.setattr(channel, "_run_channel", fake_run_channel)
     _use_backend_urls(monkeypatch, tmp_path, [PRODUCTION_BACKEND_URL, PR_URL])
     with caplog.at_level(logging.ERROR):
-        asyncio.run(channel.run_forever())
+        asyncio.run(_supervise_for_one_tick(monkeypatch))
     assert any("exited unexpectedly" in r.message for r in caplog.records)
     assert channel._STATES[PR_URL]["state"] == "failed"
 


### PR DESCRIPTION
closes #456.

URL list read once at `serve` start -> adding or removing a backend took a click on Restart Relay. an agent can edit config.toml and read relay.log, cannot press a button in a tray app. on an empty preview database nothing is testable until the channel is up, the project list comes from GP. a testing session on #455 sat idle 30+ min waiting on one click.

run_forever keeps a {url: task} map, reconciles against config.toml every 10s, the way the secret is already re-read on every reconnect.

- URL appears -> channel started
- URL disappears -> channel cancelled, /health row dropped via new forget_channel
- production's channel untouched by either

teardown gets the same treatment as setup: a closed PR's environment otherwise retries forever against a backend that no longer exists.

config.toml caught mid-write leaves the running channel set alone, warns -> a bad save costs one tick, not production's connection.
cancelled tasks awaited before their state rows are dropped -> a task still unwinding cannot re-insert its key and leave a ghost channel on /health.
no-primary warning tied to the URL set changing, not to the read -> would otherwise fire every 10s.
liveness not reconciled, task set diffed against URL set only -> a channel that escapes its own retry loop still surfaces as the bug it is.

rejected:
- local control endpoint on 7321 -> still restarts serve, production's channel drops too, adds an inbound endpoint that can restart the relay
- backend-advertises -> removes the agent's config edit, not the human's click, which was never the bottleneck. costs a registry plus a way for a preview environment to authenticate to production (the seed hash is a hash, not a credential), and lets a backend decide where the workstation dials

new tests
URL added
URL removed
unparseable config

four existing supervisor tests now drive run_forever as a task, it no longer terminates on its own.
466 relay tests pass, ruff clean.
README and channel.py module docstring updated, both said a restart was required.
