### PR TITLE
fix(import): let a shop-assembly line stepped to zero be stepped back up (#494)

### DIFF
--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -292,10 +292,23 @@ export default function ShopAssemblyStep({
         {openingDrafts.map((draft) => {
           const key = leafKey(draft);
           const coverage = leafCoverage(allocation, draft);
-          const autoDropped = coverage === 'NONE';
-          const included = includedLeafKeys.has(key) && !autoDropped;
+          // #494: membership in includedLeafKeys is the ONLY thing that enables this card's
+          // controls. It used to also require coverage !== 'NONE', which is derived from the LIVE
+          // allocation - so stepping a leaf's only line down to 0 made it read as auto-dropped,
+          // which disabled the steppers AND the include switch, and the freed unit could never be
+          // put back. Auto-dropped now means what it says: the seeder could not cover this leaf and
+          // the user has not re-included it.
+          const included = includedLeafKeys.has(key);
+          const autoDropped = !included && coverage === 'NONE';
           const owed = draft.items.reduce((sum, item) => sum + item.quantity, 0);
           const allocated = leafAllocatedTotal(allocation, draft);
+          // An included leaf sitting at zero is a deliberate state, not a dropped one - it keeps
+          // live steppers and says so with its own chip.
+          const includedButEmpty = included && allocated === 0;
+          // A seeder-dropped leaf can be re-included once the pool has something for any of its
+          // lines, which is exactly what freeing a unit off another leaf produces.
+          const poolHasStock = draft.items.some((item) => (pool.get(comboKey(item)) ?? 0) > 0);
+          const switchDisabled = autoDropped && !poolHasStock;
 
           return (
             <StaggerItem key={key}>
@@ -320,14 +333,19 @@ export default function ShopAssemblyStep({
                     <Chip size="small" variant="outlined" label="Not covered - auto-dropped" />
                   </Tooltip>
                 )}
+                {includedButEmpty && (
+                  <Tooltip title="You have stepped every line on this leaf to zero. It stays editable, but with nothing allocated it will not be sent.">
+                    <Chip size="small" variant="outlined" label="Nothing allocated - will not be sent" />
+                  </Tooltip>
+                )}
                 <Box sx={{ flexGrow: 1 }} />
                 <Typography variant="caption" color="text.secondary" sx={tabularSx}>
                   {allocated} of {owed} allocated
                 </Typography>
                 <Tooltip
                   title={
-                    autoDropped
-                      ? 'Nothing is allocated to this leaf, so there is nothing to send.'
+                    switchDisabled
+                      ? 'Nothing in the pool matches this leaf, so there is nothing to allocate to it.'
                       : included
                         ? 'Leave this leaf out - its hardware goes back to the pool for the other leaves.'
                         : 'Include this leaf in the request.'
@@ -337,7 +355,7 @@ export default function ShopAssemblyStep({
                     <Switch
                       size="small"
                       checked={included}
-                      disabled={autoDropped}
+                      disabled={switchDisabled}
                       onChange={() => toggleLeaf(draft)}
                       // `role` is restated because slotProps.input replaces the default input
                       // props rather than merging with them, and dropping it would turn the control

--- a/frontend/src/modules/import/__tests__/ShopAssemblyStep.test.tsx
+++ b/frontend/src/modules/import/__tests__/ShopAssemblyStep.test.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShopAssemblyStep from '../ShopAssemblyStep';
+import { autoAssign, draftsSignature, leafCoverage, leafKey, type Allocation } from '../allocation';
+import type { InventoryAvailabilityRow } from '../types';
+
+// #494: the reported bug is a UI deadlock. `included` was `includedLeafKeys.has(key) && coverage !==
+// 'NONE'`, and coverage is derived from the LIVE allocation - so stepping a leaf's only line down to
+// zero flipped the card to "auto-dropped", which disabled the minus, the plus AND the include
+// switch. The freed unit went back to the pool and no control on the leaf could take it back.
+
+const DRAFT = {
+  openingNumber: '101',
+  leaf: 1,
+  items: [{ hardwareCategory: 'Hinges', productCode: 'HG-100', quantity: 1 }],
+};
+
+function availability(available: number): Map<string, InventoryAvailabilityRow> {
+  return new Map([
+    [
+      'Hinges|HG-100',
+      {
+        hardwareCategory: 'Hinges',
+        productCode: 'HG-100',
+        availableQuantity: available,
+      } as InventoryAvailabilityRow,
+    ],
+  ]);
+}
+
+/** Drives the step with the wizard-owned state it normally reads from. */
+function Harness({ drafts = [DRAFT], available = 1 }: { drafts?: typeof DRAFT[]; available?: number }) {
+  const byCombo = availability(available);
+  const seeded = autoAssign(
+    drafts,
+    new Map([...byCombo].map(([k, row]) => [k, row.availableQuantity])),
+  );
+  const [allocation, setAllocation] = useState<Allocation>(seeded);
+  const [included, setIncluded] = useState<Set<string>>(
+    new Set(drafts.filter((d) => leafCoverage(seeded, d) !== 'NONE').map((d) => leafKey(d))),
+  );
+  return (
+    <ShopAssemblyStep
+      sarRequestNumber="PR-1"
+      onSarNumberChange={() => {}}
+      openingDrafts={drafts}
+      availabilityByCombo={byCombo}
+      allocation={allocation}
+      onAllocationChange={setAllocation}
+      includedLeafKeys={included}
+      onIncludedLeafKeysChange={setIncluded}
+      // The real signature, so the step's seed-once effect short-circuits. A placeholder here makes
+      // it re-seed on every render, which is an infinite loop rather than a test.
+      seededSignature={draftsSignature(drafts)}
+      onSeeded={() => {}}
+      availabilityLoading={false}
+      availabilityError={false}
+      allocationStale={false}
+      onNext={() => {}}
+      onBack={() => {}}
+    />
+  );
+}
+
+const minus = () => screen.getByRole('button', { name: 'Remove one HG-100' });
+const plus = () => screen.getByRole('button', { name: 'Add one HG-100' });
+
+it('lets a line stepped down to zero be stepped back up', () => {
+  render(<Harness />);
+
+  expect(minus()).toBeEnabled();
+  fireEvent.click(minus());
+
+  // The deadlock: before the fix both of these were disabled here.
+  expect(plus()).toBeEnabled();
+  expect(screen.queryByText('Not covered - auto-dropped')).not.toBeInTheDocument();
+
+  fireEvent.click(plus());
+  expect(minus()).toBeEnabled();
+});
+
+it('says an included leaf at zero will not be sent, without dropping it', () => {
+  render(<Harness />);
+
+  fireEvent.click(minus());
+
+  expect(screen.getByText('Nothing allocated - will not be sent')).toBeInTheDocument();
+  // Still switched in - the user can put the unit back.
+  expect(screen.getByRole('switch', { name: 'Include 101 - Leaf 1' })).toBeChecked();
+});
+
+it('keeps the include switch usable on a seeder-dropped leaf once the pool has stock', () => {
+  // Two leaves, one unit between them: auto-assign covers the first and drops the second.
+  const second = { ...DRAFT, leaf: 2 };
+  render(<Harness drafts={[DRAFT, second]} available={1} />);
+
+  const dropped = screen.getByRole('switch', { name: 'Include 101 - Leaf 2' });
+  expect(dropped).not.toBeChecked();
+  expect(dropped).toBeDisabled();
+
+  // Free the unit off leaf 1 - it lands back in the pool, so leaf 2 can now be re-included.
+  fireEvent.click(screen.getAllByRole('button', { name: 'Remove one HG-100' })[0]);
+
+  expect(screen.getByRole('switch', { name: 'Include 101 - Leaf 2' })).toBeEnabled();
+});


### PR DESCRIPTION
closes #494.

deadlock in `ShopAssemblyStep`

```
const autoDropped = coverage === 'NONE';
const included = includedLeafKeys.has(key) && !autoDropped;
```

`coverage` is `leafCoverage(allocation, draft)`, derived from the live allocation rather than from what auto-assign decided at seeding.

leaf whose only line is allocated 1 -> click minus -> allocation 0 -> coverage NONE -> autoDropped true -> included false -> every control disabled

minus and plus via `disabled={!included || ...}`, include switch via `disabled={autoDropped}`. card relabels "Not covered - auto-dropped". freed unit goes back to the pool, no control on the leaf takes it back. that is the reported "clicked minus but can't add it back to bring it back to 1".

- `included` is `includedLeafKeys.has(key)` alone, so a leaf steppered to zero keeps live steppers
- `autoDropped` is `!included && coverage === 'NONE'` - the seeder could not cover it and the user has not re-included it
- included leaf at zero gets its own outlined chip, "Nothing allocated - will not be sent"
- include switch on a seeder-dropped leaf re-enables once the pool holds stock for any of its lines, which is exactly what freeing a unit off another leaf produces. stays disabled when nothing in the pool matches

`allocation.ts` untouched. `clampCeiling`, `setLineAllocation` and `remainingPool` were always correct, and `includedCount` already required a non-zero allocation, so the submitted payload never contained an empty leaf. only the derived render state conflated seeder-dropped with steppered-to-zero.

a new `ShopAssemblyStep.test.tsx` adds three tests:
- minus then plus round-trips, plus enabled in between, no auto-dropped chip
- included leaf at zero shows the chip and stays switched in
- seeder-dropped leaf's switch re-enables once a unit is freed off another leaf
