### PR TITLE
fix(warehouse): dashboard resolver required field, back-order vendor, receive review fixes

### DIFF
--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -583,7 +583,9 @@ def get_back_ordered_items(session: Session, project_id: uuid.UUID | None = None
         select(
             POLineItemModel,
             POModel.po_number,
-            VendorModel.name,
+            # The fallback po_to_type applies everywhere a vendor is named: the snapshot taken at GP
+            # push time, and the local vendor row only for POs old enough to predate that column.
+            func.coalesce(POModel.vendor_name_snapshot, VendorModel.name),
             POModel.expected_delivery_date,
             ProjectModel.description,
             ProjectModel.project_id,

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -682,6 +682,7 @@ class WarehouseQueries:
                 received_last_7_days=d["received_last_7_days"],
                 back_ordered_count=d["back_ordered_count"],
                 deficient_count=d["deficient_count"],
+                pending_receive_draft_count=d["pending_receive_draft_count"],
             )
 
     @strawberry.field

--- a/backend/tests/test_back_ordered_items.py
+++ b/backend/tests/test_back_ordered_items.py
@@ -1,0 +1,92 @@
+"""backOrderedItems names the vendor the way every other PO view does (#474).
+
+A GP-registered PO carries its vendor as `vendor_name_snapshot` - the GP vendor picked live at push
+time - and has no Nexus vendor row at all, which is the normal case now. The back-order query
+selected only `Vendor.name` off its outer join, so the Back-Ordered Items grid showed a blank vendor
+for the very PO that POs Awaiting Receipt named correctly on the same page. The read is now the same
+coalesce `po_to_type` and the receiving history use: the snapshot first, the local vendor row only
+for POs old enough to predate that column.
+"""
+
+import uuid
+from decimal import Decimal
+
+from app.models.enums import POStatus
+from app.models.project import Project
+from app.models.purchase_order import POLineItem, PurchaseOrder
+from app.models.vendor import Vendor
+from app.repositories import warehouse as warehouse_repository
+
+
+def _make_project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def _make_back_ordered_po(session, project_id, *, vendor_id=None, vendor_name_snapshot=None):
+    po = PurchaseOrder(
+        id=uuid.uuid4(),
+        request_number=f"REQ-{uuid.uuid4().hex[:8]}",
+        project_id=project_id,
+        status=POStatus.GP_REGISTERED,
+        po_number=f"PO{uuid.uuid4().hex[:6]}",
+        gp_company="TEST",
+        vendor_id=vendor_id,
+        vendor_name_snapshot=vendor_name_snapshot,
+    )
+    session.add(po)
+    session.flush()
+    session.add(
+        POLineItem(
+            id=uuid.uuid4(),
+            po_id=po.id,
+            hardware_category="HINGE",
+            product_code="HG-100",
+            ordered_quantity=10,
+            received_quantity=0,
+            unit_cost=Decimal("1.00"),
+            gp_line_ord=1,
+        )
+    )
+    session.flush()
+    return po
+
+
+def _vendor_shown_for(session, po, project_id):
+    rows = warehouse_repository.get_back_ordered_items(session, project_id)
+    matches = [r for r in rows if r["po_line_item"].po_id == po.id]
+    assert matches, f"expected a back-ordered row for {po.po_number}"
+    return matches[0]["vendor_name"]
+
+
+def test_gp_snapshot_names_the_vendor_without_a_local_row(db_session):
+    """The regression: a GP-registered PO has no Nexus vendor row, only the snapshot, and the grid
+    showed nothing at all for it."""
+    project = _make_project(db_session)
+    po = _make_back_ordered_po(db_session, project.id, vendor_name_snapshot="GALLERY SPECIALTY HARDWARE LTD")
+
+    assert _vendor_shown_for(db_session, po, project.id) == "GALLERY SPECIALTY HARDWARE LTD"
+
+
+def test_a_pre_snapshot_po_still_falls_back_to_its_local_vendor_row(db_session):
+    """POs old enough to predate the snapshot column keep being named off the joined vendor row."""
+    project = _make_project(db_session)
+    vendor = Vendor(id=uuid.uuid4(), name="Acme Doors")
+    db_session.add(vendor)
+    db_session.flush()
+    po = _make_back_ordered_po(db_session, project.id, vendor_id=vendor.id)
+
+    assert _vendor_shown_for(db_session, po, project.id) == "Acme Doors"
+
+
+def test_the_snapshot_wins_over_the_local_row(db_session):
+    """Same precedence as po_to_type: what was pushed to GP is what the PO is named by."""
+    project = _make_project(db_session)
+    vendor = Vendor(id=uuid.uuid4(), name="Stale Local Name")
+    db_session.add(vendor)
+    db_session.flush()
+    po = _make_back_ordered_po(db_session, project.id, vendor_id=vendor.id, vendor_name_snapshot="GP VENDOR LTD")
+
+    assert _vendor_shown_for(db_session, po, project.id) == "GP VENDOR LTD"

--- a/backend/tests/test_warehouse_dashboard.py
+++ b/backend/tests/test_warehouse_dashboard.py
@@ -4,16 +4,25 @@ The Deficient Items card showed `back_ordered_count` (undelivered PO-line units,
 concept) while linking to the review screen for damaged/short-shipped units. `deficient_count`
 counts what that screen actually lists: deficient units across project inventory and the stock
 pool.
+
+The resolver-level test exists because this file used to stop at the repository, and that gap
+shipped a broken dashboard (#474): the repository grew `pending_receive_draft_count`, the Strawberry
+type declared it required, and the resolver's constructor never passed it - so every
+warehouseDashboard call raised, and no test noticed.
 """
 
+import asyncio
 import uuid
 from datetime import datetime
 
+from app import auth
 from app.models.inventory import InventoryLocation
 from app.models.project import Project
 from app.models.stock_item import StockItem
-from app.repositories import warehouse_admin_repository
+from app.repositories import user_repository, warehouse_admin_repository
 from app.repositories.warehouse import progress
+from app.schemas import warehouse as warehouse_schema_module
+from main import schema
 
 
 def _make_project(session) -> Project:
@@ -87,3 +96,42 @@ def test_deficient_count_sums_project_inventory_and_stock_pool(db_session):
 
     dashboard = progress.get_warehouse_dashboard(session)
     assert dashboard["deficient_count"] == baseline + 5
+
+
+class _FakeRequest:
+    def __init__(self, token: str):
+        self.headers = {"authorization": f"Bearer {token}"}
+
+
+def _camel(name: str) -> str:
+    head, *rest = name.split("_")
+    return head + "".join(w.capitalize() for w in rest)
+
+
+def test_the_resolver_carries_every_field_the_repository_returns(db_session, monkeypatch):
+    """Runs the real query through the real schema and compares against the repository dict, field
+    for field. The selection set is built from the schema's own WarehouseDashboard fields, so a
+    future field added to the type but dropped from the resolver's constructor fails here without
+    this test ever being edited - which is exactly how #474 got out."""
+    monkeypatch.setattr(auth, "verify_clerk_token", lambda token: {"sub": "u_dashboard"})
+    monkeypatch.setattr(user_repository, "get_user_roles", lambda user_id: [])
+
+    class _BorrowedSession:
+        """Hands the resolver the test's transaction-bound session instead of a fresh one, so it
+        reads the same uncommitted state and the rollback teardown still owns everything."""
+
+        def __enter__(self):
+            return db_session
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(warehouse_schema_module, "SessionLocal", _BorrowedSession)
+
+    field_names = list(schema._schema.type_map["WarehouseDashboard"].fields)
+    query = f"query {{ warehouseDashboard {{ {' '.join(field_names)} }} }}"
+    result = asyncio.run(schema.execute(query, context_value={"request": _FakeRequest("tok")}))
+
+    assert result.errors is None, result.errors
+    expected = progress.get_warehouse_dashboard(db_session)
+    assert result.data["warehouseDashboard"] == {_camel(k): v for k, v in expected.items()}

--- a/frontend/src/modules/warehouse/ReceiveDraftReviewModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveDraftReviewModal.tsx
@@ -44,6 +44,7 @@ import {
 } from './receiveLines';
 import type { ReceiveDraft } from './receiveDraftTypes';
 import { monoSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
 
 interface WarehouseOption {
   id: string;
@@ -341,7 +342,7 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
         disableEscapeKeyDown={isDirty && !succeeded}
       >
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Counted by <strong>{draft.createdBy}</strong> on {new Date(draft.createdAt).toLocaleString()}
+          Counted by <strong>{draft.createdBy}</strong> on {parseServerDate(draft.createdAt).toLocaleString()}
           {draft.totalQuantity > 0 && ` · ${draft.totalQuantity} units submitted`}
         </Typography>
 

--- a/frontend/src/modules/warehouse/ReceiveLinesEditor.tsx
+++ b/frontend/src/modules/warehouse/ReceiveLinesEditor.tsx
@@ -8,6 +8,7 @@ import {
   MAX_LOC_LEN,
   draftsForLine,
   emptyDraft,
+  locationIncomplete,
   type LocationDraft,
   type PODetailLineItem,
   type PODetails,
@@ -221,6 +222,10 @@ export default function ReceiveLinesEditor({
     const drafts = draftsFor(li.id, receiveNow);
     const placed = drafts.reduce((s, d) => s + (Number(d.quantity) || 0), 0);
     const remaining = receiveNow - placed;
+    // "all placed" only when the line would actually pass validatePutAway's location check -
+    // quantities that add up with Aisle/Row/Bay still blank used to claim done while submit stayed
+    // disabled with nothing saying why (#474).
+    const needsLocation = remaining === 0 && drafts.some(locationIncomplete);
     return (
       <Paper key={li.id} variant="outlined" sx={{ p: 1.5 }}>
         <Box
@@ -240,9 +245,9 @@ export default function ReceiveLinesEditor({
           </Typography>
           <Typography
             variant="caption"
-            sx={{ ...microLabelSx, color: remaining === 0 ? 'success.main' : 'error.main' }}
+            sx={{ ...microLabelSx, color: remaining === 0 && !needsLocation ? 'success.main' : 'error.main' }}
           >
-            {remaining === 0 ? 'all placed' : `${remaining} unplaced`}
+            {remaining !== 0 ? `${remaining} unplaced` : needsLocation ? 'needs aisle · row · bay' : 'all placed'}
           </Typography>
         </Box>
         <Stack spacing={1}>

--- a/frontend/src/modules/warehouse/__tests__/ReceiveDraftReviewModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveDraftReviewModal.test.tsx
@@ -430,4 +430,41 @@ describe('ReceiveDraftReviewModal', () => {
     expect(screen.getByText('Max: 3')).toBeInTheDocument();
     expect(approveButton()).toBeDisabled();
   });
+
+  it('names what put-away still needs instead of claiming all placed over blank rack fields', async () => {
+    // Quantities that sum correctly used to be the whole of "all placed" - blank the Aisle and the
+    // caption kept claiming done while approval stayed disabled with nothing saying why (#474).
+    await openModal();
+
+    fireEvent.change(screen.getByLabelText('Aisle'), { target: { value: '' } });
+
+    expect(screen.getByText('needs aisle · row · bay')).toBeInTheDocument();
+    expect(screen.queryByText('all placed')).toBeNull();
+    expect(approveButton()).toBeDisabled();
+  });
+
+  describe('the counted-at timestamp (#474)', () => {
+    // The backend serializes naive UTC with no zone suffix, and new Date() reads that as LOCAL -
+    // this modal showed a 3:48 PM count as 7:48 PM while the approvals queue, which parses through
+    // parseServerDate, showed it right. Forced behind UTC per the serverDate.test.ts pattern,
+    // because on a UTC runner the buggy parse and the fixed one agree and the test proves nothing.
+    const ORIGINAL_TZ = process.env.TZ;
+    beforeAll(() => {
+      process.env.TZ = 'America/Toronto';
+    });
+    afterAll(() => {
+      process.env.TZ = ORIGINAL_TZ;
+    });
+
+    it('renders the zoneless server instant as UTC converted to local', async () => {
+      // Not ceremony: if the forced zone stops taking effect, this fails rather than the test
+      // silently passing against the bug. August, so the offset is EDT's 240.
+      expect(new Date(2026, 7, 1).getTimezoneOffset()).toBe(240);
+
+      await openModal([], draft({ createdAt: '2026-08-02T19:48:32' }));
+
+      const expected = new Date('2026-08-02T19:48:32Z').toLocaleString();
+      expect(screen.getByText(/Counted by/)).toHaveTextContent(`on ${expected}`);
+    });
+  });
 });

--- a/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
@@ -274,7 +274,11 @@ describe('ReceiveModal', () => {
 
     setReceiveQty('3');
     expect(screen.getByText(/placing 3/)).toBeInTheDocument();
-    // row fields still blank, so put-away is incomplete
+    // Row fields still blank, so put-away is incomplete - and the caption says so. The quantity
+    // defaults to the full count, so this used to read "all placed" while submit stayed disabled
+    // with nothing naming what was missing (#474).
+    expect(screen.getByText('needs aisle · row · bay')).toBeInTheDocument();
+    expect(screen.queryByText('all placed')).toBeNull();
     expect(submitButton()).toBeDisabled();
 
     fillLocation(0, 'A1', 'B2', 'C3');

--- a/frontend/src/modules/warehouse/receiveLines.ts
+++ b/frontend/src/modules/warehouse/receiveLines.ts
@@ -72,6 +72,12 @@ export function draftsForLine(
   return lineLocations[lineId] ?? [emptyDraft(receiveNow)];
 }
 
+/** A row without all three rack coordinates cannot be put away. Shared with the editor's per-line
+ *  status caption, so what the caption calls done is exactly what validatePutAway will accept. */
+export function locationIncomplete(d: LocationDraft): boolean {
+  return !d.aisle.trim() || !d.row.trim() || !d.bay.trim();
+}
+
 /**
  * Put-away is mandatory: every received unit must land in a valid row and each row's deficient count
  * must be within its quantity. Mirrors the backend contract in warehouse_repository.create_receive
@@ -88,7 +94,7 @@ export function validatePutAway(
     for (const d of draftsForLine(lineLocations, li.id, receiveNow)) {
       const q = Number(d.quantity);
       const def = Number(d.deficient || '0');
-      if (!d.aisle.trim() || !d.row.trim() || !d.bay.trim()) return false;
+      if (locationIncomplete(d)) return false;
       if (!Number.isInteger(q) || q < 1) return false;
       if (!Number.isInteger(def) || def < 0 || def > q) return false;
       placed += q;


### PR DESCRIPTION
Fixes #474.

three defects from the pr-472 sweep, plus the put-away chip item.

warehouseDashboard resolver dropped `pending_receive_draft_count`. repository returns it since #455, Strawberry type requires it, resolver constructor omitted it. constructor now passes it. new resolver-level test executes the real query through the real schema and compares field-for-field against the repository dict; its selection set is built from the schema's own WarehouseDashboard fields, so a future field added to the type but dropped from the constructor fails the test without the test being edited.

Back-Ordered Items blanked the vendor. back-order query selected bare `Vendor.name` off its outer join; po_to_type and receiving history coalesce `vendor_name_snapshot` first. a GP-registered PO has no Nexus vendor row at all now that GP vendors are picked live at registration. now the same coalesce. new tests cover
snapshot with no local row
pre-snapshot fallback to the vendor row
snapshot precedence when both exist

receive approval modal rendered UTC as local time. ReceiveDraftReviewModal formatted `draft.createdAt` with `new Date(...).toLocaleString()`. now parses through `parseServerDate` (#399). new test forces TZ=America/Toronto per the serverDate.test.ts pattern.

put-away chip claimed "all placed" over blank rack fields. caption checked only that row quantities summed to the received count; validatePutAway also requires aisle/row/bay on every row. location check extracted into `locationIncomplete()`, shared by validatePutAway and the caption; caption now reads "needs aisle · row · bay" for that state. applies to both the receive count modal and the review modal via shared ReceiveLinesEditor.
