### PR TITLE
refactor(warehouse): call the receiving pending quantity column Back Order (#502)

### DIFF
--- a/frontend/src/modules/warehouse/ReceivingPage.tsx
+++ b/frontend/src/modules/warehouse/ReceivingPage.tsx
@@ -323,7 +323,7 @@ export default function ReceivingPage() {
       },
       {
         field: 'pendingQty',
-        headerName: 'Pending Qty',
+        headerName: 'Back Order',
         flex: 0.6,
         type: 'number',
       },


### PR DESCRIPTION
closes #502.

warehouse receiving open-POs column header "Pending Qty" -> "Back Order".

value is `sum(max(0, orderedQuantity - receivedQuantity))` across the PO's lines, which is what the warehouse calls back order.

label only, these stay unchanged:
`pendingQty` field name
row math
"Pending Lines" column
line-level back-order grid ("Outstanding")
