### PR TITLE
fix(import): stop the classification grid clipping its text columns (#485)

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -118,11 +118,43 @@ function buildGroupTree(rows: ClassificationRow[], fields: GroupByField[]): Map<
   return result;
 }
 
+// #485: every text column was sized by flex alone. Each row also carries two ToggleButtonGroups
+// that hold a fixed width, so on a narrow viewport the flex columns were squeezed to ~100px - about
+// 12-15 characters - and long product codes, categories and manufacturers were clipped. minWidth
+// stops the squeeze and lets the grid scroll horizontally instead; the widths mirror the ones
+// SelectOpeningsStep already uses. wrap-cell lets the value break across lines rather than
+// ellipsize, and title= puts the full value in a hover tooltip either way.
 const ALL_COLUMNS: GridColDef[] = [
-  { field: 'openingNumber', headerName: 'Opening #', flex: 0.7, cellClassName: 'mono-cell' },
-  { field: 'productCode', headerName: 'Product Code', flex: 1, cellClassName: 'wrap-cell mono-cell' },
-  { field: 'hardwareCategory', headerName: 'Hardware Category', flex: 1, cellClassName: 'wrap-cell' },
-  { field: 'vendorNo', headerName: 'Manufacturer', flex: 0.8, cellClassName: 'mono-cell' },
+  {
+    field: 'openingNumber',
+    headerName: 'Opening #',
+    flex: 0.7,
+    minWidth: 110,
+    cellClassName: 'mono-cell',
+    renderCell: (params) => <span title={String(params.value ?? '')}>{params.value}</span>,
+  },
+  {
+    field: 'productCode',
+    headerName: 'Product Code',
+    flex: 1,
+    minWidth: 140,
+    cellClassName: 'wrap-cell mono-cell',
+  },
+  {
+    field: 'hardwareCategory',
+    headerName: 'Hardware Category',
+    flex: 1,
+    minWidth: 150,
+    cellClassName: 'wrap-cell',
+  },
+  {
+    field: 'vendorNo',
+    headerName: 'Manufacturer',
+    flex: 0.8,
+    minWidth: 120,
+    cellClassName: 'wrap-cell mono-cell',
+    renderCell: (params) => <span title={String(params.value ?? '')}>{params.value}</span>,
+  },
   {
     field: 'listPrice',
     headerName: 'List Price',
@@ -283,7 +315,12 @@ function GroupAccordion({ node, columns, options, onClassify, readOnly, depth, s
     >
       <AccordionSummary expandIcon={<ChevronDown size={18} strokeWidth={1.75} />}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', mr: 1 }}>
-          <Typography sx={{ fontWeight: 700, ...monoSx, fontSize: '0.875rem' }}>{node.label}</Typography>
+          <Typography
+            title={node.label}
+            sx={{ fontWeight: 700, ...monoSx, fontSize: '0.875rem', whiteSpace: 'normal', wordBreak: 'break-word' }}
+          >
+            {node.label}
+          </Typography>
           <Chip
             size="small"
             label={


### PR DESCRIPTION
closes #485.

"table viewport limit set to 15 character limit (?)" reads as the classification grid clipping text at ~15 characters, which is what it does.

ALL_COLUMNS sized every text column by flex with no minWidth. two fixed-width ToggleButtonGroups per row -> flex columns squeezed to ~100px on a narrow viewport, about 12 to 15 characters -> product codes, hardware categories, manufacturers cut off.

added minWidth to the four text columns, mirroring SelectOpeningsStep:
openingNumber 110
productCode 140
hardwareCategory 150
vendorNo 120

DataGrid scrolls horizontally once the minWidth sum exceeds the container, rather than squeezing.

- vendorNo gains wrap-cell alongside productCode and hardwareCategory, so it breaks across lines instead of ellipsizing
- openingNumber and vendorNo render with a title, so the full value is in a hover tooltip either way
- group header labels in the grouped view wrap and carry a title

on the alternative reading - a 15-row viewport height - the classification grid has no height cap. auto row height, no wrapper Box, unlike ReconciliationStep's fixed 500px. no viewport to raise, so that reading does not apply.
