### PR TITLE
fix(po): Order As defaults to the product code at GP registration (#491)

### DIFF
--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -390,7 +390,10 @@ export default function GpPurchaseOrderDialog({
         orderedQuantity: String(li.orderedQuantity ?? 1),
         unitCost: li.unitCost != null ? String(li.unitCost) : '0',
         classification: li.classification ?? '',
-        orderAs: li.orderAs ?? '',
+        // #491: GP's item number is (order_as or product_code), and the backend already falls back
+        // that way. Seeding the field with the product code shows the buyer what GP will actually
+        // receive instead of an empty box the dialog then refuses to submit.
+        orderAs: li.orderAs || li.productCode || '',
         manufacturer: li.manufacturer ?? null,
       }));
       setLineItems(rows.length > 0 ? rows : [{ key: 1, ...EMPTY_LINE_ITEM }]);
@@ -525,7 +528,8 @@ export default function GpPurchaseOrderDialog({
       if (isNaN(qty) || qty < 1) errs[`li_${i}_qty`] = 'Must be >= 1';
       const cost = parseFloat(li.unitCost);
       if (isNaN(cost) || cost < 0) errs[`li_${i}_cost`] = 'Must be >= 0';
-      if (!li.orderAs.trim()) errs[`li_${i}_orderAs`] = 'Required';
+      // #491: blank is fine when the row has a product code - the payload falls back to it below.
+      if (!li.orderAs.trim() && !li.productCode.trim()) errs[`li_${i}_orderAs`] = 'Required';
     }
     // Issue #256: only register mode talks to GP - draft creation has no relay/vendor/buyer/cost-code
     // requirements at all.
@@ -584,7 +588,7 @@ export default function GpPurchaseOrderDialog({
       orderedQuantity: parseInt(li.orderedQuantity, 10),
       unitCost: parseFloat(li.unitCost),
       classification: li.classification || null,
-      orderAs: li.orderAs.trim(),
+      orderAs: li.orderAs.trim() || li.productCode.trim(),
     }));
 
     // Same key for every retry of this action so a retry is a no-op in GP (won't post a second PO).
@@ -1218,11 +1222,15 @@ export default function GpPurchaseOrderDialog({
           />
           <TextField
             size="small"
-            required
+            required={!li.productCode.trim()}
             value={li.orderAs}
             onChange={(e) => updateLineItem(li.key, 'orderAs', e.target.value)}
             error={!!errors[`li_${idx}_orderAs`]}
-            helperText={errors[`li_${idx}_orderAs`]}
+            // #491: say what GP will get when the row is left blank, rather than refusing it.
+            helperText={
+              errors[`li_${idx}_orderAs`] ??
+              (li.productCode.trim() && !li.orderAs.trim() ? 'defaults to product code' : undefined)
+            }
             placeholder="e.g. ML2010"
             sx={MONO_FIELD_SX}
           />

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -840,3 +840,46 @@ it('says the relay is down rather than leaving the GP dropdowns silently dead', 
   const notices = await screen.findAllByText(/GP relay not connected/i);
   expect(notices.length).toBeGreaterThan(0);
 });
+
+// --- Order As defaults to the product code (#491) -----------------------------------------------
+// The dialog required a non-empty Order As on every line, which was stricter than the system it
+// feeds: build_create_po_payload already sends (order_as or product_code) as GP's item number. A
+// draft raised without Order As values could not be registered at all without retyping the product
+// code into every row.
+
+it('seeds Order As from the product code when the draft line has none', async () => {
+  const noOrderAs: PurchaseOrder = {
+    ...stockDraft,
+    lineItems: [{ ...stockDraft.lineItems[0], orderAs: null }],
+  };
+  renderDialog({ registerPo: noOrderAs });
+  await waitForVendorPreselect();
+
+  // Twice: the Product Code field itself, and Order As now mirroring it.
+  expect(screen.getAllByDisplayValue('HG-100')).toHaveLength(2);
+});
+
+it('registers with the product code as the item number when Order As is cleared', async () => {
+  const calls: Record<string, unknown>[] = [];
+  const registerMock: MockedResponse = {
+    request: { query: REGISTER_PO_IN_GP, variables: () => true },
+    result: (vars) => {
+      calls.push(vars as Record<string, unknown>);
+      return { data: registerData() };
+    },
+  };
+  const { onSubmitted } = renderDialog({ registerPo: stockDraft }, [
+    ...baseMocks(),
+    registerMock,
+  ]);
+  await waitForVendorPreselect();
+
+  fireEvent.change(screen.getByDisplayValue('ML2010'), { target: { value: '' } });
+  await selectTaxDetail();
+  fireEvent.click(screen.getByRole('button', { name: 'Register in GP' }));
+
+  // No "Required" error on the cleared row - the product code covers it.
+  await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+  const input = calls[0].input as { lineItems: { orderAs: string }[] };
+  expect(input.lineItems[0].orderAs).toBe('HG-100');
+});


### PR DESCRIPTION
closes #491.

Order As defaults to the line's product code in the register-to-GP dialog.

the dialog required a non-empty Order As on every line, which was stricter than the system it feeds: `build_create_po_payload` already sends `item_number = (order_as or product_code)`, and its own validation accepts a blank `order_as` when a product code is present. a draft raised without Order As values could not be registered without retyping the product code into every row.

- register-mode rows seed `orderAs` from `li.orderAs || li.productCode`
- `validate()` requires Order As only when the row has no product code
- `handleSubmit` falls back per line, so a cleared field sends the product code
- field is `required` only when there is no product code to fall back on
- helper text says "defaults to product code" while the field is blank

field stays editable. create mode and rows added in-dialog do not auto-fill while typing.

no backend change, no migration.

two tests in `GpPurchaseOrderDialog.test.tsx`:
- seeding on a draft line with no Order As
- submit with Order As cleared, payload carries the product code
