### PR TITLE
chore(test): throwaway PR to spawn a preview environment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,5 @@
+# Throwaway marker: exists only so this PR touches backend/ and Railway spawns a backend service in
+# the preview environment. Delete with the PR.
 FROM python:3.11-slim
 
 WORKDIR /app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,5 @@
+# Throwaway marker: exists only so this PR touches frontend/ and Railway spawns a frontend service in
+# the preview environment. Delete with the PR.
 FROM node:20-alpine AS build
 
 WORKDIR /app


### PR DESCRIPTION
throwaway. spawns a Railway preview env for a probing session against master, close without merging once done.

comment-only touch to
backend/Dockerfile
frontend/Dockerfile

Railway's root-directory change filtering only deploys services whose directory the PR touches - touching one leaves the other with latestDeployment null.

#474 carries the previous session's findings, not addressed here.