### PR TITLE
ci: guard against ai attribution in commits

### DIFF
--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -1,5 +1,11 @@
 name: no-ai-attribution
 
+# Fails when a commit MESSAGE or author/committer IDENTITY mentions the vendor.
+#
+# Scope is deliberately limited to text that lands in a github text field.
+# File contents and path names are OUT of scope, so a tracked CLAUDE.md or a
+# .claude/ entry is fine and is never flagged.
+
 on:
   pull_request:
   push:
@@ -15,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: scan commits and changed content
+      - name: scan commit messages and identities
         env:
           EV: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
@@ -25,56 +31,51 @@ jobs:
         run: |
           # Actions invokes this with `bash -e`. Combined with pipefail, a grep
           # that matches nothing (exit 1) is the CLEAN case but would abort the
-          # script, so every grep-in-assignment below ends with `|| true`.
+          # script, so the grep-in-assignment below ends with `|| true`.
           set -uo pipefail
 
-          # Vendor tokens are stored encoded so this file does not match its own rule.
-          T1=$(printf '%s' 'Y2xhdWRl' | base64 -d)
-          T2=$(printf '%s' 'YW50aHJvcGlj' | base64 -d)
-          PAT="$T1|$T2"
+          PAT='claude|anthropic'
 
           if [ "$EV" = "pull_request" ]; then
             base=$(git merge-base "$PR_BASE" "$PR_HEAD" 2>/dev/null || echo "$PR_BASE")
             head="$PR_HEAD"
           elif [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            base=$(git rev-list --max-parents=0 "$PUSH_AFTER" | tail -1)
+            # New branch: only inspect commits not already on another remote ref,
+            # so a fresh branch is not judged for the whole repo's history.
+            base=""
             head="$PUSH_AFTER"
           else
             base="$PUSH_BEFORE"
             head="$PUSH_AFTER"
           fi
 
-          range=$(git rev-list "$base..$head" 2>/dev/null || echo "")
-          failed=0
+          if [ -n "$base" ]; then
+            range=$(git rev-list "$base..$head" 2>/dev/null || echo "")
+          else
+            range=$(git rev-list "$head" --not --remotes=origin --max-count=200 2>/dev/null || echo "")
+          fi
 
-          # 1. commit messages + author/committer identity
+          if [ -z "$range" ]; then
+            echo "no new commits to scan"
+            exit 0
+          fi
+
+          failed=0
           for c in $range; do
             meta=$(git show -s --format='%an <%ae>%n%cn <%ce>%n%B' "$c")
             bad=$(echo "$meta" | grep -inE "$PAT" | head -3 || true)
             if [ -n "$bad" ]; then
-              echo "::error::commit $(git show -s --format='%h %s' "$c")"
+              echo "::error::$(git show -s --format='%h %s' "$c")"
               echo "$bad" | sed 's/^/    /'
               failed=1
             fi
           done
 
-          # 2. added lines in changed files
-          added=$(git diff -U0 "$base" "$head" 2>/dev/null \
-            | awk '/^\+\+\+ /{f=substr($0,7)} /^\+[^+]/{print f"|"substr($0,2)}' \
-            | grep -iE "$PAT" | head -25 || true)
-
-          if [ -n "$added" ]; then
-            echo "$added" | while IFS='|' read -r f line; do
-              echo "::error file=$f::disallowed vendor reference in added line: $(printf '%s' "$line" | cut -c1-120)"
-            done
-            failed=1
-          fi
-
           if [ "$failed" -eq 1 ]; then
             echo ""
-            echo "Lines above reference a disallowed vendor token. Remove them before merging."
+            echo "Commit messages above reference the vendor. Reword them and force-push."
             exit 1
           fi
 
           n=$(echo "$range" | grep -c . || true)
-          echo "clean - ${n:-0} commit(s) scanned"
+          echo "clean - ${n:-0} commit message(s) scanned"

--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -1,0 +1,80 @@
+name: no-ai-attribution
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: scan commits and changed content
+        env:
+          EV: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          # Actions invokes this with `bash -e`. Combined with pipefail, a grep
+          # that matches nothing (exit 1) is the CLEAN case but would abort the
+          # script, so every grep-in-assignment below ends with `|| true`.
+          set -uo pipefail
+
+          # Vendor tokens are stored encoded so this file does not match its own rule.
+          T1=$(printf '%s' 'Y2xhdWRl' | base64 -d)
+          T2=$(printf '%s' 'YW50aHJvcGlj' | base64 -d)
+          PAT="$T1|$T2"
+
+          if [ "$EV" = "pull_request" ]; then
+            base=$(git merge-base "$PR_BASE" "$PR_HEAD" 2>/dev/null || echo "$PR_BASE")
+            head="$PR_HEAD"
+          elif [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            base=$(git rev-list --max-parents=0 "$PUSH_AFTER" | tail -1)
+            head="$PUSH_AFTER"
+          else
+            base="$PUSH_BEFORE"
+            head="$PUSH_AFTER"
+          fi
+
+          range=$(git rev-list "$base..$head" 2>/dev/null || echo "")
+          failed=0
+
+          # 1. commit messages + author/committer identity
+          for c in $range; do
+            meta=$(git show -s --format='%an <%ae>%n%cn <%ce>%n%B' "$c")
+            bad=$(echo "$meta" | grep -inE "$PAT" | head -3 || true)
+            if [ -n "$bad" ]; then
+              echo "::error::commit $(git show -s --format='%h %s' "$c")"
+              echo "$bad" | sed 's/^/    /'
+              failed=1
+            fi
+          done
+
+          # 2. added lines in changed files
+          added=$(git diff -U0 "$base" "$head" 2>/dev/null \
+            | awk '/^\+\+\+ /{f=substr($0,7)} /^\+[^+]/{print f"|"substr($0,2)}' \
+            | grep -iE "$PAT" | head -25 || true)
+
+          if [ -n "$added" ]; then
+            echo "$added" | while IFS='|' read -r f line; do
+              echo "::error file=$f::disallowed vendor reference in added line: $(printf '%s' "$line" | cut -c1-120)"
+            done
+            failed=1
+          fi
+
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "Lines above reference a disallowed vendor token. Remove them before merging."
+            exit 1
+          fi
+
+          n=$(echo "$range" | grep -c . || true)
+          echo "clean - ${n:-0} commit(s) scanned"


### PR DESCRIPTION
blocks commits carrying ai attribution from landing on any branch.

scans each commit in a pr or push for:
- co-author trailers naming an assistant, which create a contributor entry on the repo
- assistant session links
- generated-with lines
- assistant name in the author or committer identity

fails with the offending shas listed. mirrors the local commit-msg and pre-push hooks so the rule holds server-side too.
