### PR TITLE
refactor(import): drop the classification step from shop-assembly requests (#492)

### DIFF
--- a/frontend/src/graphql/import.ts
+++ b/frontend/src/graphql/import.ts
@@ -58,6 +58,7 @@ export const GET_PROJECT_HARDWARE_SCHEDULE = gql`
         itemCategoryCode
         productGroupCode
         submittalId
+        classification
       }
     }
   }

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -58,6 +58,7 @@ import {
   shippingPRItemKey,
   toClassificationInputs,
 } from './types';
+import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
 import type { Project } from '../../types/project';
 import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import { FadeIn, StaggerItem, StaggerList } from '../../motion';
@@ -408,26 +409,6 @@ export default function ImportWizard({
     });
   }, [isReimport, parsedHardwareItems, existingProjectId, fetchExcludedItems]);
 
-  // #492: a shop-assembly request has no Classification step, so the SITE/SHOP answers come from the
-  // persisted schedule - the same values a PO request wrote. Only fills keys that have no value yet,
-  // so the exclusion-table seeding above and any manual choice both win over it.
-  useEffect(() => {
-    if (purpose !== 'assembly' || !parsedHardwareItems || parsedHardwareItems.length === 0) return;
-    setClassifications((prev) => {
-      const next = new Map(prev);
-      let changed = false;
-      for (const hi of parsedHardwareItems) {
-        const cls = hi.classification;
-        if (cls !== 'SITE_HARDWARE' && cls !== 'SHOP_HARDWARE') continue;
-        const ck = `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
-        if (!next.has(ck)) {
-          next.set(ck, cls);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [purpose, parsedHardwareItems]);
 
   // ---- Derived Data ----
 
@@ -659,18 +640,26 @@ export default function ImportWizard({
   // #492: with no Classification step for this purpose, an item nobody ever classified has no
   // SITE/SHOP answer anywhere - it is silently not shop work. Counting them here lets the step say
   // so rather than leaving the user to wonder why an opening they picked produced nothing.
+  // #492: with no Classification step for the assembly purpose, the Site/Shop answer comes off the
+  // persisted item - the value a PO request wrote. Resolved at the read site rather than seeded into
+  // state, so the wizard's own map (the exclusion table's BY_OTHERS entries) still wins and no
+  // effect has to write state during render.
+  const resolveClassification = useCallback(
+    (hi: ParsedHardwareItem) => classifications.get(classificationKey(hi)) ?? hi.classification ?? '',
+    [classifications],
+  );
+
   const unclassifiedShopCandidates = useMemo(() => {
     if (purpose !== 'assembly' || !parsed) return [];
     const seen = new Set<string>();
     for (const hi of parsed.hardwareItems) {
       if (!selectedOpenings.has(hi.opening_number)) continue;
-      const ck = classificationKey(hi);
-      const cls = classifications.get(ck);
+      const cls = resolveClassification(hi);
       if (cls === 'SITE_HARDWARE' || cls === 'SHOP_HARDWARE' || cls === 'BY_OTHERS') continue;
       seen.add(`${hi.hardware_category} ${hi.product_code}`);
     }
     return Array.from(seen).sort();
-  }, [purpose, parsed, selectedOpenings, classifications]);
+  }, [purpose, parsed, selectedOpenings, resolveClassification]);
 
   // The shop-assembly work units this wizard would submit: one per (opening, leaf) with its
   // SHOP_HARDWARE items aggregated. Derived once and used by BOTH the availability gate and
@@ -684,7 +673,7 @@ export default function ImportWizard({
       .flatMap((opening) => {
         const shopItems = selectedItems.filter((hi) => {
           if (hi.opening_number !== opening.opening_number) return false;
-          return classifications.get(classificationKey(hi)) === 'SHOP_HARDWARE';
+          return resolveClassification(hi) === 'SHOP_HARDWARE';
         });
         if (shopItems.length === 0) return [];
         // One SAR opening per door leaf (#311): group SHOP_HARDWARE by leaf, then aggregate each
@@ -731,7 +720,7 @@ export default function ImportWizard({
           items: Array.from(aggMap.values()),
         }));
       });
-  }, [purpose, parsed, selectedOpenings, classifications]);
+  }, [purpose, parsed, selectedOpenings, resolveClassification]);
 
   // The exact payload the shop-assembly finalize sends: the included, non-empty leaves with both
   // numbers per line. Derived from the same drafts the allocator step renders, so what the user was

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -268,7 +268,11 @@ export default function ImportWizard({
       { id: 'openings', label: 'Select Openings' },
       { id: 'reconciliation', label: 'Reconciliation' },
     ];
-    if (purpose === 'po' || purpose === 'assembly') {
+    // #492: only the PO purpose asks. A shop-assembly request runs against a project whose schedule
+    // is already classified, so re-asking forced the user to re-answer a question the system knows -
+    // and answering it differently than the original import is exactly the drift. The assembly
+    // purpose seeds its classifications from the persisted items instead (see below).
+    if (purpose === 'po') {
       base.push({ id: 'classification', label: 'Classification' });
     }
     if (purpose === 'po') base.push({ id: 'purchase-orders', label: 'Purchase Orders' });
@@ -403,6 +407,27 @@ export default function ImportWizard({
       }
     });
   }, [isReimport, parsedHardwareItems, existingProjectId, fetchExcludedItems]);
+
+  // #492: a shop-assembly request has no Classification step, so the SITE/SHOP answers come from the
+  // persisted schedule - the same values a PO request wrote. Only fills keys that have no value yet,
+  // so the exclusion-table seeding above and any manual choice both win over it.
+  useEffect(() => {
+    if (purpose !== 'assembly' || !parsedHardwareItems || parsedHardwareItems.length === 0) return;
+    setClassifications((prev) => {
+      const next = new Map(prev);
+      let changed = false;
+      for (const hi of parsedHardwareItems) {
+        const cls = hi.classification;
+        if (cls !== 'SITE_HARDWARE' && cls !== 'SHOP_HARDWARE') continue;
+        const ck = `${hi.hardware_category}|${hi.product_code}|${hi.unit_cost ?? 0}`;
+        if (!next.has(ck)) {
+          next.set(ck, cls);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [purpose, parsedHardwareItems]);
 
   // ---- Derived Data ----
 
@@ -630,6 +655,22 @@ export default function ImportWizard({
     }
     return map;
   }, [availabilityData]);
+
+  // #492: with no Classification step for this purpose, an item nobody ever classified has no
+  // SITE/SHOP answer anywhere - it is silently not shop work. Counting them here lets the step say
+  // so rather than leaving the user to wonder why an opening they picked produced nothing.
+  const unclassifiedShopCandidates = useMemo(() => {
+    if (purpose !== 'assembly' || !parsed) return [];
+    const seen = new Set<string>();
+    for (const hi of parsed.hardwareItems) {
+      if (!selectedOpenings.has(hi.opening_number)) continue;
+      const ck = classificationKey(hi);
+      const cls = classifications.get(ck);
+      if (cls === 'SITE_HARDWARE' || cls === 'SHOP_HARDWARE' || cls === 'BY_OTHERS') continue;
+      seen.add(`${hi.hardware_category} ${hi.product_code}`);
+    }
+    return Array.from(seen).sort();
+  }, [purpose, parsed, selectedOpenings, classifications]);
 
   // The shop-assembly work units this wizard would submit: one per (opening, leaf) with its
   // SHOP_HARDWARE items aggregated. Derived once and used by BOTH the availability gate and
@@ -1728,6 +1769,7 @@ export default function ImportWizard({
               availabilityLoading={availabilityLoading && availabilityData === undefined}
               availabilityError={availabilityError !== undefined}
               allocationStale={allocationStale}
+              unclassifiedItems={unclassifiedShopCandidates}
               onNext={handleNext}
               onBack={handleBack}
             />

--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -68,6 +68,11 @@ interface ShopAssemblyStepProps {
    * finalize and the allocation has been re-derived from fresh numbers (#342 race).
    */
   allocationStale: boolean;
+  /**
+   * Selected items with no persisted SITE/SHOP answer (#492). They are not shop work and are absent
+   * from openingDrafts; naming them beats leaving the user to wonder where an opening went.
+   */
+  unclassifiedItems?: string[];
   onNext: () => void;
   onBack: () => void;
 }
@@ -86,6 +91,7 @@ export default function ShopAssemblyStep({
   availabilityLoading,
   availabilityError,
   allocationStale,
+  unclassifiedItems = [],
   onNext,
   onBack,
 }: ShopAssemblyStepProps) {
@@ -281,6 +287,17 @@ export default function ShopAssemblyStep({
           already reserved - so a shortfall can mean the stock is here but spoken for. The short
           units are not pulled and not owed to the assembler; purchasing is told about them when the
           request is sent.
+        </Alert>
+      )}
+
+      {unclassifiedItems.length > 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {unclassifiedItems.length} item{unclassifiedItems.length === 1 ? '' : 's'} on the selected
+          openings {unclassifiedItems.length === 1 ? 'has' : 'have'} never been classified as Site or
+          Shop hardware, so {unclassifiedItems.length === 1 ? 'it is' : 'they are'} not included:{' '}
+          {unclassifiedItems.slice(0, 6).join(', ')}
+          {unclassifiedItems.length > 6 ? `, and ${unclassifiedItems.length - 6} more` : ''}. Classify
+          them through a PO request first.
         </Alert>
       )}
 

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -523,14 +523,17 @@ describe('ImportWizard step transitions', () => {
     expect(stepLabels()).toEqual([...BASE_STEPS, 'Classification', 'Purchase Orders', 'Finalize']);
   });
 
-  it('assembly purpose (re-import) inserts Classification and Shop Assembly steps', async () => {
+  // #492: the assembly flow used to carry a Classification step. It asked the user to re-answer a
+  // question the persisted schedule already holds, and a different answer than the original import
+  // is the drift. Only the PO purpose classifies now.
+  it('assembly purpose (re-import) inserts only the Shop Assembly step', async () => {
     renderWizard({ project: reimportProject, mocks: reimportMocks });
     await flushApollo();
     clickNext();
 
     fireEvent.click(screen.getByRole('radio', { name: /Pull Request for Shop Assembly/i }));
 
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Classification', 'Shop Assembly', 'Finalize']);
+    expect(stepLabels()).toEqual([...BASE_STEPS, 'Shop Assembly', 'Finalize']);
   });
 
   it('shipping purpose (re-import) inserts only the Shipping PRs step', async () => {

--- a/frontend/src/modules/import/hydrateSchedule.ts
+++ b/frontend/src/modules/import/hydrateSchedule.ts
@@ -62,6 +62,8 @@ export interface ProjectHardwareScheduleHardwareItemResponse {
   itemCategoryCode: string | null;
   productGroupCode: string | null;
   submittalId: string | null;
+  // Persisted SITE_HARDWARE / SHOP_HARDWARE, or null for an item never classified (#492).
+  classification: string | null;
 }
 
 export interface ProjectHardwareScheduleResponse {
@@ -133,6 +135,7 @@ function mapHardwareItem(hi: ProjectHardwareScheduleHardwareItemResponse): Parse
     item_category_code: hi.itemCategoryCode,
     product_group_code: hi.productGroupCode,
     submittal_id: hi.submittalId,
+    classification: hi.classification,
   };
 }
 

--- a/frontend/src/types/hardwareSchedule.ts
+++ b/frontend/src/types/hardwareSchedule.ts
@@ -82,6 +82,9 @@ export interface ParsedHardwareItem {
   item_category_code: string | null;
   product_group_code: string | null;
   submittal_id: string | null;
+  // Persisted SITE_HARDWARE / SHOP_HARDWARE from a previous PO request (#492). Null on a freshly
+  // parsed XML - the file has no such concept - and on an item nobody has classified yet.
+  classification?: string | null;
 }
 
 export interface SkippedRow {

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -566,8 +566,12 @@ parser. "Choose Different Source" on the loaded panel gets you back to the two c
 | Purpose | Steps |
 | --- | --- |
 | Create Purchase Orders | Upload File -> Purpose -> Select Openings -> Reconciliation -> Classification -> Purchase Orders -> Finalize (7) |
-| Pull Request for Shop Assembly | Upload File -> Purpose -> Select Openings -> Reconciliation -> Classification -> Shop Assembly -> Finalize (7) |
+| Pull Request for Shop Assembly | Upload File -> Purpose -> Select Openings -> Reconciliation -> Shop Assembly -> Finalize (6) |
 | Pull Request for Shipping Out | Upload File -> Purpose -> Select Openings -> Reconciliation -> Shipping PRs -> Finalize (6) |
+
+Since #492 the assembly flow has no Classification step: Site/Shop is read off the persisted
+schedule (the values a PO request wrote). Items never classified are named in an info banner on the
+Shop Assembly step and left out of the request.
 
 **Reconciliation is a hard gate on the assembly flow, and it fires before the Shop Assembly step.**
 With nothing in inventory it shows a red alert - `No items have In Inventory status. There is nothing


### PR DESCRIPTION
closes #492.

a SAR always runs against an existing project whose schedule was already classified by a PO request. asking again forced the user to re-answer a question the system knows, and a different answer than the original import is exactly the drift.

assembly purpose no longer asks. Site/Shop map seeds from the persisted hardware items.

`classification` was already on the backend `HardwareItem` type but unselected, so it is threaded through:
GET_PROJECT_HARDWARE_SCHEDULE
ProjectHardwareScheduleHardwareItemResponse
ParsedHardwareItem
hydrateSchedule.mapHardwareItem

seeding only fills keys with no value yet - exclusion-table seeding (BY_OTHERS from the project's exclusion list) and manual choice still win.

items never classified are not shop work, which would otherwise leave a user wondering why an opening they picked produced nothing. Shop Assembly step names them in an info banner, says to classify them through a PO request first.

assembly step sequence 7 -> 6:
Upload File -> Purpose -> Select Openings -> Reconciliation -> Shop Assembly -> Finalize

PO purpose keeps Classification.

no backend change, no migration.

updated the ImportWizard step-sequence test, which pinned the old order, and the assembly flow step list in testing/CLAUDE.md.
