### PR TITLE
feat(po): one Create a PO button with a chooser (#480)

### DIFF
--- a/frontend/src/modules/po/CreatePOChooser.tsx
+++ b/frontend/src/modules/po/CreatePOChooser.tsx
@@ -1,0 +1,92 @@
+import { Box, ButtonBase, Typography } from '@mui/material';
+import { ClipboardPlus, Plus, ChevronRight } from 'lucide-react';
+import Modal from '../../components/Modal';
+
+const ICON = { size: 20, strokeWidth: 1.75 } as const;
+
+interface CreatePOChooserProps {
+  open: boolean;
+  onClose: () => void;
+  /** Raise the PO off a hardware schedule - the import wizard, purpose "po". */
+  onFromSchedule: () => void;
+  /** Type the lines by hand - the create-mode GP dialog. */
+  onManual: () => void;
+}
+
+interface OptionProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+}
+
+function Option({ icon, title, subtitle, onClick }: OptionProps) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        width: '100%',
+        p: 2,
+        textAlign: 'left',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        transition: 'border-color 0.15s ease, background-color 0.15s ease',
+        '&:hover': { borderColor: 'text.primary', bgcolor: 'action.hover' },
+        '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: 2 },
+      }}
+    >
+      <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
+      <Box sx={{ flex: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {subtitle}
+        </Typography>
+      </Box>
+      <Box sx={{ color: 'text.disabled', display: 'flex' }}>
+        <ChevronRight {...ICON} />
+      </Box>
+    </ButtonBase>
+  );
+}
+
+/**
+ * Which kind of PO (#480).
+ *
+ * The module used to carry two header buttons - "Start a Request" (schedule-driven, #471) and
+ * "Create PO" (manual) - which read as two unrelated features rather than one question with two
+ * answers. They are merged into one button that asks.
+ *
+ * Cards rather than a dropdown menu: each option needs the one-line explanation of when it applies,
+ * and a Menu cannot carry that legibly. Escape and a backdrop click close with no action.
+ */
+export default function CreatePOChooser({
+  open,
+  onClose,
+  onFromSchedule,
+  onManual,
+}: CreatePOChooserProps) {
+  return (
+    <Modal open={open} onClose={onClose} title="Create a PO" maxWidth="sm">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, py: 0.5 }}>
+        <Option
+          icon={<ClipboardPlus {...ICON} />}
+          title="From hardware schedule"
+          subtitle="Order off the schedule, shows what is still owed"
+          onClick={onFromSchedule}
+        />
+        <Option
+          icon={<Plus {...ICON} />}
+          title="Manual entry"
+          subtitle="Type lines by hand, no schedule involved"
+          onClick={onManual}
+        />
+      </Box>
+    </Modal>
+  );
+}

--- a/frontend/src/modules/po/__tests__/CreatePOChooser.test.tsx
+++ b/frontend/src/modules/po/__tests__/CreatePOChooser.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreatePOChooser from '../CreatePOChooser';
+
+// #480: the PO module used to carry two header buttons. They are one button now, and the chooser is
+// what keeps both routes reachable - so what matters is that each card fires its own handler and
+// only its own, and that dismissing fires neither.
+
+function renderChooser(open = true) {
+  const onClose = vi.fn();
+  const onFromSchedule = vi.fn();
+  const onManual = vi.fn();
+  render(
+    <CreatePOChooser
+      open={open}
+      onClose={onClose}
+      onFromSchedule={onFromSchedule}
+      onManual={onManual}
+    />,
+  );
+  return { onClose, onFromSchedule, onManual };
+}
+
+it('offers both routes with their one-line explanations', () => {
+  renderChooser();
+
+  expect(screen.getByText('From hardware schedule')).toBeInTheDocument();
+  expect(screen.getByText('Order off the schedule, shows what is still owed')).toBeInTheDocument();
+  expect(screen.getByText('Manual entry')).toBeInTheDocument();
+  expect(screen.getByText('Type lines by hand, no schedule involved')).toBeInTheDocument();
+});
+
+it('picks the schedule route without triggering the manual one', () => {
+  const { onFromSchedule, onManual } = renderChooser();
+
+  fireEvent.click(screen.getByText('From hardware schedule'));
+
+  expect(onFromSchedule).toHaveBeenCalledTimes(1);
+  expect(onManual).not.toHaveBeenCalled();
+});
+
+it('picks the manual route without triggering the schedule one', () => {
+  const { onFromSchedule, onManual } = renderChooser();
+
+  fireEvent.click(screen.getByText('Manual entry'));
+
+  expect(onManual).toHaveBeenCalledTimes(1);
+  expect(onFromSchedule).not.toHaveBeenCalled();
+});
+
+it('closes with no action taken', () => {
+  const { onClose, onFromSchedule, onManual } = renderChooser();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+  expect(onClose).toHaveBeenCalled();
+  expect(onFromSchedule).not.toHaveBeenCalled();
+  expect(onManual).not.toHaveBeenCalled();
+});

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -31,7 +31,6 @@ import {
   ChevronRight,
   ChevronsUpDown,
   ChevronsDownUp,
-  ClipboardPlus,
   Settings,
 } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -42,6 +41,7 @@ import { GET_PROJECTS } from '../../graphql/shared';
 import type { Project } from '../../types/project';
 import PODetailModal from './PODetailModal';
 import GpPurchaseOrderDialog from './GpPurchaseOrderDialog';
+import CreatePOChooser from './CreatePOChooser';
 import RelayStatusChip from '../../relay/RelayStatusChip';
 import { useRelayStatus } from '../../relay/useRelayStatus';
 import { poVendorName } from './poVendorName';
@@ -761,6 +761,7 @@ function POListPage() {
   const [selectedPOId, setSelectedPOId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [chooserOpen, setChooserOpen] = useState(false);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [filterState, setFilterState] = useState<FilterState>(EMPTY_FILTER_STATE);
   const [sortState, setSortState] = useState<SortState>({ field: null, direction: 'asc' });
@@ -903,27 +904,18 @@ function POListPage() {
             Document Settings
           </Button>
         )}
-        {/* #471: raising a PO off the hardware schedule used to be its own sidebar destination. It
-            is an action of this module, so it is a button here - no role gate, because whoever can
-            work this screen can raise one, and the schedule is what knows what is still owed. */}
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<ClipboardPlus {...ICON} />}
-          onClick={() => navigate('/app/import?purpose=po')}
-        >
-          Start a Request
-        </Button>
-        {/* Issue #256: creating a PO lands as a DRAFT (no GP involved), so no relay gating here -
-            the relay is only needed later, to register the draft into GP. This is the screen's one
-            filled accent: the thing you came here to do. */}
+        {/* #480: one entry point. Schedule-driven (#471) and manual creation are two answers to
+            "how do you want to raise this", not two features, so the button asks. Issue #256:
+            either way the PO lands as a DRAFT (no GP involved), so no relay gating here - the relay
+            is only needed later, to register the draft into GP. This is the screen's one filled
+            accent: the thing you came here to do. */}
         <Button
           variant="contained"
           size="small"
           startIcon={<Plus {...ICON} />}
-          onClick={() => setCreateOpen(true)}
+          onClick={() => setChooserOpen(true)}
         >
-          Create PO
+          Create a PO
         </Button>
       </Box>
 
@@ -1143,6 +1135,19 @@ function POListPage() {
       )}
 
       {/* Create PO Dialog (creates a brand-new PO directly in GP) */}
+      <CreatePOChooser
+        open={chooserOpen}
+        onClose={() => setChooserOpen(false)}
+        onFromSchedule={() => {
+          setChooserOpen(false);
+          navigate('/app/import?purpose=po');
+        }}
+        onManual={() => {
+          setChooserOpen(false);
+          setCreateOpen(true);
+        }}
+      />
+
       <GpPurchaseOrderDialog
         open={createOpen}
         onClose={() => setCreateOpen(false)}

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -376,9 +376,12 @@ caught two failures that all three stacked PRs were reporting as clean:
 /                          -> Clerk Sign-In
 /app                       -> Module Selector (6 module cards)
 /app/import                -> Start a Request (project landing -> hardware schedule wizard). NOT in the
-                              sidebar since #471 - reached from the "Start a Request" button in the PO,
-                              Shop Assembly and Shipping headers, which append ?purpose=po|assembly|shipping
-                              (Shipping also passes ?projectId=, so its button opens the wizard directly)
+                              sidebar since #471 - reached from the "Start a Request" button in the Shop
+                              Assembly and Shipping headers, which append ?purpose=assembly|shipping
+                              (Shipping also passes ?projectId=, so its button opens the wizard directly).
+                              In the PO module since #480 there is no separate Start a Request button:
+                              "Create a PO" opens a chooser, and "From hardware schedule" navigates here
+                              with ?purpose=po
 /app/po                    -> Purchase Orders (project landing -> PO list)
 /app/warehouse             -> Warehouse landing (stat cards + Go-to cards for sub-routes)
 /app/warehouse/inventory   -> Inventory (hardware/opening items by project)


### PR DESCRIPTION
closes #480.

the PO module header carried two buttons - "Start a Request" (outlined, schedule-driven, #471) and "Create PO" (contained, manual). they read as two unrelated features rather than one question with two answers.

merged into one contained "Create a PO" button that opens a chooser:

From hardware schedule, "order off the schedule, shows what is still owed" -> `/app/import?purpose=po`
Manual entry, "type lines by hand, no schedule involved" -> create-mode `GpPurchaseOrderDialog`

cards, not a dropdown Menu - each option needs its one-line explanation and a Menu cannot carry that legibly. escape and backdrop click close with no action.

"Create a PO" is the screen's one contained button.

deep links to `/app/import?purpose=po` keep working. Shop Assembly and Shipping keep their own Start a Request buttons.

new `CreatePOChooser.tsx` has four tests:
- both cards render with their subtitles
- each card fires only its own handler
- dismissing fires neither

`testing/CLAUDE.md` route map updated - the PO module no longer has a Start a Request button.
