### PR TITLE
feat(import): show handing, door quantity and material when classifying (#486)

### DIFF
--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -26,6 +26,12 @@ import { monoSx, microLabelSx } from '../../theme';
 export interface ClassificationRow {
   id: string;
   openingNumber: string;
+  // #486: the opening's own attributes, carried through so the classifier can see what door each
+  // item belongs to without leaving the step. Sourced from ParsedOpening (hand / leaf_count /
+  // door_type), not from the hardware item.
+  hand: string;
+  doorQuantity: number | null;
+  doorMaterial: string;
   productCode: string;
   hardwareCategory: string;
   vendorNo: string;
@@ -40,13 +46,14 @@ export interface ClassificationRow {
 }
 
 export type GroupByField = 'hardwareCategory' | 'vendorNo' | 'productCode' | 'openingNumber'
-  | 'unitCost' | 'listPrice' | 'vendorDiscount' | 'itemQuantity';
+  | 'doorMaterial' | 'unitCost' | 'listPrice' | 'vendorDiscount' | 'itemQuantity';
 
 const GROUP_BY_OPTIONS: { value: GroupByField; label: string }[] = [
   { value: 'hardwareCategory', label: 'Hardware Category' },
   { value: 'vendorNo', label: 'Manufacturer' },
   { value: 'productCode', label: 'Product Code' },
   { value: 'openingNumber', label: 'Opening Number' },
+  { value: 'doorMaterial', label: 'Door Material' },
   { value: 'unitCost', label: 'Unit Cost' },
   { value: 'listPrice', label: 'List Price' },
   { value: 'vendorDiscount', label: 'Vendor Discount' },
@@ -133,6 +140,17 @@ const ALL_COLUMNS: GridColDef[] = [
     cellClassName: 'mono-cell',
     renderCell: (params) => <span title={String(params.value ?? '')}>{params.value}</span>,
   },
+  // #486: fixed small widths - these are short values and the row is already crowded by the two
+  // toggle groups, so they must not take room from the text columns (#485).
+  { field: 'hand', headerName: 'Hand', width: 70 },
+  {
+    field: 'doorQuantity',
+    headerName: 'Door Qty',
+    width: 80,
+    type: 'number',
+    valueFormatter: (value: number | null) => (value != null ? String(value) : '—'),
+  },
+  { field: 'doorMaterial', headerName: 'Door Material', width: 120, cellClassName: 'wrap-cell' },
   {
     field: 'productCode',
     headerName: 'Product Code',

--- a/frontend/src/modules/import/ClassificationStep.tsx
+++ b/frontend/src/modules/import/ClassificationStep.tsx
@@ -69,7 +69,7 @@ export default function ClassificationStep({
         <>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
             {purpose === 'po'
-              ? 'Classify each item as By UCH (in scope) or By Others (excluded from scope), and each in-scope item as Site or Shop hardware.'
+              ? 'Classify each item as By UCH (in scope) or By Others (excluded from scope), and each in-scope item as Site or Shop hardware. Picking Site or Shop marks an unclassified item By UCH for you.'
               : 'Classify each item group as Site Hardware or Shop Hardware.'}
           </Typography>
           <Typography

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -50,6 +50,7 @@ import type {
 } from './types';
 import {
   aggregationKey,
+  backfillScopeFromSiteShop,
   buildLooseCoverageRows,
   classificationKey,
   computeAvailabilityShortfalls,
@@ -736,11 +737,22 @@ export default function ImportWizard({
 
   // Classification rows for DataGrid (one row per aggregated hardware item)
   const classificationRows = useMemo<ClassificationRow[]>(() => {
+    // #486: the classifier needs to see the door, not just the part. Opening attributes live on
+    // ParsedOpening, so index them by opening number once rather than scanning per row.
+    const openingByNumber = new Map(
+      (parsed?.openings ?? []).map((o) => [o.opening_number, o]),
+    );
     return aggregatedHardwareItems.map((hi) => {
       const ck = classificationKey(hi);
+      const opening = openingByNumber.get(hi.opening_number);
       return {
         id: aggregationKey(hi),
         openingNumber: hi.opening_number,
+        hand: opening?.hand ?? '',
+        // leaf_count is the door quantity. hydrateSchedule already defaults a pre-#311 schedule's
+        // missing count to 1, so the only null here is an item whose opening is not in the parse.
+        doorQuantity: opening ? opening.leaf_count : null,
+        doorMaterial: opening?.door_type ?? '',
         productCode: hi.product_code,
         hardwareCategory: hi.hardware_category,
         vendorNo: hi.vendor_no ?? '(No Manufacturer)',
@@ -753,7 +765,7 @@ export default function ImportWizard({
         siteShop: siteShopClassifications.get(ck) ?? '',
       };
     });
-  }, [aggregatedHardwareItems, classifications, siteShopClassifications]);
+  }, [aggregatedHardwareItems, classifications, siteShopClassifications, parsed]);
 
   // Items grouped by vendor for auto PO segregation (excludes BY_OTHERS items)
   const vendorGroups = useMemo(() => {
@@ -993,6 +1005,8 @@ export default function ImportWizard({
       for (const key of keys) next.set(key, value);
       return next;
     });
+    // #486: picking Site or Shop says the item is in scope, so the scope axis fills itself.
+    setClassifications((prev) => backfillScopeFromSiteShop(prev, keys));
   }, []);
 
   // Order As

--- a/frontend/src/modules/import/__tests__/classificationInputs.test.ts
+++ b/frontend/src/modules/import/__tests__/classificationInputs.test.ts
@@ -1,4 +1,4 @@
-import { toClassificationInputs } from '../types';
+import { toClassificationInputs, backfillScopeFromSiteShop } from '../types';
 
 // Regression for #321: a shop-assembly re-import pre-populates the shared classifications Map with
 // BY_OTHERS entries (from the project's exclusion table). Those must never reach the finalize
@@ -43,5 +43,33 @@ describe('toClassificationInputs', () => {
 
   it('returns an empty array for an empty Map', () => {
     expect(toClassificationInputs(new Map())).toEqual([]);
+  });
+});
+
+// #486: setting Site or Shop implies the item is in scope, so the scope axis back-fills instead of
+// demanding a second click. The direction matters - an explicit By Others must survive a bulk
+// Site/Shop action spanning it, or the wizard would silently pull an out-of-scope item into the POs.
+describe('backfillScopeFromSiteShop', () => {
+  it('marks unclassified keys By UCH', () => {
+    const before = new Map<string, string>();
+
+    const after = backfillScopeFromSiteShop(before, ['Hinges|HNG-100|10', 'Locks|LCK-200|25']);
+
+    expect(after.get('Hinges|HNG-100|10')).toBe('BY_UCSH');
+    expect(after.get('Locks|LCK-200|25')).toBe('BY_UCSH');
+  });
+
+  it('never overwrites an explicit By Others', () => {
+    const before = new Map<string, string>([['Closers|CLO-300|40', 'BY_OTHERS']]);
+
+    const after = backfillScopeFromSiteShop(before, ['Closers|CLO-300|40']);
+
+    expect(after.get('Closers|CLO-300|40')).toBe('BY_OTHERS');
+  });
+
+  it('returns the same Map when there is nothing to fill', () => {
+    const before = new Map<string, string>([['Hinges|HNG-100|10', 'BY_UCSH']]);
+
+    expect(backfillScopeFromSiteShop(before, ['Hinges|HNG-100|10'])).toBe(before);
   });
 });

--- a/frontend/src/modules/import/types.ts
+++ b/frontend/src/modules/import/types.ts
@@ -322,3 +322,25 @@ export function toClassificationInputs(classifications: Map<string, string>): Cl
       return { hardwareCategory, productCode, unitCost: parseFloat(unitCost), classification: cls };
     });
 }
+
+// #486: picking Site or Shop on a row says the item is in scope, so the scope axis fills itself
+// rather than asking for a second click that can only have one answer. One direction only: a scope
+// pick never sets Site/Shop, and an item already carrying a scope - By Others most of all - is left
+// exactly as it is. A By Others row renders an em-dash Site/Shop toggle anyway, so the only way to
+// reach this with one is a bulk action spanning it.
+//
+// Returns the same Map when nothing changed, so the caller can skip a re-render.
+export function backfillScopeFromSiteShop(
+  classifications: Map<string, string>,
+  keys: string[],
+): Map<string, string> {
+  const next = new Map(classifications);
+  let changed = false;
+  for (const key of keys) {
+    if (!next.get(key)) {
+      next.set(key, 'BY_UCSH');
+      changed = true;
+    }
+  }
+  return changed ? next : classifications;
+}


### PR DESCRIPTION
closes #486.

the classification step described the part but never the door it belongs to, so deciding scope and site/shop meant leaving the step to look the opening up.

three columns after Opening #, read off `ParsedOpening`, indexed by opening number once rather than scanned per row:

Hand, from `opening.hand`, width 70
Door Qty, from `opening.leaf_count`, width 80, numeric
Door Material, from `opening.door_type`, width 120

fixed small widths so they take no room from the text columns (#485). Door Material joins the group-by options.

`leaf_count` is non-null on the parsed type and `hydrateSchedule` defaults a pre-#311 schedule's missing count to 1. em-dash only for an item whose opening is absent from the parse.

second change, the issue's "if shop or site, automatically by ucsh": picking Site or Shop marks an unclassified item By UCH. choosing either says the item is in scope, so a second click that can only have one answer was the redundancy.

- one direction only, a scope pick never sets Site/Shop
- explicit By Others never overwritten, a bulk Site/Shop action spanning one leaves it out of scope

`backfillScopeFromSiteShop` in types.ts rather than inline in the wizard callback, with three tests:

- unclassified keys become BY_UCSH
- By Others survives
- same Map comes back when there is nothing to fill

`ClassificationStep` helper text says the scope back-fills.
