### PR TITLE
test(shipping): pin the staging drag decision, and a fixture that can fill a skid (#470)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,12 @@
 # Manual reference for backend env vars. Copy to backend/.env and fill in real values.
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/uc_nexus
 
-# Enables the GET /testing/clerk-sign-in token endpoint used by simulated user testing.
+# Enables the /testing/* endpoints used by simulated user testing: the clerk-sign-in token, and
+# seed-ship-ready-leaves, which fabricates assembled door leaves to reach states the UI cannot
+# (#470). Both are off without it.
 TESTING_ENABLED=true
 
-# SHA-256 hex of the shared testing sign-in secret (#422). /testing/clerk-sign-in additionally
+# SHA-256 hex of the shared testing sign-in secret (#422). Every /testing/* route additionally
 # requires an Admin/Manager session OR this digest's preimage in an X-Testing-Secret header -
 # the secret is how a fresh PR environment mints its first session. Generate a pair with:
 #   python -c "import secrets,hashlib; s=secrets.token_urlsafe(32); print(s, hashlib.sha256(s.encode()).hexdigest())"

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -278,6 +278,53 @@ def require_admin_request(request) -> dict:
     return {"user_id": user_id, "roles": roles}
 
 
+def require_testing_request(request):
+    """The double gate every `/testing/*` route carries (#422). Returns None to let the call through,
+    or the JSONResponse to return as the refusal.
+
+    TESTING_ENABLED first, and that ordering is the point: a production deployment refuses outright
+    rather than leaking whether the caller's credential would have been good enough. Then either an
+    Admin/Manager bearer, or the shared testing secret in X-Testing-Secret - the bootstrap path for a
+    fresh PR environment, where no session exists yet and minting one is the whole reason the route
+    is there.
+
+    A returned refusal rather than a raise, because these routes answer with a body FastAPI hands
+    back verbatim, and the two refusals do not share one status. Named alongside `require_admin_request`
+    and listed in that test's `_ROUTE_GATES`, so a `/testing/*` route added without it fails
+    `test_route_calls_an_auth_gate` (#470).
+
+    One definition rather than a copy per route: a fixture that mints rows and a route that mints
+    sessions are equally unsafe off a test target, and the second one written by hand is where the
+    ordering or the compare_digest goes missing.
+
+    The config read is function-local on purpose - the tests monkeypatch `app.config` attributes, and
+    a module-level import would bind the values at import time, before any of that runs."""
+    import hashlib
+    import hmac
+
+    from fastapi.responses import JSONResponse
+
+    from app.config import TESTING_ENABLED, TESTING_SIGN_IN_SECRET_HASH
+
+    if not TESTING_ENABLED:
+        return JSONResponse(status_code=403, content={"error": "Testing is not enabled"})
+
+    presented = (request.headers.get("x-testing-secret") or "").strip()
+    secret_ok = bool(TESTING_SIGN_IN_SECRET_HASH) and bool(presented)
+    if secret_ok:
+        digest = hashlib.sha256(presented.encode("utf-8")).hexdigest()
+        secret_ok = hmac.compare_digest(digest, TESTING_SIGN_IN_SECRET_HASH.strip().lower())
+    if secret_ok:
+        return None
+
+    try:
+        require_admin_request(request)
+    except AppError as e:
+        status = 403 if e.code == "FORBIDDEN" else 401
+        return JSONResponse(status_code=status, content={"error": str(e), "code": e.code})
+    return None
+
+
 def require_role(info, role: str) -> dict:
     """Enforce a role from INSIDE a resolver body. Returns {user_id, roles}.
 

--- a/backend/app/services/testing_fixtures.py
+++ b/backend/app/services/testing_fixtures.py
@@ -1,0 +1,119 @@
+"""Fixtures that put the database into a state the UI cannot reach by hand (#470).
+
+Only one so far, and it exists because of a ceiling nobody could ever see enforced. A skid holds
+thirty door leaves; reaching that through the app means thirty openings taken through purchase,
+receipt, a shop assembly pull, a pick, assembly, a shipping pull and a second pick. Nobody was ever
+going to do that, so the `n/30` chip, the greyed-out Place-in entry and the warning toast shipped
+having only been read, never run.
+
+Nothing here is reachable off a test target: every caller sits behind `require_testing_request`,
+the same double gate as `/testing/clerk-sign-in` (#422). Read that as load-bearing rather than
+belt-and-braces - this module writes rows that the rest of the system treats as physical objects
+sitting in a warehouse, and a leaf minted here never went through assembly, so on anything holding
+real data it is an invented door.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import NotFoundError, ValidationError
+from app.models.enums import OpeningItemState
+from app.models.opening_item import OpeningItem, OpeningItemHardware
+from app.models.project import Project
+from app.repositories import warehouse_admin_repository
+
+# Enough to fill a skid and be refused the next one, with room to spare. Capped rather than open:
+# the count arrives on a query string, and a fixture that mints a hundred thousand leaves off a
+# typo is a slow way to lose an environment.
+MAX_SEEDED_LEAVES = 200
+
+
+def seed_ship_ready_leaves(
+    session: Session,
+    project_id: uuid.UUID,
+    count: int,
+    *,
+    opening_prefix: str = "FIXT",
+) -> dict:
+    """Mint `count` assembled door leaves at SHIP_READY for one project, skipping the pull cycle.
+
+    Each leaf gets its own opening number and its own `opening_id`, so `uq_opening_items_live_leaf`
+    (one live assembled unit per project/opening/leaf) is satisfied by construction and a second call
+    on the same project adds to the pool rather than colliding with it.
+
+    They land in the staging pool immediately: `get_ship_ready_items` selects on state alone, and
+    `build_staged_pool` puts every one it returns on the floor as unplaced. Loose hardware is NOT
+    seeded - that side comes from completed shipping pulls, and the leaf paths are what this is for.
+
+    One `OpeningItemHardware` row each, so the leaf reads as an assembled unit anywhere the installed
+    hardware is shown rather than as an empty shell. It is inert to the pool arithmetic: the loose
+    quantities come from pull requests and packing slips, never from what was installed.
+    """
+    if count < 1 or count > MAX_SEEDED_LEAVES:
+        raise ValidationError(
+            f"Seed between 1 and {MAX_SEEDED_LEAVES} leaves; asked for {count}.",
+            field="count",
+        )
+
+    project = session.get(Project, project_id)
+    if project is None:
+        raise NotFoundError(f"Project {project_id} not found")
+
+    # The warehouse does not enter the staging pool or the skid ceiling, but the column is NOT NULL
+    # against a RESTRICT foreign key, so one has to exist. Same default every other row that has to
+    # land somewhere takes; it raises a ConflictError on a deployment with no warehouses at all.
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+
+    # Numbered off what this project already holds, so a second call does not reissue opening numbers
+    # the first one used and leave two rows on screen that read identically.
+    existing = session.scalars(
+        select(OpeningItem.opening_number).where(
+            OpeningItem.project_id == project_id,
+            OpeningItem.opening_number.like(f"{opening_prefix}-%"),
+        )
+    ).all()
+    start = 1
+    for number in existing:
+        suffix = number.rsplit("-", 1)[-1]
+        if suffix.isdigit():
+            start = max(start, int(suffix) + 1)
+
+    now = datetime.utcnow()
+    created = []
+    for offset in range(count):
+        opening_number = f"{opening_prefix}-{start + offset:04d}"
+        leaf = OpeningItem(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            opening_id=uuid.uuid4(),
+            warehouse_id=warehouse_id,
+            opening_number=opening_number,
+            building="Fixture",
+            floor="1",
+            location="Seeded for testing",
+            leaf=1,
+            quantity=1,
+            assembly_completed_at=now,
+            state=OpeningItemState.SHIP_READY,
+        )
+        session.add(leaf)
+        session.flush()
+        session.add(
+            OpeningItemHardware(
+                id=uuid.uuid4(),
+                opening_item_id=leaf.id,
+                product_code="FIXT-HINGE",
+                hardware_category="HINGE",
+                quantity=1,
+            )
+        )
+        created.append({"opening_item_id": str(leaf.id), "opening_number": opening_number, "leaf": 1})
+
+    return {
+        "created": len(created),
+        "warehouse_id": str(warehouse_id),
+        "leaves": created,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+import uuid
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
@@ -14,7 +15,7 @@ from graphql import GraphQLError, GraphQLResolveInfo
 from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 
-from app.auth import get_context, require_admin_request
+from app.auth import get_context, require_admin_request, require_testing_request
 from app.auth_policy import enforce_root_field
 from app.database import SessionLocal
 from app.errors import AppError
@@ -435,27 +436,13 @@ def get_clerk_sign_in_token(request: Request, email: str = "jayp@ucsh.com"):
     instance, so what this mints is a real session for a real staff account, Admin/Manager included,
     and with only the environment switch this route was a full impersonation primitive on any
     deployment where the switch was left on."""
-    import hashlib
-    import hmac
-
     import httpx
 
-    from app.config import CLERK_SECRET_KEY, TESTING_ENABLED, TESTING_SIGN_IN_SECRET_HASH
+    from app.config import CLERK_SECRET_KEY
 
-    if not TESTING_ENABLED:
-        return JSONResponse(status_code=403, content={"error": "Testing is not enabled"})
-
-    presented = (request.headers.get("x-testing-secret") or "").strip()
-    secret_ok = bool(TESTING_SIGN_IN_SECRET_HASH) and bool(presented)
-    if secret_ok:
-        digest = hashlib.sha256(presented.encode("utf-8")).hexdigest()
-        secret_ok = hmac.compare_digest(digest, TESTING_SIGN_IN_SECRET_HASH.strip().lower())
-    if not secret_ok:
-        try:
-            require_admin_request(request)
-        except AppError as e:
-            status = 403 if e.code == "FORBIDDEN" else 401
-            return JSONResponse(status_code=status, content={"error": str(e), "code": e.code})
+    refusal = require_testing_request(request)
+    if refusal is not None:
+        return refusal
 
     headers = {"Authorization": f"Bearer {CLERK_SECRET_KEY}"}
 
@@ -481,3 +468,37 @@ def get_clerk_sign_in_token(request: Request, email: str = "jayp@ucsh.com"):
     token_resp.raise_for_status()
     data = token_resp.json()
     return {"token": data["token"], "url": data.get("url", ""), "user_id": user_id}
+
+
+@app.post("/testing/seed-ship-ready-leaves")
+def seed_ship_ready_leaves(request: Request, project_id: str, count: int = 1, opening_prefix: str = "FIXT"):
+    """Put `count` assembled door leaves straight into a project's staging pool, at SHIP_READY (#470).
+
+    The skid's thirty-leaf ceiling had never been seen enforced, on the frontend or in a browser at
+    all, because reaching it by hand is thirty openings each taken through purchase, receipt, a shop
+    assembly pull, a pick, assembly, a shipping pull and a second pick. This is the only way the
+    `n/30` chip, the greyed-out Place-in entry and the refusal toast get exercised against a running
+    system rather than read.
+
+    Same double gate as `/testing/clerk-sign-in` and for the same reason (#422): a fixture that
+    fabricates physical objects has to be unreachable anywhere that is not a test target, and
+    TESTING_ENABLED alone is an environment switch rather than auth."""
+    from app.services import testing_fixtures
+
+    refusal = require_testing_request(request)
+    if refusal is not None:
+        return refusal
+
+    try:
+        pid = uuid.UUID(project_id)
+    except ValueError:
+        return JSONResponse(status_code=400, content={"error": f"{project_id} is not a project id"})
+
+    try:
+        with SessionLocal() as session:
+            result = testing_fixtures.seed_ship_ready_leaves(session, pid, count, opening_prefix=opening_prefix)
+            session.commit()
+    except AppError as e:
+        return JSONResponse(status_code=400, content={"error": str(e), "code": e.code})
+
+    return result

--- a/backend/tests/test_resolver_gate_completeness.py
+++ b/backend/tests/test_resolver_gate_completeness.py
@@ -138,9 +138,13 @@ def test_roster_backed_fields_are_role_gated():
 
 _MAIN_PY = Path(__file__).resolve().parent.parent / "main.py"
 
-# The only gate that fits a bare FastAPI Request. The GraphQL path's helpers unwrap a Strawberry Info
+# The two gates that fit a bare FastAPI Request. The GraphQL path's helpers unwrap a Strawberry Info
 # or a Strawberry context and can never appear in a route.
-_ROUTE_GATES = frozenset({"require_admin_request"})
+#
+# `require_testing_request` is `require_admin_request` with the TESTING_ENABLED check and the
+# X-Testing-Secret bootstrap path in front of it - strictly narrower, never wider, so a route calling
+# it is at least as gated as one calling the admin check alone (#470).
+_ROUTE_GATES = frozenset({"require_admin_request", "require_testing_request"})
 
 # route function name -> why it is deliberately reachable without require_admin_request.
 _ROUTE_EXEMPT: dict[str, str] = {
@@ -183,7 +187,13 @@ def test_every_main_py_route_was_collected():
     """Guard the guard, same shape as the root-field count above: if the decorator predicate
     regressed, the parametrized test below would silently shrink instead of failing."""
     collected = {fn.name for fn in _ROUTES}
-    expected = {"health", "relay_link", "reset_data", "get_clerk_sign_in_token"}
+    expected = {
+        "health",
+        "relay_link",
+        "reset_data",
+        "get_clerk_sign_in_token",
+        "seed_ship_ready_leaves",
+    }
     missing = expected - collected
     assert not missing, f"known main.py routes were not collected; the AST walk likely regressed: {sorted(missing)}"
 

--- a/backend/tests/test_seed_ship_ready_leaves.py
+++ b/backend/tests/test_seed_ship_ready_leaves.py
@@ -1,0 +1,187 @@
+"""The SHIP_READY leaf fixture, and the gate in front of it (#470).
+
+The fixture fabricates assembled door leaves - rows the rest of the system treats as physical objects
+in a warehouse - without any of the pull cycle that normally produces one. That is the only way to
+reach a skid's thirty-leaf ceiling, and it is also why the gate matters as much as the behaviour:
+on anything holding real data, a leaf minted here is an invented door.
+
+The auth half mirrors `test_testing_sign_in_auth.py`, because it is literally the same gate.
+"""
+
+import hashlib
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.errors import NotFoundError, ValidationError
+from app.models.enums import OpeningItemState
+from app.models.opening_item import OpeningItem
+from app.models.project import Project
+from app.repositories import shipment_containers as containers
+from app.services import testing_fixtures
+
+_SECRET = "correct-horse-battery-staple"
+_SECRET_HASH = hashlib.sha256(_SECRET.encode("utf-8")).hexdigest()
+_ROUTE = "/testing/seed-ship-ready-leaves"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """The environment gate open and the secret configured, so the tests below land on the AUTH gate.
+    Attributes are patched on `app.config` rather than reimporting `main`, which would rebuild the
+    app and the relay gateway singleton underneath the rest of the suite."""
+    import app.config
+    import main
+
+    monkeypatch.setattr(app.config, "TESTING_ENABLED", True, raising=False)
+    monkeypatch.setattr(app.config, "TESTING_SIGN_IN_SECRET_HASH", _SECRET_HASH, raising=False)
+    return TestClient(main.app)
+
+
+def _project(session) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+# --- the gate ------------------------------------------------------------------------------------
+
+
+def test_seeding_is_refused_when_testing_is_disabled(monkeypatch):
+    """Checked before auth, so a production deployment refuses outright rather than leaking whether
+    the caller's credential would have been good enough."""
+    import app.config
+    import main
+
+    monkeypatch.setattr(app.config, "TESTING_ENABLED", False, raising=False)
+    resp = TestClient(main.app).post(_ROUTE, params={"project_id": str(uuid.uuid4())})
+
+    assert resp.status_code == 403
+    assert "not enabled" in resp.json()["error"].lower()
+
+
+def test_seeding_is_refused_without_any_credential(client):
+    resp = client.post(_ROUTE, params={"project_id": str(uuid.uuid4())})
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "UNAUTHENTICATED"
+
+
+def test_seeding_is_refused_with_the_wrong_secret(client):
+    resp = client.post(
+        _ROUTE,
+        params={"project_id": str(uuid.uuid4())},
+        headers={"X-Testing-Secret": "not-it"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "UNAUTHENTICATED"
+
+
+def test_secret_path_is_disabled_when_no_hash_is_configured(client, monkeypatch):
+    """A blank TESTING_SIGN_IN_SECRET_HASH must fail CLOSED: any presented secret falls through to
+    the admin path rather than comparing equal to nothing."""
+    import app.config
+
+    monkeypatch.setattr(app.config, "TESTING_SIGN_IN_SECRET_HASH", "", raising=False)
+    resp = client.post(_ROUTE, params={"project_id": str(uuid.uuid4())}, headers={"X-Testing-Secret": _SECRET})
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "UNAUTHENTICATED"
+
+
+def test_the_secret_opens_it(client):
+    """Past the gate and into the body, shown by the route reaching its own argument check. A
+    malformed project id is refused at 400 before any database work, so this needs no DB."""
+    resp = client.post(_ROUTE, params={"project_id": "not-a-uuid"}, headers={"X-Testing-Secret": _SECRET})
+
+    assert resp.status_code == 400
+    assert "not a project id" in resp.json()["error"]
+
+
+# --- what it seeds -------------------------------------------------------------------------------
+
+
+def test_seeded_leaves_land_in_the_staging_pool(db_session):
+    """The point of the fixture: straight to SHIP_READY and unplaced, with no pull cycle behind it."""
+    project = _project(db_session)
+
+    result = testing_fixtures.seed_ship_ready_leaves(db_session, project.id, 3)
+
+    assert result["created"] == 3
+    pool = containers.build_staged_pool(db_session, project.id)
+    assert len(pool["leaves"]) == 3
+    assert all(holder is None for holder in pool["leaves"].values())
+    assert {uuid.UUID(leaf["opening_item_id"]) for leaf in result["leaves"]} == set(pool["leaves"])
+
+
+def test_seeded_leaves_are_ship_ready_and_belong_to_the_project(db_session):
+    project = _project(db_session)
+
+    testing_fixtures.seed_ship_ready_leaves(db_session, project.id, 2)
+
+    rows = db_session.query(OpeningItem).filter(OpeningItem.project_id == project.id).all()
+    assert len(rows) == 2
+    assert all(row.state == OpeningItemState.SHIP_READY for row in rows)
+    assert all(row.leaf == 1 for row in rows)
+    assert all(len(row.installed_hardware) == 1 for row in rows)
+
+
+def test_a_second_call_adds_rather_than_colliding(db_session):
+    """`uq_opening_items_live_leaf` is one live unit per project/opening/leaf, so re-running the
+    fixture has to issue fresh opening numbers rather than repeat the first run's."""
+    project = _project(db_session)
+
+    first = testing_fixtures.seed_ship_ready_leaves(db_session, project.id, 2)
+    second = testing_fixtures.seed_ship_ready_leaves(db_session, project.id, 2)
+
+    numbers = [leaf["opening_number"] for leaf in first["leaves"] + second["leaves"]]
+    assert len(set(numbers)) == 4
+    assert len(containers.build_staged_pool(db_session, project.id)["leaves"]) == 4
+
+
+def test_seeding_enough_to_fill_a_skid_and_be_refused_the_next_one(db_session):
+    """The state the whole fixture exists for. `test_a_skid_stops_at_thirty_leaves` proves the
+    ceiling on a hand-built pool; this proves the fixture can actually reach it."""
+    from app.models.enums import ShipmentContainerType
+
+    project = _project(db_session)
+    result = testing_fixtures.seed_ship_ready_leaves(db_session, project.id, 31)
+    leaf_ids = [leaf["opening_item_id"] for leaf in result["leaves"]]
+
+    skid = containers.create_container(
+        db_session, project.id, container_type=ShipmentContainerType.SKID, name="Skid 1", created_by="tester"
+    )
+    items = [
+        {"item_type": "OPENING_ITEM", "opening_item_id": oi_id, "hardware_category": "", "product_code": ""}
+        for oi_id in leaf_ids[:30]
+    ]
+    containers.set_container_items(db_session, skid.id, items)
+    assert len(skid.items) == 30
+
+    items.append(
+        {
+            "item_type": "OPENING_ITEM",
+            "opening_item_id": leaf_ids[30],
+            "hardware_category": "",
+            "product_code": "",
+        }
+    )
+    with pytest.raises(ValidationError, match="at most 30"):
+        containers.set_container_items(db_session, skid.id, items)
+
+
+def test_an_unknown_project_is_refused(db_session):
+    with pytest.raises(NotFoundError):
+        testing_fixtures.seed_ship_ready_leaves(db_session, uuid.uuid4(), 1)
+
+
+@pytest.mark.parametrize("count", [0, -1, testing_fixtures.MAX_SEEDED_LEAVES + 1])
+def test_the_count_is_bounded(db_session, count):
+    """Open-ended would mean a typo on a query string can mint a hundred thousand doors."""
+    project = _project(db_session)
+
+    with pytest.raises(ValidationError):
+        testing_fixtures.seed_ship_ready_leaves(db_session, project.id, count)

--- a/frontend/src/modules/shipping/StagingWorkspace.tsx
+++ b/frontend/src/modules/shipping/StagingWorkspace.tsx
@@ -45,10 +45,13 @@ import { useToast } from '../../components/Toast';
 import ContainerShipmentForm from './ContainerShipmentForm';
 import {
   canTakeAnotherLeaf,
+  containerDropId,
   CONTAINER_TYPE_LABEL,
+  dropTargetContainer,
   isStacked,
   leafCount,
   MAX_LEAVES_PER_SKID,
+  planContainerDrag,
   sameLooseStock,
   toItemsInput,
   type Container,
@@ -67,10 +70,11 @@ const CONTAINER_TYPES: ContainerType[] = ['SKID', 'DOOR_CART', 'BOX', 'ENVELOPE'
 
 // Drag ids are prefixed so one handler can tell what was picked up without a lookup table. The loose
 // id carries the opening because that is part of which stock the row is (see `sameLooseStock`).
+// `containerDropId` is the third of these and lives in `staging.ts`, next to the drag decision that
+// has to recognise it.
 const poolLeafId = (id: string) => `leaf:${id}`;
 const poolLooseId = (row: StagedLooseItem) =>
   `loose:${row.openingNumber ?? ''}|${row.hardwareCategory}|${row.productCode}`;
-const containerDropId = (id: string) => `container:${id}`;
 
 interface Props {
   projectId: string | undefined;
@@ -281,42 +285,29 @@ export default function StagingWorkspace({ projectId, project = null }: Props) {
       const activeId = String(active.id);
       const overId = String(over.id);
 
-      // The drop target, whether the pointer landed on a container card or on one of its rows.
-      const target =
-        containers.find((c) => containerDropId(c.id) === overId) ??
-        containers.find((c) => c.items.some((i) => i.id === overId));
-
-      const owner = containers.find((c) => c.items.some((i) => i.id === activeId));
-      if (owner) {
-        // Same container: a restack.
-        if (!target || target.id === owner.id) {
-          const from = owner.items.findIndex((i) => i.id === activeId);
-          const to = owner.items.findIndex((i) => i.id === overId);
-          if (to >= 0 && from !== to) save(owner, arrayMove(owner.items, from, to));
-          return;
+      // Anything already in a container: the decision is `planContainerDrag`'s, including the
+      // cross-container move this screen mostly exists for. Null means it came off the pool instead,
+      // which needs the pool rows and so stays here.
+      const plan = planContainerDrag(containers, activeId, overId);
+      if (plan) {
+        if (plan.action === 'refuse') {
+          showToast(
+            `${plan.target.name} already holds ${MAX_LEAVES_PER_SKID} leaves - start another skid.`,
+            'warning',
+          );
+        } else if (plan.action === 'reorder') {
+          save(plan.container, plan.items);
+        } else if (plan.action === 'move') {
+          // The order matters and the await is load-bearing: adding first would be refused for a
+          // leaf still recorded in the skid it is leaving.
+          await save(plan.source, plan.sourceItems);
+          await save(plan.target, plan.targetItems);
         }
-        // A different container: the move this screen mostly exists for. Two saves, and the order
-        // matters - adding first would be refused for a leaf that is still recorded in the skid it
-        // is leaving, so the source is emptied and awaited before the target is written.
-        const moving = owner.items.find((i) => i.id === activeId);
-        if (!moving) return;
-        if (moving.itemType === 'OPENING_ITEM' && !canTakeAnotherLeaf(target)) {
-          showToast(`${target.name} already holds ${MAX_LEAVES_PER_SKID} leaves - start another skid.`, 'warning');
-          return;
-        }
-        await save(owner, owner.items.filter((i) => i.id !== activeId));
-        const existing =
-          moving.itemType === 'LOOSE' ? target.items.find((i) => sameLooseStock(i, moving)) : undefined;
-        await save(
-          target,
-          existing
-            ? target.items.map((i) => (i === existing ? { ...i, quantity: i.quantity + moving.quantity } : i))
-            : [...target.items, { ...moving, id: 'new', position: target.items.length }],
-        );
         return;
       }
 
       // Otherwise it came from the pool.
+      const target = dropTargetContainer(containers, overId);
       if (!target) return;
       if (activeId.startsWith('leaf:')) {
         const leaf = unplacedLeaves.find((l) => poolLeafId(l.openingItemId) === activeId);

--- a/frontend/src/modules/shipping/__tests__/staging.test.ts
+++ b/frontend/src/modules/shipping/__tests__/staging.test.ts
@@ -1,0 +1,276 @@
+import {
+  canTakeAnotherLeaf,
+  containerDropId,
+  dropTargetContainer,
+  leafCount,
+  MAX_LEAVES_PER_SKID,
+  planContainerDrag,
+  type Container,
+  type ContainerItem,
+  type ContainerType,
+} from '../staging';
+
+/**
+ * The drag decision behind the staging workspace (#470).
+ *
+ * `StagingWorkspace.test.tsx` drives the click-equivalent controls because dnd-kit needs a pointer
+ * with real geometry and jsdom has none. That left the cross-container move - the one this screen
+ * mostly exists for - reachable only by a hand-run browser session. These pin the decision itself,
+ * which is the half that can regress silently.
+ */
+
+let nextId = 0;
+
+function item(overrides: Partial<ContainerItem> = {}): ContainerItem {
+  nextId += 1;
+  return {
+    id: `ci-${nextId}`,
+    itemType: 'LOOSE',
+    openingItemId: null,
+    openingNumber: '101',
+    leaf: null,
+    hardwareCategory: 'HINGE',
+    productCode: 'HG-100',
+    quantity: 1,
+    position: 0,
+    ...overrides,
+  };
+}
+
+function leafItem(overrides: Partial<ContainerItem> = {}): ContainerItem {
+  return item({
+    itemType: 'OPENING_ITEM',
+    openingItemId: `oi-${overrides.openingNumber ?? '101'}-${overrides.leaf ?? 1}`,
+    openingNumber: '101',
+    leaf: 1,
+    hardwareCategory: '',
+    productCode: '',
+    ...overrides,
+  });
+}
+
+function container(
+  id: string,
+  containerType: ContainerType,
+  items: ContainerItem[] = [],
+): Container {
+  return {
+    id,
+    projectId: 'proj-1',
+    containerType,
+    name: `${containerType} ${id}`,
+    packingSlipId: null,
+    createdBy: 'tester',
+    items: items.map((i, index) => ({ ...i, position: index })),
+  };
+}
+
+/** A skid loaded to its ceiling, each leaf its own opening so nothing collides. */
+function fullSkid(id: string): Container {
+  return container(
+    id,
+    'SKID',
+    Array.from({ length: MAX_LEAVES_PER_SKID }, (_, n) =>
+      leafItem({ openingNumber: `${900 + n}`, leaf: 1 }),
+    ),
+  );
+}
+
+beforeEach(() => {
+  nextId = 0;
+});
+
+describe('dropTargetContainer', () => {
+  it('resolves a drop on the container card', () => {
+    const box = container('c-1', 'BOX', [item()]);
+    expect(dropTargetContainer([box], containerDropId('c-1'))?.id).toBe('c-1');
+  });
+
+  it('resolves a drop on a row inside it - landing on a row means landing in the container', () => {
+    const box = container('c-1', 'BOX', [item({ id: 'row-1' })]);
+    expect(dropTargetContainer([box], 'row-1')?.id).toBe('c-1');
+  });
+
+  it('resolves nothing for an id belonging to neither', () => {
+    expect(dropTargetContainer([container('c-1', 'BOX')], 'leaf:oi-1')).toBeUndefined();
+  });
+});
+
+describe('a drag that started in the pool', () => {
+  it('is not this function to decide - the caller needs the pool rows and the quantity', () => {
+    const box = container('c-1', 'BOX');
+    expect(planContainerDrag([box], 'leaf:oi-1', containerDropId('c-1'))).toBeNull();
+  });
+});
+
+describe('restacking inside one container', () => {
+  it('reorders when a row is dropped on another row of the same container', () => {
+    const skid = container('c-1', 'SKID', [
+      leafItem({ id: 'a', openingNumber: '101' }),
+      leafItem({ id: 'b', openingNumber: '102' }),
+      leafItem({ id: 'c', openingNumber: '103' }),
+    ]);
+
+    const plan = planContainerDrag([skid], 'a', 'c');
+
+    expect(plan).toMatchObject({ action: 'reorder', container: { id: 'c-1' } });
+    expect(plan?.action === 'reorder' && plan.items.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('writes nothing when a row is dropped on itself', () => {
+    const skid = container('c-1', 'SKID', [leafItem({ id: 'a' }), leafItem({ id: 'b', openingNumber: '102' })]);
+    expect(planContainerDrag([skid], 'a', 'a')).toEqual({ action: 'none' });
+  });
+
+  it('writes nothing when a row is dropped on the card it already sits in', () => {
+    const skid = container('c-1', 'SKID', [leafItem({ id: 'a' })]);
+    expect(planContainerDrag([skid], 'a', containerDropId('c-1'))).toEqual({ action: 'none' });
+  });
+
+  it('writes nothing when the drop lands on something that is not a container or a row', () => {
+    const skid = container('c-1', 'SKID', [leafItem({ id: 'a' })]);
+    expect(planContainerDrag([skid], 'a', 'nowhere')).toEqual({ action: 'none' });
+  });
+});
+
+describe('moving an assembled leaf to another container', () => {
+  const source = () =>
+    container('c-1', 'SKID', [
+      leafItem({ id: 'a', openingNumber: '101', leaf: 1 }),
+      leafItem({ id: 'b', openingNumber: '102', leaf: 2 }),
+    ]);
+
+  it('empties the source and appends to the target, opening and leaf intact', () => {
+    const target = container('c-2', 'SKID');
+    const plan = planContainerDrag([source(), target], 'a', containerDropId('c-2'));
+
+    expect(plan?.action).toBe('move');
+    if (plan?.action !== 'move') return;
+    expect(plan.source.id).toBe('c-1');
+    expect(plan.sourceItems.map((i) => i.id)).toEqual(['b']);
+    expect(plan.target.id).toBe('c-2');
+    expect(plan.targetItems).toHaveLength(1);
+    expect(plan.targetItems[0]).toMatchObject({
+      id: 'new',
+      itemType: 'OPENING_ITEM',
+      openingItemId: 'oi-101-1',
+      openingNumber: '101',
+      leaf: 1,
+      position: 0,
+    });
+  });
+
+  it('counts the leaf exactly once across the two writes - it never sits in both', () => {
+    const target = container('c-2', 'SKID', [leafItem({ id: 'z', openingNumber: '900' })]);
+    const plan = planContainerDrag([source(), target], 'a', containerDropId('c-2'));
+
+    if (plan?.action !== 'move') throw new Error('expected a move');
+    const placements = [...plan.sourceItems, ...plan.targetItems].filter(
+      (i) => i.openingItemId === 'oi-101-1',
+    );
+    expect(placements).toHaveLength(1);
+  });
+
+  it('appends to the end of the target stack, which is the top of a skid', () => {
+    const target = container('c-2', 'SKID', [
+      leafItem({ id: 'y', openingNumber: '900' }),
+      leafItem({ id: 'z', openingNumber: '901' }),
+    ]);
+    const plan = planContainerDrag([source(), target], 'a', containerDropId('c-2'));
+
+    if (plan?.action !== 'move') throw new Error('expected a move');
+    expect(plan.targetItems.map((i) => i.id)).toEqual(['y', 'z', 'new']);
+    expect(plan.targetItems[2].position).toBe(2);
+  });
+
+  it('is a move, not a restack, when the drop lands on a row of the other container', () => {
+    const target = container('c-2', 'SKID', [leafItem({ id: 'z', openingNumber: '900' })]);
+    const plan = planContainerDrag([source(), target], 'a', 'z');
+
+    expect(plan).toMatchObject({ action: 'move', target: { id: 'c-2' } });
+  });
+});
+
+describe('the thirty-leaf skid ceiling', () => {
+  it('refuses a leaf onto a full skid rather than moving it', () => {
+    // Refused rather than attempted: the source is emptied first, so a move the server then rejects
+    // would take the leaf off a skid it was safely on and leave it nowhere.
+    const source = container('c-1', 'SKID', [leafItem({ id: 'a', openingNumber: '101' })]);
+    const target = fullSkid('c-2');
+
+    expect(leafCount(target)).toBe(MAX_LEAVES_PER_SKID);
+    expect(canTakeAnotherLeaf(target)).toBe(false);
+    expect(planContainerDrag([source, target], 'a', containerDropId('c-2'))).toEqual({
+      action: 'refuse',
+      target,
+    });
+  });
+
+  it('allows the thirtieth', () => {
+    const target = container(
+      'c-2',
+      'SKID',
+      Array.from({ length: MAX_LEAVES_PER_SKID - 1 }, (_, n) => leafItem({ openingNumber: `${900 + n}` })),
+    );
+    const source = container('c-1', 'SKID', [leafItem({ id: 'a', openingNumber: '101' })]);
+
+    const plan = planContainerDrag([source, target], 'a', containerDropId('c-2'));
+
+    expect(plan?.action).toBe('move');
+    expect(plan?.action === 'move' && plan.targetItems).toHaveLength(MAX_LEAVES_PER_SKID);
+  });
+
+  it('does not apply to a door cart - only a skid has a ceiling', () => {
+    const target = { ...fullSkid('c-2'), containerType: 'DOOR_CART' as const };
+    const source = container('c-1', 'SKID', [leafItem({ id: 'a', openingNumber: '101' })]);
+
+    expect(planContainerDrag([source, target], 'a', containerDropId('c-2'))).toMatchObject({
+      action: 'move',
+    });
+  });
+
+  it('does not block loose hardware onto a full skid - the cap counts leaves', () => {
+    const source = container('c-1', 'BOX', [item({ id: 'a' })]);
+    const target = fullSkid('c-2');
+
+    expect(planContainerDrag([source, target], 'a', containerDropId('c-2'))).toMatchObject({
+      action: 'move',
+    });
+  });
+});
+
+describe('moving loose hardware to another container', () => {
+  it('tops up a line already holding the same stock rather than adding a second', () => {
+    const source = container('c-1', 'BOX', [item({ id: 'a', quantity: 2 })]);
+    const target = container('c-2', 'BOX', [item({ id: 'z', quantity: 3 })]);
+
+    const plan = planContainerDrag([source, target], 'a', containerDropId('c-2'));
+
+    if (plan?.action !== 'move') throw new Error('expected a move');
+    expect(plan.targetItems).toHaveLength(1);
+    expect(plan.targetItems[0]).toMatchObject({ id: 'z', quantity: 5 });
+  });
+
+  it('keeps another openings units as their own line', () => {
+    // Two openings staging the same product are two quantities to the confirm; merging them would
+    // book units against a door they were never pulled for.
+    const source = container('c-1', 'BOX', [item({ id: 'a', openingNumber: '101', quantity: 2 })]);
+    const target = container('c-2', 'BOX', [item({ id: 'z', openingNumber: '102', quantity: 3 })]);
+
+    const plan = planContainerDrag([source, target], 'a', containerDropId('c-2'));
+
+    if (plan?.action !== 'move') throw new Error('expected a move');
+    expect(plan.targetItems).toHaveLength(2);
+    expect(plan.targetItems.map((i) => i.quantity)).toEqual([3, 2]);
+  });
+
+  it('never merges into an assembled leaf', () => {
+    const source = container('c-1', 'BOX', [item({ id: 'a', quantity: 2 })]);
+    const target = container('c-2', 'SKID', [leafItem({ id: 'z', openingNumber: '101' })]);
+
+    const plan = planContainerDrag([source, target], 'a', containerDropId('c-2'));
+
+    if (plan?.action !== 'move') throw new Error('expected a move');
+    expect(plan.targetItems).toHaveLength(2);
+  });
+});

--- a/frontend/src/modules/shipping/staging.ts
+++ b/frontend/src/modules/shipping/staging.ts
@@ -1,5 +1,7 @@
-// The staging workspace's shapes and the two rules that are easier to read as functions than as
-// conditions buried in JSX (#451).
+// The staging workspace's shapes and the rules that are easier to read as functions than as
+// conditions buried in JSX or in a drag handler (#451).
+
+import { arrayMove } from '@dnd-kit/sortable';
 
 export type ContainerType = 'SKID' | 'DOOR_CART' | 'BOX' | 'ENVELOPE' | 'BUNDLE';
 
@@ -113,4 +115,89 @@ export function toItemsInput(items: ContainerItem[]) {
     productCode: i.productCode,
     quantity: i.quantity,
   }));
+}
+
+/** A container's drop id, distinct from its item ids so one handler can tell a card from a row. */
+export const containerDropId = (id: string) => `container:${id}`;
+
+/**
+ * What a drop landed on: the container card itself, or a row inside one. Both mean the same thing to
+ * every caller - a drag that finishes over the third item of Skid 2 is a drag into Skid 2.
+ */
+export function dropTargetContainer(containers: Container[], overId: string): Container | undefined {
+  return (
+    containers.find((c) => containerDropId(c.id) === overId) ??
+    containers.find((c) => c.items.some((i) => i.id === overId))
+  );
+}
+
+/** What a drag that started inside a container turns into. */
+export type ContainerDragPlan =
+  /** Nothing to write: dropped where it started, or on the card it already sits in. */
+  | { action: 'none' }
+  /** Same container, new stacking order. */
+  | { action: 'reorder'; container: Container; items: ContainerItem[] }
+  /**
+   * A different container. Both lists are given because both have to be written, and the caller must
+   * write `source` first and await it - see below.
+   */
+  | { action: 'move'; source: Container; sourceItems: ContainerItem[]; target: Container; targetItems: ContainerItem[] }
+  /** A leaf dragged onto a skid already carrying `MAX_LEAVES_PER_SKID` of them. */
+  | { action: 'refuse'; target: Container };
+
+/**
+ * The decision behind a drag that began on something already in a container: restack it, move it to
+ * another container, or refuse it.
+ *
+ * Returns null when the drag did NOT start inside a container, which means it came off the staging
+ * pool - a different problem, needing the pool rows and the per-row quantity, and left to the caller.
+ *
+ * Pulled out of the drag handler because the move it decides is the one this screen mostly exists
+ * for and the one no test could reach: dnd-kit needs a pointer with real geometry and jsdom has
+ * none, so the only thing standing between the cross-container branch and a regression was a
+ * hand-run browser session (#470).
+ *
+ * Two rules live here that reading the handler would not tell you:
+ *
+ *   - the source is emptied BEFORE the target is written, and the caller has to await it. Adding
+ *     first is refused for a leaf still recorded in the skid it is leaving - one leaf, one container
+ *     is enforced server-side against the pool as it stands at the moment of saving.
+ *   - a leaf moved onto a full skid is refused rather than moved, because the alternative is taking
+ *     it out of the skid it was safely on and having the second save rejected.
+ *
+ * Loose stock moved onto a container already holding the same stock tops up that line instead of
+ * adding a second one, the same rule placing from the pool follows.
+ */
+export function planContainerDrag(
+  containers: Container[],
+  activeId: string,
+  overId: string,
+): ContainerDragPlan | null {
+  const source = containers.find((c) => c.items.some((i) => i.id === activeId));
+  if (!source) return null;
+
+  const target = dropTargetContainer(containers, overId);
+  if (!target || target.id === source.id) {
+    const from = source.items.findIndex((i) => i.id === activeId);
+    const to = source.items.findIndex((i) => i.id === overId);
+    if (to < 0 || from === to) return { action: 'none' };
+    return { action: 'reorder', container: source, items: arrayMove(source.items, from, to) };
+  }
+
+  const moving = source.items.find((i) => i.id === activeId);
+  if (!moving) return { action: 'none' };
+  if (moving.itemType === 'OPENING_ITEM' && !canTakeAnotherLeaf(target)) {
+    return { action: 'refuse', target };
+  }
+
+  const existing = moving.itemType === 'LOOSE' ? target.items.find((i) => sameLooseStock(i, moving)) : undefined;
+  return {
+    action: 'move',
+    source,
+    sourceItems: source.items.filter((i) => i.id !== activeId),
+    target,
+    targetItems: existing
+      ? target.items.map((i) => (i === existing ? { ...i, quantity: i.quantity + moving.quantity } : i))
+      : [...target.items, { ...moving, id: 'new', position: target.items.length }],
+  };
 }

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -52,6 +52,38 @@ This is a tester's knowledge journal for UC Nexus. It documents how the app work
     the gates above. Do not treat the endpoint answering on a given host as evidence that the host is
     a test environment - production answered it too, which is exactly what #424 shut off.
 - **Test XML file**: `testing/fixtures/contracterp-74.xml` - TITAN hardware schedule export, use for Import wizard testing (upload via `upload_file`)
+- **Fixture: assembled door leaves without the pull cycle** (`POST /testing/seed-ship-ready-leaves`,
+  #470). Takes `project_id`, `count` (1-200) and an optional `opening_prefix` (default `FIXT`) on the
+  query string, and writes that many `OpeningItem` rows straight at `SHIP_READY`, so they appear in
+  the shipping staging pool as unplaced Door leaves immediately. Behind the same double gate as
+  `/testing/clerk-sign-in` - `TESTING_ENABLED`, then an Admin/Manager bearer or the
+  `X-Testing-Secret` header.
+
+  It exists because some states are not reachable by hand. A skid's 30-leaf ceiling is the case that
+  forced it: 30 leaves through the UI is 30 openings each taken through purchase, receipt, a shop
+  assembly pull, a pick, assembly, a shipping pull and a second pick. Use it for anything keyed on
+  *how many* leaves are staged.
+
+  What it does NOT give you is a leaf with a real history - no pull request, no assembly record, no
+  inventory ever deducted, and the installed hardware is one placeholder line. Anything testing the
+  chain that produces a leaf still has to drive that chain. It also seeds no loose hardware; that
+  side only arrives via a COMPLETED shipping-out pull.
+
+  ```js
+  (async () => {
+    const SECRET = '...';  // preimage of this environment's TESTING_SIGN_IN_SECRET_HASH
+    const r = await fetch(
+      `https://backend-uc-nexus-pr-478.up.railway.app/testing/seed-ship-ready-leaves?project_id=${PID}&count=31`,
+      { method: 'POST', headers: { 'X-Testing-Secret': SECRET } });
+    return await r.json();  // { created, warehouse_id, leaves: [{opening_item_id, opening_number, leaf}] }
+  })()
+  ```
+
+  Opening numbers are issued from the highest `FIXT-NNNN` the project already holds, so calling it
+  twice tops the pool up rather than colliding on `uq_opening_items_live_leaf`.
+
+  Verified on pr-478: 31 leaves minted in one call, all 31 in the staging pool as unplaced Door
+  leaves on the next fetch, no pull request or assembly record behind any of them.
 
 ### Every resolver needs a token now (#415)
 
@@ -986,6 +1018,41 @@ cache with no reload - assert on the row, do not wait for a refetch.
 pick leaves the pull IN_PROGRESS with phase "Picked - ready to mark pulled" and the Ship tab's Loose
 Hardware grid stays empty; "Mark as Pulled" in the pull detail modal is what completes it. Budget for
 that extra step when scripting the chain.
+
+**Driving the staging workspace's drag: only the CONTAINER rows have a keyboard path.** Verified on
+pr-478 (#470). The two draggable kinds behave differently and it costs an hour to find out the hard
+way:
+
+- A row **inside a container** is `useSortable`, and the `KeyboardSensor` is wired with
+  `sortableKeyboardCoordinates`. Focus its `Reorder <leaf> in <container>` handle, press Space to
+  lift, and **one** arrow press moves it to the next droppable - the `aria-live` region names the
+  target, either a bare item uuid or `container:<uuid>`. Space drops it. This is how you exercise a
+  cross-container move.
+- A row **in the staging pool** is plain `useDraggable`. `sortableKeyboardCoordinates` has no
+  sortable context for it, so **the arrow keys do nothing at all** - the live region stays on
+  "Picked up draggable item leaf:<id>" no matter how many presses. Real presses and dispatched
+  `KeyboardEvent`s both. There is no keyboard drag out of the pool; use its "Place in" menu, which
+  is the equal-weight partner by design.
+
+Consequence for coverage: any guard that only fires on a **pool → container** drag cannot be driven
+from this harness at all (MCP pointer drag does not work against dnd-kit either). `placeLeaf`'s
+full-skid guard is the one that sits there - and the Place-in menu disables a full skid rather than
+letting the click through, so nothing reaches it. Its predicate (`canTakeAnotherLeaf`) and its exact
+message are both observable on the cross-container path, which is the honest substitute.
+
+**The 30-leaf skid ceiling, verified live on pr-478** with 31 leaves minted by the fixture route:
+- the card chip reads `30/30 leaves` and switches to MUI `colorWarning` (below the cap it is
+  `colorDefault`)
+- the Place-in menu renders the option as `Skid 3 (full)` and marks it `disabled`
+- a cross-container drag of another leaf onto it is refused with the toast
+  `Skid 3 already holds 30 leaves - start another skid.` and **neither** container changes
+- `setContainerItems` driven straight at the API with 31 leaves fails
+  `VALIDATION_ERROR` / `field: items`, "A skid holds at most 30 door leaves; this one would carry
+  31. Start another skid.", and the skid still holds exactly 30 - the rewrite is atomic, nothing
+  lands partially
+
+The toast auto-dismisses, so read it with a `MutationObserver` on `.MuiAlert-message` armed BEFORE
+the drop rather than polling after; a poll 2.5s later comes back empty and reads like no toast fired.
 
 **Incomplete-leaf guard in the Start-a-Request shipping wizard (#341).** On the Shipping PRs step, an
 assembled leaf that is still owed hardware carries an amber "Incomplete - awaiting replacement" chip


### PR DESCRIPTION
replaces #478, which was cut from the pre-rewrite master and could not be rebased onto the current one.

the same two commits, replayed onto current master with author dates preserved:
- staging drag decision pinned, plus a fixture that can fill a skid
- the staging drag paths and the 30-leaf cap run recorded

the other 62 commits on the old branch were master commits it had absorbed along the way, and are already in master. same 10 files, same 865 insertions.
