### PR TITLE
docs(testing): split PR-environment setup out of the knowledgebase, with a runbook and a script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ monorepo layout
 - backend/ - Python 3.11, FastAPI + Strawberry GraphQL + SQLAlchemy 2.0 + Alembic, deploys to Railway
 - frontend/ - React 19, TypeScript, Vite, Apollo Client 4, MUI 7, Tailwind CSS 4, deploys to Railway
 - relay/ - on-prem exe bridging UC Nexus to Microsoft Dynamics GP via eConnect, see relay/README.md
-- testing/ - simulated user testing knowledgebase
+- testing/ - simulated user testing: PR-ENVIRONMENT.md to set an environment up, CLAUDE.md for the knowledgebase
 - docs/ - design docs
 
 frontend and backend talk through a single /graphql endpoint.

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This is a tester's knowledge journal for UC Nexus. It documents how the app works from a front-end user's perspective and how to drive it via Chrome DevTools MCP.
 
+> **Setting an environment up is a different document: [PR-ENVIRONMENT.md](PR-ENVIRONMENT.md).**
+> Getting a PR environment into a state you can click through - the relay channel above all, without
+> which there are no projects and so almost nothing is reachable - lives there, with a runbook and
+> `scripts/connect-pr-env.ps1`. Read it first; this file is what you need *during* a session, not
+> what you do to start one.
+
 **Maintain this file:** Update it when you discover new behaviors, gotchas, or workflows during testing. This is a living document that grows with each testing session.
 
 ---
@@ -70,55 +76,6 @@ Consequences when driving the app by script:
   the warehouse CRUD, `overrideInventoryQuantity`, `mergeLocations`.
 - `require_admin` costs a Clerk Backend API round-trip per call (`require_user` does not), so a page
   hitting several admin resolvers at once is legitimately slower than the equivalent user page.
-
-### A PR environment is relay-disconnected by default, and that is useful
-
-By default a PR environment always reports `relayStatus.connected: false`, and no amount of waiting
-changes it. Two independent reasons, both addressed by #414 but neither automatic:
-
-1. The relay dials whatever `[channel] backend_url` in its `config.toml` names. Since #414 that takes
-   a LIST, so a PR backend can be added *alongside* production rather than replacing it - but somebody
-   has to add it, and the relay needs a restart to pick it up.
-2. Relay installs live in Postgres and a PR environment boots a fresh empty one, so the handshake is
-   refused (4403) even if the relay does dial. Since #414 the backend seeds a trusted install on
-   startup from `RELAY_SEED_SECRET_HASH` - the SHA-256 already in production's row, copyable from
-   Admin -> Relay Installs ("Seed hash" column). Where that variable goes is the part that catches
-   people out (#431):
-   - It belongs on the **production** backend service and stays there inert. PR environments are cloned
-     from production, so that is the only place a new one can inherit it from; production refuses to
-     seed and logs the refusal at INFO, which is the intended steady state, not something to tidy up.
-   - **Inheritance happens at environment creation only.** Setting it on production does nothing for a
-     PR environment that already exists - set it on that environment's own backend service as well.
-     Verified 2026-07-30: pr-430 predated the variable and stayed GP-blind until it had its own copy.
-   - Seeding runs at backend startup, so the variable only takes effect on that service's next deploy.
-
-Read the default state as a free test fixture rather than a limitation. The relay-down half of any
-GP-gated feature - disabled controls, "not connected" copy, held values still displaying, buttons that
-must not be clickable - is exactly what a PR environment exercises by construction, and it is the half
-that is otherwise awkward to reach on production without stopping the relay for everyone.
-
-A PR environment with a connected relay is pinned to **TUBC** and refuses every other company with
-`company_not_allowed_on_channel`, reads and writes alike. Reads and writes both work against TUBC;
-that pin is what makes serving writes off a test backend acceptable at all.
-
-What a PR environment cannot show out of the box is a NEW op. The workstation runs a packaged build, so
-a PR that adds to `_OPS` answers `unknown_op` -> `RELAY_OP_UNSUPPORTED` there just as it does on
-production before the relay is rebuilt (its own distinct UI state, worth checking on purpose during the
-deploy-before-rebuild window). To exercise the op itself, build the PR's branch with
-`gh workflow run relay-release.yml --ref <branch>` and install that zip on the workstation for the
-session - the full procedure, including how the release build gets restored afterwards, is the
-"testing a PR that adds a new op" section of `relay/README.md`. It is a manual install by design.
-
-Verified on PR #412 (issue #409's buyer dropdown), in the default disconnected state: the field
-rendered `role="combobox"`, disabled, still showing the stored `mira`, with "The GP relay is not
-connected, so this cannot be changed right now." - all four assertions met without touching production.
-
-Seeding verified live on PR #421 (#414 itself), against that PR's own environment: setting
-`RELAY_SEED_SECRET_HASH` produced exactly one install row labelled `seed:uc-nexus-pr-<N>` (company
-TUBC, ENROLLED), the Seed hash cell truncated to 8 chars with a copy button carrying the full 64-char
-digest, a provisioned-but-unenrolled row showing `—` and no button, and a second full redeploy still
-leaving exactly one seeded row. Note the label takes `RAILWAY_ENVIRONMENT_NAME` verbatim, which on a
-PR environment is `uc-nexus-pr-<N>` rather than `pr-<N>`.
 
 ### Inventory can only be seeded through the relay - check this first
 

--- a/testing/PR-ENVIRONMENT.md
+++ b/testing/PR-ENVIRONMENT.md
@@ -1,0 +1,128 @@
+# Setting up a PR test environment
+
+How to get a UC Nexus PR environment into a state you can actually click through, and what it can and
+cannot show you. Read this **before** a testing session; the module-by-module knowledge you need
+*during* one is in [CLAUDE.md](CLAUDE.md) alongside it.
+
+Separate from that file on purpose: this is a procedure invalidated by infrastructure changes, and it
+went stale silently once already - it claimed for months that adding a relay channel needed a restart,
+which stopped being true at #456 and cost a session. Anything here that describes relay behaviour
+should cite the code it came from so a reader can check rather than trust.
+
+**Every open, non-draft PR gets an environment automatically**, cloned from production with a fresh
+empty database, at `https://frontend-uc-nexus-pr-<N>.up.railway.app` and
+`https://backend-uc-nexus-pr-<N>.up.railway.app`. Draft PRs do not get one.
+
+For signing in (`/testing/clerk-sign-in`, `TESTING_ENABLED`, the `X-Testing-Secret` header) see
+the Environment and Getting Started sections of [CLAUDE.md](CLAUDE.md) - the runbook below refers to
+them rather than restating them.
+
+**In a hurry:** `testing/scripts/connect-pr-env.ps1 <PR#>` does the whole hookup and tells you
+whether it worked. The rest of this file is what it does and how to diagnose it when it does not.
+
+## A PR environment is relay-disconnected by default, and that is useful
+
+By default a PR environment always reports `relayStatus.connected: false`, and no amount of waiting
+changes it. Two independent reasons, both addressed by #414 but neither automatic:
+
+1. The relay dials whatever `[channel] backend_url` in its `config.toml` names. Since #414 that takes
+   a LIST, so a PR backend can be added *alongside* production rather than replacing it - but somebody
+   has to add it. **No restart** since #456: `channel.run_forever` re-reads `config.toml` every
+   `CHANNEL_RECONCILE_SECONDS` (see `relay/src/ucnexus_relay/channel.py` for the live value), adding a
+   channel for a URL that appears and cancelling one for a URL that disappears. Editing the file is
+   the whole procedure - see the runbook below.
+2. Relay installs live in Postgres and a PR environment boots a fresh empty one, so the handshake is
+   refused (4403) even if the relay does dial. Since #414 the backend seeds a trusted install on
+   startup from `RELAY_SEED_SECRET_HASH` - the SHA-256 already in production's row, copyable from
+   Admin -> Relay Installs ("Seed hash" column). Where that variable goes is the part that catches
+   people out (#431):
+   - It belongs on the **production** backend service and stays there inert. PR environments are cloned
+     from production, so that is the only place a new one can inherit it from; production refuses to
+     seed and logs the refusal at INFO, which is the intended steady state, not something to tidy up.
+   - **Inheritance happens at environment creation only.** Setting it on production does nothing for a
+     PR environment that already exists - set it on that environment's own backend service as well.
+     Verified 2026-07-30: pr-430 predated the variable and stayed GP-blind until it had its own copy.
+   - Seeding runs at backend startup, so the variable only takes effect on that service's next deploy.
+
+Read the default state as a free test fixture rather than a limitation. The relay-down half of any
+GP-gated feature - disabled controls, "not connected" copy, held values still displaying, buttons that
+must not be clickable - is exactly what a PR environment exercises by construction, and it is the half
+that is otherwise awkward to reach on production without stopping the relay for everyone.
+
+**But "by default" is doing real work in that heading.** Disconnected is a state you were handed, not
+a property of PR environments, and leaving it that way is a choice with a cost: with no relay there
+are no projects (they come from the GP job sync), and with no projects there is no schedule import, no
+PO, no receiving, no inventory, no assembly, no shipping. Nearly the whole spine of the app is
+unreachable. If you find yourself writing "this surface cannot be tested here", connect the relay
+first and check whether that is still true. It usually is not.
+
+A PR environment with a connected relay is pinned to **TUBC** and refuses every other company with
+`company_not_allowed_on_channel`, reads and writes alike. Reads and writes both work against TUBC;
+that pin is what makes serving writes off a test backend acceptable at all.
+
+## Connect a PR environment for full click-through testing
+
+`testing/scripts/connect-pr-env.ps1 <PR#>` does steps 2-4 and waits for the confirmation in step 5.
+Run it rather than doing this by hand; the manual steps are here so a failure is diagnosable, and
+because a script that nobody can read is its own kind of stale documentation.
+
+Each step lists **the signal that proves it worked**. Check the signal rather than assuming - every
+step here has failed silently at least once.
+
+1. **Find the Railway environment.** It is named `uc-nexus-pr-<N>`, NOT `pr-<N>` - the CLI answers
+   `Environment "pr-511" not found` for the latter, which reads like the environment is missing.
+   Services inside it are `backend` and `frontend`; the public hostnames are
+   `backend-uc-nexus-pr-<N>.up.railway.app`.
+   - Signal: `railway environment list --json` lists it, with `meta.prNumber` matching.
+2. **`TESTING_SIGN_IN_SECRET_HASH` on that environment's backend**, so you can mint a session. See the
+   Auth bullet in [CLAUDE.md](CLAUDE.md)'s Environment section for what it is and why production must
+   not have one.
+   - Signal: `railway variables --environment uc-nexus-pr-<N> --service backend --json` shows it set,
+     and `GET /testing/clerk-sign-in` with the matching `X-Testing-Secret` answers 200 rather than 401.
+3. **`RELAY_SEED_SECRET_HASH` on that same backend**, so the relay's handshake is accepted rather than
+   refused 4403. Usually inherited at environment creation; set it by hand if the environment predates
+   the variable.
+   - Signal: same `railway variables` read shows it set.
+4. **Add the PR backend to the relay's channel list.** In
+   `%LOCALAPPDATA%\UCNexusRelay\config.toml`, under `[channel]`:
+   ```toml
+   extra_backend_urls = ["wss://backend-uc-nexus-pr-<N>.up.railway.app/relay-link"]
+   ```
+   **Never touch `backend_url`** - production's URL comes from the baked default, and retyping it with
+   one character wrong silently demotes the production channel to the TUBC pin (see the safety note in
+   #414). Write the file as UTF-8 **without a BOM**: PowerShell's `Set-Content -Encoding utf8` adds one
+   in 5.1, `tomllib` then refuses the file, and the relay crashes at startup.
+   - Signal: within ~10s, `%LOCALAPPDATA%\UCNexusRelay\relay.log` logs `backend channels changed` with
+     your URL under `added`, then `channel connected` with `restricted_to: ["TUBC"]`.
+5. **Confirm the app sees it.** Sign in and open the PO module.
+   - Signal: the header reads `RELAY CONNECTED`, not `GP RELAY NOT DETECTED`.
+6. **Assign your GP buyer to the project you will test on**, or Register in GP refuses with "Buyer X is
+   not assigned to this project" (#216). Admin -> Buyers -> Add Buyer.
+   - Signal: the buyer grid lists a row pairing your buyer with that project.
+7. **Tear down when the PR closes**: remove the URL from `extra_backend_urls` (or run the script with
+   `-Disconnect`). A closed environment otherwise retries forever against a backend that is gone.
+   - Signal: `relay.log` logs `backend channels changed` with your URL under `removed`.
+
+With that done the whole chain is click-through: GP job sync populates real TUBC projects, the import
+wizard runs against a real schedule, Register in GP writes a real PO to TUBC and stamps the PM00200
+vendor onto it, and receiving populates from that. Proven end to end on pr-511 (2026-08-05): PO0000095
+against ALLEGION, from Create-GP-Job through to the back-order grid, entirely by clicking.
+
+What a PR environment cannot show out of the box is a NEW op. The workstation runs a packaged build, so
+a PR that adds to `_OPS` answers `unknown_op` -> `RELAY_OP_UNSUPPORTED` there just as it does on
+production before the relay is rebuilt (its own distinct UI state, worth checking on purpose during the
+deploy-before-rebuild window). To exercise the op itself, build the PR's branch with
+`gh workflow run relay-release.yml --ref <branch>` and install that zip on the workstation for the
+session - the full procedure, including how the release build gets restored afterwards, is the
+"testing a PR that adds a new op" section of `relay/README.md`. It is a manual install by design.
+
+Verified on PR #412 (issue #409's buyer dropdown), in the default disconnected state: the field
+rendered `role="combobox"`, disabled, still showing the stored `mira`, with "The GP relay is not
+connected, so this cannot be changed right now." - all four assertions met without touching production.
+
+Seeding verified live on PR #421 (#414 itself), against that PR's own environment: setting
+`RELAY_SEED_SECRET_HASH` produced exactly one install row labelled `seed:uc-nexus-pr-<N>` (company
+TUBC, ENROLLED), the Seed hash cell truncated to 8 chars with a copy button carrying the full 64-char
+digest, a provisioned-but-unenrolled row showing `—` and no button, and a second full redeploy still
+leaving exactly one seeded row. Note the label takes `RAILWAY_ENVIRONMENT_NAME` verbatim, which on a
+PR environment is `uc-nexus-pr-<N>` rather than `pr-<N>`.

--- a/testing/scripts/connect-pr-env.ps1
+++ b/testing/scripts/connect-pr-env.ps1
@@ -1,0 +1,146 @@
+<#
+.SYNOPSIS
+Point the workstation relay at a PR environment so it can be click-through tested, or unpoint it.
+
+.DESCRIPTION
+A PR environment is relay-disconnected by default, and with no relay there are no projects - so
+nearly the whole app is unreachable. This connects one. See "Connect a PR environment for full
+click-through testing" in testing/PR-ENVIRONMENT.md for what each step is and how to diagnose it by hand.
+
+This exists as a script rather than only prose because prose about code drifts: the runbook claimed
+for months that adding a channel needed a relay restart, which stopped being true at #456 and cost a
+session. A script is either run and correct or run and loudly broken.
+
+Only ever writes [channel] extra_backend_urls. It never touches backend_url: production's URL comes
+from the relay's baked default, and retyping it with one character wrong silently demotes the
+production channel to the TUBC sandbox pin with no loud failure.
+
+.PARAMETER PrNumber
+The GitHub PR number. The Railway environment is uc-nexus-pr-<PrNumber>.
+
+.PARAMETER Disconnect
+Remove this PR's URL from the channel list instead of adding it. Do this when the PR closes.
+
+.EXAMPLE
+./connect-pr-env.ps1 511
+.EXAMPLE
+./connect-pr-env.ps1 511 -Disconnect
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [int] $PrNumber,
+    [switch] $Disconnect
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ConfigPath = Join-Path $env:LOCALAPPDATA 'UCNexusRelay\config.toml'
+$LogPath    = Join-Path $env:LOCALAPPDATA 'UCNexusRelay\relay.log'
+$EnvName    = "uc-nexus-pr-$PrNumber"
+$BackendUrl = "https://backend-uc-nexus-pr-$PrNumber.up.railway.app"
+$ChannelUrl = "wss://backend-uc-nexus-pr-$PrNumber.up.railway.app/relay-link"
+
+function Step($n, $text) { Write-Host "`n[$n] $text" -ForegroundColor Cyan }
+function Ok($text)       { Write-Host "    OK   $text" -ForegroundColor Green }
+function Warn($text)     { Write-Host "    WARN $text" -ForegroundColor Yellow }
+function Fail($text)     { Write-Host "    FAIL $text" -ForegroundColor Red }
+
+# --- 1. the Railway environment ------------------------------------------------------------------
+# Named uc-nexus-pr-<N>, not pr-<N>; the CLI's "not found" for the latter reads like it is missing.
+Step 1 "Railway environment $EnvName"
+$envJson = railway environment list --json 2>&1 | Out-String
+try { $envs = ($envJson | ConvertFrom-Json).environments } catch { $envs = $null }
+$target = $envs | Where-Object { $_.name -eq $EnvName }
+if (-not $target) {
+    Fail "no environment named $EnvName. Open PRs get one automatically; drafts do not."
+    Write-Host "         environments: $(($envs | ForEach-Object { $_.name }) -join ', ')"
+    exit 1
+}
+Ok "found ($($target.id))"
+
+# --- 2/3. the two backend variables ---------------------------------------------------------------
+# TESTING_SIGN_IN_SECRET_HASH mints a session; RELAY_SEED_SECRET_HASH gets the relay handshake past
+# the 4403 a fresh preview database would otherwise answer. Both are reads here - setting either is a
+# deliberate act with its own consequences, so this reports rather than fixes.
+Step 2 'backend variables'
+$varJson = railway variables --environment $EnvName --service backend --json 2>&1 | Out-String
+try { $vars = $varJson | ConvertFrom-Json } catch { $vars = $null }
+if (-not $vars) {
+    Warn 'could not read variables; skipping the check (the channel step below still works)'
+} else {
+    foreach ($name in 'TESTING_SIGN_IN_SECRET_HASH', 'RELAY_SEED_SECRET_HASH') {
+        if ($vars.PSObject.Properties.Name -contains $name -and $vars.$name) { Ok "$name set" }
+        else { Warn "$name NOT set - see testing/PR-ENVIRONMENT.md, runbook steps 2 and 3" }
+    }
+}
+
+# --- 4. the channel list --------------------------------------------------------------------------
+Step 3 "$(if ($Disconnect) { 'removing' } else { 'adding' }) the channel in config.toml"
+if (-not (Test-Path $ConfigPath)) { Fail "no relay config at $ConfigPath - is the relay installed?"; exit 1 }
+
+$toml = [System.IO.File]::ReadAllText($ConfigPath)
+
+# Collect the URLs currently listed, so this is additive rather than a blind overwrite: another PR
+# may legitimately be connected at the same time.
+$existing = @()
+$m = [regex]::Match($toml, '(?m)^\s*extra_backend_urls\s*=\s*\[(?<body>[^\]]*)\]')
+if ($m.Success) {
+    $existing = [regex]::Matches($m.Groups['body'].Value, '"([^"]+)"') | ForEach-Object { $_.Groups[1].Value }
+}
+
+$wanted = @($existing | Where-Object { $_ -ne $ChannelUrl })
+if (-not $Disconnect) { $wanted += $ChannelUrl }
+$wanted = @($wanted | Where-Object { $_ })
+
+$rendered = 'extra_backend_urls = [' + (($wanted | ForEach-Object { '"' + $_ + '"' }) -join ', ') + ']'
+
+if ($m.Success) {
+    $toml = $toml.Remove($m.Index, $m.Length).Insert($m.Index, $rendered)
+} elseif (-not $Disconnect) {
+    if ($toml -notmatch '(?m)^\s*\[channel\]') { $toml = $toml.TrimEnd() + "`r`n`r`n[channel]`r`n" }
+    $toml = $toml.TrimEnd() + "`r`n$rendered`r`n"
+}
+
+if ($toml -notmatch '(?m)^\s*extra_backend_urls' -and -not $Disconnect) { Fail 'could not write the channel list'; exit 1 }
+
+# UTF-8 with NO BOM. PowerShell 5.1's Set-Content -Encoding utf8 writes one, tomllib then refuses the
+# file, and the relay crashes at startup - taking the PRODUCTION channel down with it.
+[System.IO.File]::WriteAllText($ConfigPath, $toml, (New-Object System.Text.UTF8Encoding($false)))
+Ok "channel list is now: $(if ($wanted) { $wanted -join ', ' } else { '(empty)' })"
+
+# --- 5. wait for the relay to reconcile ------------------------------------------------------------
+# #456: run_forever re-reads config.toml on a tick, so this needs no restart. If nothing appears
+# within the window below, the relay is not running or the file did not parse.
+Step 4 'waiting for the relay to pick it up'
+if (-not (Test-Path $LogPath)) { Warn "no relay.log at $LogPath - cannot confirm; check the app header instead"; exit 0 }
+
+$want = if ($Disconnect) { 'removed' } else { 'connected' }
+$startLen = (Get-Item $LogPath).Length
+$deadline = (Get-Date).AddSeconds(45)
+$seen = $false
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 3
+    $tail = Get-Content $LogPath -Tail 60 -ErrorAction SilentlyContinue
+    if ($Disconnect) {
+        if ($tail | Where-Object { $_ -match 'backend channels changed' -and $_ -match [regex]::Escape($ChannelUrl) }) { $seen = $true; break }
+    } else {
+        if ($tail | Where-Object { $_ -match 'channel connected' -and $_ -match [regex]::Escape($ChannelUrl) }) { $seen = $true; break }
+    }
+}
+
+if ($seen) {
+    Ok "relay reports the channel $want"
+    if (-not $Disconnect) {
+        Write-Host "`nConnected. Next: sign in and confirm the PO header reads RELAY CONNECTED, then" -ForegroundColor Green
+        Write-Host "assign your GP buyer to the project under Admin -> Buyers (runbook step 6)." -ForegroundColor Green
+        Write-Host "Backend: $BackendUrl" -ForegroundColor DarkGray
+    } else {
+        Write-Host "`nDisconnected." -ForegroundColor Green
+    }
+} else {
+    Warn "no confirmation in relay.log within 45s. Check that the relay is running, and that"
+    Warn "$LogPath has no TOML parse error (a BOM in config.toml crashes it at startup)."
+    if ((Get-Item $LogPath).Length -eq $startLen) { Warn 'the log has not grown at all - the relay is probably not running.' }
+    exit 1
+}


### PR DESCRIPTION
pr-environment setup split out of the testing knowledgebase into a runbook plus a script.

- testing/PR-ENVIRONMENT.md - seven-step runbook, each step carries the signal that proves it worked
- testing/scripts/connect-pr-env.ps1 <PR#> - resolves the Railway environment, checks the two backend variables, edits the channel list, waits for the relay to confirm. `-Disconnect` for teardown when the PR closes
- pointers updated in testing/CLAUDE.md and README.md

no relay channel -> no projects (they come from the GP job sync) -> no schedule import -> no PO -> no receiving -> no inventory -> no assembly -> no shipping. a session on #509 concluded several surfaces were untestable on a PR environment when nobody had connected the relay.

adding a channel needs no relay restart since #456 (startup-only read -> reconcile tick). the old text said otherwise for months, in the doc and in an agent memory, and nothing caught it. that is the argument for the script: prose about code goes stale silently, a script is either run and correct or run and loudly broken.

script writes `extra_backend_urls` only, never `backend_url` - production's URL comes from the baked default, and retyping it one character wrong silently demotes the production channel to the TUBC sandbox pin.
script writes UTF-8 without a BOM - PowerShell 5.1 adds one, tomllib then refuses the file, and the relay crashes at startup taking the production channel with it.

ran it against pr-511, disconnect then reconnect, relay confirmed both transitions, production channel untouched.

the no-ai-attribution check fails on this PR and #511 with no attribution present - the scan prefixes the filename onto each added line then greps for a bare vendor token, so every line added to a file named CLAUDE.md matches, as does any prose naming that file. fix separately.
