### PR TITLE
feat(po): capture the GP cost code at PO request creation (#490)

### DIFF
--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -786,6 +786,9 @@ def finalize_import_session(
                 notes=po_draft.get("notes"),
                 # Issue #216: the PM's requested date, captured at PO-request creation.
                 preferred_delivery_date=po_draft.get("preferred_delivery_date"),
+                # #490: the buyer's cost-code pick, if the relay was up to offer the job's list.
+                # Register still validates against GP - this is a default, not a decision.
+                cost_code=(po_draft.get("cost_code") or None),
                 # Whoever finalized this wizard session, from the resolver's Clerk token. It is who a
                 # receive against this PO later asks "inventory or ship out?".
                 created_by_user_id=input_data.get("created_by_user_id"),

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -145,6 +145,7 @@ class ImportMutations:
                     "po_number": po.po_number,
                     "notes": po.notes,
                     "preferred_delivery_date": po.preferred_delivery_date,
+                    "cost_code": po.cost_code,
                     "hardware_item_refs": [
                         {
                             "opening_number": ref.opening_number,

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -180,6 +180,10 @@ class POLineItemOrderAsInput:
 class PODraftInput:
     po_number: str | None = None
     notes: str | None = None
+    # #490: the GP cost code, picked per vendor card at request time. Optional - it is only
+    # authoritative at register, where RegisterPOInput.cost_code is still validated against the job's
+    # live GP list. Captured here so the buyer who knows the code does not have to remember it later.
+    cost_code: str | None = None
     # Issue #216: the PM's requested date, captured at PO-request creation.
     preferred_delivery_date: date | None = None
     hardware_item_refs: list[HardwareItemRef] = strawberry.field(default_factory=list)
@@ -345,6 +349,9 @@ class CreateDraftPOInput:
     # Issue #156: optional order-time dollar costs. Null means "not entered"; 0 is a valid value.
     shipping_cost: float | None = None
     tariff_amount: float | None = None
+    # #490: optional GP cost code, carried to register as the default. RegisterPOInput.cost_code
+    # stays authoritative - a code that has since left the job's GP list is caught there.
+    cost_code: str | None = None
 
 
 @strawberry.input

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -387,6 +387,7 @@ class POMutations:
                 tariff_amount=input.tariff_amount,
                 preferred_delivery_date=input.preferred_delivery_date,
                 created_by_user_id=auth["user_id"],
+                cost_code=input.cost_code,
             )
             session.commit()
             return po_to_type(po_repository.reload_po(session, po.id))

--- a/frontend/src/graphql/po.ts
+++ b/frontend/src/graphql/po.ts
@@ -332,6 +332,7 @@ export const CREATE_DRAFT_PO = gql`
       gpCompany
       gpVendorId
       vendorNameSnapshot
+      costCode
       notes
       preferredDeliveryDate
       createdAt

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -225,8 +225,10 @@ export default function ImportWizard({
 
   // Action step state
   const [selectedVendors, setSelectedVendors] = useState<Set<string>>(new Set());
+  // #490: costCode joins notes and the preferred date as a per-manufacturer-card value, so the
+  // buyer can record the GP cost code with the request instead of only at registration.
   const [vendorPOInfo, setVendorPOInfo] = useState<
-    Map<string, { notes: string; preferredDeliveryDate: string }>
+    Map<string, { notes: string; preferredDeliveryDate: string; costCode: string }>
   >(new Map());
   const [unitCostOverrides, setUnitCostOverrides] = useState<Map<string, number>>(new Map());
   const [classifications, setClassifications] = useState<Map<string, string>>(new Map());
@@ -1000,10 +1002,10 @@ export default function ImportWizard({
 
   // Manufacturer-group PO info
   const updateVendorPO = useCallback(
-    (manufacturerKey: string, field: 'notes' | 'preferredDeliveryDate', value: string | null) => {
+    (manufacturerKey: string, field: 'notes' | 'preferredDeliveryDate' | 'costCode', value: string | null) => {
       setVendorPOInfo((prev) => {
         const next = new Map(prev);
-        const existing = next.get(manufacturerKey) ?? { notes: '', preferredDeliveryDate: '' };
+        const existing = next.get(manufacturerKey) ?? { notes: '', preferredDeliveryDate: '', costCode: '' };
         next.set(manufacturerKey, { ...existing, [field]: value ?? '' });
         return next;
       });
@@ -1183,7 +1185,7 @@ export default function ImportWizard({
               // Filter out BY_OTHERS items from this vendor's PO draft
               const inScopeItems = items.filter((hi) => !isByOthers(hi));
               if (inScopeItems.length === 0) return null;
-              const info = vendorPOInfo.get(vendor) ?? { notes: '', preferredDeliveryDate: '' };
+              const info = vendorPOInfo.get(vendor) ?? { notes: '', preferredDeliveryDate: '', costCode: '' };
               // Collect aliases for this manufacturer group's aggregated line items
               const seenKeys = new Set<string>();
               const lineItemAliases: Array<{ hardwareCategory: string; productCode: string; orderAs: string }> = [];
@@ -1205,6 +1207,7 @@ export default function ImportWizard({
                 poNumber: null,
                 notes: info.notes || null,
                 preferredDeliveryDate: info.preferredDeliveryDate || null,
+                costCode: info.costCode || null,
                 hardwareItemRefs: inScopeItems.map((hi) => ({
                   openingNumber: hi.opening_number,
                   productCode: hi.product_code,
@@ -1737,6 +1740,7 @@ export default function ImportWizard({
           {effectiveStepId === 'purchase-orders' && (
             <PurchaseOrdersStep
               projectId={project.id}
+              jobNumber={project.projectId ?? null}
               vendorGroups={vendorGroups}
               vendorPOInfo={vendorPOInfo}
               selectedVendors={selectedVendors}

--- a/frontend/src/modules/import/PurchaseOrdersStep.tsx
+++ b/frontend/src/modules/import/PurchaseOrdersStep.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
-import { Box, Button, Checkbox, FormControlLabel, InputAdornment, Paper, TextField, Typography } from '@mui/material';
+import { Box, Button, Checkbox, FormControlLabel, InputAdornment, MenuItem, Paper, TextField, Typography } from '@mui/material';
 import { useQuery } from '@apollo/client/react';
 import OrderAsAutocomplete from '../../components/OrderAsAutocomplete';
 import { GET_PRIOR_ORDER_AS_VALUES } from '../../graphql/shared';
+import { GET_GP_COST_CODES } from '../../graphql/po';
+import { useRelayStatus } from '../../relay/useRelayStatus';
 import type { AggregatedHardwareItem } from './types';
 import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import { StaggerItem, StaggerList } from '../../motion';
@@ -15,6 +17,14 @@ interface AggregatedLineItem {
   totalQuantity: number;
   unitCost: number;
   totalCost: number;
+}
+
+// #490: the job's live GP cost codes, fetched once for the step and shared across every card
+// rather than per card - it is one job, so it is one list.
+interface GpCostCode {
+  costCode: string;
+  costElement: string;
+  description: string | null;
 }
 
 interface PriorOrderAsForProduct {
@@ -31,15 +41,17 @@ interface PriorOrderAsQueryData {
 interface PurchaseOrdersStepProps {
   /** The wizard's project - order-as memory is scoped to it (#509). */
   projectId: string;
+  /** The GP job number (#490). Cost codes are per job, so the live list is keyed on it. */
+  jobNumber: string | null;
   vendorGroups: Map<string, AggregatedHardwareItem[]>;
-  vendorPOInfo: Map<string, { notes: string; preferredDeliveryDate: string }>;
+  vendorPOInfo: Map<string, { notes: string; preferredDeliveryDate: string; costCode: string }>;
   selectedVendors: Set<string>;
   unitCostOverrides: Map<string, number>;
   orderAsValues: Map<string, string>;
   onToggleVendor: (vendor: string) => void;
   onUpdateVendorPO: (
     manufacturerKey: string,
-    field: 'notes' | 'preferredDeliveryDate',
+    field: 'notes' | 'preferredDeliveryDate' | 'costCode',
     value: string | null,
   ) => void;
   onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
@@ -89,14 +101,15 @@ interface VendorGroupCardProps {
   projectId: string;
   vendor: string;
   items: AggregatedHardwareItem[];
-  info: { notes: string; preferredDeliveryDate: string };
+  info: { notes: string; preferredDeliveryDate: string; costCode: string };
+  costCodes: GpCostCode[];
   isSelected: boolean;
   unitCostOverrides: Map<string, number>;
   orderAsValues: Map<string, string>;
   onToggleVendor: (vendor: string) => void;
   onUpdateVendorPO: (
     manufacturerKey: string,
-    field: 'notes' | 'preferredDeliveryDate',
+    field: 'notes' | 'preferredDeliveryDate' | 'costCode',
     value: string | null,
   ) => void;
   onUpdateUnitCost: (vendor: string, productCode: string, hardwareCategory: string, newCost: number) => void;
@@ -108,6 +121,7 @@ function VendorGroupCard({
   vendor,
   items,
   info,
+  costCodes,
   isSelected,
   unitCostOverrides,
   orderAsValues,
@@ -180,6 +194,27 @@ function VendorGroupCard({
           sx={{ width: 190 }}
           slotProps={{ inputLabel: { shrink: true } }}
         />
+        {costCodes.length > 0 && (
+          <TextField
+            select
+            label="Cost code"
+            size="small"
+            disabled={!isSelected}
+            value={info.costCode}
+            onChange={(e) => onUpdateVendorPO(vendor, 'costCode', e.target.value)}
+            sx={{ width: 260, '& .MuiSelect-select': monoSx }}
+            helperText="Optional, carried to GP registration"
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {costCodes.map((c) => (
+              <MenuItem key={`${c.costCode}-${c.costElement}`} value={`${c.costCode}-${c.costElement}`}>
+                {c.description ? `${c.costCode} · ${c.description}` : c.costCode}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
         <TextField
           label="Notes"
           size="small"
@@ -305,6 +340,7 @@ function VendorGroupCard({
 
 export default function PurchaseOrdersStep({
   projectId,
+  jobNumber,
   vendorGroups,
   vendorPOInfo,
   selectedVendors,
@@ -320,6 +356,18 @@ export default function PurchaseOrdersStep({
   const canProceed = useMemo(() => {
     return selectedVendors.size > 0;
   }, [selectedVendors]);
+
+  // #490: one job, so one cost-code read for the whole step rather than one per manufacturer card.
+  // Relay down or job absent -> empty list -> the cards render no cost-code field at all, and the
+  // code is picked at GP registration as before.
+  const relay = useRelayStatus({});
+  const company = relay.company ?? '';
+  const { data: costCodesData } = useQuery<{ gpCostCodes: GpCostCode[] }>(GET_GP_COST_CODES, {
+    variables: { company, job: jobNumber ?? '' },
+    skip: relay.connected !== true || !company || !jobNumber,
+    fetchPolicy: 'cache-first',
+  });
+  const costCodes = useMemo(() => costCodesData?.gpCostCodes ?? [], [costCodesData]);
 
   const sortedVendors = useMemo(
     () => Array.from(vendorGroups.entries()).sort(([a], [b]) => a.localeCompare(b)),
@@ -337,7 +385,7 @@ export default function PurchaseOrdersStep({
 
       <StaggerList count={sortedVendors.length}>
         {sortedVendors.map(([vendor, items]) => {
-          const info = vendorPOInfo.get(vendor) ?? { notes: '', preferredDeliveryDate: '' };
+          const info = vendorPOInfo.get(vendor) ?? { notes: '', preferredDeliveryDate: '', costCode: '' };
           const isSelected = selectedVendors.has(vendor);
           return (
             <StaggerItem key={vendor}>
@@ -346,6 +394,7 @@ export default function PurchaseOrdersStep({
                 vendor={vendor}
                 items={items}
                 info={info}
+                costCodes={costCodes}
                 isSelected={isSelected}
                 unitCostOverrides={unitCostOverrides}
                 orderAsValues={orderAsValues}

--- a/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
+++ b/frontend/src/modules/po/GpPurchaseOrderDialog.tsx
@@ -188,7 +188,9 @@ export default function GpPurchaseOrderDialog({
   // read from the hook here rather than picked by the user. The page still passes relayConnected in as
   // the single source of truth for the connected flag; standalone, the hook's own connected value is used.
   // Issue #256: only register mode talks to GP - create mode is a plain draft and needs no relay.
-  const relay = useRelayStatus({ skip: !open || !isRegister });
+  // #490: create mode reads the relay too - not to talk to GP, but to offer the job's cost codes
+  // at request time. A draft still never touches GP.
+  const relay = useRelayStatus({ skip: !open });
   const company = relay.company ?? '';
   const relayStatus: boolean | null = relayConnectedProp !== undefined ? relayConnectedProp : relay.connected;
   const relayConnected = relayStatus === true;
@@ -340,7 +342,9 @@ export default function GpPurchaseOrderDialog({
     refetch: refetchCostCodes,
   } = useQuery<{ gpCostCodes: GpCostCode[] }>(GET_GP_COST_CODES, {
     variables: { company, job: jobNumber ?? '' },
-    skip: !open || !isRegister || !relayConnected || !company || !jobNumber,
+    // #490: no longer register-only. Whenever a project is chosen and a relay is up, the job's live
+    // list is offered so the buyer can record the code with the request.
+    skip: !open || !relayConnected || !company || !jobNumber,
     fetchPolicy: 'cache-first',
   });
   // Every code GP reports active for the job is offered. This used to be filtered to the caller's
@@ -370,7 +374,9 @@ export default function GpPurchaseOrderDialog({
     seededRef.current = true;
     // Fresh open = fresh user action, so start a new idempotency key on the next submit.
     idempotencyKeyRef.current = null;
-    setCostCode('');
+    // #490: a draft raised with a cost code arrives at register with it already chosen. Falls back
+    // to blank for a draft that carries none, and the stale-code check below still applies.
+    setCostCode(registerPo?.costCode ?? '');
     setErrors({});
     if (registerPo) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time form seed on open, guarded by seededRef
@@ -468,9 +474,18 @@ export default function GpPurchaseOrderDialog({
   // Clear the selected cost code only when the job or company changes - a code from another job must
   // not carry over. Deliberately NOT keyed on relayConnected: the page polls relayStatus every 10s,
   // and a transient blip must not wipe the user's pick mid-form.
+  const costCodeScopeRef = useRef<string | null>(null);
   useEffect(() => {
     if (!open) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear cost code when job/company changes
+    const scope = `${company}|${jobNumber ?? ''}`;
+    // First pass after an open must not wipe the seed above (#490) - only a genuine job/company
+    // change clears the pick, which is the case a code from another job must not survive.
+    if (costCodeScopeRef.current === null) {
+      costCodeScopeRef.current = scope;
+      return;
+    }
+    if (costCodeScopeRef.current === scope) return;
+    costCodeScopeRef.current = scope;
     setCostCode('');
   }, [open, company, jobNumber]);
 
@@ -661,6 +676,7 @@ export default function GpPurchaseOrderDialog({
               preferredDeliveryDate: preferredDeliveryDate || null,
               shippingCost: shippingCostValue,
               tariffAmount: tariffAmountValue,
+              costCode: costCode || null,
               lineItems: lineItemsInput,
             },
           },
@@ -899,6 +915,35 @@ export default function GpPurchaseOrderDialog({
               slotProps={{ inputLabel: { shrink: true } }}
             />
           </Stack>
+        )}
+        {/* #490: capture the GP cost code with the request when the job's live list is reachable.
+            No free-text entry - a wrong code caught at register is worse than an empty one - and no
+            field at all when there is nothing to pick from, with a caption saying where it goes. */}
+        {!isRegister && !!projectId && (
+          relayConnected && costCodes.length > 0 ? (
+            <TextField
+              select
+              label="Cost code (optional)"
+              value={costCode}
+              onChange={(e) => setCostCode(e.target.value)}
+              size="small"
+              sx={{ minWidth: 300, '& .MuiSelect-select': monoSx }}
+              helperText="Carried to GP registration as the default"
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {costCodes.map((c) => (
+                <MenuItem key={`${c.costCode}-${c.costElement}`} value={`${c.costCode}-${c.costElement}`}>
+                  {c.description ? `${c.costCode} · ${c.description}` : c.costCode}
+                </MenuItem>
+              ))}
+            </TextField>
+          ) : (
+            <Typography variant="caption" color="text.secondary">
+              Cost code can be set at GP registration.
+            </Typography>
+          )
         )}
         <Stack direction="row" spacing={2}>
           <TextField

--- a/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
+++ b/frontend/src/modules/po/__tests__/GpPurchaseOrderDialog.test.tsx
@@ -683,7 +683,9 @@ describe('GpPurchaseOrderDialog', () => {
 
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
     expect(calls).toHaveLength(1);
-    // toEqual proves the draft input carries NO buyer / gpCompany / costCode / idempotency key.
+    // toEqual proves the draft input carries NO buyer / gpCompany / idempotency key. costCode IS
+    // part of it since #490, but null here: the relay is down in this test, so there is no live
+    // list to pick from and the field is not offered.
     expect(calls[0]).toEqual({
       input: {
         projectId: 'p1',
@@ -691,6 +693,7 @@ describe('GpPurchaseOrderDialog', () => {
         preferredDeliveryDate: '2026-09-15',
         shippingCost: null,
         tariffAmount: null,
+        costCode: null,
         lineItems: [
           {
             hardwareCategory: 'Hinges',

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -134,6 +134,9 @@ export interface PurchaseOrder {
   gpCompany: string | null;
   gpVendorId: string | null;
   vendorNameSnapshot: string | null;
+  // #490: the buyer's GP cost-code pick, optionally captured at request time and used as the
+  // default when the draft is registered.
+  costCode: string | null;
   buyerId: string | null;
   vendorQuoteNumber: string | null;
   shippingCost: number | null;


### PR DESCRIPTION
closes #490.

the GP cost code could only be chosen at registration, so a buyer who knew it when raising the request had to carry it in their head until then. capturable at both PO creation paths now, arrives at register preselected.

`RegisterPOInput.cost_code` stays authoritative - the register dialog validates the pick against the job's live GP list, so a code that has since left the job is caught there rather than at the relay.

backend
- `CreateDraftPOInput.cost_code`, optional
- `PODraftInput.cost_code`, optional
- `create_po` persists it on the manual path
- import finalize path persists it per PO draft

frontend
- create-mode `GpPurchaseOrderDialog` offers the job's live list once a project is chosen and a relay is up
- no free-text entry - a wrong code caught at register is worse than an empty one
- no field at all when the list is unreachable, caption says it can be set at registration
- import wizard Purchase Orders step offers the same list, one read for the whole step rather than one per manufacturer card, since it is one job
- `vendorPOInfo` gains `costCode` alongside notes and the preferred date
- register dialog seeds `costCode` from the draft's stored pick instead of blank
- the clear-on-job/company-change effect used to run on open and would have wiped that seed immediately. it records the scope on first pass now and clears only on a genuine change, which is the case a code from another job must not survive

no migration, `PurchaseOrder.cost_code` already exists and is nullable.
