### PR TITLE
refactor(import): name the PO step column Scheduled Part Number (#482)

### DIFF
--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -224,7 +224,9 @@ function VendorGroupCard({
       >
         {/* Header row */}
         <Box className="po-head">Order As</Box>
-        <Box className="po-head">Product Code</Box>
+        {/* TITAN's scheduled part number, read-only from the schedule. "Order As" beside it is the
+            vendor-facing alias the buyer types. Data field stays productCode (#482). */}
+        <Box className="po-head">Scheduled Part Number</Box>
         <Box className="po-head">Hardware Category</Box>
         <Box className="po-head" sx={{ textAlign: 'right' }}>
           Total Qty


### PR DESCRIPTION
closes #482.

import wizard Purchase Orders step, column header "Product Code" -> "Scheduled Part Number".

that column carries TITAN's scheduled part number, read-only from the schedule. "Order As" beside it is the vendor-facing alias the buyer types, so calling both a product code hid the distinction.

data field stays `productCode`. no backend, GraphQL or migration change.

these keep "Product Code":
GpPurchaseOrderDialog
PODetailModal line-item grid
every warehouse view
