### PR TITLE
feat(warehouse): pick sheet shows Order As and PO number per location (#496)

### DIFF
--- a/backend/app/repositories/warehouse/pull_requests.py
+++ b/backend/app/repositories/warehouse/pull_requests.py
@@ -36,6 +36,8 @@ from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.pull_pick_line import PullPickLine as PullPickLineModel
 from app.models.pull_request import PullRequest as PullRequestModel
 from app.models.pull_request import PullRequestItem as PullRequestItemModel
+from app.models.purchase_order import POLineItem as POLineItemModel
+from app.models.purchase_order import PurchaseOrder as POModel
 from app.models.shipping_out_request import ShippingOutRequest as ShippingOutRequestModel
 from app.models.shop_assembly import ShopAssemblyOpening
 from app.models.shop_assembly import ShopAssemblyRequest as ShopAssemblyRequestModel
@@ -393,6 +395,12 @@ class PickSheetLocation:
     received_at: datetime
     draft_quantity: int
     applied_quantity: int
+    # #496: what the vendor called this part, and the PO it arrived on. Per location rather than per
+    # section: one product can sit in inventory from several POs with different Order As values, so
+    # a section-level value would be wrong for every row but one. Null on a stock-origin row, which
+    # has no PO line behind it.
+    order_as: str | None = None
+    po_number: str | None = None
 
 
 @dataclass(frozen=True)
@@ -622,8 +630,11 @@ def get_pick_sheet(session: Session, pr_id: uuid.UUID) -> PickSheet:
         if referenced_location_ids:
             visibility = or_(visibility, InventoryLocationModel.id.in_(referenced_location_ids))
         rows = session.execute(
-            select(InventoryLocationModel, WarehouseModel.code)
+            select(InventoryLocationModel, WarehouseModel.code, POLineItemModel.order_as, POModel.po_number)
             .outerjoin(WarehouseModel, WarehouseModel.id == InventoryLocationModel.warehouse_id)
+            # #496: one joined read for the whole sheet, no per-row lazy loads.
+            .outerjoin(POLineItemModel, POLineItemModel.id == InventoryLocationModel.po_line_item_id)
+            .outerjoin(POModel, POModel.id == POLineItemModel.po_id)
             .where(
                 InventoryLocationModel.project_id == pr.project_id,
                 combo_clause,
@@ -631,7 +642,7 @@ def get_pick_sheet(session: Session, pr_id: uuid.UUID) -> PickSheet:
             )
             .order_by(InventoryLocationModel.received_at.asc(), InventoryLocationModel.id.asc())
         ).all()
-        for il, warehouse_code in rows:
+        for il, warehouse_code, order_as, po_number in rows:
             combo = (il.hardware_category, il.product_code)
             counts = by_location.get((*combo, il.id), {"draft": 0, "applied": 0})
             locations_by_combo[combo].append(
@@ -646,6 +657,8 @@ def get_pick_sheet(session: Session, pr_id: uuid.UUID) -> PickSheet:
                     received_at=il.received_at,
                     draft_quantity=counts["draft"],
                     applied_quantity=counts["applied"],
+                    order_as=order_as,
+                    po_number=po_number,
                 )
             )
 

--- a/backend/app/schemas/converters.py
+++ b/backend/app/schemas/converters.py
@@ -896,6 +896,8 @@ def pick_sheet_to_type(sheet, staging=None, partially_picked=None) -> PickSheet:
                         received_at=loc.received_at,
                         draft_quantity=loc.draft_quantity,
                         applied_quantity=loc.applied_quantity,
+                        order_as=loc.order_as,
+                        po_number=loc.po_number,
                     )
                     for loc in section.locations
                 ],

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1486,6 +1486,10 @@ class PickSheetLocation:
     # What the saved draft has against this row, and what has already been confirmed off it.
     draft_quantity: int
     applied_quantity: int
+    # #496: the vendor's name for the part and the PO it arrived on, per location - one product can
+    # sit in inventory from several POs with different Order As values. Null on stock-origin rows.
+    order_as: str | None
+    po_number: str | None
 
 
 @strawberry.type

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -669,7 +669,7 @@ const PICK_SHEET_FIELDS = `
     leaves { openingNumber leaf quantity }
     locations {
       inventoryLocationId warehouseId warehouseCode aisle row bay
-      available receivedAt draftQuantity appliedQuantity
+      available receivedAt draftQuantity appliedQuantity orderAs poNumber
     }
   }
   fetchItems {

--- a/frontend/src/modules/warehouse/PickSection.tsx
+++ b/frontend/src/modules/warehouse/PickSection.tsx
@@ -144,6 +144,10 @@ export default function PickSection({ section, entries, onChange, editable }: Pi
           <Box component="thead">
             <Box component="tr" sx={{ '& th': { ...microLabelSx, textAlign: 'left', pb: 0.5 } }}>
               <Box component="th">Location</Box>
+              {/* #496: same two columns as the printed sheet, in the same order, so screen and
+                  paper agree line for line. */}
+              <Box component="th">PO #</Box>
+              <Box component="th">Order As</Box>
               <Box component="th">Received</Box>
               <Box component="th" sx={{ textAlign: 'right !important' }}>
                 Available
@@ -188,6 +192,16 @@ export default function PickSection({ section, entries, onChange, editable }: Pi
                         {loc.appliedQuantity} already pulled from here
                       </Typography>
                     )}
+                  </Box>
+                  <Box component="td">
+                    <Typography component="span" variant="body2" sx={monoSx} color="text.secondary">
+                      {loc.poNumber ?? '—'}
+                    </Typography>
+                  </Box>
+                  <Box component="td">
+                    <Typography component="span" variant="body2" sx={monoSx} color="text.secondary">
+                      {loc.orderAs ?? '—'}
+                    </Typography>
                   </Box>
                   <Box component="td" sx={{ ...tabularSx }}>
                     <Typography component="span" variant="body2" color="text.secondary">

--- a/frontend/src/modules/warehouse/PickSheetDocument.tsx
+++ b/frontend/src/modules/warehouse/PickSheetDocument.tsx
@@ -128,23 +128,30 @@ export default function PickSheetDocument({
               <Text style={styles.empty}>No inventory rows hold this product for this project.</Text>
             ) : (
               <>
+                {/* #496: PO # and Order As per location - the picker matches what is on the box,
+                    which carries the vendor's name for the part, not ours. The write-in box keeps
+                    its width; the location and received columns give up the room. */}
                 <View style={styles.tableHeaderRow}>
-                  <Text style={[styles.th, { width: '38%' }]}>Location</Text>
-                  <Text style={[styles.th, { width: '22%' }]}>Received</Text>
-                  <Text style={[styles.th, { width: '18%' }]}>Available</Text>
-                  <Text style={[styles.th, { width: '22%' }]}>Pulled</Text>
+                  <Text style={[styles.th, { width: '26%' }]}>Location</Text>
+                  <Text style={[styles.th, { width: '16%' }]}>PO #</Text>
+                  <Text style={[styles.th, { width: '18%' }]}>Order As</Text>
+                  <Text style={[styles.th, { width: '14%' }]}>Received</Text>
+                  <Text style={[styles.th, { width: '12%' }]}>Available</Text>
+                  <Text style={[styles.th, { width: '14%' }]}>Pulled</Text>
                 </View>
                 {section.locations.map((loc) => (
                   <View key={loc.inventoryLocationId} style={styles.tableRow} wrap={false}>
-                    <Text style={[styles.td, { width: '38%' }]}>
+                    <Text style={[styles.td, { width: '26%' }]}>
                       {loc.warehouseCode ? `${loc.warehouseCode} ` : ''}
                       {locationLabel(loc) ?? 'Unlocated'}
                     </Text>
-                    <Text style={[styles.td, { width: '22%' }]}>
+                    <Text style={[styles.td, { width: '16%' }]}>{loc.poNumber ?? '—'}</Text>
+                    <Text style={[styles.td, { width: '18%' }]}>{loc.orderAs ?? '—'}</Text>
+                    <Text style={[styles.td, { width: '14%' }]}>
                       {parseServerDate(loc.receivedAt).toLocaleDateString()}
                     </Text>
-                    <Text style={[styles.td, { width: '18%' }]}>{loc.available}</Text>
-                    <View style={{ width: '22%' }}>
+                    <Text style={[styles.td, { width: '12%' }]}>{loc.available}</Text>
+                    <View style={{ width: '14%' }}>
                       <View style={styles.writeIn} />
                     </View>
                   </View>

--- a/frontend/src/modules/warehouse/pick.ts
+++ b/frontend/src/modules/warehouse/pick.ts
@@ -27,6 +27,13 @@ export interface PickSheetLocation {
   receivedAt: string;
   draftQuantity: number;
   appliedQuantity: number;
+  /**
+   * What the vendor calls this part, and the PO it arrived on (#496). Per location, not per
+   * section: one product can sit in inventory from several POs with different Order As values, so a
+   * section-level value would be wrong for every row but one. Null on a stock-origin row.
+   */
+  orderAs: string | null;
+  poNumber: string | null;
 }
 
 export interface PickSheetSection {


### PR DESCRIPTION
closes #496

the picker matches what is written on the box, and the box carries the vendor's name for the part, not ours. the sheet showed neither that nor the PO the stock arrived on, so reconciling a rack against the sheet meant a lookup.

Order As and PO number on every location row, screen and paper.

per location, not per section: one product can sit in inventory from several POs with different Order As values, so a section-level value would be wrong for every row but one. a stock-origin row has no PO line behind it, renders an em-dash.

`PickSheetLocation` gains `order_as` and `po_number` in:
repository dataclass
Strawberry type
frontend type

pick-sheet query gains one outer join `POLineItem` -> `PurchaseOrder`, so it stays a single read with no per-row lazy loads.

screen and printed sheet carry the same two columns in the same order, so they agree line for line (#367).
on the printed sheet the write-in box keeps its width, Location and Received give up the room:

Location 26%
PO # 16%
Order As 18%
Received 14%
Available 12%
Pulled 14%

shop-assembly and shipping-out pulls both run through this view, so both get the columns.

no migration.
