### PR TITLE
feat(shipping): shipment method management (#451)

### DIFF
--- a/backend/alembic/versions/082_shipment_methods.py
+++ b/backend/alembic/versions/082_shipment_methods.py
@@ -1,0 +1,45 @@
+"""Shipment methods, and the method a slip left under
+
+Revision ID: 082
+Revises: 081
+Create Date: 2026-08-03
+
+How a load travelled was nowhere on the Delivery Request (#451). The shipping department answers it
+from the same handful of options every time - our truck, a named courier, customer pickup - so it is
+a managed list rather than free text, which is what stops one carrier being spelled five ways across
+a year of shipments.
+
+`packing_slips.shipment_method` is a plain string, not a foreign key, in the same spirit as
+`pickup_location` beside it: a reprint pulled up in a site dispute has to say what the driver was
+told on the day, and a method renamed or retired since must not be able to rewrite or erase it.
+
+Retiring a method is `is_active = False`; the table has no delete path that would orphan history.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "082"
+down_revision = "081"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "shipment_methods",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("name", name="uq_shipment_methods_name"),
+    )
+    op.add_column("packing_slips", sa.Column("shipment_method", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("packing_slips", "shipment_method")
+    op.drop_table("shipment_methods")

--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -167,6 +167,12 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     # --- shipping.py ----------------------------------------------------------------------
     "packingSlips": SIGNED_IN,
     "returnableLines": SIGNED_IN,
+    # The shipping department's own list of how a load travels (#451). SIGNED_IN like the rest of
+    # shipping: it is documentation the same people maintain and consume, and it gates nothing.
+    "shipmentMethods": SIGNED_IN,
+    "createShipmentMethod": SIGNED_IN,
+    "updateShipmentMethod": SIGNED_IN,
+    "deleteShipmentMethod": SIGNED_IN,
     "shipReadyItems": SIGNED_IN,
     # Read-only coverage for the shipping-out builder (#451). SIGNED_IN because its caller is the
     # Start-a-Task wizard, which every module's users reach.

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -73,6 +73,9 @@ type PackingSlip {
   # Snapshot of the warehouse address, not a reference - the warehouse record can be edited or
   # retired long after the truck left, and the form has to keep printing where it was sent.
   pickupLocation: String
+  # How the load travelled (#451): a snapshot of the ShipmentMethod name, not a reference, so a
+  # renamed or retired method cannot rewrite what an already-shipped slip says.
+  shipmentMethod: String
   carrierTagBol: String
   weightLbs: Float
   deliveryAddress: String
@@ -107,6 +110,7 @@ type PackingSlip {
 #   shipperEmail: String
 #   shipperPhone: String
 #   pickupLocation: String
+#   shipmentMethod: String
 #   carrierTagBol: String
 #   weightLbs: Float
 #   deliveryAddress: String
@@ -190,6 +194,21 @@ type ShippingCoverageLeaf {
   lines: [ShippingCoverageLine!]!
 }
 
+# --- Shipment methods (#451) ---
+# The shipping department's own list of how a load can travel. Documentation, not an entity anything
+# downstream reasons about - nothing joins to it and the slip keeps a string copy of the name.
+
+type ShipmentMethod {
+  id: ID!
+  name: String!
+  # Retiring is isActive=false, never a delete: the form offers only active methods while shipments
+  # that went out under it keep printing their own snapshot.
+  isActive: Boolean!
+  sortOrder: Int!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
 type ReturnableLine {
   packingSlipItemId: ID!
   openingNumber: String
@@ -206,6 +225,9 @@ type Query {
   returnableLines(packingSlipId: ID!): [ReturnableLine!]!
   # Shipping-out builder coverage (#451): one row per door leaf of the given openings.
   shippingCoverage(projectId: ID!, openingNumbers: [String!]!): [ShippingCoverageLeaf!]!
+  # activeOnly is what the Delivery Request form passes; the management screen leaves it off so a
+  # retired method stays visible to reactivate.
+  shipmentMethods(activeOnly: Boolean! = false): [ShipmentMethod!]!
   # Accept UI (#293): shipping-out requests, PENDING by default.
   # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
   shippingOutRequests(projectId: ID, status: ShippingOutRequestStatus, reopenableOnly: Boolean! = false): [ShippingOutRequest!]!
@@ -250,6 +272,11 @@ type Mutation {
   # against availability with the request's own claim released first, so reducing a line is never
   # refused for stock it already holds.
   editShippingOutRequest(input: EditShippingOutRequestInput!): ShippingOutRequest!
+  # Shipment method list management (#451). A rename never touches shipments already sent under the
+  # old name; delete is safe for the same reason - no shipment references the row.
+  createShipmentMethod(name: String!, sortOrder: Int! = 0): ShipmentMethod!
+  updateShipmentMethod(id: ID!, name: String, isActive: Boolean, sortOrder: Int): ShipmentMethod!
+  deleteShipmentMethod(id: ID!): Boolean!
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
   # Delivery Request lifecycle (#447). Any signed-in user. All three answer with the same PackingSlip

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -27,6 +27,7 @@ from .receive_decision import ReceiveDecision  # noqa: E402, F401
 from .receive_draft import ReceiveDraft, ReceiveDraftLineItem  # noqa: E402, F401
 from .receiving import ReceiveLineItem, ReceiveRecord  # noqa: E402, F401
 from .relay_install import RelayInstall  # noqa: E402, F401
+from .shipment_method import ShipmentMethod  # noqa: E402, F401
 from .shipping import (  # noqa: E402, F401
     PackingSlip,
     PackingSlipItem,

--- a/backend/app/models/shipment_method.py
+++ b/backend/app/models/shipment_method.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class ShipmentMethod(Base):
+    """How a shipment travels: the shipping department's own list of carriers and services (#451).
+
+    A managed list rather than free text on the slip, because the same handful of answers come back
+    every time - "our truck", a named courier, customer pickup - and free text spells them five ways
+    across a year of shipments. It is deliberately NOT a GP entity: nothing downstream consumes it,
+    it is documentation of how a load left the building.
+
+    Retiring one is `is_active = False`, not a delete. A method that carried shipments last year
+    still has to be readable on those shipments, and the dropdown only offers active ones. `name` is
+    unique so the list cannot grow two spellings of the same carrier, which is the whole point.
+
+    Note what does NOT reference this table: `packing_slips.shipment_method` is a plain string
+    snapshot, taken at confirm time, exactly like `pickup_location` beside it. A shipment printed a
+    year later has to say what the driver was told, and a method that has since been renamed or
+    deleted must not be able to change or erase that.
+    """
+
+    __tablename__ = "shipment_methods"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # Where it sits in the dropdown. The shipping department's most-used method should be first, and
+    # alphabetical is not that order.
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/models/shipping.py
+++ b/backend/app/models/shipping.py
@@ -67,6 +67,10 @@ class PackingSlip(Base):
     # Snapshot of the warehouse address, not a foreign key: the warehouse record can be edited or
     # retired years after the truck left, and the form has to keep printing where it was sent.
     pickup_location: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # How the load travelled (#451). A snapshot of the chosen ShipmentMethod's name, not a foreign
+    # key, for the same reason `pickup_location` beside it is a snapshot: the method can be renamed
+    # or retired years later and the reprint has to keep saying what the driver was told.
+    shipment_method: Mapped[str | None] = mapped_column(String, nullable=True)
     carrier_tag_bol: Mapped[str | None] = mapped_column(String, nullable=True)
     weight_lbs: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
     delivery_address: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/repositories/shipment_method_repository.py
+++ b/backend/app/repositories/shipment_method_repository.py
@@ -1,0 +1,94 @@
+"""The shipping department's list of how a load can travel (#451).
+
+Small deliberately. A shipment method is documentation, not an entity anything downstream reasons
+about: nothing joins to it, nothing is gated on it, and the slip keeps a string copy rather than a
+reference. What this module is really protecting is the *list* - one spelling per carrier, and a
+retired method that still reads correctly on the shipments it carried.
+"""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.errors import ConflictError, NotFoundError, ValidationError
+from app.models.shipment_method import ShipmentMethod
+
+
+def get_shipment_methods(session: Session, *, active_only: bool = False) -> list[ShipmentMethod]:
+    """The list, in the order the dropdown shows it: sort_order, then name.
+
+    `active_only` is what the Delivery Request form passes. The management screen leaves it off so a
+    retired method is still visible to reactivate - hiding it there would make retirement a one-way
+    door with no undo.
+    """
+    stmt = select(ShipmentMethod).order_by(ShipmentMethod.sort_order.asc(), ShipmentMethod.name.asc())
+    if active_only:
+        stmt = stmt.where(ShipmentMethod.is_active.is_(True))
+    return list(session.scalars(stmt).all())
+
+
+def create_shipment_method(session: Session, *, name: str, sort_order: int = 0) -> ShipmentMethod:
+    name = (name or "").strip()
+    if not name:
+        raise ValidationError("A shipment method needs a name.", field="name")
+    _check_name_free(session, name)
+    method = ShipmentMethod(id=uuid.uuid4(), name=name, is_active=True, sort_order=sort_order)
+    session.add(method)
+    session.flush()
+    return method
+
+
+def update_shipment_method(
+    session: Session,
+    method_id: uuid.UUID,
+    *,
+    name: str | None = None,
+    is_active: bool | None = None,
+    sort_order: int | None = None,
+) -> ShipmentMethod:
+    """Rename, retire or reorder one. Only the fields actually sent are touched.
+
+    Renaming does NOT rewrite the shipments that already carry the old name - they hold their own
+    copy on purpose (see `packing_slips.shipment_method`), so this changes what future shipments
+    will be offered and nothing else.
+    """
+    method = session.get(ShipmentMethod, method_id)
+    if method is None:
+        raise NotFoundError(f"Shipment method {method_id} not found")
+
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValidationError("A shipment method needs a name.", field="name")
+        if name != method.name:
+            _check_name_free(session, name)
+            method.name = name
+    if is_active is not None:
+        method.is_active = is_active
+    if sort_order is not None:
+        method.sort_order = sort_order
+    session.flush()
+    return method
+
+
+def delete_shipment_method(session: Session, method_id: uuid.UUID) -> None:
+    """Remove a method from the list outright.
+
+    Safe because no shipment references this row - each one snapshotted the name it shipped under -
+    so deleting affects what can be picked next, never what was picked before. Retiring
+    (`is_active = False`) is still the better move for a carrier that may come back; this is for a
+    row that was a mistake.
+    """
+    method = session.get(ShipmentMethod, method_id)
+    if method is None:
+        raise NotFoundError(f"Shipment method {method_id} not found")
+    session.delete(method)
+    session.flush()
+
+
+def _check_name_free(session: Session, name: str) -> None:
+    """One spelling per carrier, case-insensitively - "Flatbed" and "flatbed" are the same answer."""
+    existing = session.scalars(select(ShipmentMethod).where(func.lower(ShipmentMethod.name) == name.lower())).first()
+    if existing is not None:
+        raise ConflictError(f"A shipment method named {existing.name} already exists", field="name")

--- a/backend/app/repositories/shipping_repository.py
+++ b/backend/app/repositories/shipping_repository.py
@@ -149,6 +149,7 @@ DELIVERY_REQUEST_FIELDS = (
     "shipper_email",
     "shipper_phone",
     "pickup_location",
+    "shipment_method",
     "carrier_tag_bol",
     "weight_lbs",
     "delivery_address",

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -591,6 +591,9 @@ class DeliveryRequestHeaderInput:
     shipper_email: str | None = None
     shipper_phone: str | None = None
     pickup_location: str | None = None
+    # The name of a ShipmentMethod, snapshotted onto the slip (#451). Sent as a string rather than
+    # an id so a shipment keeps printing the method it left under after that method is renamed.
+    shipment_method: str | None = None
     carrier_tag_bol: str | None = None
     weight_lbs: float | None = None
     delivery_address: str | None = None

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -6,7 +6,12 @@ import strawberry
 
 from app.auth import current_user, resolve_display_name
 from app.database import SessionLocal
-from app.repositories import shipping_coverage, shipping_repository, shipping_requests
+from app.repositories import (
+    shipment_method_repository,
+    shipping_coverage,
+    shipping_repository,
+    shipping_requests,
+)
 
 from .converters import (
     opening_item_to_type,
@@ -26,6 +31,7 @@ from .inputs import (
 from .types import (
     PackingSlip,
     ReturnableLine,
+    ShipmentMethod,
     ShipmentReturn,
     ShippingCoverageLeaf,
     ShippingCoverageLine,
@@ -33,6 +39,17 @@ from .types import (
     ShipReadyItems,
     ShipReadyLooseItem,
 )
+
+
+def _shipment_method_to_type(m) -> ShipmentMethod:
+    return ShipmentMethod(
+        id=strawberry.ID(str(m.id)),
+        name=m.name,
+        is_active=m.is_active,
+        sort_order=m.sort_order,
+        created_at=m.created_at,
+        updated_at=m.updated_at,
+    )
 
 
 def _delivery_details(input) -> dict:
@@ -127,6 +144,16 @@ class ShippingQueries:
             ]
 
     @strawberry.field
+    def shipment_methods(self, info: strawberry.Info, active_only: bool = False) -> list[ShipmentMethod]:
+        """How a load can travel (#451). `activeOnly` is what the Delivery Request form passes; the
+        management screen leaves it off so a retired method can still be seen and reactivated."""
+        with SessionLocal() as session:
+            return [
+                _shipment_method_to_type(m)
+                for m in shipment_method_repository.get_shipment_methods(session, active_only=active_only)
+            ]
+
+    @strawberry.field
     def returnable_lines(self, info: strawberry.Info, packing_slip_id: strawberry.ID) -> list[ReturnableLine]:
         with SessionLocal() as session:
             lines = shipping_repository.get_returnable_lines(session, uuid.UUID(str(packing_slip_id)))
@@ -213,6 +240,49 @@ class ShippingMutations:
             session.commit()
             refreshed = shipping_repository.get_shipping_out_request(session, req.id)
             return shipping_out_request_to_type(refreshed)
+
+    @strawberry.mutation
+    def create_shipment_method(self, info: strawberry.Info, name: str, sort_order: int = 0) -> ShipmentMethod:
+        """Add a way a load can travel (#451). Names are unique case-insensitively, so the list
+        cannot grow two spellings of the same carrier."""
+        with SessionLocal() as session:
+            method = shipment_method_repository.create_shipment_method(session, name=name, sort_order=sort_order)
+            session.commit()
+            session.refresh(method)
+            return _shipment_method_to_type(method)
+
+    @strawberry.mutation
+    def update_shipment_method(
+        self,
+        info: strawberry.Info,
+        id: strawberry.ID,
+        name: str | None = None,
+        is_active: bool | None = None,
+        sort_order: int | None = None,
+    ) -> ShipmentMethod:
+        """Rename, retire or reorder a method (#451). Only what is sent is changed.
+
+        A rename does not touch the shipments that already went out under the old name - each one
+        holds its own copy - so this only changes what future shipments are offered."""
+        with SessionLocal() as session:
+            method = shipment_method_repository.update_shipment_method(
+                session, uuid.UUID(str(id)), name=name, is_active=is_active, sort_order=sort_order
+            )
+            session.commit()
+            session.refresh(method)
+            return _shipment_method_to_type(method)
+
+    @strawberry.mutation
+    def delete_shipment_method(self, info: strawberry.Info, id: strawberry.ID) -> bool:
+        """Drop a method from the list (#451).
+
+        No shipment references it - each snapshotted the name it shipped under - so this changes
+        what can be picked next and never what was picked before. Retiring is the better move for a
+        carrier that may come back; this is for a row that was a mistake."""
+        with SessionLocal() as session:
+            shipment_method_repository.delete_shipment_method(session, uuid.UUID(str(id)))
+            session.commit()
+            return True
 
     @strawberry.mutation
     def accept_shipping_out_request(self, info: strawberry.Info, id: strawberry.ID) -> ShippingOutRequest:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1123,6 +1123,9 @@ class PackingSlip:
     shipper_email: str | None
     shipper_phone: str | None
     pickup_location: str | None
+    # How the load travelled (#451). A snapshot of the method's name, so a renamed or retired method
+    # cannot rewrite what an already-shipped slip says.
+    shipment_method: str | None
     carrier_tag_bol: str | None
     weight_lbs: float | None
     delivery_address: str | None
@@ -1249,6 +1252,23 @@ class ShipReadyLooseItem:
     hardware_category: str
     product_code: str
     available_quantity: int
+
+
+@strawberry.type
+class ShipmentMethod:
+    """How a load can travel, as the shipping department maintains it (#451).
+
+    Retiring one flips `isActive` rather than deleting it: the Delivery Request form offers only
+    active methods, while shipments that already went out under it keep printing their own snapshot
+    of the name.
+    """
+
+    id: strawberry.ID
+    name: str
+    is_active: bool
+    sort_order: int
+    created_at: datetime
+    updated_at: datetime
 
 
 @strawberry.type

--- a/backend/tests/test_shipment_delivery_request.py
+++ b/backend/tests/test_shipment_delivery_request.py
@@ -31,6 +31,7 @@ FULL_DETAILS = {
     "shipper_email": "shipping@example.com",
     "shipper_phone": "555-0100",
     "pickup_location": "UC Hardware\n12 Depot Rd\nToronto ON M1M 1M1",
+    "shipment_method": "Our truck",
     "carrier_tag_bol": "BOL-4471",
     "weight_lbs": 812.5,
     "delivery_address": "40 Site Blvd\nMississauga ON",

--- a/backend/tests/test_shipment_methods.py
+++ b/backend/tests/test_shipment_methods.py
@@ -1,0 +1,140 @@
+"""The shipping department's list of how a load travels (#451).
+
+Small surface, and the tests are almost entirely about the two things that make it a *list* rather
+than a free-text box: one spelling per carrier, and a retired method that still reads correctly on
+the shipments it already carried.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from app.errors import ConflictError, NotFoundError, ValidationError
+from app.models.enums import ShipmentStatus
+from app.models.project import Project
+from app.models.shipping import PackingSlip
+from app.repositories import shipment_method_repository as methods
+
+
+def _project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def test_created_methods_come_back_in_dropdown_order(db_session):
+    methods.create_shipment_method(db_session, name="Courier", sort_order=2)
+    methods.create_shipment_method(db_session, name="Our truck", sort_order=1)
+    methods.create_shipment_method(db_session, name="Customer pickup", sort_order=1)
+
+    # sort_order first, then name - so the department's most-used method leads and ties stay stable.
+    assert [m.name for m in methods.get_shipment_methods(db_session)] == [
+        "Customer pickup",
+        "Our truck",
+        "Courier",
+    ]
+
+
+def test_a_name_is_taken_case_insensitively(db_session):
+    methods.create_shipment_method(db_session, name="Flatbed")
+    with pytest.raises(ConflictError):
+        methods.create_shipment_method(db_session, name="flatbed")
+
+
+def test_a_blank_name_is_refused(db_session):
+    with pytest.raises(ValidationError):
+        methods.create_shipment_method(db_session, name="   ")
+
+
+def test_names_are_trimmed(db_session):
+    method = methods.create_shipment_method(db_session, name="  Our truck  ")
+    assert method.name == "Our truck"
+
+
+def test_retiring_keeps_the_row_and_takes_it_out_of_the_form_list(db_session):
+    method = methods.create_shipment_method(db_session, name="Courier")
+    methods.update_shipment_method(db_session, method.id, is_active=False)
+
+    # The management screen still sees it, so retirement is not a one-way door...
+    assert [m.name for m in methods.get_shipment_methods(db_session)] == ["Courier"]
+    # ...while the Delivery Request form does not offer it.
+    assert methods.get_shipment_methods(db_session, active_only=True) == []
+
+
+def test_a_retired_method_can_be_brought_back(db_session):
+    method = methods.create_shipment_method(db_session, name="Courier")
+    methods.update_shipment_method(db_session, method.id, is_active=False)
+    methods.update_shipment_method(db_session, method.id, is_active=True)
+    assert [m.name for m in methods.get_shipment_methods(db_session, active_only=True)] == ["Courier"]
+
+
+def test_renaming_onto_another_name_is_refused(db_session):
+    methods.create_shipment_method(db_session, name="Courier")
+    other = methods.create_shipment_method(db_session, name="Our truck")
+    with pytest.raises(ConflictError):
+        methods.update_shipment_method(db_session, other.id, name="courier")
+
+
+def test_renaming_to_the_same_name_is_not_a_conflict_with_itself(db_session):
+    method = methods.create_shipment_method(db_session, name="Courier")
+    methods.update_shipment_method(db_session, method.id, name="Courier", sort_order=5)
+    assert method.sort_order == 5
+
+
+def test_only_the_fields_sent_are_changed(db_session):
+    method = methods.create_shipment_method(db_session, name="Courier", sort_order=3)
+    methods.update_shipment_method(db_session, method.id, is_active=False)
+    assert (method.name, method.sort_order, method.is_active) == ("Courier", 3, False)
+
+
+def test_renaming_does_not_touch_a_shipment_already_sent_under_the_old_name(db_session):
+    # The whole reason packing_slips.shipment_method is a string and not a foreign key: a reprint is
+    # the copy pulled up in a site dispute, and it has to keep saying what the driver was told.
+    project = _project(db_session)
+    method = methods.create_shipment_method(db_session, name="Courier")
+    slip = PackingSlip(
+        id=uuid.uuid4(),
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:8]}",
+        project_id=project.id,
+        shipped_by="shipper",
+        shipped_at=datetime.utcnow(),
+        status=ShipmentStatus.SCHEDULED,
+        shipment_method=method.name,
+    )
+    db_session.add(slip)
+    db_session.flush()
+
+    methods.update_shipment_method(db_session, method.id, name="Overnight courier")
+    db_session.refresh(slip)
+    assert slip.shipment_method == "Courier"
+
+
+def test_deleting_leaves_a_shipment_that_used_it_readable(db_session):
+    project = _project(db_session)
+    method = methods.create_shipment_method(db_session, name="Courier")
+    slip = PackingSlip(
+        id=uuid.uuid4(),
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:8]}",
+        project_id=project.id,
+        shipped_by="shipper",
+        shipped_at=datetime.utcnow(),
+        status=ShipmentStatus.SCHEDULED,
+        shipment_method=method.name,
+    )
+    db_session.add(slip)
+    db_session.flush()
+
+    methods.delete_shipment_method(db_session, method.id)
+    db_session.refresh(slip)
+    assert slip.shipment_method == "Courier"
+    assert methods.get_shipment_methods(db_session) == []
+
+
+def test_updating_or_deleting_something_that_is_not_there(db_session):
+    missing = uuid.uuid4()
+    with pytest.raises(NotFoundError):
+        methods.update_shipment_method(db_session, missing, name="Courier")
+    with pytest.raises(NotFoundError):
+        methods.delete_shipment_method(db_session, missing)

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -16,6 +16,36 @@ export const GET_SHIP_READY_ITEMS = gql`
   }
 `;
 
+// The shipping department's list of how a load can travel (#451). `activeOnly` is what the Delivery
+// Request form passes; the management screen leaves it off so a retired method stays visible.
+const SHIPMENT_METHOD_FIELDS = 'id name isActive sortOrder createdAt updatedAt';
+
+export const GET_SHIPMENT_METHODS = gql`
+  query GetShipmentMethods($activeOnly: Boolean) {
+    shipmentMethods(activeOnly: $activeOnly) { ${SHIPMENT_METHOD_FIELDS} }
+  }
+`;
+
+export const CREATE_SHIPMENT_METHOD = gql`
+  mutation CreateShipmentMethod($name: String!, $sortOrder: Int) {
+    createShipmentMethod(name: $name, sortOrder: $sortOrder) { ${SHIPMENT_METHOD_FIELDS} }
+  }
+`;
+
+export const UPDATE_SHIPMENT_METHOD = gql`
+  mutation UpdateShipmentMethod($id: ID!, $name: String, $isActive: Boolean, $sortOrder: Int) {
+    updateShipmentMethod(id: $id, name: $name, isActive: $isActive, sortOrder: $sortOrder) {
+      ${SHIPMENT_METHOD_FIELDS}
+    }
+  }
+`;
+
+export const DELETE_SHIPMENT_METHOD = gql`
+  mutation DeleteShipmentMethod($id: ID!) {
+    deleteShipmentMethod(id: $id)
+  }
+`;
+
 // Composing a request from the Shipping module rather than from Start a Task (#451). Both answer
 // with the whole request, so the pending list updates through the Apollo cache.
 const SHIPPING_OUT_REQUEST_FIELDS = `

--- a/frontend/src/modules/shipping/DeliveryRequestDocument.tsx
+++ b/frontend/src/modules/shipping/DeliveryRequestDocument.tsx
@@ -258,6 +258,7 @@ export default function DeliveryRequestDocument({
         <StackedField label="PICKUP LOCATION:" value={values.pickupLocation} minLines={3} />
 
         <Field label="PHONE NUMBER:" value={values.shipperPhone} />
+        <Field label="SHIPMENT METHOD:" value={values.shipmentMethod} />
         <Field label="CARRIER/TAG/BOL:" value={values.carrierTagBol} />
 
         <View style={styles.sectionRow}>

--- a/frontend/src/modules/shipping/DeliveryRequestFields.tsx
+++ b/frontend/src/modules/shipping/DeliveryRequestFields.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Box, Stack, TextField, Typography } from '@mui/material';
+import { Box, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { microLabelSx, monoSx } from '../../theme';
 import type { DeliveryDetails } from './deliveryRequest';
 
@@ -48,6 +48,11 @@ interface Props {
   disabled?: boolean;
   /** The Shipment section's leading field. Only the create form has a slip number to take. */
   leadingShipmentField?: ReactNode;
+  /**
+   * Active shipment methods (#451). Empty is a real state - a company that has not set any up yet -
+   * and the field degrades to free text rather than blocking the booking.
+   */
+  shipmentMethods?: { id: string; name: string }[];
 }
 
 export default function DeliveryRequestFields({
@@ -56,6 +61,7 @@ export default function DeliveryRequestFields({
   shipperName,
   disabled = false,
   leadingShipmentField,
+  shipmentMethods = [],
 }: Props) {
   const set = (field: keyof DeliveryDetails) => (value: string) => onChange({ [field]: value });
 
@@ -85,6 +91,36 @@ export default function DeliveryRequestFields({
               slotProps={{ inputLabel: { shrink: true } }}
             />
           </Stack>
+          {/* The managed list (#451). A free-text fallback rather than a strict select: the list is
+              maintained by the same department filling this in, and a method nobody has added yet
+              must not be able to stop a shipment being booked. */}
+          <TextField
+            label="Shipment method"
+            select={shipmentMethods.length > 0}
+            value={details.shipmentMethod}
+            onChange={(e) => set('shipmentMethod')(e.target.value)}
+            disabled={disabled}
+            fullWidth
+            helperText={
+              shipmentMethods.length === 0
+                ? 'No shipment methods have been set up yet - add them from the Shipping module.'
+                : undefined
+            }
+            slotProps={{ select: { displayEmpty: true } }}
+          >
+            {shipmentMethods.length > 0 && <MenuItem value="">(none)</MenuItem>}
+            {/* A slip booked under a method that has since been retired keeps showing it, or the
+                edit form would silently blank the value the moment it was opened. */}
+            {shipmentMethods.every((m) => m.name !== details.shipmentMethod) &&
+              details.shipmentMethod !== '' && (
+                <MenuItem value={details.shipmentMethod}>{details.shipmentMethod}</MenuItem>
+              )}
+            {shipmentMethods.map((m) => (
+              <MenuItem key={m.id} value={m.name}>
+                {m.name}
+              </MenuItem>
+            ))}
+          </TextField>
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
             <TextField
               label="Carrier / Tag / BOL"

--- a/frontend/src/modules/shipping/DeliveryRequestForm.tsx
+++ b/frontend/src/modules/shipping/DeliveryRequestForm.tsx
@@ -16,6 +16,7 @@ import { SHIPPING_REFETCH_QUERIES, SHIPPING_STALE_ROOT_FIELDS } from '../../grap
 import { extractGpError } from '../../graphql/gpError';
 import DeliveryRequestDocument from './DeliveryRequestDocument';
 import DeliveryRequestFields from './DeliveryRequestFields';
+import { useShipmentMethods } from './useShipmentMethods';
 import {
   buildMaterialLines,
   deliveryDetailsInput,
@@ -101,6 +102,7 @@ export default function DeliveryRequestForm({
   const { showToast } = useToast();
   const navigate = useNavigate();
   const client = useApolloClient();
+  const shipmentMethods = useShipmentMethods(!open);
 
   const [view, setView] = useState<'form' | 'success'>('form');
   const [packingSlipNumber, setPackingSlipNumber] = useState('');
@@ -355,6 +357,7 @@ export default function DeliveryRequestForm({
                 onChange={patchDetails}
                 shipperName={displayName}
                 disabled={confirming}
+                shipmentMethods={shipmentMethods}
                 leadingShipmentField={
                   <TextField
                     label="Packing Slip Number"

--- a/frontend/src/modules/shipping/EditShipmentDialog.tsx
+++ b/frontend/src/modules/shipping/EditShipmentDialog.tsx
@@ -5,6 +5,7 @@ import Modal from '../../components/Modal';
 import { useToast } from '../../components/Toast';
 import { UPDATE_SHIPMENT_DETAILS } from '../../graphql/shipping';
 import DeliveryRequestFields from './DeliveryRequestFields';
+import { useShipmentMethods } from './useShipmentMethods';
 import {
   deliveryDetailsInput,
   detailsFromSlip,
@@ -32,6 +33,7 @@ export default function EditShipmentDialog({ slip, onClose }: Props) {
   const stored = useMemo(() => detailsFromSlip(slip), [slip]);
   const [details, setDetails] = useState<DeliveryDetails>(stored);
   const [error, setError] = useState<string | null>(null);
+  const shipmentMethods = useShipmentMethods();
 
   const [updateShipment, { loading }] = useMutation(UPDATE_SHIPMENT_DETAILS, {
     onCompleted: () => {
@@ -99,6 +101,7 @@ export default function EditShipmentDialog({ slip, onClose }: Props) {
           onChange={(patch) => setDetails((prev) => ({ ...prev, ...patch }))}
           shipperName={slip.shippedBy}
           disabled={loading}
+          shipmentMethods={shipmentMethods}
         />
       </Stack>
     </Modal>

--- a/frontend/src/modules/shipping/ShipmentMethodsDialog.tsx
+++ b/frontend/src/modules/shipping/ShipmentMethodsDialog.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Plus, Trash2 } from 'lucide-react';
+import { useMutation, useQuery } from '@apollo/client/react';
+import {
+  CREATE_SHIPMENT_METHOD,
+  DELETE_SHIPMENT_METHOD,
+  GET_SHIPMENT_METHODS,
+  UPDATE_SHIPMENT_METHOD,
+} from '../../graphql/shipping';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useToast } from '../../components/Toast';
+import { microLabelSx, monoSx } from '../../theme';
+import type { ShipmentMethod } from './useShipmentMethods';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * The shipping department's own list of how a load can travel (#451).
+ *
+ * Kept here rather than in Admin because the people who maintain it are the people who pick from it
+ * on the Delivery Request, and a list that needs an admin to extend is a list that gets worked
+ * around with free text.
+ *
+ * Retiring is the ordinary action and deleting is the exception: a carrier that comes back should
+ * keep its spelling and its history, so the dropdown filters on active while this screen shows
+ * everything. Deleting is still safe - each shipment snapshotted the name it went out under - so it
+ * is offered for rows that were simply a mistake.
+ */
+export default function ShipmentMethodsDialog({ open, onClose }: Props) {
+  const { showToast } = useToast();
+  const [newName, setNewName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<ShipmentMethod | null>(null);
+
+  const { data, refetch } = useQuery<{ shipmentMethods: ShipmentMethod[] }>(GET_SHIPMENT_METHODS, {
+    variables: { activeOnly: false },
+    skip: !open,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const settle = (message: string) => {
+    showToast(message, 'success');
+    setError(null);
+    refetch();
+  };
+
+  const [createMethod, { loading: creating }] = useMutation(CREATE_SHIPMENT_METHOD, {
+    onCompleted: () => {
+      setNewName('');
+      settle('Shipment method added');
+    },
+    onError: (e) => setError(e.message),
+  });
+  const [updateMethod] = useMutation(UPDATE_SHIPMENT_METHOD, {
+    onCompleted: () => settle('Shipment method updated'),
+    onError: (e) => setError(e.message),
+  });
+  const [deleteMethod] = useMutation(DELETE_SHIPMENT_METHOD, {
+    onCompleted: () => settle('Shipment method removed'),
+    onError: (e) => setError(e.message),
+  });
+
+  const methods = data?.shipmentMethods ?? [];
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogTitle>Shipment methods</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 0.5 }}>
+            <Alert severity="info">
+              How a load travels, offered on every Delivery Request. Retiring one keeps it on the
+              shipments it already carried and takes it out of the dropdown.
+            </Alert>
+
+            {error && <Alert severity="error">{error}</Alert>}
+
+            <Stack direction="row" spacing={1}>
+              <TextField
+                size="small"
+                label="New method"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newName.trim()) {
+                    createMethod({ variables: { name: newName.trim(), sortOrder: methods.length } });
+                  }
+                }}
+                fullWidth
+              />
+              <Button
+                variant="outlined"
+                startIcon={<Plus size={16} strokeWidth={1.75} />}
+                disabled={!newName.trim() || creating}
+                onClick={() =>
+                  createMethod({ variables: { name: newName.trim(), sortOrder: methods.length } })
+                }
+              >
+                Add
+              </Button>
+            </Stack>
+
+            <Box>
+              <Typography sx={{ ...microLabelSx, display: 'block', mb: 0.5 }}>
+                {methods.length} method(s)
+              </Typography>
+              {methods.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  None yet. Until one is added the Delivery Request takes the method as free text.
+                </Typography>
+              ) : (
+                <Stack spacing={0.5}>
+                  {methods.map((m) => (
+                    <Box
+                      key={m.id}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                        py: 0.75,
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                        <Typography variant="body2" sx={monoSx}>
+                          {m.name}
+                        </Typography>
+                        {!m.isActive && <Chip size="small" variant="outlined" label="Retired" />}
+                      </Box>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Button
+                          size="small"
+                          onClick={() =>
+                            updateMethod({ variables: { id: m.id, isActive: !m.isActive } })
+                          }
+                        >
+                          {m.isActive ? 'Retire' : 'Reactivate'}
+                        </Button>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          aria-label={`Delete ${m.name}`}
+                          onClick={() => setConfirmDelete(m)}
+                        >
+                          <Trash2 size={16} strokeWidth={1.75} />
+                        </IconButton>
+                      </Stack>
+                    </Box>
+                  ))}
+                </Stack>
+              )}
+            </Box>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Done</Button>
+        </DialogActions>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmDelete !== null}
+        title="Delete this shipment method?"
+        message={
+          confirmDelete
+            ? `${confirmDelete.name} goes off the list for good. Shipments already sent under it keep printing it - they hold their own copy of the name - so nothing already booked changes. Retire it instead if the carrier may come back.`
+            : ''
+        }
+        confirmLabel="Delete"
+        confirmColor="error"
+        onConfirm={() => {
+          const id = confirmDelete?.id;
+          setConfirmDelete(null);
+          if (id) deleteMethod({ variables: { id } });
+        }}
+        onCancel={() => setConfirmDelete(null)}
+      />
+    </>
+  );
+}

--- a/frontend/src/modules/shipping/ShipmentMethodsDialog.tsx
+++ b/frontend/src/modules/shipping/ShipmentMethodsDialog.tsx
@@ -79,6 +79,25 @@ export default function ShipmentMethodsDialog({ open, onClose }: Props) {
 
   const methods = data?.shipmentMethods ?? [];
 
+  /**
+   * Add the new method at the end of the list.
+   *
+   * The position comes off the highest sortOrder in use, not the row count: the count is short by
+   * every deleted row, so after any delete the next method would be minted onto a value another one
+   * already holds and the dropdown order would stop being stable. Retired methods count too - they
+   * hold their place for the day they are reactivated.
+   *
+   * One entry point for both the button and Enter, so the in-flight guard cannot be on one and not
+   * the other. Without it a fast double-Enter fires two creates and the second comes back as a name
+   * conflict the user did nothing to cause.
+   */
+  const submitNew = () => {
+    const name = newName.trim();
+    if (!name || creating) return;
+    const sortOrder = methods.reduce((highest, m) => Math.max(highest, m.sortOrder + 1), 0);
+    createMethod({ variables: { name, sortOrder } });
+  };
+
   return (
     <>
       <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -99,9 +118,7 @@ export default function ShipmentMethodsDialog({ open, onClose }: Props) {
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && newName.trim()) {
-                    createMethod({ variables: { name: newName.trim(), sortOrder: methods.length } });
-                  }
+                  if (e.key === 'Enter') submitNew();
                 }}
                 fullWidth
               />
@@ -109,9 +126,7 @@ export default function ShipmentMethodsDialog({ open, onClose }: Props) {
                 variant="outlined"
                 startIcon={<Plus size={16} strokeWidth={1.75} />}
                 disabled={!newName.trim() || creating}
-                onClick={() =>
-                  createMethod({ variables: { name: newName.trim(), sortOrder: methods.length } })
-                }
+                onClick={submitNew}
               >
                 Add
               </Button>

--- a/frontend/src/modules/shipping/ShipmentsList.tsx
+++ b/frontend/src/modules/shipping/ShipmentsList.tsx
@@ -232,7 +232,9 @@ export default function ShipmentsList({ projectId, heading }: Props) {
     }
   }, [lifecycle, markPickedUp, markDelivered, showToast]);
 
-  const columnCount = isGlobal ? 8 : 7;
+  // Slip #, [project], status, shipped by, created, pick-up, delivery, method, carrier. The
+  // expansion row spans all of them plus the chevron, so this has to move with the header.
+  const columnCount = isGlobal ? 9 : 8;
 
   return (
     <FadeIn>
@@ -309,6 +311,7 @@ export default function ShipmentsList({ projectId, heading }: Props) {
                 <TableCell>Created</TableCell>
                 <TableCell>Pick-up</TableCell>
                 <TableCell>Delivery</TableCell>
+                <TableCell>Method</TableCell>
                 <TableCell>Carrier / Tag / BOL</TableCell>
               </TableRow>
             </TableHead>
@@ -359,6 +362,7 @@ export default function ShipmentsList({ projectId, heading }: Props) {
                       </TableCell>
                       <TableCell sx={tabularSx}>{formatDay(slip.pickupDate)}</TableCell>
                       <TableCell sx={tabularSx}>{formatDay(slip.deliveryDate)}</TableCell>
+                      <TableCell>{slip.shipmentMethod || '-'}</TableCell>
                       <TableCell>{slip.carrierTagBol || '-'}</TableCell>
                     </TableRow>
                     <TableRow>

--- a/frontend/src/modules/shipping/__tests__/DeliveryRequestForm.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/DeliveryRequestForm.test.tsx
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../../../components/Toast';
 import { CartProvider, useCart, type CartItem } from '../../../contexts/CartContext';
 import DeliveryRequestForm from '../DeliveryRequestForm';
-import { CONFIRM_SHIPMENT, GET_SHIP_READY_ITEMS } from '../../../graphql/shipping';
+import { CONFIRM_SHIPMENT, GET_SHIP_READY_ITEMS, GET_SHIPMENT_METHODS } from '../../../graphql/shipping';
 import { GET_WAREHOUSES } from '../../../graphql/shared';
 
 // MUI Dialog under jsdom is slow, and slower still when the whole suite runs in parallel - the same
@@ -60,6 +60,7 @@ const BLANK_DETAILS = {
   shipperEmail: null as string | null,
   shipperPhone: null as string | null,
   pickupLocation: null as string | null,
+  shipmentMethod: null as string | null,
   carrierTagBol: null as string | null,
   weightLbs: null as number | null,
   deliveryAddress: null as string | null,
@@ -222,9 +223,18 @@ function seededCache() {
   return cache;
 }
 
+// The form reads the shipment-method list on open (#451). Folded in here rather than added to every
+// mock list below: an empty list is the state these tests want - the method field degrades to free
+// text and none of them assert on it - and a missing mock would fail each one on an unrelated query.
+const shipmentMethodsMock: MockedResponse = {
+  request: { query: GET_SHIPMENT_METHODS, variables: { activeOnly: true } },
+  maxUsageCount: Number.POSITIVE_INFINITY,
+  result: { data: { shipmentMethods: [] } },
+};
+
 function renderForm(mocks: MockedResponse[], cache: InMemoryCache, withShipReadyProbe = false) {
   render(
-    <MockedProvider mocks={mocks} cache={cache}>
+    <MockedProvider mocks={[shipmentMethodsMock, ...mocks]} cache={cache}>
       <MemoryRouter>
         <ToastProvider>
           <CartProvider>

--- a/frontend/src/modules/shipping/__tests__/ShipmentMethodsDialog.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/ShipmentMethodsDialog.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import ShipmentMethodsDialog from '../ShipmentMethodsDialog';
+import { CREATE_SHIPMENT_METHOD, GET_SHIPMENT_METHODS } from '../../../graphql/shipping';
+
+/**
+ * The shipping department's list of how a load can travel (#451).
+ *
+ * What is pinned here is where a new method lands in the order and how many times Add can fire,
+ * because both are silent when wrong: a reused sortOrder just makes the dropdown order arbitrary,
+ * and a double submit surfaces as a name conflict the user did nothing to cause.
+ */
+
+const INFINITE = Number.POSITIVE_INFINITY;
+
+function method(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'ShipmentMethod',
+    id: 'sm-1',
+    name: 'Our truck',
+    isActive: true,
+    sortOrder: 0,
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function listMock(methods: Record<string, unknown>[]): MockedResponse {
+  return {
+    request: { query: GET_SHIPMENT_METHODS, variables: { activeOnly: false } },
+    maxUsageCount: INFINITE,
+    result: { data: { shipmentMethods: methods } },
+  };
+}
+
+function createMock(name: string, sortOrder: number, onFire?: () => void): MockedResponse {
+  return {
+    request: { query: CREATE_SHIPMENT_METHOD, variables: { name, sortOrder } },
+    // One only: a second matching call has no mock left and the test fails loudly rather than
+    // quietly passing on a duplicate submit.
+    result: () => {
+      onFire?.();
+      return { data: { createShipmentMethod: method({ id: 'sm-new', name, sortOrder }) } };
+    },
+  };
+}
+
+function renderDialog(mocks: MockedResponse[]) {
+  render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <ShipmentMethodsDialog open onClose={vi.fn()} />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+it('puts a new method past the highest position in use, not at the row count', async () => {
+  // Two rows numbered 0 and 4 - what a list looks like after a delete. The count would mint this
+  // one onto 2, which nothing holds today but which the next reactivated row could.
+  const fired = vi.fn();
+  renderDialog([
+    listMock([method({ id: 'sm-1', sortOrder: 0 }), method({ id: 'sm-2', name: 'Flatbed', sortOrder: 4 })]),
+    createMock('Courier', 5, fired),
+  ]);
+  await flush();
+
+  fireEvent.change(await screen.findByRole('textbox', { name: /New method/i }), {
+    target: { value: 'Courier' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Add/i }));
+
+  await waitFor(() => expect(fired).toHaveBeenCalled());
+});
+
+it('counts a retired method when working out the next position', async () => {
+  // It keeps its place for the day it is reactivated, so the next method has to go past it.
+  const fired = vi.fn();
+  renderDialog([
+    listMock([method({ id: 'sm-1', sortOrder: 0 }), method({ id: 'sm-2', name: 'Rail', sortOrder: 1, isActive: false })]),
+    createMock('Courier', 2, fired),
+  ]);
+  await flush();
+
+  fireEvent.change(await screen.findByRole('textbox', { name: /New method/i }), {
+    target: { value: 'Courier' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Add/i }));
+
+  await waitFor(() => expect(fired).toHaveBeenCalled());
+});
+
+it('does not fire a second create while the first is still in flight', async () => {
+  const fired = vi.fn();
+  renderDialog([listMock([]), createMock('Courier', 0, fired)]);
+  await flush();
+
+  const box = await screen.findByRole('textbox', { name: /New method/i });
+  fireEvent.change(box, { target: { value: 'Courier' } });
+  fireEvent.keyDown(box, { key: 'Enter' });
+  fireEvent.keyDown(box, { key: 'Enter' });
+
+  await waitFor(() => expect(fired).toHaveBeenCalledTimes(1));
+  // The second Enter would have had no mock to match, which surfaces as an error alert.
+  expect(screen.queryByText(/No more mocked responses/i)).not.toBeInTheDocument();
+});
+
+it('ignores Enter on an empty box', async () => {
+  renderDialog([listMock([])]);
+  await flush();
+
+  const box = await screen.findByRole('textbox', { name: /New method/i });
+  fireEvent.keyDown(box, { key: 'Enter' });
+
+  await flush();
+  expect(screen.queryByText(/No more mocked responses/i)).not.toBeInTheDocument();
+});

--- a/frontend/src/modules/shipping/__tests__/ShipmentsList.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/ShipmentsList.test.tsx
@@ -35,6 +35,7 @@ const HEADER = {
   shipperEmail: 'darrenw@ucsh.com',
   shipperPhone: '604 235 2609',
   pickupLocation: 'Coast Meridian\n1120 1725 Coast Meridian Road',
+  shipmentMethod: 'Our truck',
   carrierTagBol: 'BOL-8891',
   weightLbs: 420,
   deliveryAddress: '6775 Bell McKinnon Rd., Duncan, BC',

--- a/frontend/src/modules/shipping/__tests__/deliveryRequest.test.ts
+++ b/frontend/src/modules/shipping/__tests__/deliveryRequest.test.ts
@@ -7,6 +7,7 @@ import {
   slipMaterialLines,
   warehouseAddressLines,
 } from '../deliveryRequest';
+import { DELIVERY_REQUEST_FIELDS } from '../../../types/deliveryRequestFields';
 
 describe('buildMaterialLines', () => {
   it('writes an assembled leaf as one unit of a named opening', () => {
@@ -135,7 +136,10 @@ describe('buildMaterialLines', () => {
 describe('deliveryDetailsInput', () => {
   it('sends every field, blanks as null, so a cleared field clears', () => {
     const input = deliveryDetailsInput(EMPTY_DELIVERY_DETAILS);
-    expect(Object.keys(input)).toHaveLength(20);
+    // Counted off the shared list rather than hard-coded: the point of #453 is that adding a header
+    // field reaches every derived shape at once, and a literal here would make each addition look
+    // like a regression instead.
+    expect(Object.keys(input).sort()).toEqual([...DELIVERY_REQUEST_FIELDS].sort());
     expect(Object.values(input).every((v) => v === null)).toBe(true);
   });
 

--- a/frontend/src/modules/shipping/index.tsx
+++ b/frontend/src/modules/shipping/index.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { Box, Typography, Badge, IconButton, Button, ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { ArrowLeft, ShoppingCart } from 'lucide-react';
+import { ArrowLeft, ShoppingCart, Truck } from 'lucide-react';
 import { useCart } from '../../contexts/CartContext';
 import ShipReadyBrowser from './ShipReadyBrowser';
 import ShipmentsList from './ShipmentsList';
 import ShippingCart from './ShippingCart';
 import ShippingRequestsPage from './ShippingRequestsPage';
+import ShipmentMethodsDialog from './ShipmentMethodsDialog';
 import ProjectLandingPage from '../../components/ProjectLandingPage';
 import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
 import type { Project } from '../../types/project';
@@ -14,6 +15,7 @@ import type { Project } from '../../types/project';
 export default function ShippingModule() {
   const [selectedProject, setSelectedProject] = useState<Project | 'all' | null>(null);
   const [cartOpen, setCartOpen] = useState(false);
+  const [methodsOpen, setMethodsOpen] = useState(false);
   const { itemCount } = useCart();
   const navigate = useNavigate();
   const location = useLocation();
@@ -65,6 +67,11 @@ export default function ShippingModule() {
             <ToggleButton value="ship">Ship</ToggleButton>
             <ToggleButton value="returns">Returns</ToggleButton>
           </ToggleButtonGroup>
+          {/* The method list is maintained by the same people who pick from it on the Delivery
+              Request (#451), so it lives here rather than behind Admin. */}
+          <IconButton onClick={() => setMethodsOpen(true)} aria-label="Manage shipment methods">
+            <Truck size={18} strokeWidth={1.75} />
+          </IconButton>
           <IconButton onClick={() => setCartOpen(true)} aria-label="Open shipping cart">
             <Badge badgeContent={itemCount} color="primary">
               <ShoppingCart size={18} strokeWidth={1.75} />
@@ -87,6 +94,7 @@ export default function ShippingModule() {
         jobNumber={selectedProject !== 'all' ? selectedProject.projectId : undefined}
         project={gpSetupProject}
       />
+      <ShipmentMethodsDialog open={methodsOpen} onClose={() => setMethodsOpen(false)} />
     </Box>
   );
 }

--- a/frontend/src/modules/shipping/useShipmentMethods.ts
+++ b/frontend/src/modules/shipping/useShipmentMethods.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@apollo/client/react';
+import { GET_SHIPMENT_METHODS } from '../../graphql/shipping';
+
+export interface ShipmentMethod {
+  id: string;
+  name: string;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+/**
+ * The active shipment methods, for the Delivery Request form (#451).
+ *
+ * Both the create form and the edit dialog need the same list, and both have to degrade to an empty
+ * one rather than blocking: a company that has not set any methods up yet still has to be able to
+ * book and correct shipments, and the field falls back to free text when the list is empty.
+ */
+export function useShipmentMethods(skip = false): ShipmentMethod[] {
+  const { data } = useQuery<{ shipmentMethods: ShipmentMethod[] }>(GET_SHIPMENT_METHODS, {
+    variables: { activeOnly: true },
+    skip,
+    fetchPolicy: 'cache-and-network',
+  });
+  return data?.shipmentMethods ?? [];
+}

--- a/frontend/src/types/deliveryRequestFields.ts
+++ b/frontend/src/types/deliveryRequestFields.ts
@@ -1,4 +1,4 @@
-// The twenty fields of the Delivery Request header, named once for the whole frontend (#453).
+// The Delivery Request header's fields, named once for the whole frontend (#453).
 //
 // Two places need this list and they are on opposite sides of the Apollo boundary: `graphql/shipping.ts`
 // builds the GraphQL selection every PackingSlip read and mutation shares, and
@@ -7,7 +7,7 @@
 // other - a module importing the shared GraphQL layer is the direction this codebase runs in, and
 // the reverse would invert it.
 //
-// A twenty-first field used to be able to drift in two directions, and neither broke the build or
+// A new field used to be able to drift in two directions, and neither broke the build or
 // any test:
 //   - missing from the backend tuple -> GraphQL accepts it and never persists or clears it
 //   - missing from the selection     -> saves, reads back undefined, prints blank on the form
@@ -22,6 +22,9 @@ export const DELIVERY_REQUEST_FIELDS = [
   'shipperEmail',
   'shipperPhone',
   'pickupLocation',
+  // How the load travels (#451). Chosen from the managed ShipmentMethod list but stored as its
+  // name, so a method renamed or retired later cannot rewrite an already-shipped slip.
+  'shipmentMethod',
   'carrierTagBol',
   'weightLbs',
   'deliveryAddress',


### PR DESCRIPTION
phase 4 of #451. stacked on #463 (phases 1 and 2), review that first. phase 3, staging workspace with containers, still open.

how a load travelled was nowhere on the Delivery Request, and the answer comes back from the same handful of options every time - our truck, a named courier, customer pickup - so free text would spell each of them several ways across a year of shipments.

new `ShipmentMethod` table + CRUD, maintained from the Shipping module, not Admin: the people who pick from the list are the people who maintain it, and a list that needs an admin to extend is a list that gets worked around with free text.

retiring is `isActive = false`, not a delete. a carrier that comes back keeps its spelling, the form offers only active methods, the management screen shows all so retirement is not a one-way door. delete still offered for a row that was simply a mistake.

`packing_slips.shipment_method` is a plain string like `pickup_location` beside it, not a foreign key. a reprint is the copy pulled up in a site dispute, so a method renamed or deleted since must not be able to rewrite or erase what the driver was told - which is also what makes deleting safe at all.

field reaches confirm input -> edit input -> columns -> GraphQL selection -> form state -> printed document by being added to `DELIVERY_REQUEST_FIELDS` on each side, the pair of lists from #453, with `test_delivery_request_field_parity.py` holding them together.

where it shows up:
- Delivery Request form, create and edit, select over active methods; free text when no methods exist yet, so a company that has not set any up can still book
- slip booked under a since-retired method keeps showing it in the edit form rather than silently blanking
- SHIPMENT METHOD on the printed Delivery Request
- Method column on the Shipments page
- truck icon in the Shipping module header opens the management dialog

all four fields SIGNED_IN. one migration, 082, additive.

`backend/tests/test_shipment_methods.py` covers
dropdown ordering
case-insensitive uniqueness
blank and trimmed names
retire and reactivate
renaming onto another name
renaming to itself
partial updates
rename not touching a shipment already sent under the old name
delete leaving that shipment readable

frontend `deliveryDetailsInput` test counts the header off the shared field list instead of the literal 20, so adding a field reads as the addition it is rather than as a regression.

simulated user testing not yet run against a PR environment. once one is up:

1. Shipping -> truck icon in header -> add "Flatbed" and "Our truck"
2. retire "Our truck" -> keeps a Retired chip on the management screen
3. ship something -> Delivery Request's Shipment method select offers Flatbed, not Our truck
4. confirm -> Shipments page Method column and printed Delivery Request both read Flatbed
5. delete Flatbed from the management screen -> reprint that shipment's Delivery Request -> still says Flatbed
