### PR TITLE
feat(shipping): staging workspace and shipment containers (#451)

### DIFF
--- a/backend/alembic/versions/083_shipment_containers.py
+++ b/backend/alembic/versions/083_shipment_containers.py
@@ -29,6 +29,16 @@ depends_on = None
 
 
 def upgrade() -> None:
+    postgresql.ENUM(
+        "SKID",
+        "DOOR_CART",
+        "BOX",
+        "ENVELOPE",
+        "BUNDLE",
+        name="shipment_container_type",
+    ).create(op.get_bind(), checkfirst=True)
+    # Created above, so the column's reference must NOT try again - a bare postgresql.ENUM defaults
+    # to emitting its own CREATE TYPE during create_table, which is a DuplicateObject on a fresh DB.
     container_type = postgresql.ENUM(
         "SKID",
         "DOOR_CART",
@@ -36,8 +46,8 @@ def upgrade() -> None:
         "ENVELOPE",
         "BUNDLE",
         name="shipment_container_type",
+        create_type=False,
     )
-    container_type.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "shipment_containers",

--- a/backend/alembic/versions/083_shipment_containers.py
+++ b/backend/alembic/versions/083_shipment_containers.py
@@ -1,0 +1,110 @@
+"""Shipment containers and what is stacked in them
+
+Revision ID: 083
+Revises: 082
+Create Date: 2026-08-03
+
+Shipping out went straight from "these units are ship-ready" to a packing slip (#451). The work in
+between - stacking a skid in an order the site can unload, building a shipment up over days out of
+several containers - happened on the floor and was recorded nowhere, so nobody could see what was
+already loaded without walking to it.
+
+`packing_slip_id` is the whole lifecycle: null while the container is being built, stamped when a
+shipment is confirmed, and from then on history. That is why there is no status column - the only
+question ever asked is "has this left".
+
+Nothing here moves inventory. The hardware left when its pull was picked (#367); a container records
+how what is already staged is arranged for the truck.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "083"
+down_revision = "082"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    container_type = postgresql.ENUM(
+        "SKID",
+        "DOOR_CART",
+        "BOX",
+        "ENVELOPE",
+        "BUNDLE",
+        name="shipment_container_type",
+    )
+    container_type.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "shipment_containers",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("project_id", sa.UUID(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("container_type", container_type, nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("packing_slip_id", sa.UUID(), sa.ForeignKey("packing_slips.id"), nullable=True),
+        sa.Column("created_by", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_shipment_containers_project_slip",
+        "shipment_containers",
+        ["project_id", "packing_slip_id"],
+    )
+    # One name per OPEN container per project. Shipped ones are excluded so next month's "Skid 1" is
+    # not refused because a shipment in March used the name.
+    op.create_index(
+        "uq_shipment_containers_open_name",
+        "shipment_containers",
+        ["project_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("packing_slip_id IS NULL"),
+    )
+
+    op.create_table(
+        "shipment_container_items",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "shipment_container_id",
+            sa.UUID(),
+            sa.ForeignKey("shipment_containers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Reuses the enum migration 004 created; this migration must not try to make it again.
+        sa.Column(
+            "item_type",
+            postgresql.ENUM("LOOSE", "OPENING_ITEM", name="pull_request_item_type", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("opening_item_id", sa.UUID(), sa.ForeignKey("opening_items.id"), nullable=True),
+        sa.Column("opening_number", sa.String(), nullable=True),
+        sa.Column("leaf", sa.SmallInteger(), nullable=True),
+        sa.Column("hardware_category", sa.String(), nullable=False),
+        sa.Column("product_code", sa.String(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("quantity >= 1", name="ck_shipment_container_items_quantity_positive"),
+    )
+    op.create_index(
+        "ix_shipment_container_items_container",
+        "shipment_container_items",
+        ["shipment_container_id"],
+    )
+    op.create_index(
+        "ix_shipment_container_items_opening_item",
+        "shipment_container_items",
+        ["opening_item_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("shipment_container_items")
+    op.drop_index("uq_shipment_containers_open_name", table_name="shipment_containers")
+    op.drop_index("ix_shipment_containers_project_slip", table_name="shipment_containers")
+    op.drop_table("shipment_containers")
+    postgresql.ENUM(name="shipment_container_type").drop(op.get_bind(), checkfirst=True)

--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -169,6 +169,14 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     "returnableLines": SIGNED_IN,
     # The shipping department's own list of how a load travels (#451). SIGNED_IN like the rest of
     # shipping: it is documentation the same people maintain and consume, and it gates nothing.
+    # The staging workspace and its containers (#451). SIGNED_IN like the rest of shipping - the
+    # warehouse and the shipping department both load a truck, and neither owns the screen.
+    "stagingPool": SIGNED_IN,
+    "createShipmentContainer": SIGNED_IN,
+    "renameShipmentContainer": SIGNED_IN,
+    "deleteShipmentContainer": SIGNED_IN,
+    "setContainerItems": SIGNED_IN,
+    "confirmShipmentFromContainers": SIGNED_IN,
     "shipmentMethods": SIGNED_IN,
     "createShipmentMethod": SIGNED_IN,
     "updateShipmentMethod": SIGNED_IN,

--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -167,8 +167,6 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     # --- shipping.py ----------------------------------------------------------------------
     "packingSlips": SIGNED_IN,
     "returnableLines": SIGNED_IN,
-    # The shipping department's own list of how a load travels (#451). SIGNED_IN like the rest of
-    # shipping: it is documentation the same people maintain and consume, and it gates nothing.
     # The staging workspace and its containers (#451). SIGNED_IN like the rest of shipping - the
     # warehouse and the shipping department both load a truck, and neither owns the screen.
     "stagingPool": SIGNED_IN,
@@ -177,6 +175,8 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     "deleteShipmentContainer": SIGNED_IN,
     "setContainerItems": SIGNED_IN,
     "confirmShipmentFromContainers": SIGNED_IN,
+    # The shipping department's own list of how a load travels (#451). SIGNED_IN like the rest of
+    # shipping: it is documentation the same people maintain and consume, and it gates nothing.
     "shipmentMethods": SIGNED_IN,
     "createShipmentMethod": SIGNED_IN,
     "updateShipmentMethod": SIGNED_IN,

--- a/backend/app/graphql/shipping.graphql
+++ b/backend/app/graphql/shipping.graphql
@@ -209,6 +209,108 @@ type ShipmentMethod {
   updatedAt: DateTime!
 }
 
+# --- Staging workspace and containers (#451) ----------------------------------------------------
+# The staging pool is everything a completed shipping pull put on the floor: assembled leaves at
+# SHIP_READY, and loose quantities picked but not yet shipped. Containers are how that pool gets
+# arranged into what physically goes on the truck, built up over hours or days and then confirmed as
+# one shipment. Nothing here moves inventory - the hardware left when its pull was picked (#367).
+#
+# A container is open while packingSlipId is null and shipped once it is stamped. There is no status
+# column: the slip IS the lifecycle, so a container cannot read as shipped without one.
+
+enum ShipmentContainerType {
+  SKID
+  DOOR_CART
+  BOX
+  ENVELOPE
+  BUNDLE
+}
+
+type ShipmentContainerItem {
+  id: ID!
+  shipmentContainerId: ID!
+  itemType: PullRequestItemType!
+  openingItemId: ID
+  # Null on loose stock pulled by a request raised off inventory (#451).
+  openingNumber: String
+  leaf: Int
+  hardwareCategory: String!
+  productCode: String!
+  quantity: Int!
+  # Load order. 0 is loaded first, which on a skid is the bottom of the stack. Only meaningful for
+  # SKID and DOOR_CART, the two that are unloaded in reverse.
+  position: Int!
+}
+
+type ShipmentContainer {
+  id: ID!
+  projectId: ID!
+  containerType: ShipmentContainerType!
+  name: String!
+  # Set when this container shipped. Null means open, and open is the only thing that can be edited.
+  packingSlipId: ID
+  createdBy: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  items: [ShipmentContainerItem!]!
+}
+
+type StagedLeaf {
+  openingItemId: ID!
+  openingNumber: String!
+  leaf: Int
+  building: String
+  floor: String
+  location: String
+  # The container holding it, or null if it is still loose on the floor. One leaf, one container.
+  placedInContainerId: ID
+}
+
+type StagedLooseItem {
+  # Part of this row's identity, not a label: get_ship_ready_items groups the staged pool by
+  # (opening, category, product) and confirmShipment checks availability the same way, so a product
+  # staged for two openings is two rows here.
+  openingNumber: String
+  hardwareCategory: String!
+  productCode: String!
+  stagedQuantity: Int!
+  placedQuantity: Int!
+  unplacedQuantity: Int!
+}
+
+type StagingPool {
+  leaves: [StagedLeaf!]!
+  looseItems: [StagedLooseItem!]!
+  containers: [ShipmentContainer!]!
+}
+
+input ContainerItemInput {
+  itemType: PullRequestItemType!
+  openingItemId: ID
+  # Part of a loose placement's identity, not decoration: it is what confirmShipment checks the
+  # units against. Send back the openingNumber of the StagedLooseItem row the units came from.
+  openingNumber: String
+  leaf: Int
+  hardwareCategory: String! = ""
+  productCode: String! = ""
+  quantity: Int! = 1
+}
+
+input SetContainerItemsInput {
+  containerId: ID!
+  # FULL REPLACE, and the list order IS the stacking order - position comes from the index, so the
+  # caller never computes it. One batch call rather than place/remove/reorder as three, because a
+  # drag-and-drop surface already holds the whole list.
+  items: [ContainerItemInput!]!
+}
+
+input ConfirmShipmentFromContainersInput {
+  projectId: ID!
+  packingSlipNumber: String!
+  containerIds: [ID!]!
+  # + every field of the Delivery Request header block above.
+}
+
 type ReturnableLine {
   packingSlipItemId: ID!
   openingNumber: String
@@ -228,6 +330,10 @@ type Query {
   # activeOnly is what the Delivery Request form passes; the management screen leaves it off so a
   # retired method stays visible to reactivate.
   shipmentMethods(activeOnly: Boolean! = false): [ShipmentMethod!]!
+  # The staging workspace's whole read (#451): what is on the floor and where it has been put. One
+  # query rather than two, because two could disagree about whether a leaf has been loaded and that
+  # disagreement is the mistake containers exist to prevent.
+  stagingPool(projectId: ID!): StagingPool!
   # Accept UI (#293): shipping-out requests, PENDING by default.
   # reopenableOnly (#325): keep only requests whose minted PR is still PENDING (the Approved/reopen view).
   shippingOutRequests(projectId: ID, status: ShippingOutRequestStatus, reopenableOnly: Boolean! = false): [ShippingOutRequest!]!
@@ -277,6 +383,18 @@ type Mutation {
   createShipmentMethod(name: String!, sortOrder: Int! = 0): ShipmentMethod!
   updateShipmentMethod(id: ID!, name: String, isActive: Boolean, sortOrder: Int): ShipmentMethod!
   deleteShipmentMethod(id: ID!): Boolean!
+  # Containers (#451). All four refuse a container that has already shipped - it is part of that
+  # shipment's record. Delete returns the container's contents to the unplaced pool.
+  createShipmentContainer(projectId: ID!, containerType: ShipmentContainerType!, name: String!): ShipmentContainer!
+  renameShipmentContainer(id: ID!, name: String!): ShipmentContainer!
+  deleteShipmentContainer(id: ID!): Boolean!
+  # Re-gated inside the write transaction against the pool as it is at save time, not as it was when
+  # the screen was drawn: a skid's leaf cap, one leaf per open container, and loose placements
+  # against what is staged and unplaced.
+  setContainerItems(input: SetContainerItemsInput!): ShipmentContainer!
+  # Ship the named containers as one shipment, then stamp the slip onto each so they read as shipped.
+  # A thin wrapper over confirmShipment, which still owns every rule about what may leave.
+  confirmShipmentFromContainers(input: ConfirmShipmentFromContainersInput!): PackingSlip!
   confirmShipment(input: ConfirmShipmentInput!): PackingSlip!
   createShipmentReturn(input: CreateShipmentReturnInput!): ShipmentReturn!
   # Delivery Request lifecycle (#447). Any signed-in user. All three answer with the same PackingSlip

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -27,6 +27,10 @@ from .receive_decision import ReceiveDecision  # noqa: E402, F401
 from .receive_draft import ReceiveDraft, ReceiveDraftLineItem  # noqa: E402, F401
 from .receiving import ReceiveLineItem, ReceiveRecord  # noqa: E402, F401
 from .relay_install import RelayInstall  # noqa: E402, F401
+from .shipment_container import (  # noqa: E402, F401
+    ShipmentContainer,
+    ShipmentContainerItem,
+)
 from .shipment_method import ShipmentMethod  # noqa: E402, F401
 from .shipping import (  # noqa: E402, F401
     PackingSlip,

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -51,6 +51,21 @@ class PullPickLineState(str, enum.Enum):
     APPLIED = "APPLIED"
 
 
+class ShipmentContainerType(str, enum.Enum):
+    """What the warehouse physically loads a shipment into (#451).
+
+    SKID and DOOR_CART are the two that carry an ordered stack somebody has to unload in reverse, so
+    they are the ones whose `position` means anything. The other three hold things whose order does
+    not matter.
+    """
+
+    SKID = "SKID"
+    DOOR_CART = "DOOR_CART"
+    BOX = "BOX"
+    ENVELOPE = "ENVELOPE"
+    BUNDLE = "BUNDLE"
+
+
 class OpeningItemState(str, enum.Enum):
     IN_INVENTORY = "IN_INVENTORY"
     SHIP_READY = "SHIP_READY"

--- a/backend/app/models/shipment_container.py
+++ b/backend/app/models/shipment_container.py
@@ -1,0 +1,104 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Integer, SmallInteger, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+from .enums import PullRequestItemType, ShipmentContainerType
+
+# A skid is loaded by hand and a stack taller than this is not safe to strap or to lift. It is a
+# physical limit on the object, not a policy, which is why it lives beside the model rather than in
+# a settings table somebody could raise without buying a bigger skid.
+MAX_LEAVES_PER_SKID = 30
+
+
+class ShipmentContainer(Base):
+    """A physical thing the warehouse loads: a skid, a door cart, a box, an envelope, a bundle (#451).
+
+    Shipping out used to go straight from "these units are ship-ready" to a packing slip, with the
+    organising done on the floor and recorded nowhere. It is real work - a skid has to be stacked in
+    an order the site can unload, and a shipment is several containers that get built up over days -
+    so it is an entity rather than a step inside the confirm dialog.
+
+    `packing_slip_id` is what makes a container open or shipped. Null means it is still being built
+    and can be renamed, added to and emptied; once a shipment is confirmed the id is stamped and the
+    container is history, exactly like the slip's own items. That single column is also why an
+    "open" container needs no status enum: the question is only ever "has this left".
+
+    Nothing here moves inventory. The hardware left inventory when its pull was picked (#367); this
+    is a record of how what is already staged is arranged for the truck.
+    """
+
+    __tablename__ = "shipment_containers"
+    __table_args__ = (
+        Index("ix_shipment_containers_project_slip", "project_id", "packing_slip_id"),
+        # One name per open container per project, so "Skid 1" cannot be built twice at once. Shipped
+        # ones are excluded: next month's Skid 1 is a different skid, and refusing the name because a
+        # shipment used it in March would make the numbering unusable.
+        Index(
+            "uq_shipment_containers_open_name",
+            "project_id",
+            "name",
+            unique=True,
+            postgresql_where="packing_slip_id IS NULL",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), nullable=False)
+    container_type: Mapped[ShipmentContainerType] = mapped_column(
+        Enum(ShipmentContainerType, name="shipment_container_type", create_constraint=True),
+        nullable=False,
+    )
+    # What the floor calls it - "Skid 1", "Door Cart 3". Operator-chosen rather than generated: the
+    # label goes on the physical thing in marker, and a uuid does not.
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    packing_slip_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("packing_slips.id"), nullable=True)
+    created_by: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    items: Mapped[list["ShipmentContainerItem"]] = relationship(
+        back_populates="container", cascade="all, delete-orphan"
+    )
+
+
+class ShipmentContainerItem(Base):
+    """One thing placed in a container, and where in the stack it sits (#451).
+
+    Mirrors `PackingSlipItem` on purpose: confirming a shipment copies these onto the slip, so a
+    shape that could not become a slip line would be a container that cannot ship.
+
+    `position` is the stacking order, and it is only meaningful on a skid or a door cart - the two
+    that are loaded in a sequence somebody has to reverse at the far end. Position 1 is the FIRST
+    one loaded, which on a skid is the bottom of the stack. A box of loose hardware has an arbitrary
+    order and simply carries whatever positions it was given.
+    """
+
+    __tablename__ = "shipment_container_items"
+    __table_args__ = (
+        Index("ix_shipment_container_items_container", "shipment_container_id"),
+        Index("ix_shipment_container_items_opening_item", "opening_item_id"),
+        CheckConstraint("quantity >= 1", name="ck_shipment_container_items_quantity_positive"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    shipment_container_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("shipment_containers.id", ondelete="CASCADE"), nullable=False
+    )
+    item_type: Mapped[PullRequestItemType] = mapped_column(
+        Enum(PullRequestItemType, name="pull_request_item_type", create_constraint=True),
+        nullable=False,
+    )
+    opening_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("opening_items.id"), nullable=True)
+    # Null on loose stock with no opening attribution (#451), same as everywhere else in the chain.
+    opening_number: Mapped[str | None] = mapped_column(String, nullable=True)
+    leaf: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    hardware_category: Mapped[str] = mapped_column(String, nullable=False)
+    product_code: Mapped[str] = mapped_column(String, nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, default=datetime.utcnow)
+
+    container: Mapped["ShipmentContainer"] = relationship(back_populates="items")

--- a/backend/app/repositories/shipment_containers.py
+++ b/backend/app/repositories/shipment_containers.py
@@ -32,6 +32,21 @@ from app.models.shipment_container import (
 STACKED_TYPES = (ShipmentContainerType.SKID, ShipmentContainerType.DOOR_CART)
 
 
+def loose_key(opening_number: str | None, hardware_category: str, product_code: str) -> tuple[str | None, str, str]:
+    """How a staged loose quantity is identified, everywhere on this path.
+
+    The opening is part of it because `get_ship_ready_items` groups the staged pool that way and
+    `confirm_shipment` checks availability that way. Keying containers on the product alone reads as
+    harmless right up until two openings stage the same product: the pool would report one of the two
+    quantities as if it were the total, and a placement the staging rules accepted would be refused
+    at confirm - or booked against an opening it was never pulled for.
+
+    Null is a real value here, not a missing one. A pull raised straight off inventory has no opening
+    to attribute (#451), and those units are their own bucket rather than everyone's.
+    """
+    return (opening_number, hardware_category, product_code)
+
+
 def get_containers(session: Session, project_id: uuid.UUID, *, open_only: bool = True) -> list[ShipmentContainer]:
     """Containers for one project, items eagerly loaded (the type builder walks them).
 
@@ -115,7 +130,7 @@ def set_container_items(
     staged_pool = build_staged_pool(session, container.project_id)
 
     leaf_ids: set[uuid.UUID] = set()
-    loose_wanted: dict[tuple[str, str], int] = {}
+    loose_wanted: dict[tuple[str | None, str, str], int] = {}
     for item in items:
         item_type = PullRequestItemType(item["item_type"])
         if item_type == PullRequestItemType.OPENING_ITEM:
@@ -129,7 +144,7 @@ def set_container_items(
                 raise ValidationError("The same door leaf cannot be placed twice in one container.", field="items")
             leaf_ids.add(oi_id)
         else:
-            key = (item["hardware_category"], item["product_code"])
+            key = loose_key(item.get("opening_number"), item["hardware_category"], item["product_code"])
             loose_wanted[key] = loose_wanted.get(key, 0) + int(item.get("quantity", 1))
 
     if container.container_type is ShipmentContainerType.SKID and len(leaf_ids) > MAX_LEAVES_PER_SKID:
@@ -195,7 +210,10 @@ def confirm_shipment_from_containers(
     if not container_ids:
         raise ValidationError("Pick at least one container to ship.", field="containerIds")
 
-    containers = [_open_container(session, cid) for cid in container_ids]
+    # Deduplicated before loading. The same id twice builds the item list twice, which doubles every
+    # loose quantity on the slip and makes `confirm_shipment`'s leaf count disagree with the number
+    # of distinct leaves it found - reported as the leaf not existing.
+    containers = [_open_container(session, cid) for cid in dict.fromkeys(container_ids)]
     for container in containers:
         if container.project_id != project_id:
             raise ValidationError(f"{container.name} belongs to another project.", field="containerIds")
@@ -232,27 +250,41 @@ def confirm_shipment_from_containers(
     return slip
 
 
-def build_staged_pool(session: Session, project_id: uuid.UUID) -> dict:
+def build_staged_pool(
+    session: Session,
+    project_id: uuid.UUID,
+    *,
+    ready: dict | None = None,
+    containers: list[ShipmentContainer] | None = None,
+) -> dict:
     """What this project has staged, and how much of it is already in an open container.
 
     `{"leaves": {opening_item_id: placed_in_container_id | None},
-      "loose": {(category, product): {"staged": n, "placed": n}}}`
+      "loose": {(opening, category, product): {"staged": n, "placed": n}}}`
 
     The staged side comes from `get_ship_ready_items`, which is the existing definition of what is
     out of inventory and not yet shipped; this only adds where it has been put since.
+
+    `ready` and `containers` are accepted so a caller that has already read them - the workspace
+    query renders all three - can hand them over instead of paying for the same two reads twice.
+    `get_ship_ready_items` alone is three statements plus a selectinload.
     """
     from app.repositories import shipping_repository
 
-    ready = shipping_repository.get_ship_ready_items(session, project_id)
-    pool = {
-        "leaves": {oi.id: None for oi in ready["opening_items"]},
-        "loose": {
-            (li["hardware_category"], li["product_code"]): {"staged": li["available_quantity"], "placed": 0}
-            for li in ready["loose_items"]
-        },
-    }
+    if ready is None:
+        ready = shipping_repository.get_ship_ready_items(session, project_id)
+    if containers is None:
+        containers = get_containers(session, project_id, open_only=True)
 
-    for container in get_containers(session, project_id, open_only=True):
+    pool: dict = {"leaves": {oi.id: None for oi in ready["opening_items"]}, "loose": {}}
+    for li in ready["loose_items"]:
+        # Summed, not assigned. Two openings staging the same product are two rows here, and the last
+        # one winning would publish one opening's quantity as if it were the whole floor.
+        key = loose_key(li["opening_number"], li["hardware_category"], li["product_code"])
+        bucket = pool["loose"].setdefault(key, {"staged": 0, "placed": 0})
+        bucket["staged"] += li["available_quantity"]
+
+    for container in containers:
         for item in container.items:
             if item.item_type == PullRequestItemType.OPENING_ITEM and item.opening_item_id is not None:
                 # Only stamp a leaf the pool already knows about. A container can outlive its
@@ -262,7 +294,7 @@ def build_staged_pool(session: Session, project_id: uuid.UUID) -> dict:
                 if item.opening_item_id in pool["leaves"]:
                     pool["leaves"][item.opening_item_id] = container.id
             elif item.item_type == PullRequestItemType.LOOSE:
-                key = (item.hardware_category, item.product_code)
+                key = loose_key(item.opening_number, item.hardware_category, item.product_code)
                 bucket = pool["loose"].setdefault(key, {"staged": 0, "placed": 0})
                 bucket["placed"] += item.quantity
     return pool
@@ -295,7 +327,7 @@ def _check_leaves_available(
 def _check_loose_available(
     session: Session,
     container: ShipmentContainer,
-    wanted: dict[tuple[str, str], int],
+    wanted: dict[tuple[str | None, str, str], int],
     staged_pool: dict,
 ) -> None:
     """Loose placements cannot exceed what is staged, counting what OTHER open containers hold.
@@ -303,19 +335,21 @@ def _check_loose_available(
     This container's own current contents are added back before comparing, so re-saving a container
     unchanged - or trimming it - is never refused for the units it is already holding.
     """
-    held_here: dict[tuple[str, str], int] = {}
+    held_here: dict[tuple[str | None, str, str], int] = {}
     for item in container.items:
         if item.item_type == PullRequestItemType.LOOSE:
-            key = (item.hardware_category, item.product_code)
+            key = loose_key(item.opening_number, item.hardware_category, item.product_code)
             held_here[key] = held_here.get(key, 0) + item.quantity
 
-    for key, quantity in sorted(wanted.items()):
+    for key, quantity in sorted(wanted.items(), key=lambda pair: tuple(str(part) for part in pair[0])):
+        opening_number, category, product = key
         bucket = staged_pool["loose"].get(key, {"staged": 0, "placed": 0})
         free = bucket["staged"] - bucket["placed"] + held_here.get(key, 0)
         if quantity > free:
+            owed_to = f" for opening {opening_number}" if opening_number else ""
             raise ValidationError(
-                f"{key[0]} {key[1]}: {quantity} placed but only {max(0, free)} staged and unplaced. "
-                "Ship what is staged, or pull more first.",
+                f"{category} {product}{owed_to}: {quantity} placed but only {max(0, free)} staged and "
+                "unplaced. Ship what is staged, or pull more first.",
                 field="items",
             )
 

--- a/backend/app/repositories/shipment_containers.py
+++ b/backend/app/repositories/shipment_containers.py
@@ -255,7 +255,12 @@ def build_staged_pool(session: Session, project_id: uuid.UUID) -> dict:
     for container in get_containers(session, project_id, open_only=True):
         for item in container.items:
             if item.item_type == PullRequestItemType.OPENING_ITEM and item.opening_item_id is not None:
-                pool["leaves"][item.opening_item_id] = container.id
+                # Only stamp a leaf the pool already knows about. A container can outlive its
+                # contents' staged state - the cart on the Ship tab can still ship a leaf out from
+                # under a skid while both paths exist - and inventing a key here would make that
+                # phantom look like a legitimately placed leaf and let it be placed again.
+                if item.opening_item_id in pool["leaves"]:
+                    pool["leaves"][item.opening_item_id] = container.id
             elif item.item_type == PullRequestItemType.LOOSE:
                 key = (item.hardware_category, item.product_code)
                 bucket = pool["loose"].setdefault(key, {"staged": 0, "placed": 0})

--- a/backend/app/repositories/shipment_containers.py
+++ b/backend/app/repositories/shipment_containers.py
@@ -1,0 +1,348 @@
+"""Organising staged hardware into the things that physically go on the truck (#451).
+
+The staging pool is everything a completed shipping pull has put on the floor: assembled leaves at
+SHIP_READY, and loose quantities that were picked but not yet shipped. Containers are how that pool
+gets arranged - a skid stacked in unload order, a box of loose parts, an envelope of keys - built up
+over hours or days and then confirmed as one shipment.
+
+Three ceilings, and they are all about physical objects rather than policy:
+
+  - a skid holds at most `MAX_LEAVES_PER_SKID` leaves, because a taller stack cannot be strapped
+  - one assembled leaf sits in at most one open container, because there is one of it
+  - loose placements cannot exceed what is actually staged and unplaced
+
+Nothing here moves inventory. The hardware left when its pull was picked (#367).
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
+from app.models.enums import PullRequestItemType, ShipmentContainerType
+from app.models.shipment_container import (
+    MAX_LEAVES_PER_SKID,
+    ShipmentContainer,
+    ShipmentContainerItem,
+)
+
+# The two container types loaded in a sequence somebody reverses at the far end, and therefore the
+# only two whose `position` is worth showing.
+STACKED_TYPES = (ShipmentContainerType.SKID, ShipmentContainerType.DOOR_CART)
+
+
+def get_containers(session: Session, project_id: uuid.UUID, *, open_only: bool = True) -> list[ShipmentContainer]:
+    """Containers for one project, items eagerly loaded (the type builder walks them).
+
+    `open_only` is what the staging workspace asks for: a shipped container is on its slip and is
+    not something anyone can still load.
+    """
+    stmt = (
+        select(ShipmentContainer)
+        .options(selectinload(ShipmentContainer.items))
+        .where(ShipmentContainer.project_id == project_id)
+        .order_by(ShipmentContainer.created_at.asc())
+    )
+    if open_only:
+        stmt = stmt.where(ShipmentContainer.packing_slip_id.is_(None))
+    return list(session.scalars(stmt).unique().all())
+
+
+def create_container(
+    session: Session,
+    project_id: uuid.UUID,
+    *,
+    container_type: ShipmentContainerType,
+    name: str,
+    created_by: str,
+) -> ShipmentContainer:
+    name = (name or "").strip()
+    if not name:
+        raise ValidationError("A container needs a name - the label that goes on it.", field="name")
+    _check_name_free(session, project_id, name)
+    container = ShipmentContainer(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        container_type=container_type,
+        name=name,
+        created_by=created_by,
+    )
+    session.add(container)
+    session.flush()
+    return container
+
+
+def rename_container(session: Session, container_id: uuid.UUID, name: str) -> ShipmentContainer:
+    container = _open_container(session, container_id)
+    name = (name or "").strip()
+    if not name:
+        raise ValidationError("A container needs a name - the label that goes on it.", field="name")
+    if name != container.name:
+        _check_name_free(session, container.project_id, name)
+        container.name = name
+    session.flush()
+    return container
+
+
+def delete_container(session: Session, container_id: uuid.UUID) -> None:
+    """Break a container back down. Its contents return to the unplaced pool.
+
+    Open only. A shipped container is part of a slip's record of what went on the truck, and there
+    is nothing to undo about it here - that is what a return is for.
+    """
+    container = _open_container(session, container_id)
+    session.delete(container)
+    session.flush()
+
+
+def set_container_items(
+    session: Session,
+    container_id: uuid.UUID,
+    items: list[dict],
+) -> ShipmentContainer:
+    """Rewrite a container's contents to exactly `items`, in the order given.
+
+    One batch call rather than place / remove / reorder as three, because a drag-and-drop surface
+    already holds the whole list and saving it in pieces means a moment where the stack is in an
+    order nobody chose. `position` is assigned from the list index, so the caller never computes it.
+
+    The staged pool is read here, inside the same transaction as the write, rather than taken from
+    the caller: what is free to place has to be measured against the other containers as they are at
+    the moment of saving, not as they were when the screen was drawn.
+    """
+    container = _open_container(session, container_id)
+    staged_pool = build_staged_pool(session, container.project_id)
+
+    leaf_ids: set[uuid.UUID] = set()
+    loose_wanted: dict[tuple[str, str], int] = {}
+    for item in items:
+        item_type = PullRequestItemType(item["item_type"])
+        if item_type == PullRequestItemType.OPENING_ITEM:
+            oi_id = item.get("opening_item_id")
+            if not oi_id:
+                raise ValidationError(
+                    "An assembled-leaf placement must name its opening item.", field="opening_item_id"
+                )
+            oi_id = uuid.UUID(str(oi_id))
+            if oi_id in leaf_ids:
+                raise ValidationError("The same door leaf cannot be placed twice in one container.", field="items")
+            leaf_ids.add(oi_id)
+        else:
+            key = (item["hardware_category"], item["product_code"])
+            loose_wanted[key] = loose_wanted.get(key, 0) + int(item.get("quantity", 1))
+
+    if container.container_type is ShipmentContainerType.SKID and len(leaf_ids) > MAX_LEAVES_PER_SKID:
+        raise ValidationError(
+            f"A skid holds at most {MAX_LEAVES_PER_SKID} door leaves; this one would carry {len(leaf_ids)}. "
+            "Start another skid.",
+            field="items",
+        )
+
+    _check_leaves_available(session, container, leaf_ids, staged_pool)
+    _check_loose_available(session, container, loose_wanted, staged_pool)
+
+    for existing in list(container.items):
+        session.delete(existing)
+    session.flush()
+
+    for index, item in enumerate(items):
+        item_type = PullRequestItemType(item["item_type"])
+        session.add(
+            ShipmentContainerItem(
+                id=uuid.uuid4(),
+                shipment_container_id=container.id,
+                item_type=item_type,
+                opening_item_id=(uuid.UUID(str(item["opening_item_id"])) if item.get("opening_item_id") else None),
+                opening_number=item.get("opening_number"),
+                leaf=item.get("leaf"),
+                hardware_category=item["hardware_category"],
+                product_code=item["product_code"],
+                quantity=int(item.get("quantity", 1)),
+                # The list order IS the stacking order. Index 0 is loaded first, which on a skid is
+                # the bottom of the stack.
+                position=index,
+            )
+        )
+    session.flush()
+    # The rows were written by id rather than appended, so the loaded collection is stale - the same
+    # trap the shipping-request edit hit (#451).
+    session.expire(container, ["items"])
+    return container
+
+
+def confirm_shipment_from_containers(
+    session: Session,
+    project_id: uuid.UUID,
+    container_ids: list[uuid.UUID],
+    *,
+    packing_slip_number: str,
+    shipped_by: str,
+    details: dict | None,
+):
+    """Ship the named containers as one shipment (#451).
+
+    Deliberately a thin wrapper over `confirm_shipment` rather than a second confirm path: that
+    function owns the quarantine gate, the slip-number uniqueness check, the SHIP_READY transition
+    and the loose-availability arithmetic, and a container flow that re-implemented any of them
+    would be a second set of rules to keep in step.
+
+    All this adds is where the items come from and, afterwards, stamping the slip onto the
+    containers so they read as shipped instead of staying open and re-shippable.
+    """
+    from app.repositories import shipping_repository
+
+    if not container_ids:
+        raise ValidationError("Pick at least one container to ship.", field="containerIds")
+
+    containers = [_open_container(session, cid) for cid in container_ids]
+    for container in containers:
+        if container.project_id != project_id:
+            raise ValidationError(f"{container.name} belongs to another project.", field="containerIds")
+        if not container.items:
+            raise ValidationError(
+                f"{container.name} is empty. Put something in it or leave it behind.",
+                field="containerIds",
+            )
+
+    items = [
+        {
+            "item_type": item.item_type,
+            "opening_item_id": item.opening_item_id,
+            "opening_number": item.opening_number,
+            "product_code": item.product_code,
+            "hardware_category": item.hardware_category,
+            "quantity": item.quantity,
+        }
+        for container in containers
+        for item in sorted(container.items, key=lambda i: i.position)
+    ]
+
+    slip = shipping_repository.confirm_shipment(
+        session,
+        project_id,
+        packing_slip_number,
+        shipped_by,
+        items,
+        details,
+    )
+    for container in containers:
+        container.packing_slip_id = slip.id
+    session.flush()
+    return slip
+
+
+def build_staged_pool(session: Session, project_id: uuid.UUID) -> dict:
+    """What this project has staged, and how much of it is already in an open container.
+
+    `{"leaves": {opening_item_id: placed_in_container_id | None},
+      "loose": {(category, product): {"staged": n, "placed": n}}}`
+
+    The staged side comes from `get_ship_ready_items`, which is the existing definition of what is
+    out of inventory and not yet shipped; this only adds where it has been put since.
+    """
+    from app.repositories import shipping_repository
+
+    ready = shipping_repository.get_ship_ready_items(session, project_id)
+    pool = {
+        "leaves": {oi.id: None for oi in ready["opening_items"]},
+        "loose": {
+            (li["hardware_category"], li["product_code"]): {"staged": li["available_quantity"], "placed": 0}
+            for li in ready["loose_items"]
+        },
+    }
+
+    for container in get_containers(session, project_id, open_only=True):
+        for item in container.items:
+            if item.item_type == PullRequestItemType.OPENING_ITEM and item.opening_item_id is not None:
+                pool["leaves"][item.opening_item_id] = container.id
+            elif item.item_type == PullRequestItemType.LOOSE:
+                key = (item.hardware_category, item.product_code)
+                bucket = pool["loose"].setdefault(key, {"staged": 0, "placed": 0})
+                bucket["placed"] += item.quantity
+    return pool
+
+
+def _check_leaves_available(
+    session: Session,
+    container: ShipmentContainer,
+    leaf_ids: set[uuid.UUID],
+    staged_pool: dict,
+) -> None:
+    """Every leaf named must be staged, and must not already sit in a different open container."""
+    leaves = staged_pool["leaves"]
+    for oi_id in sorted(leaf_ids, key=str):
+        if oi_id not in leaves:
+            raise ValidationError(
+                "That door leaf is not staged for shipping - only leaves whose pull has completed can be loaded.",
+                field="opening_item_id",
+            )
+        holder = leaves[oi_id]
+        if holder is not None and holder != container.id:
+            other = session.get(ShipmentContainer, holder)
+            raise ConflictError(
+                f"That door leaf is already in {other.name if other else 'another container'}. "
+                "Take it out of there first - there is only one of it.",
+                field="opening_item_id",
+            )
+
+
+def _check_loose_available(
+    session: Session,
+    container: ShipmentContainer,
+    wanted: dict[tuple[str, str], int],
+    staged_pool: dict,
+) -> None:
+    """Loose placements cannot exceed what is staged, counting what OTHER open containers hold.
+
+    This container's own current contents are added back before comparing, so re-saving a container
+    unchanged - or trimming it - is never refused for the units it is already holding.
+    """
+    held_here: dict[tuple[str, str], int] = {}
+    for item in container.items:
+        if item.item_type == PullRequestItemType.LOOSE:
+            key = (item.hardware_category, item.product_code)
+            held_here[key] = held_here.get(key, 0) + item.quantity
+
+    for key, quantity in sorted(wanted.items()):
+        bucket = staged_pool["loose"].get(key, {"staged": 0, "placed": 0})
+        free = bucket["staged"] - bucket["placed"] + held_here.get(key, 0)
+        if quantity > free:
+            raise ValidationError(
+                f"{key[0]} {key[1]}: {quantity} placed but only {max(0, free)} staged and unplaced. "
+                "Ship what is staged, or pull more first.",
+                field="items",
+            )
+
+
+def _open_container(session: Session, container_id: uuid.UUID) -> ShipmentContainer:
+    container = (
+        session.scalars(
+            select(ShipmentContainer)
+            .options(selectinload(ShipmentContainer.items))
+            .where(ShipmentContainer.id == container_id)
+        )
+        .unique()
+        .first()
+    )
+    if container is None:
+        raise NotFoundError(f"Shipment container {container_id} not found")
+    if container.packing_slip_id is not None:
+        raise InvalidStateTransitionError(
+            f"{container.name} has already shipped. A shipped container is part of that shipment's "
+            "record and cannot be changed."
+        )
+    return container
+
+
+def _check_name_free(session: Session, project_id: uuid.UUID, name: str) -> None:
+    """One open container per name per project, so "Skid 1" cannot be built twice at once."""
+    existing = session.scalars(
+        select(ShipmentContainer).where(
+            ShipmentContainer.project_id == project_id,
+            ShipmentContainer.packing_slip_id.is_(None),
+            ShipmentContainer.name == name,
+        )
+    ).first()
+    if existing is not None:
+        raise ConflictError(f"An open container named {name} already exists on this project", field="name")

--- a/backend/app/schemas/enums.py
+++ b/backend/app/schemas/enums.py
@@ -66,6 +66,9 @@ from app.models.enums import (
     ReturnDisposition as ReturnDispositionDB,
 )
 from app.models.enums import (
+    ShipmentContainerType as ShipmentContainerTypeDB,
+)
+from app.models.enums import (
     ShipmentStatus as ShipmentStatusDB,
 )
 from app.models.enums import (
@@ -89,6 +92,7 @@ OpeningItemState = strawberry.enum(OpeningItemStateDB)
 ShopAssemblyRequestStatus = strawberry.enum(ShopAssemblyRequestStatusDB)
 ShippingOutRequestStatus = strawberry.enum(ShippingOutRequestStatusDB)
 ShipmentStatus = strawberry.enum(ShipmentStatusDB)
+ShipmentContainerType = strawberry.enum(ShipmentContainerTypeDB)
 PullStatus = strawberry.enum(PullStatusDB)
 AssemblyStatus = strawberry.enum(AssemblyStatusDB)
 NotificationType = strawberry.enum(NotificationTypeDB)

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -216,6 +216,32 @@ class ShippingOutPRDraftInput:
 
 
 @strawberry.input
+class ContainerItemInput:
+    """One placement in a container (#451). Order in the list IS the stacking order."""
+
+    item_type: PullRequestItemType
+    opening_item_id: strawberry.ID | None = None
+    opening_number: str | None = None
+    leaf: int | None = None
+    hardware_category: str = ""
+    product_code: str = ""
+    quantity: int = 1
+
+
+@strawberry.input
+class SetContainerItemsInput:
+    """Rewrite one container's contents to exactly these placements, in this order (#451).
+
+    A batch rather than place / remove / reorder as three calls: a drag-and-drop surface already
+    holds the whole list, and saving it in pieces leaves a moment where the stack is in an order
+    nobody chose.
+    """
+
+    container_id: strawberry.ID
+    items: list[ContainerItemInput] = strawberry.field(default_factory=list)
+
+
+@strawberry.input
 class CreateShippingOutRequestInput:
     """Raise a shipping-out request from the Shipping module rather than from Start a Task (#451).
 
@@ -618,6 +644,20 @@ class ConfirmShipmentInput(DeliveryRequestHeaderInput):
     project_id: strawberry.ID
     packing_slip_number: str
     items: list[ShipmentItemInput] = strawberry.field(default_factory=list)
+
+
+@strawberry.input
+class ConfirmShipmentFromContainersInput(DeliveryRequestHeaderInput):
+    """Ship whole containers as one shipment (#451).
+
+    The container flow's confirm. Same Delivery Request header as `ConfirmShipmentInput` above and
+    the same slip at the far end - only where the items come from differs, which is why this carries
+    container ids instead of a hand-built item list.
+    """
+
+    project_id: strawberry.ID
+    packing_slip_number: str
+    container_ids: list[strawberry.ID] = strawberry.field(default_factory=list)
 
 
 @strawberry.input

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -205,9 +205,12 @@ class ShippingQueries:
         """
         pid = uuid.UUID(str(project_id))
         with SessionLocal() as session:
-            pool = shipment_containers.build_staged_pool(session, pid)
-            containers = shipment_containers.get_containers(session, pid, open_only=True)
+            # Both reads are done here and handed to the pool builder, which would otherwise repeat
+            # them internally - `get_ship_ready_items` alone is three statements plus a selectinload,
+            # and this is the workspace's main read (CLAUDE.md perf rules).
             ready = shipping_repository.get_ship_ready_items(session, pid)
+            containers = shipment_containers.get_containers(session, pid, open_only=True)
+            pool = shipment_containers.build_staged_pool(session, pid, ready=ready, containers=containers)
             by_id = {oi.id: oi for oi in ready["opening_items"]}
             return StagingPool(
                 leaves=[
@@ -223,23 +226,23 @@ class ShippingQueries:
                     for oi_id, holder in pool["leaves"].items()
                     if oi_id in by_id
                 ],
+                # The opening comes off the pool key rather than being looked up by product. The
+                # workspace row IS the (opening, category, product) bucket the confirm checks
+                # availability on, so a product staged for two openings is two rows - one wearing
+                # an arbitrary opening number would be refused at confirm, or would book units
+                # against a door they were never pulled for.
                 loose_items=[
                     StagedLooseItem(
-                        opening_number=next(
-                            (
-                                li["opening_number"]
-                                for li in ready["loose_items"]
-                                if (li["hardware_category"], li["product_code"]) == key
-                            ),
-                            None,
-                        ),
-                        hardware_category=key[0],
-                        product_code=key[1],
+                        opening_number=key[0],
+                        hardware_category=key[1],
+                        product_code=key[2],
                         staged_quantity=counts["staged"],
                         placed_quantity=counts["placed"],
                         unplaced_quantity=max(0, counts["staged"] - counts["placed"]),
                     )
-                    for key, counts in sorted(pool["loose"].items())
+                    for key, counts in sorted(
+                        pool["loose"].items(), key=lambda pair: tuple(str(part) for part in pair[0])
+                    )
                 ],
                 containers=[_container_to_type(c) for c in containers],
             )

--- a/backend/app/schemas/shipping.py
+++ b/backend/app/schemas/shipping.py
@@ -7,6 +7,7 @@ import strawberry
 from app.auth import current_user, resolve_display_name
 from app.database import SessionLocal
 from app.repositories import (
+    shipment_containers,
     shipment_method_repository,
     shipping_coverage,
     shipping_repository,
@@ -20,17 +21,22 @@ from .converters import (
     shipping_out_request_to_type,
 )
 from .enums import LeafStatus, ShippingOutRequestStatus
+from .enums import ShipmentContainerType as ShipmentContainerTypeEnum
 from .inputs import (
+    ConfirmShipmentFromContainersInput,
     ConfirmShipmentInput,
     CreateShipmentReturnInput,
     CreateShippingOutRequestInput,
     EditShippingOutRequestInput,
+    SetContainerItemsInput,
     ShippingOutPRDraftItemInput,
     UpdateShipmentDetailsInput,
 )
 from .types import (
     PackingSlip,
     ReturnableLine,
+    ShipmentContainer,
+    ShipmentContainerItem,
     ShipmentMethod,
     ShipmentReturn,
     ShippingCoverageLeaf,
@@ -38,7 +44,53 @@ from .types import (
     ShippingOutRequest,
     ShipReadyItems,
     ShipReadyLooseItem,
+    StagedLeaf,
+    StagedLooseItem,
+    StagingPool,
 )
+
+
+def _container_to_type(c) -> ShipmentContainer:
+    return ShipmentContainer(
+        id=strawberry.ID(str(c.id)),
+        project_id=strawberry.ID(str(c.project_id)),
+        container_type=c.container_type,
+        name=c.name,
+        packing_slip_id=strawberry.ID(str(c.packing_slip_id)) if c.packing_slip_id else None,
+        created_by=c.created_by,
+        created_at=c.created_at,
+        updated_at=c.updated_at,
+        items=[
+            ShipmentContainerItem(
+                id=strawberry.ID(str(i.id)),
+                shipment_container_id=strawberry.ID(str(i.shipment_container_id)),
+                item_type=i.item_type,
+                opening_item_id=strawberry.ID(str(i.opening_item_id)) if i.opening_item_id else None,
+                opening_number=i.opening_number,
+                leaf=i.leaf,
+                hardware_category=i.hardware_category,
+                product_code=i.product_code,
+                quantity=i.quantity,
+                position=i.position,
+            )
+            for i in sorted(c.items, key=lambda i: i.position)
+        ],
+    )
+
+
+def _container_items_input(items) -> list[dict]:
+    return [
+        {
+            "item_type": i.item_type.value,
+            "opening_item_id": str(i.opening_item_id) if i.opening_item_id else None,
+            "opening_number": i.opening_number,
+            "leaf": i.leaf,
+            "hardware_category": i.hardware_category,
+            "product_code": i.product_code,
+            "quantity": i.quantity,
+        }
+        for i in items
+    ]
 
 
 def _shipment_method_to_type(m) -> ShipmentMethod:
@@ -144,6 +196,55 @@ class ShippingQueries:
             ]
 
     @strawberry.field
+    def staging_pool(self, info: strawberry.Info, project_id: strawberry.ID) -> StagingPool:
+        """Everything staged for shipping and where it has been put (#451).
+
+        One query for both halves of the workspace - what is still loose on the floor, and what is
+        already in a container - because two would be able to disagree about whether a leaf has been
+        loaded, and that disagreement is exactly the mistake containers exist to prevent.
+        """
+        pid = uuid.UUID(str(project_id))
+        with SessionLocal() as session:
+            pool = shipment_containers.build_staged_pool(session, pid)
+            containers = shipment_containers.get_containers(session, pid, open_only=True)
+            ready = shipping_repository.get_ship_ready_items(session, pid)
+            by_id = {oi.id: oi for oi in ready["opening_items"]}
+            return StagingPool(
+                leaves=[
+                    StagedLeaf(
+                        opening_item_id=strawberry.ID(str(oi_id)),
+                        opening_number=by_id[oi_id].opening_number,
+                        leaf=by_id[oi_id].leaf,
+                        building=by_id[oi_id].building,
+                        floor=by_id[oi_id].floor,
+                        location=by_id[oi_id].location,
+                        placed_in_container_id=strawberry.ID(str(holder)) if holder else None,
+                    )
+                    for oi_id, holder in pool["leaves"].items()
+                    if oi_id in by_id
+                ],
+                loose_items=[
+                    StagedLooseItem(
+                        opening_number=next(
+                            (
+                                li["opening_number"]
+                                for li in ready["loose_items"]
+                                if (li["hardware_category"], li["product_code"]) == key
+                            ),
+                            None,
+                        ),
+                        hardware_category=key[0],
+                        product_code=key[1],
+                        staged_quantity=counts["staged"],
+                        placed_quantity=counts["placed"],
+                        unplaced_quantity=max(0, counts["staged"] - counts["placed"]),
+                    )
+                    for key, counts in sorted(pool["loose"].items())
+                ],
+                containers=[_container_to_type(c) for c in containers],
+            )
+
+    @strawberry.field
     def shipment_methods(self, info: strawberry.Info, active_only: bool = False) -> list[ShipmentMethod]:
         """How a load can travel (#451). `activeOnly` is what the Delivery Request form passes; the
         management screen leaves it off so a retired method can still be seen and reactivated."""
@@ -240,6 +341,89 @@ class ShippingMutations:
             session.commit()
             refreshed = shipping_repository.get_shipping_out_request(session, req.id)
             return shipping_out_request_to_type(refreshed)
+
+    @strawberry.mutation
+    def create_shipment_container(
+        self,
+        info: strawberry.Info,
+        project_id: strawberry.ID,
+        container_type: ShipmentContainerTypeEnum,
+        name: str,
+    ) -> ShipmentContainer:
+        """Start a skid, cart, box, envelope or bundle (#451). Named by whoever is loading it,
+        because the label goes on the physical thing in marker."""
+        auth = current_user(info)
+        actor = resolve_display_name(auth["user_id"])
+        with SessionLocal() as session:
+            container = shipment_containers.create_container(
+                session,
+                uuid.UUID(str(project_id)),
+                container_type=container_type,
+                name=name,
+                created_by=actor,
+            )
+            session.commit()
+            session.refresh(container)
+            return _container_to_type(container)
+
+    @strawberry.mutation
+    def rename_shipment_container(self, info: strawberry.Info, id: strawberry.ID, name: str) -> ShipmentContainer:
+        """Relabel an open container. Refused once it has shipped."""
+        with SessionLocal() as session:
+            container = shipment_containers.rename_container(session, uuid.UUID(str(id)), name)
+            session.commit()
+            session.refresh(container)
+            return _container_to_type(container)
+
+    @strawberry.mutation
+    def delete_shipment_container(self, info: strawberry.Info, id: strawberry.ID) -> bool:
+        """Break an open container back down; its contents return to the unplaced pool."""
+        with SessionLocal() as session:
+            shipment_containers.delete_container(session, uuid.UUID(str(id)))
+            session.commit()
+            return True
+
+    @strawberry.mutation
+    def set_container_items(self, info: strawberry.Info, input: SetContainerItemsInput) -> ShipmentContainer:
+        """Rewrite a container's contents to exactly the placements sent, in that order (#451).
+
+        The order IS the stacking order, so a drag-and-drop reorder is the same call as a placement.
+        Gated on what is genuinely staged and unplaced, on one leaf living in one container, and on
+        a skid's thirty-leaf ceiling."""
+        with SessionLocal() as session:
+            updated = shipment_containers.set_container_items(
+                session,
+                uuid.UUID(str(input.container_id)),
+                _container_items_input(input.items),
+            )
+            session.commit()
+            session.refresh(updated)
+            return _container_to_type(updated)
+
+    @strawberry.mutation
+    def confirm_shipment_from_containers(
+        self, info: strawberry.Info, input: ConfirmShipmentFromContainersInput
+    ) -> PackingSlip:
+        """Cut the packing slip for whole containers (#451).
+
+        The container flow's confirm. It composes the slip's items out of what was loaded and stamps
+        the slip onto each container, then hands off to the same `confirmShipment` machinery - the
+        quarantine gate, the SHIP_READY transition and the loose arithmetic are not re-implemented
+        here. Recorded against the Clerk-authenticated caller (#427)."""
+        auth = current_user(info)
+        actor = resolve_display_name(auth["user_id"])
+        with SessionLocal() as session:
+            slip = shipment_containers.confirm_shipment_from_containers(
+                session,
+                uuid.UUID(str(input.project_id)),
+                [uuid.UUID(str(cid)) for cid in input.container_ids],
+                packing_slip_number=input.packing_slip_number,
+                shipped_by=actor,
+                details=_delivery_details(input),
+            )
+            session.commit()
+            refreshed = shipping_repository.get_packing_slip(session, slip.id)
+            return packing_slip_to_type(refreshed)
 
     @strawberry.mutation
     def create_shipment_method(self, info: strawberry.Info, name: str, sort_order: int = 0) -> ShipmentMethod:

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -27,6 +27,7 @@ from .enums import (
     ReceiveDraftStatus,
     ReconciliationStatus,
     ReturnDisposition,
+    ShipmentContainerType,
     ShipmentStatus,
     ShippingOutRequestStatus,
     ShopAssemblyRequestStatus,
@@ -1252,6 +1253,83 @@ class ShipReadyLooseItem:
     hardware_category: str
     product_code: str
     available_quantity: int
+
+
+@strawberry.type
+class ShipmentContainerItem:
+    """One thing placed in a container, and where in the stack it sits (#451)."""
+
+    id: strawberry.ID
+    shipment_container_id: strawberry.ID
+    item_type: PullRequestItemType
+    opening_item_id: strawberry.ID | None
+    opening_number: str | None
+    leaf: int | None
+    hardware_category: str
+    product_code: str
+    quantity: int
+    # Stacking order. Only meaningful on a skid or a door cart - the two loaded in a sequence
+    # somebody reverses at the far end. Position 0 is loaded FIRST, so on a skid it is the bottom.
+    position: int
+
+
+@strawberry.type
+class ShipmentContainer:
+    """A skid, door cart, box, envelope or bundle the warehouse loads (#451).
+
+    `packingSlipId` is the whole lifecycle: null while it is being built and can be changed, stamped
+    once its shipment is confirmed and from then on history.
+    """
+
+    id: strawberry.ID
+    project_id: strawberry.ID
+    container_type: ShipmentContainerType
+    name: str
+    packing_slip_id: strawberry.ID | None
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+    items: list[ShipmentContainerItem]
+
+
+@strawberry.type
+class StagedLooseItem:
+    """One loose product staged for shipping, and how much of it is already in a container (#451)."""
+
+    opening_number: str | None
+    hardware_category: str
+    product_code: str
+    staged_quantity: int
+    placed_quantity: int
+    # staged - placed: what is still loose on the floor waiting to be put somewhere.
+    unplaced_quantity: int
+
+
+@strawberry.type
+class StagedLeaf:
+    """One assembled leaf staged for shipping, and the container holding it if any (#451)."""
+
+    opening_item_id: strawberry.ID
+    opening_number: str
+    leaf: int | None
+    building: str | None
+    floor: str | None
+    location: str | None
+    placed_in_container_id: strawberry.ID | None
+
+
+@strawberry.type
+class StagingPool:
+    """Everything a project has staged for shipping, and where it has been put (#451).
+
+    The left-hand side of the staging workspace reads `unplaced*`; the container cards read
+    `containers`. One query rather than two so the two halves can never disagree about whether a
+    leaf has been loaded.
+    """
+
+    leaves: list[StagedLeaf]
+    loose_items: list[StagedLooseItem]
+    containers: list[ShipmentContainer]
 
 
 @strawberry.type

--- a/backend/tests/test_shipment_containers.py
+++ b/backend/tests/test_shipment_containers.py
@@ -354,3 +354,111 @@ def test_a_container_from_another_project_cannot_join_the_shipment(db_session):
 def test_a_missing_container_is_a_not_found(db_session):
     with pytest.raises(NotFoundError):
         containers.rename_container(db_session, uuid.uuid4(), "Skid 1")
+
+
+# --- two openings, one product -------------------------------------------------------------------
+# The staged pool is grouped by (opening, category, product), and so is the availability check the
+# confirm applies. A container path keyed on the product alone reads as harmless until the same
+# product is staged for two openings, at which point the two numbers become one and disagree with
+# what the confirm will accept.
+
+
+def _pool_loose(session, project):
+    return containers.build_staged_pool(session, project.id)["loose"]
+
+
+def test_two_openings_staging_one_product_are_two_quantities(db_session):
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    _staged_loose(db_session, project, qty=3, opening="102")
+
+    pool = _pool_loose(db_session, project)
+    assert pool[("101", "HINGE", "HG-100")]["staged"] == 4
+    assert pool[("102", "HINGE", "HG-100")]["staged"] == 3
+
+
+def test_placing_one_openings_units_leaves_the_others_alone(db_session):
+    # Keyed on the product alone, placing 4 for 101 would read as 4 placed against the 3 staged for
+    # 102 as well, and the second placement would be refused with stock sitting on the floor.
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    _staged_loose(db_session, project, qty=3, opening="102")
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+
+    containers.set_container_items(db_session, box.id, [_loose_item(4, opening="101")])
+
+    pool = _pool_loose(db_session, project)
+    assert pool[("101", "HINGE", "HG-100")]["placed"] == 4
+    assert pool[("102", "HINGE", "HG-100")]["placed"] == 0
+
+
+def test_one_openings_staged_stock_cannot_cover_another_openings_placement(db_session):
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+
+    with pytest.raises(ValidationError, match="for opening 102"):
+        containers.set_container_items(db_session, box.id, [_loose_item(1, opening="102")])
+
+
+def test_the_same_pull_split_over_two_pulls_sums_rather_than_replacing(db_session):
+    # Two completed pulls for the same opening and product are two rows out of get_ship_ready_items.
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    _staged_loose(db_session, project, qty=2, opening="101")
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+
+    containers.set_container_items(db_session, box.id, [_loose_item(6, opening="101")])
+
+    assert _pool_loose(db_session, project)[("101", "HINGE", "HG-100")]["staged"] == 6
+
+
+def test_a_product_can_be_split_across_two_containers(db_session):
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    first = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    second = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 2")
+
+    containers.set_container_items(db_session, first.id, [_loose_item(2)])
+    containers.set_container_items(db_session, second.id, [_loose_item(2)])
+
+    pool = _pool_loose(db_session, project)
+    assert pool[("101", "HINGE", "HG-100")]["placed"] == 4
+
+
+def test_unattributed_stock_is_its_own_bucket(db_session):
+    # A pull raised straight off inventory has no opening to attribute (#451), and those units are
+    # not everyone's to spend.
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=3, opening=None)
+    _staged_loose(db_session, project, qty=2, opening="101")
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+
+    containers.set_container_items(db_session, box.id, [_loose_item(3, opening=None)])
+
+    pool = _pool_loose(db_session, project)
+    assert pool[(None, "HINGE", "HG-100")]["placed"] == 3
+    assert pool[("101", "HINGE", "HG-100")]["placed"] == 0
+
+
+def test_the_same_container_named_twice_ships_once(db_session):
+    # Building the item list twice doubles every loose quantity on the slip, and makes the confirm's
+    # distinct-leaf count disagree with the ids it was handed - reported as the leaf not existing.
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4, opening="101")
+    oi = _leaf(db_session, project)
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    containers.set_container_items(db_session, box.id, [_leaf_item(oi), _loose_item(4)])
+
+    slip = containers.confirm_shipment_from_containers(
+        db_session,
+        project.id,
+        [box.id, box.id],
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+        shipped_by="shipper",
+        details=None,
+    )
+    db_session.flush()
+
+    quantities = sorted((i.item_type, i.quantity) for i in slip.items)
+    assert quantities == [(PullRequestItemType.LOOSE, 4), (PullRequestItemType.OPENING_ITEM, 1)]

--- a/backend/tests/test_shipment_containers.py
+++ b/backend/tests/test_shipment_containers.py
@@ -1,0 +1,356 @@
+"""Organising staged hardware into containers (#451).
+
+The rules under test are all about physical objects rather than policy, which is why they are worth
+pinning: a skid that cannot be strapped, a leaf that exists once, and loose stock that cannot be
+placed twice over.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
+from app.models.enums import (
+    OpeningItemState,
+    PullRequestItemType,
+    PullRequestSource,
+    PullRequestStatus,
+    ShipmentContainerType,
+)
+from app.models.opening_item import OpeningItem
+from app.models.project import Project
+from app.models.pull_request import PullRequest, PullRequestItem
+from app.repositories import shipment_containers as containers
+from app.repositories import warehouse_admin_repository
+
+
+def _project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _leaf(session, project, *, opening="101", leaf=1, state=OpeningItemState.SHIP_READY) -> OpeningItem:
+    oi = OpeningItem(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        opening_id=uuid.uuid4(),
+        warehouse_id=warehouse_admin_repository.get_primary_warehouse_id(session),
+        opening_number=opening,
+        leaf=leaf,
+        quantity=1,
+        assembly_completed_at=datetime.utcnow(),
+        state=state,
+    )
+    session.add(oi)
+    session.flush()
+    return oi
+
+
+def _staged_loose(session, project, *, code="HG-100", cat="HINGE", qty=4, opening="101"):
+    """Loose stock reaches the staging pool by a COMPLETED shipping pull, which is what
+    `get_ship_ready_items` counts. Building that is the only honest way to seed it."""
+    pr = PullRequest(
+        id=uuid.uuid4(),
+        request_number=f"SOR-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        source=PullRequestSource.SHIPPING_OUT,
+        status=PullRequestStatus.COMPLETED,
+        requested_by="tester",
+    )
+    session.add(pr)
+    session.flush()
+    session.add(
+        PullRequestItem(
+            id=uuid.uuid4(),
+            pull_request_id=pr.id,
+            item_type=PullRequestItemType.LOOSE,
+            opening_number=opening,
+            hardware_category=cat,
+            product_code=code,
+            requested_quantity=qty,
+        )
+    )
+    session.flush()
+
+
+def _container(session, project, *, kind=ShipmentContainerType.SKID, name="Skid 1"):
+    return containers.create_container(session, project.id, container_type=kind, name=name, created_by="tester")
+
+
+def _leaf_item(oi):
+    return {
+        "item_type": "OPENING_ITEM",
+        "opening_item_id": str(oi.id),
+        "opening_number": oi.opening_number,
+        "leaf": oi.leaf,
+        "hardware_category": "",
+        "product_code": "",
+        "quantity": 1,
+    }
+
+
+def _loose_item(qty, code="HG-100", cat="HINGE", opening="101"):
+    return {
+        "item_type": "LOOSE",
+        "opening_item_id": None,
+        "opening_number": opening,
+        "leaf": None,
+        "hardware_category": cat,
+        "product_code": code,
+        "quantity": qty,
+    }
+
+
+# --- the container itself ----------------------------------------------------------------------
+
+
+def test_an_open_container_name_is_taken_only_while_it_is_open(db_session):
+    project = _project(db_session)
+    _container(db_session, project, name="Skid 1")
+    with pytest.raises(ConflictError):
+        _container(db_session, project, name="Skid 1")
+
+
+def test_a_blank_name_is_refused(db_session):
+    project = _project(db_session)
+    with pytest.raises(ValidationError):
+        _container(db_session, project, name="   ")
+
+
+def test_breaking_down_a_container_returns_its_contents_to_the_pool(db_session):
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    container = _container(db_session, project)
+    containers.set_container_items(db_session, container.id, [_leaf_item(oi)])
+
+    assert containers.build_staged_pool(db_session, project.id)["leaves"][oi.id] == container.id
+    containers.delete_container(db_session, container.id)
+    assert containers.build_staged_pool(db_session, project.id)["leaves"][oi.id] is None
+
+
+# --- what may be placed ------------------------------------------------------------------------
+
+
+def test_a_leaf_that_is_not_staged_cannot_be_loaded(db_session):
+    # IN_INVENTORY means assembled but not pulled for shipping - it is not on the floor yet.
+    project = _project(db_session)
+    oi = _leaf(db_session, project, state=OpeningItemState.IN_INVENTORY)
+    container = _container(db_session, project)
+    with pytest.raises(ValidationError, match="not staged"):
+        containers.set_container_items(db_session, container.id, [_leaf_item(oi)])
+
+
+def test_one_leaf_cannot_sit_in_two_containers(db_session):
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    first = _container(db_session, project, name="Skid 1")
+    second = _container(db_session, project, name="Skid 2")
+    containers.set_container_items(db_session, first.id, [_leaf_item(oi)])
+
+    with pytest.raises(ConflictError, match="already in"):
+        containers.set_container_items(db_session, second.id, [_leaf_item(oi)])
+
+
+def test_the_same_leaf_twice_in_one_container_is_refused(db_session):
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    container = _container(db_session, project)
+    with pytest.raises(ValidationError, match="cannot be placed twice"):
+        containers.set_container_items(db_session, container.id, [_leaf_item(oi), _leaf_item(oi)])
+
+
+def test_a_skid_stops_at_thirty_leaves(db_session):
+    project = _project(db_session)
+    leaves = [_leaf(db_session, project, opening=f"{n:03d}", leaf=1) for n in range(31)]
+    container = _container(db_session, project)
+    with pytest.raises(ValidationError, match="at most 30 door leaves"):
+        containers.set_container_items(db_session, container.id, [_leaf_item(oi) for oi in leaves])
+
+
+def test_a_door_cart_has_no_leaf_ceiling(db_session):
+    # The thirty is a property of a skid, not of containers - a cart is loaded until it is full and
+    # nothing in the system can know when that is.
+    project = _project(db_session)
+    leaves = [_leaf(db_session, project, opening=f"{n:03d}", leaf=1) for n in range(31)]
+    cart = _container(db_session, project, kind=ShipmentContainerType.DOOR_CART, name="Cart 1")
+    result = containers.set_container_items(db_session, cart.id, [_leaf_item(oi) for oi in leaves])
+    assert len(result.items) == 31
+
+
+def test_loose_placement_cannot_exceed_what_is_staged(db_session):
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4)
+    container = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    with pytest.raises(ValidationError, match="only 4 staged"):
+        containers.set_container_items(db_session, container.id, [_loose_item(9)])
+
+
+def test_another_containers_placement_counts_against_what_is_free(db_session):
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4)
+    first = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    second = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 2")
+    containers.set_container_items(db_session, first.id, [_loose_item(3)])
+
+    with pytest.raises(ValidationError, match="only 1 staged"):
+        containers.set_container_items(db_session, second.id, [_loose_item(2)])
+
+
+def test_re_saving_a_container_is_not_gated_against_what_it_already_holds(db_session):
+    # The same release-before-measure trap the request edit had: without adding this container's own
+    # units back, saving it unchanged would read as asking for them a second time.
+    project = _project(db_session)
+    _staged_loose(db_session, project, qty=4)
+    container = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    containers.set_container_items(db_session, container.id, [_loose_item(4)])
+
+    result = containers.set_container_items(db_session, container.id, [_loose_item(4)])
+    assert [i.quantity for i in result.items] == [4]
+
+
+# --- the stack ----------------------------------------------------------------------------------
+
+
+def test_position_comes_from_the_list_order(db_session):
+    project = _project(db_session)
+    a = _leaf(db_session, project, opening="101", leaf=1)
+    b = _leaf(db_session, project, opening="102", leaf=1)
+    container = _container(db_session, project)
+
+    result = containers.set_container_items(db_session, container.id, [_leaf_item(a), _leaf_item(b)])
+    assert [(i.opening_number, i.position) for i in sorted(result.items, key=lambda i: i.position)] == [
+        ("101", 0),
+        ("102", 1),
+    ]
+
+    # Reordering is the same call with the list the other way round.
+    result = containers.set_container_items(db_session, container.id, [_leaf_item(b), _leaf_item(a)])
+    assert [(i.opening_number, i.position) for i in sorted(result.items, key=lambda i: i.position)] == [
+        ("102", 0),
+        ("101", 1),
+    ]
+
+
+def test_emptying_a_container_is_allowed(db_session):
+    # Unlike a request, an empty container is a real state - it is a skid nobody has loaded yet.
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    container = _container(db_session, project)
+    containers.set_container_items(db_session, container.id, [_leaf_item(oi)])
+
+    result = containers.set_container_items(db_session, container.id, [])
+    assert result.items == []
+    assert containers.build_staged_pool(db_session, project.id)["leaves"][oi.id] is None
+
+
+# --- shipping -----------------------------------------------------------------------------------
+
+
+def test_shipping_stamps_the_slip_and_closes_the_containers(db_session):
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    _staged_loose(db_session, project, qty=2)
+    skid = _container(db_session, project, name="Skid 1")
+    box = _container(db_session, project, kind=ShipmentContainerType.BOX, name="Box 1")
+    containers.set_container_items(db_session, skid.id, [_leaf_item(oi)])
+    containers.set_container_items(db_session, box.id, [_loose_item(2)])
+
+    slip = containers.confirm_shipment_from_containers(
+        db_session,
+        project.id,
+        [skid.id, box.id],
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+        shipped_by="shipper",
+        details=None,
+    )
+    db_session.flush()
+
+    assert {i.item_type for i in slip.items} == {
+        PullRequestItemType.OPENING_ITEM,
+        PullRequestItemType.LOOSE,
+    }
+    db_session.refresh(skid)
+    db_session.refresh(box)
+    assert skid.packing_slip_id == slip.id
+    assert box.packing_slip_id == slip.id
+    # The leaf went out with it.
+    db_session.refresh(oi)
+    assert oi.state == OpeningItemState.SHIPPED_OUT
+    # And a shipped container is out of the staging workspace.
+    assert containers.get_containers(db_session, project.id, open_only=True) == []
+
+
+def test_an_empty_container_cannot_be_shipped(db_session):
+    project = _project(db_session)
+    container = _container(db_session, project)
+    with pytest.raises(ValidationError, match="is empty"):
+        containers.confirm_shipment_from_containers(
+            db_session,
+            project.id,
+            [container.id],
+            packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+            shipped_by="shipper",
+            details=None,
+        )
+
+
+def test_shipping_nothing_is_refused(db_session):
+    project = _project(db_session)
+    with pytest.raises(ValidationError, match="at least one container"):
+        containers.confirm_shipment_from_containers(
+            db_session,
+            project.id,
+            [],
+            packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+            shipped_by="shipper",
+            details=None,
+        )
+
+
+def test_a_shipped_container_cannot_be_edited_or_broken_down(db_session):
+    project = _project(db_session)
+    oi = _leaf(db_session, project)
+    container = _container(db_session, project)
+    containers.set_container_items(db_session, container.id, [_leaf_item(oi)])
+    containers.confirm_shipment_from_containers(
+        db_session,
+        project.id,
+        [container.id],
+        packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+        shipped_by="shipper",
+        details=None,
+    )
+    db_session.flush()
+
+    with pytest.raises(InvalidStateTransitionError, match="already shipped"):
+        containers.set_container_items(db_session, container.id, [])
+    with pytest.raises(InvalidStateTransitionError, match="already shipped"):
+        containers.delete_container(db_session, container.id)
+    with pytest.raises(InvalidStateTransitionError, match="already shipped"):
+        containers.rename_container(db_session, container.id, "Skid 9")
+
+
+def test_a_container_from_another_project_cannot_join_the_shipment(db_session):
+    project = _project(db_session)
+    other = _project(db_session)
+    oi = _leaf(db_session, other)
+    container = _container(db_session, other)
+    containers.set_container_items(db_session, container.id, [_leaf_item(oi)])
+
+    with pytest.raises(ValidationError, match="another project"):
+        containers.confirm_shipment_from_containers(
+            db_session,
+            project.id,
+            [container.id],
+            packing_slip_number=f"PS-{uuid.uuid4().hex[:6]}",
+            shipped_by="shipper",
+            details=None,
+        )
+
+
+def test_a_missing_container_is_a_not_found(db_session):
+    with pytest.raises(NotFoundError):
+        containers.rename_container(db_session, uuid.uuid4(), "Skid 1")

--- a/frontend/src/graphql/shipping.ts
+++ b/frontend/src/graphql/shipping.ts
@@ -16,6 +16,53 @@ export const GET_SHIP_READY_ITEMS = gql`
   }
 `;
 
+// The staging workspace (#451): what is staged, and which container it has been put in. One query
+// for both halves so they can never disagree about whether a leaf has been loaded.
+const CONTAINER_FIELDS = `
+  id projectId containerType name packingSlipId createdBy createdAt updatedAt
+  items {
+    id shipmentContainerId itemType openingItemId openingNumber leaf
+    hardwareCategory productCode quantity position
+  }
+`;
+
+export const GET_STAGING_POOL = gql`
+  query GetStagingPool($projectId: ID!) {
+    stagingPool(projectId: $projectId) {
+      leaves { openingItemId openingNumber leaf building floor location placedInContainerId }
+      looseItems { openingNumber hardwareCategory productCode stagedQuantity placedQuantity unplacedQuantity }
+      containers { ${CONTAINER_FIELDS} }
+    }
+  }
+`;
+
+export const CREATE_SHIPMENT_CONTAINER = gql`
+  mutation CreateShipmentContainer($projectId: ID!, $containerType: ShipmentContainerType!, $name: String!) {
+    createShipmentContainer(projectId: $projectId, containerType: $containerType, name: $name) {
+      ${CONTAINER_FIELDS}
+    }
+  }
+`;
+
+export const RENAME_SHIPMENT_CONTAINER = gql`
+  mutation RenameShipmentContainer($id: ID!, $name: String!) {
+    renameShipmentContainer(id: $id, name: $name) { ${CONTAINER_FIELDS} }
+  }
+`;
+
+export const DELETE_SHIPMENT_CONTAINER = gql`
+  mutation DeleteShipmentContainer($id: ID!) {
+    deleteShipmentContainer(id: $id)
+  }
+`;
+
+// Full replace over one container's contents; the list order IS the stacking order.
+export const SET_CONTAINER_ITEMS = gql`
+  mutation SetContainerItems($input: SetContainerItemsInput!) {
+    setContainerItems(input: $input) { ${CONTAINER_FIELDS} }
+  }
+`;
+
 // The shipping department's list of how a load can travel (#451). `activeOnly` is what the Delivery
 // Request form passes; the management screen leaves it off so a retired method stays visible.
 const SHIPMENT_METHOD_FIELDS = 'id name isActive sortOrder createdAt updatedAt';
@@ -165,6 +212,30 @@ export const GET_RETURNABLE_LINES = gql`
 export const CONFIRM_SHIPMENT = gql`
   mutation ConfirmShipment($input: ConfirmShipmentInput!) {
     confirmShipment(input: $input) {
+      ${PACKING_SLIP_FIELDS}
+      items {
+        id
+        packingSlipId
+        itemType
+        openingItemId
+        openingNumber
+        leaf
+        building
+        floor
+        location
+        productCode
+        hardwareCategory
+        quantity
+      }
+    }
+  }
+`;
+
+// The container flow's confirm (#451): the same slip, composed from whole containers instead of a
+// hand-built item list.
+export const CONFIRM_SHIPMENT_FROM_CONTAINERS = gql`
+  mutation ConfirmShipmentFromContainers($input: ConfirmShipmentFromContainersInput!) {
+    confirmShipmentFromContainers(input: $input) {
       ${PACKING_SLIP_FIELDS}
       items {
         id

--- a/frontend/src/modules/shipping/ContainerShipmentForm.tsx
+++ b/frontend/src/modules/shipping/ContainerShipmentForm.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@apollo/client/react';
+import { CONFIRM_SHIPMENT_FROM_CONTAINERS } from '../../graphql/shipping';
+import { SHIPPING_REFETCH_QUERIES, SHIPPING_STALE_ROOT_FIELDS } from '../../graphql/refetch';
+import { useToast } from '../../components/Toast';
+import { useIdentity } from '../../hooks/useIdentity';
+import DeliveryRequestFields from './DeliveryRequestFields';
+import { useShipmentMethods } from './useShipmentMethods';
+import {
+  deliveryDetailsInput,
+  EMPTY_DELIVERY_DETAILS,
+  isWeightInvalid,
+  WEIGHT_ERROR,
+  type DeliveryDetails,
+} from './deliveryRequest';
+import { CONTAINER_TYPE_LABEL, isStacked, type Container } from './staging';
+import { leafSuffix } from '../../utils/leaf';
+import { microLabelSx, monoSx } from '../../theme';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  projectId: string;
+  containers: Container[];
+  onShipped: () => void;
+}
+
+/**
+ * Confirm a shipment out of whole containers (#451).
+ *
+ * The same Delivery Request the cart flow fills in - it is one paper form and the site signs one of
+ * them - with the manifest above it showing what is actually on the truck, container by container.
+ * A skid prints its stack in order, because that is the thing the driver and the site both need and
+ * the reason containers exist at all.
+ */
+export default function ContainerShipmentForm({
+  open,
+  onClose,
+  projectId,
+  containers,
+  onShipped,
+}: Props) {
+  const { showToast } = useToast();
+  const { displayName } = useIdentity();
+  const shipmentMethods = useShipmentMethods(!open);
+  const [packingSlipNumber, setPackingSlipNumber] = useState('');
+  const [details, setDetails] = useState<DeliveryDetails>(EMPTY_DELIVERY_DETAILS);
+  const [error, setError] = useState<string | null>(null);
+
+  const totals = useMemo(() => {
+    const leaves = containers.reduce(
+      (n, c) => n + c.items.filter((i) => i.itemType === 'OPENING_ITEM').length,
+      0,
+    );
+    const looseUnits = containers.reduce(
+      (n, c) => n + c.items.filter((i) => i.itemType === 'LOOSE').reduce((m, i) => m + i.quantity, 0),
+      0,
+    );
+    return { leaves, looseUnits };
+  }, [containers]);
+
+  const [confirm, { loading }] = useMutation(CONFIRM_SHIPMENT_FROM_CONTAINERS, {
+    refetchQueries: SHIPPING_REFETCH_QUERIES,
+    update(cache) {
+      for (const fieldName of [...SHIPPING_STALE_ROOT_FIELDS, 'stagingPool']) {
+        cache.evict({ id: 'ROOT_QUERY', fieldName });
+      }
+      cache.gc();
+    },
+    onCompleted: () => {
+      showToast(`Shipment ${packingSlipNumber} confirmed`, 'success');
+      onShipped();
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  const submit = () => {
+    setError(null);
+    if (!packingSlipNumber.trim()) {
+      setError('A packing slip number is required.');
+      return;
+    }
+    if (isWeightInvalid(details.weightLbs)) {
+      setError(WEIGHT_ERROR);
+      return;
+    }
+    confirm({
+      variables: {
+        input: {
+          projectId,
+          packingSlipNumber: packingSlipNumber.trim(),
+          containerIds: containers.map((c) => c.id),
+          ...deliveryDetailsInput(details),
+        },
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Confirm shipment</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <Box>
+            <Typography sx={{ ...microLabelSx, display: 'block', mb: 0.5 }}>
+              On the truck: {containers.length} container(s), {totals.leaves} door leaf/leaves,{' '}
+              {totals.looseUnits} loose unit(s)
+            </Typography>
+            <Stack spacing={1}>
+              {containers.map((c) => (
+                <Box key={c.id} sx={{ pl: 1, borderLeft: '2px solid', borderColor: 'divider' }}>
+                  <Typography variant="body2" sx={{ ...monoSx, fontWeight: 700 }}>
+                    {c.name} ({CONTAINER_TYPE_LABEL[c.containerType]})
+                  </Typography>
+                  {c.items.map((i, index) => (
+                    <Typography key={i.id} variant="caption" sx={{ display: 'block', ...monoSx }}>
+                      {isStacked(c.containerType) && `${index + 1}. `}
+                      {i.itemType === 'OPENING_ITEM'
+                        ? `${i.openingNumber}${leafSuffix(i.leaf)}`
+                        : `${i.productCode} × ${i.quantity}`}
+                    </Typography>
+                  ))}
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+
+          <DeliveryRequestFields
+            details={details}
+            onChange={(patch) => setDetails((prev) => ({ ...prev, ...patch }))}
+            shipperName={displayName}
+            disabled={loading}
+            shipmentMethods={shipmentMethods}
+            leadingShipmentField={
+              <TextField
+                label="Packing Slip Number"
+                required
+                value={packingSlipNumber}
+                onChange={(e) => setPackingSlipNumber(e.target.value)}
+                disabled={loading}
+                fullWidth
+              />
+            }
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={submit} disabled={loading || containers.length === 0}>
+          Confirm shipment
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/modules/shipping/StagingWorkspace.tsx
+++ b/frontend/src/modules/shipping/StagingWorkspace.tsx
@@ -1,0 +1,727 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ChevronDown, ChevronUp, GripVertical, Package, Plus, Trash2 } from 'lucide-react';
+import { useMutation, useQuery } from '@apollo/client/react';
+import {
+  CREATE_SHIPMENT_CONTAINER,
+  DELETE_SHIPMENT_CONTAINER,
+  GET_STAGING_POOL,
+  SET_CONTAINER_ITEMS,
+} from '../../graphql/shipping';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { useToast } from '../../components/Toast';
+import ContainerShipmentForm from './ContainerShipmentForm';
+import {
+  canTakeAnotherLeaf,
+  CONTAINER_TYPE_LABEL,
+  isStacked,
+  leafCount,
+  MAX_LEAVES_PER_SKID,
+  toItemsInput,
+  type Container,
+  type ContainerItem,
+  type ContainerType,
+  type StagedLeaf,
+  type StagedLooseItem,
+  type StagingPool,
+} from './staging';
+import { leafSuffix } from '../../utils/leaf';
+import { microLabelSx, monoSx, tabularSx } from '../../theme';
+
+const CONTAINER_TYPES: ContainerType[] = ['SKID', 'DOOR_CART', 'BOX', 'ENVELOPE', 'BUNDLE'];
+
+// Drag ids are prefixed so one handler can tell what was picked up without a lookup table.
+const poolLeafId = (id: string) => `leaf:${id}`;
+const poolLooseId = (cat: string, code: string) => `loose:${cat}|${code}`;
+const containerDropId = (id: string) => `container:${id}`;
+
+interface Props {
+  projectId: string | undefined;
+}
+
+/**
+ * Organising what is staged into the things that physically go on the truck (#451).
+ *
+ * The left column is everything staged and not yet in a container; the right is the containers
+ * being built. Work moves left to right, and a shipment is confirmed out of whole containers -
+ * which is the difference from the cart this replaces: a cart was a session, and a skid gets loaded
+ * over days.
+ *
+ * Drag to place and to restack, with an equivalent control beside every item. The keyboard path is
+ * not decoration here: this screen is used on a tablet in a warehouse, and a drag that misses puts
+ * a door leaf on the wrong skid - so the up/down buttons and the "Place in" menu are the reliable
+ * path and the drag is the fast one.
+ */
+export default function StagingWorkspace({ projectId }: Props) {
+  const { showToast } = useToast();
+  const [newType, setNewType] = useState<ContainerType>('SKID');
+  const [newName, setNewName] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirmDelete, setConfirmDelete] = useState<Container | null>(null);
+  const [shipOpen, setShipOpen] = useState(false);
+  const [dragging, setDragging] = useState<string | null>(null);
+
+  const { data, loading, refetch } = useQuery<{ stagingPool: StagingPool }>(GET_STAGING_POOL, {
+    variables: { projectId },
+    skip: !projectId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const pool = data?.stagingPool;
+  const containers = useMemo(() => pool?.containers ?? [], [pool]);
+  const unplacedLeaves = useMemo(() => (pool?.leaves ?? []).filter((l) => !l.placedInContainerId), [pool]);
+  const unplacedLoose = useMemo(() => (pool?.looseItems ?? []).filter((l) => l.unplacedQuantity > 0), [pool]);
+
+  const onError = useCallback((e: { message: string }) => showToast(e.message, 'error'), [showToast]);
+  const afterChange = useCallback(() => refetch(), [refetch]);
+
+  const [createContainer] = useMutation(CREATE_SHIPMENT_CONTAINER, {
+    onCompleted: () => {
+      setNewName('');
+      showToast('Container created', 'success');
+      afterChange();
+    },
+    onError,
+  });
+  const [deleteContainer] = useMutation(DELETE_SHIPMENT_CONTAINER, {
+    onCompleted: () => {
+      showToast('Container broken down - its contents are back in the pool', 'success');
+      afterChange();
+    },
+    onError,
+  });
+  const [setItems] = useMutation(SET_CONTAINER_ITEMS, { onCompleted: afterChange, onError });
+
+  const save = useCallback(
+    (container: Container, items: ContainerItem[]) =>
+      setItems({ variables: { input: { containerId: container.id, items: toItemsInput(items) } } }),
+    [setItems],
+  );
+
+  const placeLeaf = useCallback(
+    (container: Container, leaf: StagedLeaf) => {
+      if (!canTakeAnotherLeaf(container)) {
+        showToast(
+          `${container.name} already holds ${MAX_LEAVES_PER_SKID} leaves - start another skid.`,
+          'warning',
+        );
+        return;
+      }
+      save(container, [
+        ...container.items,
+        {
+          id: 'new',
+          itemType: 'OPENING_ITEM',
+          openingItemId: leaf.openingItemId,
+          openingNumber: leaf.openingNumber,
+          leaf: leaf.leaf,
+          hardwareCategory: '',
+          productCode: '',
+          quantity: 1,
+          position: container.items.length,
+        },
+      ]);
+    },
+    [save, showToast],
+  );
+
+  const placeLoose = useCallback(
+    (container: Container, item: StagedLooseItem) => {
+      const existing = container.items.find(
+        (i) =>
+          i.itemType === 'LOOSE' &&
+          i.hardwareCategory === item.hardwareCategory &&
+          i.productCode === item.productCode,
+      );
+      // Placing the same product twice tops up the line rather than adding a second one: a box with
+      // "HG-100 x2" and "HG-100 x1" in it is two ways of saying three hinges.
+      const next = existing
+        ? container.items.map((i) =>
+            i === existing ? { ...i, quantity: i.quantity + item.unplacedQuantity } : i,
+          )
+        : [
+            ...container.items,
+            {
+              id: 'new',
+              itemType: 'LOOSE' as const,
+              openingItemId: null,
+              openingNumber: item.openingNumber,
+              leaf: null,
+              hardwareCategory: item.hardwareCategory,
+              productCode: item.productCode,
+              quantity: item.unplacedQuantity,
+              position: container.items.length,
+            },
+          ];
+      save(container, next);
+    },
+    [save],
+  );
+
+  const removeItem = useCallback(
+    (container: Container, itemId: string) => save(container, container.items.filter((i) => i.id !== itemId)),
+    [save],
+  );
+
+  /** Move one entry along the stack. The list order is what becomes `position` server-side. */
+  const move = useCallback(
+    (container: Container, index: number, delta: number) => {
+      const target = index + delta;
+      if (target < 0 || target >= container.items.length) return;
+      save(container, arrayMove(container.items, index, target));
+    },
+    [save],
+  );
+
+  const sensors = useSensors(
+    // A few pixels of slop so a tap on the remove button beside the handle is not read as a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setDragging(null);
+      const { active, over } = event;
+      if (!over) return;
+      const activeId = String(active.id);
+      const overId = String(over.id);
+
+      // Reorder inside one container: both ends are items of the same stack.
+      const owner = containers.find((c) => c.items.some((i) => i.id === activeId));
+      if (owner) {
+        const from = owner.items.findIndex((i) => i.id === activeId);
+        const to = owner.items.findIndex((i) => i.id === overId);
+        if (to >= 0 && from !== to) save(owner, arrayMove(owner.items, from, to));
+        return;
+      }
+
+      // Otherwise it came from the pool, and the drop target is a container (or one of its items).
+      const target =
+        containers.find((c) => containerDropId(c.id) === overId) ??
+        containers.find((c) => c.items.some((i) => i.id === overId));
+      if (!target) return;
+
+      if (activeId.startsWith('leaf:')) {
+        const leaf = unplacedLeaves.find((l) => poolLeafId(l.openingItemId) === activeId);
+        if (leaf) placeLeaf(target, leaf);
+        return;
+      }
+      const loose = unplacedLoose.find((l) => poolLooseId(l.hardwareCategory, l.productCode) === activeId);
+      if (loose) placeLoose(target, loose);
+    },
+    [containers, unplacedLeaves, unplacedLoose, placeLeaf, placeLoose, save],
+  );
+
+  const toggleSelected = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const selectedContainers = containers.filter((c) => selected.has(c.id) && c.items.length > 0);
+
+  if (!projectId) {
+    return <Alert severity="info">Pick a project to organise its shipment.</Alert>;
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={(e: DragStartEvent) => setDragging(String(e.active.id))}
+      onDragCancel={() => setDragging(null)}
+      onDragEnd={handleDragEnd}
+    >
+      <Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, mb: 2 }}>
+          <Typography variant="body2" color="text.secondary">
+            Everything pulled for shipping and not yet sent. Put it into the skids, carts and boxes
+            that go on the truck, then ship whole containers.
+          </Typography>
+          <Button
+            variant="contained"
+            disabled={selectedContainers.length === 0}
+            onClick={() => setShipOpen(true)}
+          >
+            Ship {selectedContainers.length || ''} container{selectedContainers.length === 1 ? '' : 's'}
+          </Button>
+        </Box>
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">
+          <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 0, width: '100%' }}>
+            <Typography sx={{ ...microLabelSx, display: 'block', mb: 1 }}>
+              Staged, not yet in a container
+            </Typography>
+
+            {loading && !pool && (
+              <Typography variant="body2" color="text.secondary">
+                Reading the staging pool...
+              </Typography>
+            )}
+
+            {pool && unplacedLeaves.length === 0 && unplacedLoose.length === 0 && (
+              <Alert severity="info">
+                Nothing is waiting to be loaded. Hardware arrives here once its shipping pull has
+                been picked and marked as pulled.
+              </Alert>
+            )}
+
+            {unplacedLeaves.length > 0 && (
+              <Box sx={{ mb: 2 }}>
+                <Typography sx={{ ...microLabelSx, display: 'block', mb: 0.5 }}>Door leaves</Typography>
+                <Stack spacing={0.5}>
+                  {unplacedLeaves.map((l) => (
+                    <PoolRow
+                      key={l.openingItemId}
+                      dragId={poolLeafId(l.openingItemId)}
+                      primary={`${l.openingNumber}${leafSuffix(l.leaf)}`}
+                      secondary={
+                        [l.building, l.floor, l.location].filter(Boolean).join(' / ') ||
+                        'No placement recorded'
+                      }
+                      containers={containers}
+                      onPick={(c) => placeLeaf(c, l)}
+                      disabledFor={(c) => !canTakeAnotherLeaf(c)}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            )}
+
+            {unplacedLoose.length > 0 && (
+              <Box>
+                <Typography sx={{ ...microLabelSx, display: 'block', mb: 0.5 }}>Loose hardware</Typography>
+                <Stack spacing={0.5}>
+                  {unplacedLoose.map((l) => (
+                    <PoolRow
+                      key={`${l.hardwareCategory}|${l.productCode}`}
+                      dragId={poolLooseId(l.hardwareCategory, l.productCode)}
+                      primary={`${l.productCode} | ${l.hardwareCategory}`}
+                      secondary={`${l.openingNumber ?? 'Unattributed'} · ${l.unplacedQuantity} of ${l.stagedQuantity} unplaced`}
+                      containers={containers}
+                      onPick={(c) => placeLoose(c, l)}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            )}
+          </Paper>
+
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%' }}>
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography sx={{ ...microLabelSx, display: 'block', mb: 1 }}>New container</Typography>
+              <Stack direction="row" spacing={1}>
+                <TextField
+                  select
+                  size="small"
+                  label="Type"
+                  value={newType}
+                  onChange={(e) => setNewType(e.target.value as ContainerType)}
+                  sx={{ minWidth: 130 }}
+                >
+                  {CONTAINER_TYPES.map((t) => (
+                    <MenuItem key={t} value={t}>
+                      {CONTAINER_TYPE_LABEL[t]}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <TextField
+                  size="small"
+                  label="Name"
+                  placeholder="Skid 1"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  fullWidth
+                />
+                <Button
+                  variant="outlined"
+                  startIcon={<Plus size={16} strokeWidth={1.75} />}
+                  disabled={!newName.trim()}
+                  onClick={() =>
+                    createContainer({
+                      variables: { projectId, containerType: newType, name: newName.trim() },
+                    })
+                  }
+                >
+                  Add
+                </Button>
+              </Stack>
+            </Paper>
+
+            {containers.length === 0 && (
+              <Alert severity="info">
+                No containers yet. A shipment is made of them, so start with the skid or box you are
+                loading first.
+              </Alert>
+            )}
+
+            <Stack spacing={2}>
+              {containers.map((c) => (
+                <ContainerCard
+                  key={c.id}
+                  container={c}
+                  selected={selected.has(c.id)}
+                  onToggleSelected={() => toggleSelected(c.id)}
+                  onDelete={() => setConfirmDelete(c)}
+                  onRemoveItem={(itemId) => removeItem(c, itemId)}
+                  onMove={(index, delta) => move(c, index, delta)}
+                />
+              ))}
+            </Stack>
+          </Box>
+        </Stack>
+
+        <ConfirmDialog
+          open={confirmDelete !== null}
+          title="Break down this container?"
+          message={
+            confirmDelete
+              ? `${confirmDelete.name} goes away and everything in it returns to the staging pool. Nothing is shipped or unshipped by this - it is only how the load is arranged.`
+              : ''
+          }
+          confirmLabel="Break it down"
+          confirmColor="error"
+          onConfirm={() => {
+            const id = confirmDelete?.id;
+            setConfirmDelete(null);
+            if (id) deleteContainer({ variables: { id } });
+          }}
+          onCancel={() => setConfirmDelete(null)}
+        />
+
+        {shipOpen && (
+          <ContainerShipmentForm
+            open
+            onClose={() => setShipOpen(false)}
+            projectId={projectId}
+            containers={selectedContainers}
+            onShipped={() => {
+              setSelected(new Set());
+              setShipOpen(false);
+              refetch();
+            }}
+          />
+        )}
+      </Box>
+
+      {/* What follows the cursor. Without it the row stays in place and the drag reads as a
+          no-op until it lands. */}
+      <DragOverlay>
+        {dragging ? (
+          <Paper variant="outlined" sx={{ px: 1.5, py: 0.75, ...monoSx }}>
+            {dragging.replace(/^(leaf|loose):/, '')}
+          </Paper>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+/** One row of the unplaced pool: draggable, with a "Place in" menu doing the same job by click. */
+function PoolRow({
+  dragId,
+  primary,
+  secondary,
+  containers,
+  onPick,
+  disabledFor,
+}: {
+  dragId: string;
+  primary: string;
+  secondary: string;
+  containers: Container[];
+  onPick: (c: Container) => void;
+  disabledFor?: (c: Container) => boolean;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: dragId });
+  return (
+    <Box
+      ref={setNodeRef}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 1,
+        py: 0.5,
+        opacity: isDragging ? 0.4 : 1,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+        <Box
+          {...attributes}
+          {...listeners}
+          aria-label={`Drag ${primary}`}
+          sx={{ display: 'flex', cursor: 'grab', color: 'text.secondary', flexShrink: 0 }}
+        >
+          <GripVertical size={16} strokeWidth={1.75} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="body2" sx={{ ...monoSx, ...tabularSx }}>
+            {primary}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {secondary}
+          </Typography>
+        </Box>
+      </Box>
+      <PlaceMenu containers={containers} onPick={onPick} disabledFor={disabledFor} />
+    </Box>
+  );
+}
+
+/** A container and its stack. Droppable as a whole; its items are sortable when order matters. */
+function ContainerCard({
+  container,
+  selected,
+  onToggleSelected,
+  onDelete,
+  onRemoveItem,
+  onMove,
+}: {
+  container: Container;
+  selected: boolean;
+  onToggleSelected: () => void;
+  onDelete: () => void;
+  onRemoveItem: (itemId: string) => void;
+  onMove: (index: number, delta: number) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: containerDropId(container.id) });
+  const stacked = isStacked(container.containerType);
+  const full = !canTakeAnotherLeaf(container);
+
+  return (
+    <Paper
+      ref={setNodeRef}
+      variant="outlined"
+      sx={{
+        p: 2,
+        transition: 'border-color 0.15s ease, background-color 0.15s ease',
+        borderColor: isOver ? 'primary.main' : undefined,
+        bgcolor: isOver ? 'action.hover' : undefined,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, mb: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggleSelected}
+            aria-label={`Include ${container.name} in this shipment`}
+          />
+          <Package size={16} strokeWidth={1.75} />
+          <Typography variant="body2" sx={{ ...monoSx, fontWeight: 700 }}>
+            {container.name}
+          </Typography>
+          <Chip size="small" variant="outlined" label={CONTAINER_TYPE_LABEL[container.containerType]} />
+          {container.containerType === 'SKID' && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={full ? 'warning' : 'default'}
+              label={`${leafCount(container)}/${MAX_LEAVES_PER_SKID} leaves`}
+            />
+          )}
+        </Box>
+        <IconButton size="small" color="error" aria-label={`Break down ${container.name}`} onClick={onDelete}>
+          <Trash2 size={16} strokeWidth={1.75} />
+        </IconButton>
+      </Box>
+
+      {stacked && container.items.length > 1 && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+          Loaded in this order - the first one listed goes on first, at the bottom.
+        </Typography>
+      )}
+
+      {container.items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Empty. Drag something in, or use the Place in menu on the left.
+        </Typography>
+      ) : (
+        <SortableContext
+          items={container.items.map((i) => i.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <Stack spacing={0.25}>
+            {container.items.map((item, index) => (
+              <ContainerRow
+                key={item.id}
+                item={item}
+                index={index}
+                stacked={stacked}
+                count={container.items.length}
+                containerName={container.name}
+                onRemove={() => onRemoveItem(item.id)}
+                onMove={(delta) => onMove(index, delta)}
+              />
+            ))}
+          </Stack>
+        </SortableContext>
+      )}
+    </Paper>
+  );
+}
+
+function ContainerRow({
+  item,
+  index,
+  stacked,
+  count,
+  containerName,
+  onRemove,
+  onMove,
+}: {
+  item: ContainerItem;
+  index: number;
+  stacked: boolean;
+  count: number;
+  containerName: string;
+  onRemove: () => void;
+  onMove: (delta: number) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
+  const label = item.itemType === 'OPENING_ITEM' ? `${item.openingNumber}${leafSuffix(item.leaf)}` : item.productCode;
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 1,
+        py: 0.25,
+        opacity: isDragging ? 0.4 : 1,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+        {stacked && (
+          <Box
+            {...attributes}
+            {...listeners}
+            aria-label={`Reorder ${label} in ${containerName}`}
+            sx={{ display: 'flex', cursor: 'grab', color: 'text.secondary', flexShrink: 0 }}
+          >
+            <GripVertical size={14} strokeWidth={1.75} />
+          </Box>
+        )}
+        <Typography variant="body2" sx={{ ...monoSx, ...tabularSx, minWidth: 0 }}>
+          {stacked && `${index + 1}. `}
+          {item.itemType === 'OPENING_ITEM' ? label : `${label} × ${item.quantity}`}
+        </Typography>
+      </Box>
+      <Stack direction="row" spacing={0.5} alignItems="center">
+        {stacked && count > 1 && (
+          <>
+            <IconButton
+              size="small"
+              aria-label={`Move ${label} up`}
+              disabled={index === 0}
+              onClick={() => onMove(-1)}
+            >
+              <ChevronUp size={16} strokeWidth={1.75} />
+            </IconButton>
+            <IconButton
+              size="small"
+              aria-label={`Move ${label} down`}
+              disabled={index === count - 1}
+              onClick={() => onMove(1)}
+            >
+              <ChevronDown size={16} strokeWidth={1.75} />
+            </IconButton>
+          </>
+        )}
+        <IconButton
+          size="small"
+          color="error"
+          aria-label={`Take ${label} out of ${containerName}`}
+          onClick={onRemove}
+        >
+          <Trash2 size={14} strokeWidth={1.75} />
+        </IconButton>
+      </Stack>
+    </Box>
+  );
+}
+
+/**
+ * Where to put this, by click. The equal-weight partner to dragging rather than a fallback: the
+ * pool can be long, the containers are small, and this screen is worked on a tablet in a warehouse.
+ */
+function PlaceMenu({
+  containers,
+  onPick,
+  disabledFor,
+}: {
+  containers: Container[];
+  onPick: (c: Container) => void;
+  disabledFor?: (c: Container) => boolean;
+}) {
+  const [value, setValue] = useState('');
+  if (containers.length === 0) {
+    return (
+      <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+        No containers yet
+      </Typography>
+    );
+  }
+  return (
+    <TextField
+      select
+      size="small"
+      label="Place in"
+      value={value}
+      onChange={(e) => {
+        const c = containers.find((x) => x.id === e.target.value);
+        if (c) onPick(c);
+        setValue('');
+      }}
+      sx={{ minWidth: 150, flexShrink: 0 }}
+    >
+      {containers.map((c) => (
+        <MenuItem key={c.id} value={c.id} disabled={disabledFor?.(c) ?? false}>
+          {c.name}
+          {disabledFor?.(c) ? ' (full)' : ''}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}

--- a/frontend/src/modules/shipping/StagingWorkspace.tsx
+++ b/frontend/src/modules/shipping/StagingWorkspace.tsx
@@ -48,6 +48,7 @@ import {
   isStacked,
   leafCount,
   MAX_LEAVES_PER_SKID,
+  sameLooseStock,
   toItemsInput,
   type Container,
   type ContainerItem,
@@ -61,9 +62,11 @@ import { microLabelSx, monoSx, tabularSx } from '../../theme';
 
 const CONTAINER_TYPES: ContainerType[] = ['SKID', 'DOOR_CART', 'BOX', 'ENVELOPE', 'BUNDLE'];
 
-// Drag ids are prefixed so one handler can tell what was picked up without a lookup table.
+// Drag ids are prefixed so one handler can tell what was picked up without a lookup table. The loose
+// id carries the opening because that is part of which stock the row is (see `sameLooseStock`).
 const poolLeafId = (id: string) => `leaf:${id}`;
-const poolLooseId = (cat: string, code: string) => `loose:${cat}|${code}`;
+const poolLooseId = (row: StagedLooseItem) =>
+  `loose:${row.openingNumber ?? ''}|${row.hardwareCategory}|${row.productCode}`;
 const containerDropId = (id: string) => `container:${id}`;
 
 interface Props {
@@ -129,6 +132,21 @@ export default function StagingWorkspace({ projectId }: Props) {
     [setItems],
   );
 
+  /**
+   * How much of each pool row the next placement takes. Keyed by the row's drag id, absent until the
+   * user changes it - the default is the whole unplaced quantity, which is the common case.
+   *
+   * Held here rather than inside the row so a drag and the "Place in" menu take the same number.
+   * Without it a product could only ever go into one container whole, and four hinges could not be
+   * split two into Box 1 and two into Box 2.
+   */
+  const [placeQuantities, setPlaceQuantities] = useState<Record<string, number>>({});
+  const quantityFor = useCallback(
+    (row: StagedLooseItem) =>
+      Math.max(1, Math.min(placeQuantities[poolLooseId(row)] ?? row.unplacedQuantity, row.unplacedQuantity)),
+    [placeQuantities],
+  );
+
   const placeLeaf = useCallback(
     (container: Container, leaf: StagedLeaf) => {
       if (!canTakeAnotherLeaf(container)) {
@@ -157,19 +175,14 @@ export default function StagingWorkspace({ projectId }: Props) {
   );
 
   const placeLoose = useCallback(
-    (container: Container, item: StagedLooseItem) => {
-      const existing = container.items.find(
-        (i) =>
-          i.itemType === 'LOOSE' &&
-          i.hardwareCategory === item.hardwareCategory &&
-          i.productCode === item.productCode,
-      );
-      // Placing the same product twice tops up the line rather than adding a second one: a box with
+    (container: Container, item: StagedLooseItem, quantity: number) => {
+      const take = Math.max(0, Math.min(quantity, item.unplacedQuantity));
+      if (take === 0) return;
+      const existing = container.items.find((i) => sameLooseStock(i, item));
+      // Placing the same stock twice tops up the line rather than adding a second one: a box with
       // "HG-100 x2" and "HG-100 x1" in it is two ways of saying three hinges.
       const next = existing
-        ? container.items.map((i) =>
-            i === existing ? { ...i, quantity: i.quantity + item.unplacedQuantity } : i,
-          )
+        ? container.items.map((i) => (i === existing ? { ...i, quantity: i.quantity + take } : i))
         : [
             ...container.items,
             {
@@ -180,7 +193,7 @@ export default function StagingWorkspace({ projectId }: Props) {
               leaf: null,
               hardwareCategory: item.hardwareCategory,
               productCode: item.productCode,
-              quantity: item.unplacedQuantity,
+              quantity: take,
               position: container.items.length,
             },
           ];
@@ -191,6 +204,17 @@ export default function StagingWorkspace({ projectId }: Props) {
 
   const removeItem = useCallback(
     (container: Container, itemId: string) => save(container, container.items.filter((i) => i.id !== itemId)),
+    [save],
+  );
+
+  /** Correct how much of a loose line a container holds. Down to zero takes the line out. */
+  const setItemQuantity = useCallback(
+    (container: Container, itemId: string, quantity: number) => {
+      const next = quantity <= 0
+        ? container.items.filter((i) => i.id !== itemId)
+        : container.items.map((i) => (i.id === itemId ? { ...i, quantity } : i));
+      save(container, next);
+    },
     [save],
   );
 
@@ -211,37 +235,59 @@ export default function StagingWorkspace({ projectId }: Props) {
   );
 
   const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
+    async (event: DragEndEvent) => {
       setDragging(null);
       const { active, over } = event;
       if (!over) return;
       const activeId = String(active.id);
       const overId = String(over.id);
 
-      // Reorder inside one container: both ends are items of the same stack.
-      const owner = containers.find((c) => c.items.some((i) => i.id === activeId));
-      if (owner) {
-        const from = owner.items.findIndex((i) => i.id === activeId);
-        const to = owner.items.findIndex((i) => i.id === overId);
-        if (to >= 0 && from !== to) save(owner, arrayMove(owner.items, from, to));
-        return;
-      }
-
-      // Otherwise it came from the pool, and the drop target is a container (or one of its items).
+      // The drop target, whether the pointer landed on a container card or on one of its rows.
       const target =
         containers.find((c) => containerDropId(c.id) === overId) ??
         containers.find((c) => c.items.some((i) => i.id === overId));
-      if (!target) return;
 
+      const owner = containers.find((c) => c.items.some((i) => i.id === activeId));
+      if (owner) {
+        // Same container: a restack.
+        if (!target || target.id === owner.id) {
+          const from = owner.items.findIndex((i) => i.id === activeId);
+          const to = owner.items.findIndex((i) => i.id === overId);
+          if (to >= 0 && from !== to) save(owner, arrayMove(owner.items, from, to));
+          return;
+        }
+        // A different container: the move this screen mostly exists for. Two saves, and the order
+        // matters - adding first would be refused for a leaf that is still recorded in the skid it
+        // is leaving, so the source is emptied and awaited before the target is written.
+        const moving = owner.items.find((i) => i.id === activeId);
+        if (!moving) return;
+        if (moving.itemType === 'OPENING_ITEM' && !canTakeAnotherLeaf(target)) {
+          showToast(`${target.name} already holds ${MAX_LEAVES_PER_SKID} leaves - start another skid.`, 'warning');
+          return;
+        }
+        await save(owner, owner.items.filter((i) => i.id !== activeId));
+        const existing =
+          moving.itemType === 'LOOSE' ? target.items.find((i) => sameLooseStock(i, moving)) : undefined;
+        await save(
+          target,
+          existing
+            ? target.items.map((i) => (i === existing ? { ...i, quantity: i.quantity + moving.quantity } : i))
+            : [...target.items, { ...moving, id: 'new', position: target.items.length }],
+        );
+        return;
+      }
+
+      // Otherwise it came from the pool.
+      if (!target) return;
       if (activeId.startsWith('leaf:')) {
         const leaf = unplacedLeaves.find((l) => poolLeafId(l.openingItemId) === activeId);
         if (leaf) placeLeaf(target, leaf);
         return;
       }
-      const loose = unplacedLoose.find((l) => poolLooseId(l.hardwareCategory, l.productCode) === activeId);
-      if (loose) placeLoose(target, loose);
+      const loose = unplacedLoose.find((l) => poolLooseId(l) === activeId);
+      if (loose) placeLoose(target, loose, quantityFor(loose));
     },
-    [containers, unplacedLeaves, unplacedLoose, placeLeaf, placeLoose, save],
+    [containers, unplacedLeaves, unplacedLoose, placeLeaf, placeLoose, quantityFor, save, showToast],
   );
 
   const toggleSelected = (id: string) =>
@@ -308,6 +354,7 @@ export default function StagingWorkspace({ projectId }: Props) {
                       key={l.openingItemId}
                       dragId={poolLeafId(l.openingItemId)}
                       primary={`${l.openingNumber}${leafSuffix(l.leaf)}`}
+                      itemLabel={`${l.openingNumber}${leafSuffix(l.leaf)}`}
                       secondary={
                         [l.building, l.floor, l.location].filter(Boolean).join(' / ') ||
                         'No placement recorded'
@@ -327,12 +374,23 @@ export default function StagingWorkspace({ projectId }: Props) {
                 <Stack spacing={0.5}>
                   {unplacedLoose.map((l) => (
                     <PoolRow
-                      key={`${l.hardwareCategory}|${l.productCode}`}
-                      dragId={poolLooseId(l.hardwareCategory, l.productCode)}
+                      key={poolLooseId(l)}
+                      dragId={poolLooseId(l)}
                       primary={`${l.productCode} | ${l.hardwareCategory}`}
+                      itemLabel={`${l.productCode} for ${l.openingNumber ?? 'no opening'}`}
                       secondary={`${l.openingNumber ?? 'Unattributed'} · ${l.unplacedQuantity} of ${l.stagedQuantity} unplaced`}
                       containers={containers}
-                      onPick={(c) => placeLoose(c, l)}
+                      onPick={(c) => placeLoose(c, l, quantityFor(l))}
+                      quantity={
+                        l.unplacedQuantity > 1
+                          ? {
+                              value: quantityFor(l),
+                              max: l.unplacedQuantity,
+                              onChange: (value) =>
+                                setPlaceQuantities((prev) => ({ ...prev, [poolLooseId(l)]: value })),
+                            }
+                          : undefined
+                      }
                     />
                   ))}
                 </Stack>
@@ -398,6 +456,7 @@ export default function StagingWorkspace({ projectId }: Props) {
                   onDelete={() => setConfirmDelete(c)}
                   onRemoveItem={(itemId) => removeItem(c, itemId)}
                   onMove={(index, delta) => move(c, index, delta)}
+                  onSetQuantity={(itemId, q) => setItemQuantity(c, itemId, q)}
                 />
               ))}
             </Stack>
@@ -455,21 +514,35 @@ function PoolRow({
   dragId,
   primary,
   secondary,
+  itemLabel,
   containers,
   onPick,
   disabledFor,
+  quantity,
 }: {
   dragId: string;
   primary: string;
   secondary: string;
+  /**
+   * What this row is, for the controls that announce themselves. Distinct per row where `primary`
+   * is not: one product staged for two openings is two rows reading "HG-100 | HINGE", and a screen
+   * reader hearing two identical "Place in" menus has no way to tell which door it is loading.
+   */
+  itemLabel: string;
   containers: Container[];
   onPick: (c: Container) => void;
   disabledFor?: (c: Container) => boolean;
+  /** How much of this row the next placement takes. Absent on a leaf - there is one of it. */
+  quantity?: { value: number; max: number; onChange: (value: number) => void };
 }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: dragId });
   return (
     <Box
       ref={setNodeRef}
+      // Named as a group, because the controls inside it cannot name themselves apart: one product
+      // staged for two openings puts two "Place in" menus on screen reading identically.
+      role="group"
+      aria-label={itemLabel}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -499,7 +572,23 @@ function PoolRow({
           </Typography>
         </Box>
       </Box>
-      <PlaceMenu containers={containers} onPick={onPick} disabledFor={disabledFor} />
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
+        {quantity && (
+          <TextField
+            size="small"
+            type="number"
+            label="Qty"
+            value={quantity.value}
+            onChange={(e) => {
+              const next = Number.parseInt(e.target.value, 10);
+              quantity.onChange(Number.isNaN(next) ? 1 : Math.max(1, Math.min(next, quantity.max)));
+            }}
+            inputProps={{ min: 1, max: quantity.max, 'aria-label': `Quantity of ${itemLabel} to place` }}
+            sx={{ width: 88 }}
+          />
+        )}
+        <PlaceMenu containers={containers} onPick={onPick} disabledFor={disabledFor} />
+      </Stack>
     </Box>
   );
 }
@@ -512,6 +601,7 @@ function ContainerCard({
   onDelete,
   onRemoveItem,
   onMove,
+  onSetQuantity,
 }: {
   container: Container;
   selected: boolean;
@@ -519,6 +609,7 @@ function ContainerCard({
   onDelete: () => void;
   onRemoveItem: (itemId: string) => void;
   onMove: (index: number, delta: number) => void;
+  onSetQuantity: (itemId: string, quantity: number) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: containerDropId(container.id) });
   const stacked = isStacked(container.containerType);
@@ -588,6 +679,7 @@ function ContainerCard({
                 containerName={container.name}
                 onRemove={() => onRemoveItem(item.id)}
                 onMove={(delta) => onMove(index, delta)}
+                onSetQuantity={(q) => onSetQuantity(item.id, q)}
               />
             ))}
           </Stack>
@@ -605,6 +697,7 @@ function ContainerRow({
   containerName,
   onRemove,
   onMove,
+  onSetQuantity,
 }: {
   item: ContainerItem;
   index: number;
@@ -613,6 +706,7 @@ function ContainerRow({
   containerName: string;
   onRemove: () => void;
   onMove: (delta: number) => void;
+  onSetQuantity: (quantity: number) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.id,
@@ -645,10 +739,25 @@ function ContainerRow({
         )}
         <Typography variant="body2" sx={{ ...monoSx, ...tabularSx, minWidth: 0 }}>
           {stacked && `${index + 1}. `}
-          {item.itemType === 'OPENING_ITEM' ? label : `${label} × ${item.quantity}`}
+          {label}
         </Typography>
       </Box>
       <Stack direction="row" spacing={0.5} alignItems="center">
+        {/* Correctable in place. Splitting a product across two containers means getting the split
+            wrong sometimes, and pulling the line out and starting over is a poor answer to that. */}
+        {item.itemType === 'LOOSE' && (
+          <TextField
+            size="small"
+            type="number"
+            value={item.quantity}
+            onChange={(e) => {
+              const next = Number.parseInt(e.target.value, 10);
+              onSetQuantity(Number.isNaN(next) ? 0 : Math.max(0, next));
+            }}
+            inputProps={{ min: 0, 'aria-label': `Quantity of ${label} in ${containerName}` }}
+            sx={{ width: 80 }}
+          />
+        )}
         {stacked && count > 1 && (
           <>
             <IconButton

--- a/frontend/src/modules/shipping/__tests__/StagingWorkspace.test.tsx
+++ b/frontend/src/modules/shipping/__tests__/StagingWorkspace.test.tsx
@@ -1,0 +1,253 @@
+import { render, screen, fireEvent, waitFor, within, configure } from '@testing-library/react';
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing/react';
+import { ToastProvider } from '../../../components/Toast';
+import StagingWorkspace from '../StagingWorkspace';
+import { sameLooseStock } from '../staging';
+import { GET_STAGING_POOL, SET_CONTAINER_ITEMS } from '../../../graphql/shipping';
+
+/**
+ * Arranging the staging pool into what physically goes on the truck (#451).
+ *
+ * The drag itself is not exercised here - dnd-kit needs a pointer with real geometry, which jsdom
+ * does not have. What is pinned is the state each gesture produces, through the click-equivalent
+ * controls that exist beside every drag for exactly this reason.
+ */
+
+const PROJECT_ID = 'proj-1';
+const INFINITE = Number.POSITIVE_INFINITY;
+
+vi.setConfig({ testTimeout: 30_000 });
+configure({ asyncUtilTimeout: 10_000 });
+
+function looseRow(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'StagedLooseItem',
+    openingNumber: '101',
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    stagedQuantity: 4,
+    placedQuantity: 0,
+    unplacedQuantity: 4,
+    ...overrides,
+  };
+}
+
+function container(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'ShipmentContainer',
+    id: 'c-1',
+    projectId: PROJECT_ID,
+    containerType: 'BOX',
+    name: 'Box 1',
+    packingSlipId: null,
+    createdBy: 'tester',
+    items: [],
+    ...overrides,
+  };
+}
+
+function poolMock(pool: Record<string, unknown>): MockedResponse {
+  return {
+    request: { query: GET_STAGING_POOL, variables: { projectId: PROJECT_ID } },
+    maxUsageCount: INFINITE,
+    result: {
+      data: {
+        stagingPool: { __typename: 'StagingPool', leaves: [], looseItems: [], containers: [], ...pool },
+      },
+    },
+  };
+}
+
+function setItemsMock(containerId: string, items: Record<string, unknown>[], onFire?: () => void): MockedResponse {
+  return {
+    request: { query: SET_CONTAINER_ITEMS, variables: { input: { containerId, items } } },
+    maxUsageCount: INFINITE,
+    result: () => {
+      onFire?.();
+      return { data: { setContainerItems: container({ id: containerId }) } };
+    },
+  };
+}
+
+function looseInput(quantity: number, overrides: Record<string, unknown> = {}) {
+  return {
+    itemType: 'LOOSE',
+    openingItemId: null,
+    openingNumber: '101',
+    leaf: null,
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    quantity,
+    ...overrides,
+  };
+}
+
+/** One pool row, by the group name it carries - the only thing that tells two rows of the same
+ *  product apart. */
+function poolRow(itemLabel: string) {
+  return screen.getByRole('group', { name: itemLabel });
+}
+
+function renderWorkspace(mocks: MockedResponse[]) {
+  render(
+    <MockedProvider mocks={mocks}>
+      <ToastProvider>
+        <StagingWorkspace projectId={PROJECT_ID} />
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
+
+describe('splitting loose hardware', () => {
+  it('places only the quantity asked for, so a product can go into two containers', async () => {
+    // Four hinges, two into Box 1. Without a quantity control the whole staged amount goes in one
+    // container and the split is impossible.
+    const fired = vi.fn();
+    renderWorkspace([
+      poolMock({ looseItems: [looseRow()], containers: [container()] }),
+      setItemsMock('c-1', [looseInput(2)], fired),
+    ]);
+
+    const qty = await screen.findByRole('spinbutton', { name: 'Quantity of HG-100 for 101 to place' });
+    fireEvent.change(qty, { target: { value: '2' } });
+
+    fireEvent.mouseDown(within(poolRow('HG-100 for 101')).getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Box 1' }));
+
+    await waitFor(() => expect(fired).toHaveBeenCalled());
+  });
+
+  it('defaults to everything unplaced, which is the ordinary case', async () => {
+    const fired = vi.fn();
+    renderWorkspace([
+      poolMock({ looseItems: [looseRow()], containers: [container()] }),
+      setItemsMock('c-1', [looseInput(4)], fired),
+    ]);
+
+    await screen.findByText('HG-100 | HINGE');
+    fireEvent.mouseDown(within(poolRow('HG-100 for 101')).getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Box 1' }));
+
+    await waitFor(() => expect(fired).toHaveBeenCalled());
+  });
+
+  it('offers no quantity box for a single unit - there is nothing to split', async () => {
+    renderWorkspace([poolMock({ looseItems: [looseRow({ stagedQuantity: 1, unplacedQuantity: 1 })] })]);
+
+    await screen.findByText('HG-100 | HINGE');
+    expect(screen.queryByRole('spinbutton', { name: /to place/i })).not.toBeInTheDocument();
+  });
+
+  it('corrects a quantity already in a container without emptying the line first', async () => {
+    const fired = vi.fn();
+    const held = {
+      __typename: 'ShipmentContainerItem',
+      id: 'ci-1',
+      itemType: 'LOOSE',
+      openingItemId: null,
+      openingNumber: '101',
+      leaf: null,
+      hardwareCategory: 'HINGE',
+      productCode: 'HG-100',
+      quantity: 4,
+      position: 0,
+    };
+    renderWorkspace([
+      poolMock({ containers: [container({ items: [held] })] }),
+      setItemsMock('c-1', [looseInput(3)], fired),
+    ]);
+
+    const qty = await screen.findByRole('spinbutton', { name: /Quantity of HG-100 in Box 1/i });
+    fireEvent.change(qty, { target: { value: '3' } });
+
+    await waitFor(() => expect(fired).toHaveBeenCalled());
+  });
+
+  it('takes the line out when its quantity is corrected to zero', async () => {
+    const fired = vi.fn();
+    const held = {
+      __typename: 'ShipmentContainerItem',
+      id: 'ci-1',
+      itemType: 'LOOSE',
+      openingItemId: null,
+      openingNumber: '101',
+      leaf: null,
+      hardwareCategory: 'HINGE',
+      productCode: 'HG-100',
+      quantity: 4,
+      position: 0,
+    };
+    renderWorkspace([
+      poolMock({ containers: [container({ items: [held] })] }),
+      setItemsMock('c-1', [], fired),
+    ]);
+
+    const qty = await screen.findByRole('spinbutton', { name: /Quantity of HG-100 in Box 1/i });
+    fireEvent.change(qty, { target: { value: '0' } });
+
+    await waitFor(() => expect(fired).toHaveBeenCalled());
+  });
+});
+
+describe('two openings staging one product', () => {
+  it('shows them as separate rows, each naming its opening', async () => {
+    // They are separate quantities to the confirm, so merging them on screen would offer units the
+    // shipment would then refuse.
+    renderWorkspace([
+      poolMock({
+        looseItems: [looseRow({ openingNumber: '101' }), looseRow({ openingNumber: '102', stagedQuantity: 3, unplacedQuantity: 3 })],
+      }),
+    ]);
+
+    const rows = await screen.findAllByText('HG-100 | HINGE');
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText(/^101 ·/)).toBeInTheDocument();
+    expect(screen.getByText(/^102 ·/)).toBeInTheDocument();
+  });
+
+  it('places one openings units against that opening', async () => {
+    const fired = vi.fn();
+    renderWorkspace([
+      poolMock({
+        looseItems: [looseRow({ openingNumber: '101' }), looseRow({ openingNumber: '102', stagedQuantity: 3, unplacedQuantity: 3 })],
+        containers: [container()],
+      }),
+      setItemsMock('c-1', [looseInput(3, { openingNumber: '102' })], fired),
+    ]);
+
+    await screen.findByText(/^102 ·/);
+    fireEvent.mouseDown(within(poolRow('HG-100 for 102')).getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Box 1' }));
+
+    await waitFor(() => expect(fired).toHaveBeenCalled());
+  });
+});
+
+describe('sameLooseStock', () => {
+  const row = { openingNumber: '101', hardwareCategory: 'HINGE', productCode: 'HG-100' };
+  const base = {
+    id: 'ci-1',
+    itemType: 'LOOSE' as const,
+    openingItemId: null,
+    leaf: null,
+    quantity: 1,
+    position: 0,
+    ...row,
+  };
+
+  it('matches the same product owed to the same opening', () => {
+    expect(sameLooseStock(base, row)).toBe(true);
+  });
+
+  it('does not merge one openings units into another', () => {
+    expect(sameLooseStock({ ...base, openingNumber: '102' }, row)).toBe(false);
+  });
+
+  it('keeps unattributed stock separate from an attributed line', () => {
+    expect(sameLooseStock({ ...base, openingNumber: null }, row)).toBe(false);
+  });
+
+  it('never matches an assembled leaf', () => {
+    expect(sameLooseStock({ ...base, itemType: 'OPENING_ITEM' }, row)).toBe(false);
+  });
+});

--- a/frontend/src/modules/shipping/index.tsx
+++ b/frontend/src/modules/shipping/index.tsx
@@ -8,6 +8,7 @@ import ShipmentsList from './ShipmentsList';
 import ShippingCart from './ShippingCart';
 import ShippingRequestsPage from './ShippingRequestsPage';
 import ShipmentMethodsDialog from './ShipmentMethodsDialog';
+import StagingWorkspace from './StagingWorkspace';
 import ProjectLandingPage from '../../components/ProjectLandingPage';
 import GpSetupQuarantineBanner from '../../components/GpSetupQuarantineBanner';
 import type { Project } from '../../types/project';
@@ -23,7 +24,9 @@ export default function ShippingModule() {
     ? 'returns'
     : location.pathname.endsWith('/requests')
       ? 'requests'
-      : 'ship';
+      : location.pathname.endsWith('/staging')
+        ? 'staging'
+        : 'ship';
 
   if (selectedProject === null) {
     return (
@@ -64,6 +67,7 @@ export default function ShippingModule() {
             }}
           >
             <ToggleButton value="requests">Requests</ToggleButton>
+            <ToggleButton value="staging">Staging</ToggleButton>
             <ToggleButton value="ship">Ship</ToggleButton>
             <ToggleButton value="returns">Returns</ToggleButton>
           </ToggleButtonGroup>
@@ -82,6 +86,7 @@ export default function ShippingModule() {
       <GpSetupQuarantineBanner project={gpSetupProject} action="shipping from it" />
       <Routes>
         <Route path="requests" element={<ShippingRequestsPage projectId={projectId} />} />
+        <Route path="staging" element={<StagingWorkspace projectId={projectId} />} />
         <Route path="browse" element={<ShipReadyBrowser projectId={projectId} />} />
         <Route path="returns" element={<ShipmentsList projectId={projectId} />} />
         <Route index element={<Navigate to="browse" replace />} />

--- a/frontend/src/modules/shipping/staging.ts
+++ b/frontend/src/modules/shipping/staging.ts
@@ -82,6 +82,26 @@ export function canTakeAnotherLeaf(container: Container): boolean {
   return container.containerType !== 'SKID' || leafCount(container) < MAX_LEAVES_PER_SKID;
 }
 
+/**
+ * Whether a container line and a staged pool row are the same loose stock.
+ *
+ * The opening is part of it, not decoration. `get_ship_ready_items` groups the staged pool by
+ * (opening, category, product) and `confirmShipment` checks availability the same way, so two
+ * openings staging the same product are two separate quantities - merging them here would top up a
+ * line booked against the wrong door.
+ */
+export function sameLooseStock(
+  item: ContainerItem,
+  row: { openingNumber: string | null; hardwareCategory: string; productCode: string },
+): boolean {
+  return (
+    item.itemType === 'LOOSE' &&
+    item.openingNumber === row.openingNumber &&
+    item.hardwareCategory === row.hardwareCategory &&
+    item.productCode === row.productCode
+  );
+}
+
 /** The payload `setContainerItems` takes: the list order is what becomes `position`. */
 export function toItemsInput(items: ContainerItem[]) {
   return items.map((i) => ({

--- a/frontend/src/modules/shipping/staging.ts
+++ b/frontend/src/modules/shipping/staging.ts
@@ -1,0 +1,96 @@
+// The staging workspace's shapes and the two rules that are easier to read as functions than as
+// conditions buried in JSX (#451).
+
+export type ContainerType = 'SKID' | 'DOOR_CART' | 'BOX' | 'ENVELOPE' | 'BUNDLE';
+
+/** A skid loaded higher than this cannot be strapped safely. Mirrors MAX_LEAVES_PER_SKID server-side. */
+export const MAX_LEAVES_PER_SKID = 30;
+
+export const CONTAINER_TYPE_LABEL: Record<ContainerType, string> = {
+  SKID: 'Skid',
+  DOOR_CART: 'Door cart',
+  BOX: 'Box',
+  ENVELOPE: 'Envelope',
+  BUNDLE: 'Bundle',
+};
+
+/**
+ * The two container types loaded in a sequence somebody reverses at the far end, and therefore the
+ * only two where the order on screen means anything physical. A box of loose parts is a set.
+ */
+export function isStacked(type: ContainerType): boolean {
+  return type === 'SKID' || type === 'DOOR_CART';
+}
+
+export interface ContainerItem {
+  id: string;
+  itemType: 'LOOSE' | 'OPENING_ITEM';
+  openingItemId: string | null;
+  openingNumber: string | null;
+  leaf: number | null;
+  hardwareCategory: string;
+  productCode: string;
+  quantity: number;
+  position: number;
+}
+
+export interface Container {
+  id: string;
+  projectId: string;
+  containerType: ContainerType;
+  name: string;
+  packingSlipId: string | null;
+  createdBy: string;
+  items: ContainerItem[];
+}
+
+export interface StagedLeaf {
+  openingItemId: string;
+  openingNumber: string;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  placedInContainerId: string | null;
+}
+
+export interface StagedLooseItem {
+  openingNumber: string | null;
+  hardwareCategory: string;
+  productCode: string;
+  stagedQuantity: number;
+  placedQuantity: number;
+  unplacedQuantity: number;
+}
+
+export interface StagingPool {
+  leaves: StagedLeaf[];
+  looseItems: StagedLooseItem[];
+  containers: Container[];
+}
+
+/** How many door leaves a container is carrying - the number a skid's 30 cap is measured against. */
+export function leafCount(container: Container): number {
+  return container.items.filter((i) => i.itemType === 'OPENING_ITEM').length;
+}
+
+/**
+ * Whether one more leaf will fit. Only a skid has a ceiling; the others are bounded by what the
+ * warehouse can physically get on them, which is not something the system can know.
+ */
+export function canTakeAnotherLeaf(container: Container): boolean {
+  return container.containerType !== 'SKID' || leafCount(container) < MAX_LEAVES_PER_SKID;
+}
+
+/** The payload `setContainerItems` takes: the list order is what becomes `position`. */
+export function toItemsInput(items: ContainerItem[]) {
+  return items.map((i) => ({
+    itemType: i.itemType,
+    openingItemId: i.openingItemId,
+    openingNumber: i.openingNumber,
+    leaf: i.leaf,
+    hardwareCategory: i.hardwareCategory,
+    productCode: i.productCode,
+    quantity: i.quantity,
+  }));
+}

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -316,6 +316,27 @@ rest with `classification = null`. Anything reading Site/Shop - the #451 coverag
 shop-assembly filter - then sees them as unclassified. Re-run the PO purpose over the opening and
 classify the whole grid to restore it.
 
+### A stacked PR gets NO CI, and backend tests are the thing you lose
+
+`.github/workflows/ci.yml` triggers on `push`/`pull_request` to **master only**. A PR based on
+another feature branch - the shape a stack of dependent PRs takes - therefore runs no Frontend, no
+Backend, no Migration Integrity and no Relay job at all. `gh pr checks` on it shows only the two
+Railway deploys, both green, which reads exactly like a healthy PR.
+
+That matters most for the backend, because there is no local Postgres: `pytest` skips ~470 of ~600
+tests here, so CI is the only thing that ever runs them. A stacked backend change is effectively
+unverified until it reaches master.
+
+The cheap fix is a throwaway **draft PR from the top of the stack to master**, which runs the whole
+stack's suite in one go; close it once green. Done on the #451 stack (PR #466) and it immediately
+caught two failures that all three stacked PRs were reporting as clean:
+
+- migration 083 creating its enum twice, because the column referenced a bare `postgresql.ENUM`,
+  which emits its own `CREATE TYPE` during `create_table` on top of the explicit `.create()`. Fresh
+  database -> `DuplicateObject` -> Migration Integrity dead AND every backend test dead, since they
+  all build the schema. Pass `create_type=False` on the column's reference.
+- a delivery-request fixture one field short after `DELIVERY_REQUEST_FIELDS` grew.
+
 ## Getting Started (Every Session)
 
 0. **Pick the environment first.** Testing runs against the PR environment for the PR you are working on. Set `PR` once and let both URLs derive from it, so there is no production URL in the snippet to fat-finger:


### PR DESCRIPTION
phase 3 of #451, last one. stacked on #464 (phase 4), which is stacked on #463 (phases 1 and 2) - review those first.

shipping out went straight from "these units are ship-ready" to a packing slip. the work in between - stacking a skid in an order the site can unload, building a shipment up over days out of several containers - happened on the floor and was recorded nowhere, so nobody could see what was already loaded without walking to it.

new `ShipmentContainer` and `ShipmentContainerItem`, named by whoever loads it because the label goes on the physical thing in marker. a container is one of:
skid
door cart
box
envelope
bundle

`packingSlipId` carries the whole lifecycle, no status column - the only question ever asked is "has this left":
- null while being built
- stamped when its shipment is confirmed
- history from then on

placement enforces three ceilings, all about physical objects rather than policy:
- 30 leaves to a skid, because a taller stack cannot be strapped
- one leaf in one open container, because there is one of it
- loose placements bounded by what is staged and unplaced, counting what other open containers hold

re-saving a container is measured with its own units added back, so saving unchanged or trimming is never refused for what it already holds - the same release-before-measure trap the request edit had in phase 2.

`setContainerItems` is one batch call, not place + remove + reorder as three: a drag-and-drop surface already holds the whole list, and saving it in pieces leaves a moment where the stack is in an order nobody chose. list index IS the position, position 0 loaded first -> bottom of a skid.

`confirmShipmentFromContainers` is a thin wrapper over `confirmShipment` rather than a second confirm path, because that function still owns:
quarantine gate
slip-number uniqueness check
SHIP_READY transition
loose arithmetic

wrapper adds only where items come from, plus stamping the slip onto the containers afterwards.

staging pool is one query, not two. left column reads `unplaced*`, container cards read `containers`; two queries could disagree about whether a leaf has been loaded, which is the exact mistake containers exist to prevent.

new Staging tab in the Shipping module. drag to place and to restack, with an equal control beside every item - a "Place in" menu on each pool row, up/down buttons in each stack. the buttons are not a fallback bolted on for compliance: this screen is worked on a tablet in a warehouse, and a drag that misses puts a door leaf on the wrong skid, where the undo is walking to the rack.

a skid shows n/30 and refuses the 31st leaf client-side with a toast as well as server-side. confirm dialog prints each container's stack in order, so the driver and the site read the same thing.

cart untouched on the Ship tab, retired in the follow-up that moves its last consumer over - shipping has to keep working while both exist.

`stagingPool` and the five container mutations are all SIGNED_IN. one migration, 083, additive, reuses the `pull_request_item_type` enum rather than creating a second one.

`backend/tests/test_shipment_containers.py` covers:
open-name uniqueness
blank name
breaking down returns contents to the pool
unstaged leaf refused
one leaf in two containers refused
same leaf twice in one container refused
skid 30 cap
door cart has no cap
loose over-placement refused
another container's placement counting against what is free
re-saving not gated against its own units
position from list order
reordering
emptying allowed
shipping stamps the slip, closes the containers, flips the leaf to SHIPPED_OUT
empty container refused
shipping nothing refused
shipped container refuses edit/delete/rename
container from another project refused

simulated user testing not yet run against a PR environment. once one is up, with a project that has staged hardware:

1. Shipping -> Staging -> add "Skid 1" (Skid) and "Box 1" (Box)
2. drag a door leaf onto Skid 1, use the Place in menu for a second - both leave the pool
3. reorder the skid by dragging, then with the up/down buttons - numbers renumber
4. put loose hardware in Box 1 - pool row's unplaced count drops
5. tick both containers, Ship - dialog lists both, skid in stack order
6. confirm, check Shipments shows the slip and Staging no longer lists either container
7. place a leaf already on Skid 1 into Box 1 - refused, naming the container holding it
