### PR TITLE
feat(import): refuse a reconciliation selection that over-orders the project (#483)

### DIFF
--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -69,6 +69,7 @@ import ReconciliationStep from './ReconciliationStep';
 import ClassificationStep from './ClassificationStep';
 import PurchaseOrdersStep from './PurchaseOrdersStep';
 import ShopAssemblyStep from './ShopAssemblyStep';
+import { buildProductReconRows } from './reconciliation';
 import {
   autoAssign,
   buildAllocatedDrafts,
@@ -1361,9 +1362,22 @@ export default function ImportWizard({
   const canProceedStep0 = parser.state === 'done';
   const canProceedStep1 = purpose !== null;
   const canProceedStep2 = selectedOpenings.size > 0;
+  // #483: the same rollup the Reconciliation step renders, so the numbers the user is blocked by are
+  // by construction the numbers they are shown.
+  const reconBlockingProducts = useMemo(() => {
+    if (purpose !== 'po' || !isReimport) return [];
+    return buildProductReconRows({
+      purpose,
+      reconciliationRows,
+      selectedHardwareItems,
+      allHardwareItems: parsed?.hardwareItems ?? [],
+      selectedReconItems,
+    }).filter((r) => r.blocksProceed);
+  }, [purpose, isReimport, reconciliationRows, selectedHardwareItems, parsed, selectedReconItems]);
+
   const canProceedStep3 = useMemo(() => {
     if (!isReimport) return true;
-    if (purpose === 'po') return selectedReconItems.size > 0;
+    if (purpose === 'po') return selectedReconItems.size > 0 && reconBlockingProducts.length === 0;
     if (purpose === 'assembly') {
       return reconciliationRows.some((r) => r.status === 'RECEIVED' && r.quantity > 0);
     }
@@ -1373,7 +1387,7 @@ export default function ImportWizard({
       );
     }
     return true;
-  }, [purpose, isReimport, selectedReconItems, reconciliationRows]);
+  }, [purpose, isReimport, selectedReconItems, reconciliationRows, reconBlockingProducts]);
 
   // ---- Render ----
 

--- a/frontend/src/modules/import/ReconciliationStep.tsx
+++ b/frontend/src/modules/import/ReconciliationStep.tsx
@@ -3,7 +3,8 @@ import { Alert, Box, Button, Chip, CircularProgress, Tooltip, Typography } from 
 import { AlertTriangle, Info } from 'lucide-react';
 import { DataGrid, type GridColDef, type GridRowSelectionModel } from '@mui/x-data-grid';
 import type { ImportPurpose, ReconciliationRow } from './types';
-import { aggregationKey, itemGroupKey } from './types';
+import { buildProductReconRows, STATUS_PRIORITY } from './reconciliation';
+import type { ProductReconRow } from './reconciliation';
 import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
 import { monoSx, tabularSx } from '../../theme';
 
@@ -29,33 +30,7 @@ interface ReconciliationStepProps {
 
 // ---- Aggregated row type (per-product across project) ----
 
-interface ProductReconRow {
-  id: string; // itemGroupKey: `${hardwareCategory}|${productCode}`
-  hardwareCategory: string;
-  productCode: string;
-  quantityNeeded: number; // sum of HS qty across selected openings
-  quantityRequiredByProject: number; // sum of HS qty across ALL openings in schedule
-  qtyAvailable: number; // for assembly/shipping eligibility
-  statusBreakdown: Map<string, number>; // bucket totals across openings
-  underlyingOpeningKeys: string[]; // (opening, product, category) keys
-  existingCommitted: number; // sum of all non-NOT_COVERED, non-BY_OTHERS bucket qty
-  selectedNewPOQty: number; // HS qty for selected (opening, product, category) keys
-  overCommitAmount: number; // (existingCommitted + selectedNewPOQty) - quantityNeeded, clamped to 0
-}
-
 // ---- Helpers ----
-
-const STATUS_PRIORITY: Record<string, number> = {
-  RECEIVED: 0,
-  ASSEMBLED: 1,
-  SHIPPED_OUT: 2,
-  SHIPPING_OUT: 3,
-  ASSEMBLING: 4,
-  ORDERED: 5,
-  PO_DRAFTED: 6,
-  NOT_COVERED: 7,
-  BY_OTHERS: 8,
-};
 
 const STATUS_COLOR_MAP: Record<string, 'success' | 'warning' | 'error' | 'info' | 'default'> = {
   PO_DRAFTED: 'info',
@@ -82,16 +57,6 @@ const STATUS_LABEL_MAP: Record<string, string> = {
 };
 
 // Buckets that count as "already committed" toward the project need
-const COMMITTED_STATUSES = [
-  'PO_DRAFTED',
-  'ORDERED',
-  'RECEIVED',
-  'ASSEMBLING',
-  'ASSEMBLED',
-  'SHIPPING_OUT',
-  'SHIPPED_OUT',
-] as const;
-
 const HEADER_TOOLTIPS: Record<ImportPurpose, string> = {
   po: 'Reconciliation compares the hardware schedule against existing purchase orders. Items already drafted, ordered, or received are shown so you can decide which remaining items to create new POs for.',
   assembly:
@@ -99,16 +64,6 @@ const HEADER_TOOLTIPS: Record<ImportPurpose, string> = {
   shipping:
     'Reconciliation shows the lifecycle state of each item. Only items that are received or assembled can be included in shipping pull requests. Items still on order or being assembled are not eligible.',
 };
-
-function computeAvailableQty(purpose: ImportPurpose, breakdown: Map<string, number>): number {
-  if (purpose === 'assembly') {
-    return breakdown.get('RECEIVED') ?? 0;
-  }
-  if (purpose === 'shipping') {
-    return (breakdown.get('RECEIVED') ?? 0) + (breakdown.get('ASSEMBLED') ?? 0);
-  }
-  return 0;
-}
 
 // ---- Component ----
 
@@ -129,92 +84,24 @@ export default function ReconciliationStep({
 }: ReconciliationStepProps) {
   const hasAutoSelected = useRef(false);
 
-  // qtyNeededByProduct: qty needed per (category, product) across selected openings
-  const qtyNeededByProduct = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const hi of selectedHardwareItems) {
-      const key = itemGroupKey(hi);
-      map.set(key, (map.get(key) ?? 0) + hi.item_quantity);
-    }
-    return map;
-  }, [selectedHardwareItems]);
+  const aggregatedProductRows = useMemo<ProductReconRow[]>(
+    () =>
+      buildProductReconRows({
+        purpose,
+        reconciliationRows,
+        selectedHardwareItems,
+        allHardwareItems,
+        selectedReconItems,
+      }),
+    [purpose, reconciliationRows, selectedHardwareItems, allHardwareItems, selectedReconItems],
+  );
 
-  // qtyRequiredByProjectByProduct: qty needed per (category, product) across ALL openings in schedule
-  const qtyRequiredByProjectByProduct = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const hi of allHardwareItems) {
-      const key = itemGroupKey(hi);
-      map.set(key, (map.get(key) ?? 0) + hi.item_quantity);
-    }
-    return map;
-  }, [allHardwareItems]);
-
-  // hsQtyByOpeningKey: HS demand per (opening, product, category)
-  const hsQtyByOpeningKey = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const hi of selectedHardwareItems) {
-      const key = aggregationKey(hi);
-      map.set(key, (map.get(key) ?? 0) + hi.item_quantity);
-    }
-    return map;
-  }, [selectedHardwareItems]);
-
-  // Aggregate reconciliation rows per (category, product) across the project
-  const aggregatedProductRows = useMemo<ProductReconRow[]>(() => {
-    const map = new Map<string, ProductReconRow>();
-    // Deduped alongside the rows rather than with `underlyingOpeningKeys.includes`, which is a scan
-    // of every key already collected for that product on every row. A schedule-wide selection puts
-    // thousands of openings behind one product, and the scan turns quadratic there - enough to hang
-    // the tab for the whole aggregation.
-    const openingKeysByProduct = new Map<string, Set<string>>();
-    for (const row of reconciliationRows) {
-      const productKey = `${row.hardwareCategory}|${row.productCode}`;
-      const openingKey = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
-      let entry = map.get(productKey);
-      if (!entry) {
-        entry = {
-          id: productKey,
-          hardwareCategory: row.hardwareCategory,
-          productCode: row.productCode,
-          quantityNeeded: qtyNeededByProduct.get(productKey) ?? 0,
-          quantityRequiredByProject: qtyRequiredByProjectByProduct.get(productKey) ?? 0,
-          qtyAvailable: 0,
-          statusBreakdown: new Map(),
-          underlyingOpeningKeys: [],
-          existingCommitted: 0,
-          selectedNewPOQty: 0,
-          overCommitAmount: 0,
-        };
-        map.set(productKey, entry);
-        openingKeysByProduct.set(productKey, new Set());
-      }
-      openingKeysByProduct.get(productKey)!.add(openingKey);
-      entry.statusBreakdown.set(
-        row.status,
-        (entry.statusBreakdown.get(row.status) ?? 0) + row.quantity,
-      );
-    }
-    const rows = Array.from(map.values());
-    for (const row of rows) {
-      row.underlyingOpeningKeys = Array.from(openingKeysByProduct.get(row.id) ?? []);
-      row.qtyAvailable = computeAvailableQty(purpose, row.statusBreakdown);
-      row.existingCommitted = COMMITTED_STATUSES.reduce(
-        (sum, s) => sum + (row.statusBreakdown.get(s) ?? 0),
-        0,
-      );
-      row.selectedNewPOQty = row.underlyingOpeningKeys
-        .filter((k) => selectedReconItems.has(k))
-        .reduce((sum, k) => sum + (hsQtyByOpeningKey.get(k) ?? 0), 0);
-      const futureCommitted = row.existingCommitted + row.selectedNewPOQty;
-      row.overCommitAmount = Math.max(0, futureCommitted - row.quantityNeeded);
-    }
-    rows.sort((a, b) => {
-      const bestA = Math.min(...Array.from(a.statusBreakdown.keys()).map((s) => STATUS_PRIORITY[s] ?? 99));
-      const bestB = Math.min(...Array.from(b.statusBreakdown.keys()).map((s) => STATUS_PRIORITY[s] ?? 99));
-      return bestA - bestB;
-    });
-    return rows;
-  }, [reconciliationRows, qtyNeededByProduct, qtyRequiredByProjectByProduct, hsQtyByOpeningKey, selectedReconItems, purpose]);
+  // #483: the products this selection pushes past the project total. Named in the error alert and
+  // the reason Next is refused.
+  const blockingRows = useMemo(
+    () => aggregatedProductRows.filter((r) => r.blocksProceed),
+    [aggregatedProductRows],
+  );
 
   // Determine which products have eligible quantity for SAR/SOR
   const eligibleRowIds = useMemo<Set<string>>(() => {
@@ -317,6 +204,25 @@ export default function ReconciliationStep({
         type: 'number',
         cellClassName: 'figure-cell',
       });
+      // #483: the two numbers the buyer is actually reasoning about. Both are project totals, not
+      // per-opening: the hardware lands in fungible project inventory, so what the selected openings
+      // happen to be is irrelevant to whether the project has bought enough.
+      cols.push({
+        field: 'projectTotalOrdered',
+        headerName: 'Project Ordered',
+        description: 'Quantity the project has placed on a GP PO, including everything received since.',
+        flex: 0.8,
+        type: 'number',
+        cellClassName: 'figure-cell',
+      });
+      cols.push({
+        field: 'projectTotalReceived',
+        headerName: 'Project Received',
+        description: 'Quantity that reached the warehouse and beyond. Never more than Project Ordered.',
+        flex: 0.8,
+        type: 'number',
+        cellClassName: 'figure-cell',
+      });
     }
 
     if (showQtyAvailable) {
@@ -364,13 +270,17 @@ export default function ReconciliationStep({
             {row.overCommitAmount > 0 && (
               <Tooltip
                 arrow
-                title={`Total committed (${row.existingCommitted + row.selectedNewPOQty}) exceeds project need (${row.quantityNeeded}) by ${row.overCommitAmount}. Reconciliation is advisory — you may proceed.`}
+                title={
+                  row.blocksProceed
+                    ? `Ordering this would put the project at ${row.existingCommitted + row.selectedNewPOQty} against a schedule need of ${row.quantityRequiredByProject}. Deselect this product to continue.`
+                    : `The project has already committed ${row.existingCommitted} against a schedule need of ${row.quantityRequiredByProject}. Nothing on this screen changes that, so it does not block you.`
+                }
               >
                 <Chip
                   size="small"
                   icon={<AlertTriangle size={14} strokeWidth={1.75} />}
                   label={`Over-committed by ${row.overCommitAmount}`}
-                  color="warning"
+                  color={row.blocksProceed ? 'error' : 'warning'}
                   variant="outlined"
                 />
               </Tooltip>
@@ -447,11 +357,27 @@ export default function ReconciliationStep({
           )}
 
           {/* Purpose-specific alerts */}
+          {purpose === 'po' && blockingRows.length > 0 && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              Ordering these would take the project past what its hardware schedule needs. Deselect
+              them to continue:
+              <Box component="ul" sx={{ m: 0, mt: 1, pl: 3 }}>
+                {blockingRows.map((row) => (
+                  <li key={row.id}>
+                    {row.productCode}: project needs {row.quantityRequiredByProject}, ordered{' '}
+                    {row.projectTotalOrdered}, received {row.projectTotalReceived}, already committed{' '}
+                    {row.existingCommitted} (including drafts), selection adds {row.selectedNewPOQty}
+                  </li>
+                ))}
+              </Box>
+            </Alert>
+          )}
+
           {purpose === 'po' && (
             <Alert severity="warning" sx={{ mb: 2 }}>
               Select the products you want to carry forward to Purchase Order creation.
               Products with a remaining gap are pre-selected. Only checked products will be included.
-              Reconciliation is advisory — over-committed products are flagged but never block you from proceeding.
+              Ordering a product past the project's total quantity is refused.
             </Alert>
           )}
 

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -790,10 +790,13 @@ describe('ImportWizard reconciliation failure', () => {
     // Two products, each seen once despite O-1's two status rows, and both pre-selected off their
     // remaining gap.
     expect(screen.getByText('2 of 2 product(s) selected')).toBeInTheDocument();
-    expect(nextButton()).toBeEnabled();
 
-    clickNext();
-    expect(screen.getByRole('heading', { name: 'Classification' })).toBeInTheDocument();
+    // #483: HNG-100 needs 3 across the project and 1 is already ORDERED. Selecting it carries the
+    // opening's full demand of 3 into PO creation, which would put the project at 4 against a need
+    // of 3 - so Next is refused and the alert names it. LCK-200 has nothing committed and is fine.
+    expect(nextButton()).toBeDisabled();
+    expect(screen.getByText(/take the project past what its hardware schedule needs/i)).toBeInTheDocument();
+    expect(screen.getByText(/HNG-100: project needs 3/)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/modules/import/__tests__/buildProductReconRows.test.ts
+++ b/frontend/src/modules/import/__tests__/buildProductReconRows.test.ts
@@ -1,0 +1,145 @@
+import { buildProductReconRows } from '../reconciliation';
+import type { ReconciliationRow } from '../types';
+import type { ParsedHardwareItem } from '../../../types/hardwareSchedule';
+
+// #483: over-commit used to be measured against the demand of the SELECTED openings, and it only
+// advised. It is measured against the project total now, and a selection that pushes past it blocks.
+
+function hi(overrides: Partial<ParsedHardwareItem> & { opening_number: string; item_quantity: number }) {
+  return {
+    product_code: 'LCK-200',
+    material_id: '',
+    leaf: null,
+    hardware_category: 'Locks',
+    unit_cost: 10,
+    unit_price: null,
+    list_price: null,
+    vendor_discount: null,
+    markup_pct: null,
+    vendor_no: null,
+    manufacturer: null,
+    phase_code: null,
+    item_category_code: null,
+    product_group_code: null,
+    submittal_id: null,
+    ...overrides,
+  } as ParsedHardwareItem;
+}
+
+function recon(openingNumber: string, status: string, quantity: number): ReconciliationRow {
+  return {
+    openingNumber,
+    productCode: 'LCK-200',
+    hardwareCategory: 'Locks',
+    status,
+    quantity,
+  } as ReconciliationRow;
+}
+
+const openingKey = (n: string) => `${n}|LCK-200|Locks`;
+
+function build(args: {
+  all: ParsedHardwareItem[];
+  selected: ParsedHardwareItem[];
+  rows: ReconciliationRow[];
+  selectedKeys: string[];
+}) {
+  return buildProductReconRows({
+    purpose: 'po',
+    reconciliationRows: args.rows,
+    selectedHardwareItems: args.selected,
+    allHardwareItems: args.all,
+    selectedReconItems: new Set(args.selectedKeys),
+  });
+}
+
+it('measures over-commit against the project total, not the selection', () => {
+  // The project needs 40 across two openings. 20 are already ordered. Selecting the other opening's
+  // 20 lands exactly on the total, so nothing is over-committed - even though the SELECTED openings
+  // only need 20 and the old rule would have called that a 20 over-commit.
+  const all = [hi({ opening_number: '101', item_quantity: 20 }), hi({ opening_number: '102', item_quantity: 20 })];
+  const selected = [hi({ opening_number: '102', item_quantity: 20 })];
+
+  const [row] = build({
+    all,
+    selected,
+    rows: [recon('101', 'ORDERED', 20), recon('102', 'NOT_COVERED', 20)],
+    selectedKeys: [openingKey('102')],
+  });
+
+  expect(row.quantityRequiredByProject).toBe(40);
+  expect(row.existingCommitted).toBe(20);
+  expect(row.selectedNewPOQty).toBe(20);
+  expect(row.overCommitAmount).toBe(0);
+  expect(row.blocksProceed).toBe(false);
+});
+
+it('blocks a selection that pushes the product past the project total', () => {
+  // The project needs 40 and all 40 are already ordered. Selecting anything more over-orders.
+  const all = [hi({ opening_number: '101', item_quantity: 40 })];
+  const selected = [hi({ opening_number: '101', item_quantity: 10 })];
+
+  const [row] = build({
+    all,
+    selected,
+    rows: [recon('101', 'ORDERED', 40)],
+    selectedKeys: [openingKey('101')],
+  });
+
+  expect(row.overCommitAmount).toBe(10);
+  expect(row.blocksProceed).toBe(true);
+});
+
+it('does not block when nothing is selected, however over-committed history is', () => {
+  // A re-uploaded schedule with reduced scope: 60 ordered against a project that now needs 40.
+  // Nothing on the reconciliation screen fixes that, so it is flagged but must not strand the user.
+  const all = [hi({ opening_number: '101', item_quantity: 40 })];
+
+  const [row] = build({
+    all,
+    selected: [],
+    rows: [recon('101', 'ORDERED', 60)],
+    selectedKeys: [],
+  });
+
+  expect(row.overCommitAmount).toBe(20);
+  expect(row.blocksProceed).toBe(false);
+});
+
+it('clears the block when the product is deselected', () => {
+  const all = [hi({ opening_number: '101', item_quantity: 40 })];
+  const selected = [hi({ opening_number: '101', item_quantity: 10 })];
+  const rows = [recon('101', 'ORDERED', 40)];
+
+  const blocked = build({ all, selected, rows, selectedKeys: [openingKey('101')] });
+  expect(blocked[0].blocksProceed).toBe(true);
+
+  const cleared = build({ all, selected, rows, selectedKeys: [] });
+  expect(cleared[0].blocksProceed).toBe(false);
+});
+
+// The two project-total columns (#483). Ordered counts everything placed on a GP PO; received
+// counts everything that reached the warehouse. Received can never exceed ordered.
+it('rolls up project totals ordered and received', () => {
+  const all = [hi({ opening_number: '101', item_quantity: 10 })];
+
+  const [row] = build({
+    all,
+    selected: [],
+    rows: [
+      recon('101', 'PO_DRAFTED', 1),
+      recon('101', 'ORDERED', 2),
+      recon('101', 'RECEIVED', 3),
+      recon('101', 'ASSEMBLED', 1),
+      recon('101', 'SHIPPED_OUT', 1),
+    ],
+    selectedKeys: [],
+  });
+
+  // Drafted is not ordered.
+  expect(row.projectTotalOrdered).toBe(7);
+  expect(row.projectTotalReceived).toBe(5);
+  expect(row.projectTotalReceived).toBeLessThanOrEqual(row.projectTotalOrdered);
+  // The block counts drafts too - a draft becomes an order.
+  expect(row.existingCommitted).toBe(8);
+});

--- a/frontend/src/modules/import/reconciliation.ts
+++ b/frontend/src/modules/import/reconciliation.ts
@@ -1,0 +1,174 @@
+/**
+ * The per-product reconciliation rollup, as pure functions.
+ *
+ * Split out of ReconciliationStep because the wizard gates Next on the same numbers the step
+ * renders (#483). A second, parallel calculation there is a bug waiting to diverge, and what the
+ * user is blocked by has to be what they are shown. Nothing here touches React.
+ */
+
+import type { ImportPurpose, ReconciliationRow } from './types';
+import type { ParsedHardwareItem } from '../../types/hardwareSchedule';
+import { aggregationKey, itemGroupKey } from './types';
+
+export interface ProductReconRow {
+  id: string; // itemGroupKey: `${hardwareCategory}|${productCode}`
+  hardwareCategory: string;
+  productCode: string;
+  quantityNeeded: number; // sum of HS qty across selected openings
+  quantityRequiredByProject: number; // sum of HS qty across ALL openings in schedule
+  qtyAvailable: number; // for assembly/shipping eligibility
+  statusBreakdown: Map<string, number>; // bucket totals across openings
+  underlyingOpeningKeys: string[]; // (opening, product, category) keys
+  existingCommitted: number; // sum of all non-NOT_COVERED, non-BY_OTHERS bucket qty
+  selectedNewPOQty: number; // HS qty for selected (opening, product, category) keys
+  // Everything the project has actually placed on a PO: ORDERED and every state past it. Shown as
+  // its own column (#483) - "how much of this has the project already bought" is the question the
+  // buyer is answering, and it was only derivable by adding up status chips.
+  projectTotalOrdered: number;
+  // Everything that reached the warehouse and beyond. Can never exceed projectTotalOrdered: you
+  // cannot receive what was never ordered.
+  projectTotalReceived: number;
+  // #483: measured against quantityRequiredByProject, never against the selected openings. Opening
+  // identity is not a thing at this step - the selection is a quality-of-life way to decide what to
+  // buy, and the hardware lands in fungible project inventory rather than against the openings that
+  // were ticked. So there is no such thing as over-committing an opening, only the project.
+  overCommitAmount: number;
+  // The one refusal: ordering this selection would take the project past what its hardware schedule
+  // says it needs. A product whose EXISTING commitments already exceed the total is flagged but
+  // never blocks - nothing on this screen fixes history, and refusing would strand the user.
+  blocksProceed: boolean;
+}
+
+export const STATUS_PRIORITY: Record<string, number> = {
+  RECEIVED: 0,
+  ASSEMBLED: 1,
+  SHIPPED_OUT: 2,
+  SHIPPING_OUT: 3,
+  ASSEMBLING: 4,
+  ORDERED: 5,
+  PO_DRAFTED: 6,
+  NOT_COVERED: 7,
+  BY_OTHERS: 8,
+};
+
+// Placed on a PO, in every sense that counts against the project's need. PO_DRAFTED is in here
+// because a draft becomes an order: letting a second draft push past the total would only move the
+// over-order one step later, to a registration nobody is watching.
+const COMMITTED_STATUSES = [
+  'PO_DRAFTED',
+  'ORDERED',
+  'RECEIVED',
+  'ASSEMBLING',
+  'ASSEMBLED',
+  'SHIPPING_OUT',
+  'SHIPPED_OUT',
+] as const;
+
+// Actually on a GP PO. PO_DRAFTED is deliberately absent - a draft has not been ordered.
+const ORDERED_STATUSES = ['ORDERED', 'RECEIVED', 'ASSEMBLING', 'ASSEMBLED', 'SHIPPING_OUT', 'SHIPPED_OUT'] as const;
+
+// In the warehouse or past it. Can never exceed the ordered total.
+const RECEIVED_STATUSES = ['RECEIVED', 'ASSEMBLING', 'ASSEMBLED', 'SHIPPING_OUT', 'SHIPPED_OUT'] as const;
+
+function computeAvailableQty(purpose: ImportPurpose, breakdown: Map<string, number>): number {
+  if (purpose === 'assembly') {
+    return breakdown.get('RECEIVED') ?? 0;
+  }
+  if (purpose === 'shipping') {
+    return (breakdown.get('RECEIVED') ?? 0) + (breakdown.get('ASSEMBLED') ?? 0);
+  }
+  return 0;
+}
+
+/**
+ * The per-product reconciliation rollup (#483).
+ *
+ * Pure and exported because the step renders it and the wizard gates Next on it. A second,
+ * parallel calculation in the wizard is a bug waiting to diverge, and the numbers the user is
+ * blocked by have to be the numbers they are shown.
+ */
+export function buildProductReconRows(args: {
+  purpose: ImportPurpose;
+  reconciliationRows: ReconciliationRow[];
+  selectedHardwareItems: ParsedHardwareItem[];
+  allHardwareItems: ParsedHardwareItem[];
+  selectedReconItems: Set<string>;
+}): ProductReconRow[] {
+  const { purpose, reconciliationRows, selectedHardwareItems, allHardwareItems, selectedReconItems } = args;
+
+  const qtyNeededByProduct = new Map<string, number>();
+  const hsQtyByOpeningKey = new Map<string, number>();
+  for (const hi of selectedHardwareItems) {
+    const key = itemGroupKey(hi);
+    qtyNeededByProduct.set(key, (qtyNeededByProduct.get(key) ?? 0) + hi.item_quantity);
+    const ak = aggregationKey(hi);
+    hsQtyByOpeningKey.set(ak, (hsQtyByOpeningKey.get(ak) ?? 0) + hi.item_quantity);
+  }
+  const qtyRequiredByProjectByProduct = new Map<string, number>();
+  for (const hi of allHardwareItems) {
+    const key = itemGroupKey(hi);
+    qtyRequiredByProjectByProduct.set(key, (qtyRequiredByProjectByProduct.get(key) ?? 0) + hi.item_quantity);
+  }
+
+  const map = new Map<string, ProductReconRow>();
+  // Deduped alongside the rows rather than with `underlyingOpeningKeys.includes`, which is a scan
+  // of every key already collected for that product on every row. A schedule-wide selection puts
+  // thousands of openings behind one product, and the scan turns quadratic there - enough to hang
+  // the tab for the whole aggregation.
+  const openingKeysByProduct = new Map<string, Set<string>>();
+  for (const row of reconciliationRows) {
+    const productKey = `${row.hardwareCategory}|${row.productCode}`;
+    const openingKey = `${row.openingNumber}|${row.productCode}|${row.hardwareCategory}`;
+    let entry = map.get(productKey);
+    if (!entry) {
+      entry = {
+        id: productKey,
+        hardwareCategory: row.hardwareCategory,
+        productCode: row.productCode,
+        quantityNeeded: qtyNeededByProduct.get(productKey) ?? 0,
+        quantityRequiredByProject: qtyRequiredByProjectByProduct.get(productKey) ?? 0,
+        qtyAvailable: 0,
+        statusBreakdown: new Map(),
+        underlyingOpeningKeys: [],
+        existingCommitted: 0,
+        selectedNewPOQty: 0,
+        projectTotalOrdered: 0,
+        projectTotalReceived: 0,
+        overCommitAmount: 0,
+        blocksProceed: false,
+      };
+      map.set(productKey, entry);
+      openingKeysByProduct.set(productKey, new Set());
+    }
+    openingKeysByProduct.get(productKey)!.add(openingKey);
+    entry.statusBreakdown.set(row.status, (entry.statusBreakdown.get(row.status) ?? 0) + row.quantity);
+  }
+
+  const rows = Array.from(map.values());
+  for (const row of rows) {
+    row.underlyingOpeningKeys = Array.from(openingKeysByProduct.get(row.id) ?? []);
+    row.qtyAvailable = computeAvailableQty(purpose, row.statusBreakdown);
+    row.existingCommitted = COMMITTED_STATUSES.reduce(
+      (sum, s) => sum + (row.statusBreakdown.get(s) ?? 0),
+      0,
+    );
+    row.projectTotalOrdered = ORDERED_STATUSES.reduce((sum, s) => sum + (row.statusBreakdown.get(s) ?? 0), 0);
+    row.projectTotalReceived = RECEIVED_STATUSES.reduce((sum, s) => sum + (row.statusBreakdown.get(s) ?? 0), 0);
+    row.selectedNewPOQty = row.underlyingOpeningKeys
+      .filter((k) => selectedReconItems.has(k))
+      .reduce((sum, k) => sum + (hsQtyByOpeningKey.get(k) ?? 0), 0);
+    const futureCommitted = row.existingCommitted + row.selectedNewPOQty;
+    row.overCommitAmount = Math.max(0, futureCommitted - row.quantityRequiredByProject);
+    // A re-uploaded schedule with reduced scope can push existing commitments past the new project
+    // total on their own. Those rows show the badge but must not block: nothing selectable here
+    // fixes them, and refusing to advance would strand the user.
+    row.blocksProceed = row.selectedNewPOQty > 0 && futureCommitted > row.quantityRequiredByProject;
+  }
+  rows.sort((a, b) => {
+    const bestA = Math.min(...Array.from(a.statusBreakdown.keys()).map((s) => STATUS_PRIORITY[s] ?? 99));
+    const bestB = Math.min(...Array.from(b.statusBreakdown.keys()).map((s) => STATUS_PRIORITY[s] ?? 99));
+    return bestA - bestB;
+  });
+  return rows;
+}
+


### PR DESCRIPTION
closes #483.

over-commit measured against demand of SELECTED openings, and only advised. both wrong.

no opening identity at this step. picking openings is a quality-of-life way to decide what to buy; the hardware lands in fungible project inventory, not against the ticked openings. over-commit exists at project level only.

two new columns on the PO purpose, both project totals:
Project Ordered - quantity placed on a GP PO, plus everything received since. PO_DRAFTED excluded, a draft has not been ordered
Project Received - quantity that reached the warehouse and beyond, never exceeds Project Ordered

existing lifecycle breakdown chips already carry six states per product:
PO drafted
ordered
received
assembling/assembled
shipping out
shipped out

blocking rule `existingCommitted + selectedNewPOQty > quantityRequiredByProject` refuses Next, names every offending product with its numbers.

product whose EXISTING commitments already exceed the total keeps its badge, never blocks - a re-uploaded schedule with reduced scope produces exactly that, and nothing on this screen fixes it.

"Over-committed by X" badge stays, measured at project level. not a blocker on its own.

rollup moves out of ReconciliationStep into a pure `reconciliation.ts`, alongside `allocation.ts`. wizard gates Next on the same numbers the step renders, so a second calculation there cannot diverge.

judgment call worth your eye: the block counts PO_DRAFTED alongside ordered quantities. a draft becomes an order, and ignoring drafts would only move the over-order to a registration nobody is watching. say so if you want drafts excluded.

five unit tests on the pure helper. ImportWizard reconciliation test updated - fixture (needs 3, 1 already ORDERED, selection carries the opening's full 3) is now a genuine over-order and asserts the refusal.
