### PR TITLE
feat(warehouse): assembled leaves get a real put-away location (#498)

### DIFF
--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -293,6 +293,7 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     "receivingHistoryPos": SIGNED_IN,
     "recentReceiveRecords": SIGNED_IN,
     "unlocatedInventory": SIGNED_IN,
+    "unlocatedOpeningItems": SIGNED_IN,
     "warehouse": SIGNED_IN,
     "warehouseDashboard": SIGNED_IN,
     "warehouses": SIGNED_IN,

--- a/backend/app/repositories/shop_assembly_repository.py
+++ b/backend/app/repositories/shop_assembly_repository.py
@@ -437,9 +437,6 @@ def record_assembly_progress(
 def complete_opening(
     session: Session,
     opening_id: uuid.UUID,
-    aisle: str | None,
-    row: str | None,
-    bay: str | None,
     completed_by: str | None = None,
 ) -> OpeningItemModel:
     """Mark an opening's assembly as complete. Creates OpeningItem + OpeningItemHardware records.
@@ -449,6 +446,12 @@ def complete_opening(
     what the assembler actually recorded fitting, unit by unit - not a claim made in the same call.
     Deficiencies were already returned to inventory and replaced when they were flagged, so this
     function no longer writes any of that.
+
+    Completion no longer records a location either (#498). It used to take free-text aisle/row/bay
+    from the ASSEMBLER, against no warehouse choice and no validation that the place existed - so
+    the "put-away location" on an assembled leaf was whatever the person at the bench typed, and
+    warehouse staff could not correct it. The leaf lands unlocated and joins the warehouse put-away
+    queue, which is the same route received stock takes.
     """
     # 1. Load and validate ShopAssemblyOpening (with pessimistic lock)
     sa_opening = _load_workable_opening(session, opening_id)
@@ -561,9 +564,11 @@ def complete_opening(
         quantity=1,
         assembly_completed_at=now,
         state=OpeningItemState.IN_INVENTORY,
-        aisle=aisle,
-        row=row,
-        bay=bay,
+        # #498: unlocated on purpose. The warehouse assigns a real warehouse + aisle/row/bay from
+        # the put-away queue; until then this leaf reads "not put away yet".
+        aisle=None,
+        row=None,
+        bay=None,
     )
     session.add(opening_item)
     try:
@@ -632,9 +637,8 @@ def complete_opening(
                 }
                 for item in sa_opening.items
             ],
-            "aisle": aisle,
-            "row": row,
-            "bay": bay,
+            # #498: no location here any more. Completion does not place the leaf; the PUT_AWAY
+            # audit row written when the warehouse assigns it is what records where it went.
         },
     )
 

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -19,6 +19,7 @@ from .inventory import (
     get_opening_leaf_counts,
     get_opening_leaf_status,
     get_unlocated_inventory,
+    get_unlocated_opening_items,
     override_inventory_quantity,
 )
 from .locations import (
@@ -194,6 +195,7 @@ __all__ = [
     "get_reserved_quantities",
     "get_reserved_total",
     "get_unlocated_inventory",
+    "get_unlocated_opening_items",
     "get_warehouse_dashboard",
     "mark_approved",
     "mark_inventory_unlocated",

--- a/backend/app/repositories/warehouse/inventory.py
+++ b/backend/app/repositories/warehouse/inventory.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.errors import NotFoundError, ValidationError
-from app.models.enums import AuditAction, AuditEntityType
+from app.models.enums import AuditAction, AuditEntityType, OpeningItemState
 from app.models.inventory import InventoryLocation as InventoryLocationModel
 from app.models.opening_item import OpeningItem as OpeningItemModel
 from app.models.project import Opening as OpeningModel
@@ -609,3 +609,29 @@ def get_inventory_rows(
             }
         )
     return rows
+
+
+def get_unlocated_opening_items(session: Session, project_id: uuid.UUID | None = None):
+    """Assembled leaves sitting in inventory with no bin assigned (#498).
+
+    The other half of the put-away queue. Completion no longer records a location, so a finished
+    leaf arrives here and waits for the warehouse to say which warehouse and bin it went into -
+    exactly what received stock does in get_unlocated_inventory above.
+
+    Only IN_INVENTORY leaves qualify: one already pulled for shipping has left the rack, and asking
+    someone to put it away would be asking them to find something that is not there.
+    """
+    stmt = select(OpeningItemModel).where(
+        OpeningItemModel.state == OpeningItemState.IN_INVENTORY,
+        OpeningItemModel.aisle.is_(None),
+        OpeningItemModel.row.is_(None),
+        OpeningItemModel.bay.is_(None),
+    )
+    if project_id is not None:
+        stmt = stmt.where(OpeningItemModel.project_id == project_id)
+    stmt = stmt.order_by(
+        OpeningItemModel.assembly_completed_at.desc(),
+        OpeningItemModel.opening_number,
+        OpeningItemModel.leaf,
+    )
+    return list(session.scalars(stmt).all())

--- a/backend/app/repositories/warehouse/locations.py
+++ b/backend/app/repositories/warehouse/locations.py
@@ -547,14 +547,38 @@ def mark_opening_item_unlocated(session: Session, oi_id: uuid.UUID, *, performed
 
 
 def assign_opening_item_location(
-    session: Session, oi_id: uuid.UUID, aisle: str, row: str, bay: str, *, performed_by: str
+    session: Session,
+    oi_id: uuid.UUID,
+    aisle: str,
+    row: str,
+    bay: str,
+    *,
+    performed_by: str,
+    warehouse_id: uuid.UUID | None = None,
 ) -> OpeningItemModel:
-    """Assign aisle/row/bay to an OpeningItem."""
+    """Put an assembled leaf away: a warehouse plus a bin within it.
+
+    #498: the warehouse is part of the assignment now. Completion used to stamp the primary
+    warehouse and take free-text aisle/row/bay from the assembler, so a leaf could sit in a bin that
+    named no real place and warehouse staff had no way to say which building it was in.
+    warehouse_id is optional only so the admin correction path can keep moving a bin without
+    re-picking the building.
+    """
+    from app.models.warehouse import Warehouse as WarehouseModel
+
     oi = session.get(OpeningItemModel, oi_id)
     if oi is None:
         raise NotFoundError(f"Opening item {oi_id} not found")
 
     aisle, row, bay = _normalize_and_validate_location_fields(aisle, row, bay)
+
+    if warehouse_id is not None:
+        warehouse = session.get(WarehouseModel, warehouse_id)
+        if warehouse is None:
+            raise NotFoundError(f"Warehouse {warehouse_id} not found")
+        if not warehouse.is_active:
+            raise ValidationError("That warehouse is not active", field="warehouse_id")
+        oi.warehouse_id = warehouse_id
 
     oi.aisle = aisle
     oi.row = row
@@ -567,7 +591,14 @@ def assign_opening_item_location(
         entity_id=oi.id,
         action=AuditAction.PUT_AWAY,
         performed_by=performed_by,
-        detail={"toLocation": {"aisle": aisle, "row": row, "bay": bay}},
+        detail={
+            "toLocation": {
+                "warehouseId": str(oi.warehouse_id) if oi.warehouse_id else None,
+                "aisle": aisle,
+                "row": row,
+                "bay": bay,
+            }
+        },
     )
 
     return oi

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -762,6 +762,9 @@ class CancelPullRequestInput:
 @strawberry.input
 class CompleteOpeningInput:
     opening_id: strawberry.ID
+    # #498: deprecated and ignored. Completion no longer records a location - the assembler was
+    # typing free text with no warehouse choice and no validation, and warehouse staff could not
+    # correct it. Kept in the schema until frontends stop sending them (#438 pattern).
     aisle: str | None = None
     row: str | None = None
     bay: str | None = None

--- a/backend/app/schemas/shop_assembly.py
+++ b/backend/app/schemas/shop_assembly.py
@@ -312,16 +312,17 @@ class ShopAssemblyMutations:
         Takes no checklist (#340): completion reads the per-item counts recordAssemblyProgress has
         been persisting, and is refused while any unit is still unaccounted for. Open to any signed-in
         user - it writes inventory, so it must not be reachable anonymously. Who completed the leaf is
-        the Clerk-authenticated caller (#427)."""
+        the Clerk-authenticated caller (#427).
+
+        #498: the input's aisle/row/bay are deprecated and ignored. The leaf lands unlocated and the
+        warehouse assigns a real warehouse plus bin from the put-away queue, the same route received
+        stock takes. The fields stay in the schema until frontends stop sending them (#438)."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = shop_assembly_repository.complete_opening(
                 session,
                 uuid.UUID(str(input.opening_id)),
-                input.aisle,
-                input.row,
-                input.bay,
                 completed_by=actor,
             )
             session.commit()

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -519,6 +519,19 @@ class WarehouseQueries:
             ]
 
     @strawberry.field
+    def unlocated_opening_items(
+        self, info: strawberry.Info, project_id: strawberry.ID | None = None
+    ) -> list[OpeningItem]:
+        """Assembled leaves waiting to be put away (#498) - the other half of the put-away queue."""
+        with SessionLocal() as session:
+            return [
+                opening_item_to_type(oi)
+                for oi in warehouse_repository.get_unlocated_opening_items(
+                    session, uuid.UUID(str(project_id)) if project_id else None
+                )
+            ]
+
+    @strawberry.field
     def unlocated_inventory(
         self, info: strawberry.Info, project_id: strawberry.ID | None = None
     ) -> list[InventoryItemDetail]:
@@ -1588,13 +1601,23 @@ class WarehouseMutations:
         aisle: str,
         row: str,
         bay: str,
+        warehouse_id: strawberry.ID | None = None,
     ) -> OpeningItem:
-        """Put an assembled leaf away, writing a PUT_AWAY audit row naming the caller (#427)."""
+        """Put an assembled leaf away, writing a PUT_AWAY audit row naming the caller (#427).
+
+        #498: warehouse_id is part of the assignment. Omitting it moves the bin within the leaf's
+        current warehouse, which is what the admin correction path wants."""
         auth = current_user(info)
         actor = resolve_display_name(auth["user_id"])
         with SessionLocal() as session:
             result = warehouse_repository.assign_opening_item_location(
-                session, uuid.UUID(str(opening_item_id)), aisle, row, bay, performed_by=actor
+                session,
+                uuid.UUID(str(opening_item_id)),
+                aisle,
+                row,
+                bay,
+                performed_by=actor,
+                warehouse_id=uuid.UUID(str(warehouse_id)) if warehouse_id else None,
             )
             session.commit()
             session.refresh(result)

--- a/backend/tests/test_assembly_progress.py
+++ b/backend/tests/test_assembly_progress.py
@@ -410,7 +410,7 @@ def test_progress_refused_once_completed(db_session):
     shop_assembly_repository.record_assembly_progress(
         db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
     )
-    shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
 
     with pytest.raises(InvalidStateTransitionError):
@@ -435,7 +435,7 @@ def test_completion_blocked_while_units_are_unaccounted_for(db_session):
     db_session.flush()
 
     with pytest.raises(ValidationError) as excinfo:
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, opening.id)
     # The message names the line that is short so the assembler knows where to go back to.
     assert HINGE[1] in str(excinfo.value)
     assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
@@ -447,7 +447,7 @@ def test_untouched_opening_cannot_be_completed(db_session):
     project = _make_project(db_session)
     opening, _ = _make_pulled_opening(db_session, project.id, request_number="PR-SA-P14", items=[(*HINGE, 2)])
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, opening.id)
 
 
 def test_opening_item_hardware_quantities_are_the_installed_counts(db_session):
@@ -472,7 +472,7 @@ def test_opening_item_hardware_quantities_are_the_installed_counts(db_session):
     )
     db_session.flush()
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "1", "1", completed_by="ada")
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="ada")
     db_session.flush()
 
     hw = list(
@@ -578,7 +578,7 @@ def test_completed_openings_cannot_be_unassigned_or_reassigned(db_session):
     shop_assembly_repository.record_assembly_progress(
         db_session, opening.id, [Update(sao[HINGE[1]].id, installed_quantity=2)]
     )
-    shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
 
     with pytest.raises(InvalidStateTransitionError):

--- a/backend/tests/test_completion_deficiency_checklist.py
+++ b/backend/tests/test_completion_deficiency_checklist.py
@@ -195,12 +195,14 @@ def test_deficiency_returns_unit_and_mints_replacement_before_completion(db_sess
     # ...and the opening is now in progress, not pending.
     assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "2", "3", completed_by="assembler")
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="assembler")
     db_session.flush()
 
     # Assembled leaf returns to inventory carrying only what was installed.
     assert result.state == OpeningItemState.IN_INVENTORY
-    assert result.aisle == "A" and result.row == "2" and result.bay == "3"
+    # #498: completion no longer places the leaf. It lands unlocated and the warehouse assigns a
+    # real warehouse and bin from the put-away queue.
+    assert result.aisle is None and result.row is None and result.bay is None
     hw = _installed_hardware(db_session, result.id)
     assert {h.product_code for h in hw} == {INSTALLED[1]}
 
@@ -228,7 +230,7 @@ def test_no_deficiency_means_no_replacement_pull(db_session):
         ],
         performed_by="assembler",
     )
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    result = shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
 
     hw = _installed_hardware(db_session, result.id)
@@ -283,7 +285,7 @@ def test_deficiency_creates_inventory_row_when_deleted(db_session):
         ],
         performed_by="assembler",
     )
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, "A", "2", "3", completed_by="assembler")
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="assembler")
     db_session.flush()
 
     # Installed item is still snapshotted despite the missing deficient-product row.

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -858,6 +858,6 @@ def test_complete_opening_stamps_leaf(db_session):
         item.installed_quantity = item.quantity
     db_session.flush()
 
-    opening_item = shop_assembly_repository.complete_opening(db_session, sao.id, "A", "1", "1", completed_by="tester")
+    opening_item = shop_assembly_repository.complete_opening(db_session, sao.id, completed_by="tester")
     db_session.flush()
     assert opening_item.leaf == 2

--- a/backend/tests/test_pipeline_observability.py
+++ b/backend/tests/test_pipeline_observability.py
@@ -312,7 +312,7 @@ def test_pipeline_walks_a_request_from_requested_to_shipped(db_session):
         performed_by="Ana",
     )
     db_session.flush()
-    leaf_one = shop_assembly_repository.complete_opening(db_session, openings[0].id, "B", "2", "3", completed_by="Ana")
+    leaf_one = shop_assembly_repository.complete_opening(db_session, openings[0].id, completed_by="Ana")
     db_session.flush()
     detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
     assert detail.openings[0].stage == "COMPLETED"
@@ -521,7 +521,7 @@ def test_awaiting_replacement_and_arrived_after_ship_are_both_visible(db_session
         performed_by="Ana",
     )
     db_session.flush()
-    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by="Ana")
+    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="Ana")
     leaf.state = OpeningItemState.SHIPPED_OUT
     db_session.flush()
 
@@ -739,7 +739,7 @@ def _leaf_with_deficiency(db_session, project, *, complete=False, assign_to=("us
             performed_by=assign_to[1],
         )
         db_session.flush()
-        shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by=assign_to[1])
+        shop_assembly_repository.complete_opening(db_session, opening.id, completed_by=assign_to[1])
         db_session.flush()
     repl = db_session.scalar(select(PullRequest).where(PullRequest.request_number == f"PR-REPL-{pr.request_number}"))
     return sar, pr, opening, item, repl
@@ -1024,7 +1024,7 @@ def test_assembly_status_values_are_all_reachable(db_session):
     db_session.flush()
     assert opening.assembly_status == AssemblyStatus.IN_PROGRESS
 
-    shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by="Ana")
+    shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="Ana")
     db_session.flush()
     assert opening.assembly_status == AssemblyStatus.COMPLETED
 
@@ -1051,7 +1051,7 @@ def _build_and_complete(db_session, sar, *, assign_to=("user_1", "Ana")):
         performed_by=assign_to[1],
     )
     db_session.flush()
-    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, "B", "2", "3", completed_by=assign_to[1])
+    leaf = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by=assign_to[1])
     db_session.flush()
     return pr, opening, leaf
 

--- a/backend/tests/test_pipeline_observability.py
+++ b/backend/tests/test_pipeline_observability.py
@@ -316,7 +316,9 @@ def test_pipeline_walks_a_request_from_requested_to_shipped(db_session):
     db_session.flush()
     detail = shop_assembly_repository.get_assembly_pipeline(db_session, sar.id)
     assert detail.openings[0].stage == "COMPLETED"
-    assert detail.openings[0].assembled_location == "B-2-3"
+    # #498: completion no longer places the leaf, so the pipeline shows it unlocated until the
+    # warehouse assigns a warehouse and bin from the put-away queue.
+    assert detail.openings[0].assembled_location is None
     assert detail.openings[0].opening_item_id == leaf_one.id
     assert _summary(db_session, sar).completed_opening_count == 1
 

--- a/backend/tests/test_pull_staging_cancel.py
+++ b/backend/tests/test_pull_staging_cancel.py
@@ -799,7 +799,7 @@ def test_complete_opening_works_while_the_pull_is_only_part_staged(db_session):
     )
     db_session.flush()
 
-    opening_item = shop_assembly_repository.complete_opening(db_session, openings[0].id, "A", "1", "1")
+    opening_item = shop_assembly_repository.complete_opening(db_session, openings[0].id)
     db_session.flush()
     assert opening_item.opening_number == "A01"
     assert openings[0].assembly_status == AssemblyStatus.COMPLETED
@@ -809,7 +809,7 @@ def test_complete_opening_works_while_the_pull_is_only_part_staged(db_session):
     openings[1].assigned_to_user_id = "user-1"
     db_session.flush()
     with pytest.raises(InvalidStateTransitionError):
-        shop_assembly_repository.complete_opening(db_session, openings[1].id, "A", "1", "1")
+        shop_assembly_repository.complete_opening(db_session, openings[1].id)
 
 
 def test_get_pull_request_openings_orders_by_opening_and_leaf(db_session):

--- a/backend/tests/test_replacement_loop.py
+++ b/backend/tests/test_replacement_loop.py
@@ -186,7 +186,7 @@ def _complete(session, opening, sao_items):
     ]
     shop_assembly_repository.record_assembly_progress(session, opening.id, updates, performed_by="ada")
     session.flush()
-    return shop_assembly_repository.complete_opening(session, opening.id, "A", "1", "B", completed_by="ada")
+    return shop_assembly_repository.complete_opening(session, opening.id, completed_by="ada")
 
 
 # --- 1. arrival restores the leaf's expectation --------------------------------------------------
@@ -215,7 +215,7 @@ def test_repl_completion_restores_expectation_on_an_in_progress_leaf(db_session)
 
     # And completion is still blocked on it.
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, opening.id)
 
 
 def test_repl_completion_writes_an_audit_row(db_session):

--- a/backend/tests/test_shop_assembly_completion_guards.py
+++ b/backend/tests/test_shop_assembly_completion_guards.py
@@ -165,7 +165,7 @@ def test_completion_refused_when_leaf_already_assembled(db_session):
     )
 
     with pytest.raises(ConflictError):
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, opening.id)
 
     # Nothing was minted and the opening stays workable.
     db_session.flush()
@@ -188,7 +188,7 @@ def test_completion_allowed_when_only_the_other_leaf_is_assembled(db_session):
         opening_id=opening_id,
     )
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    result = shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
     assert result.leaf == 2
     assert opening.assembly_status == AssemblyStatus.COMPLETED
@@ -208,7 +208,7 @@ def test_completion_allowed_when_prior_unit_shipped_out(db_session):
         opening_id=opening_id,
     )
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    result = shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
     assert result.state == OpeningItemState.IN_INVENTORY
 
@@ -227,7 +227,7 @@ def test_legacy_null_leaf_unit_only_blocks_a_null_leaf_completion(db_session):
         leaf=1,
         opening_id=opening_id,
     )
-    shop_assembly_repository.complete_opening(db_session, leafed.id, None, None, None)
+    shop_assembly_repository.complete_opening(db_session, leafed.id)
     db_session.flush()
 
     legacy, _ = _make_pulled_opening(
@@ -239,7 +239,7 @@ def test_legacy_null_leaf_unit_only_blocks_a_null_leaf_completion(db_session):
         opening_id=opening_id,
     )
     with pytest.raises(ConflictError):
-        shop_assembly_repository.complete_opening(db_session, legacy.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, legacy.id)
 
 
 def test_duplicate_guard_is_project_scoped(db_session):
@@ -257,7 +257,7 @@ def test_duplicate_guard_is_project_scoped(db_session):
         opening_id=opening_id,
     )
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    result = shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
     assert result.project_id == project.id
 
@@ -306,7 +306,7 @@ def test_all_deficient_completion_is_refused(db_session):
     _flag_all_deficient(db_session, opening, sao)
 
     with pytest.raises(ValidationError):
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None, completed_by="assembler")
+        shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="assembler")
     db_session.flush()
 
     # No assembled unit exists and the leaf stays open (IN_PROGRESS - it has recorded work on it).
@@ -345,9 +345,7 @@ def test_partially_deficient_completion_still_succeeds(db_session):
     )
     db_session.flush()
 
-    result = shop_assembly_repository.complete_opening(
-        db_session, opening.id, None, None, None, completed_by="assembler"
-    )
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="assembler")
     db_session.flush()
     assert result.state == OpeningItemState.IN_INVENTORY
     # Only the installed line is snapshotted onto the leaf.
@@ -373,9 +371,7 @@ def test_completion_excuses_units_that_were_never_pulled(db_session):
         install_all=True,
     )
 
-    result = shop_assembly_repository.complete_opening(
-        db_session, opening.id, None, None, None, completed_by="assembler"
-    )
+    result = shop_assembly_repository.complete_opening(db_session, opening.id, completed_by="assembler")
     db_session.flush()
 
     assert opening.assembly_status == AssemblyStatus.COMPLETED
@@ -404,7 +400,7 @@ def test_completion_still_refuses_a_leaf_that_was_entirely_short(db_session):
     )
 
     with pytest.raises(ValidationError) as excinfo:
-        shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+        shop_assembly_repository.complete_opening(db_session, opening.id)
     assert "never pulled" in str(excinfo.value)
     assert opening.completed_at is None
 
@@ -420,7 +416,7 @@ def test_opening_with_no_items_still_completes(db_session):
         leaf=1,
     )
 
-    result = shop_assembly_repository.complete_opening(db_session, opening.id, None, None, None)
+    result = shop_assembly_repository.complete_opening(db_session, opening.id)
     db_session.flush()
     assert result.state == OpeningItemState.IN_INVENTORY
     assert opening.assembly_status == AssemblyStatus.COMPLETED

--- a/frontend/src/graphql/admin.ts
+++ b/frontend/src/graphql/admin.ts
@@ -246,10 +246,13 @@ export const OVERRIDE_INVENTORY_QUANTITY = gql`
   }
 `;
 
+// #498: warehouseId is part of the assignment - putting a leaf away is choosing a building and a
+// bin within it. Omitting it moves the bin inside the leaf's current warehouse, which is what the
+// admin correction path does.
 export const ASSIGN_OPENING_ITEM_LOCATION = gql`
-  mutation AssignOpeningItemLocation($openingItemId: ID!, $aisle: String!, $row: String!, $bay: String!) {
-    assignOpeningItemLocation(openingItemId: $openingItemId, aisle: $aisle, row: $row, bay: $bay) {
-      id projectId openingId openingNumber building floor location quantity assemblyCompletedAt state aisle row bay createdAt updatedAt
+  mutation AssignOpeningItemLocation($openingItemId: ID!, $aisle: String!, $row: String!, $bay: String!, $warehouseId: ID) {
+    assignOpeningItemLocation(openingItemId: $openingItemId, aisle: $aisle, row: $row, bay: $bay, warehouseId: $warehouseId) {
+      id projectId openingId openingNumber building floor location leaf quantity assemblyCompletedAt state warehouseId aisle row bay createdAt updatedAt
       installedHardware { id openingItemId productCode hardwareCategory quantity }
     }
   }

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -60,6 +60,20 @@ export const GET_INVENTORY_ROWS = gql`
   }
 `;
 
+// #498: assembled leaves that finished on the bench and have no bin yet - the other half of the
+// put-away queue, alongside unlocatedInventory.
+export const GET_UNLOCATED_OPENING_ITEMS = gql`
+  query GetUnlocatedOpeningItems($projectId: ID) {
+    unlocatedOpeningItems(projectId: $projectId) {
+      id projectId openingId openingNumber
+      building floor location leaf leafCount quantity
+      assemblyCompletedAt state warehouseId
+      aisle row bay
+      createdAt updatedAt
+    }
+  }
+`;
+
 export const GET_OPENING_ITEMS = gql`
   query GetOpeningItems($projectId: ID) {
     openingItems(projectId: $projectId) {

--- a/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
+++ b/frontend/src/modules/shop-assembly/AssemblyDetailModal.tsx
@@ -78,9 +78,6 @@ export default function AssemblyDetailModal({
   onCompleted,
 }: AssemblyDetailModalProps) {
   const { showToast } = useToast();
-  const [aisle, setAisle] = useState('');
-  const [row, setRow] = useState('');
-  const [bay, setBay] = useState('');
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Draft installed counts, keyed by item id, held as strings so a half-typed field is not coerced to
@@ -136,11 +133,6 @@ export default function AssemblyDetailModal({
     onError: (err) => showToast(err.message, 'error'),
   });
 
-  const validateField = (value: string): boolean => {
-    if (value === '') return true;
-    return value.length >= 1 && value.length <= 20;
-  };
-
   // The most a line can be marked installed: everything pulled that is not already condemned.
   const maxInstalled = (item: OpeningItem): number =>
     item.allocatedQuantity - item.deficientQuantity - item.replacementPendingQuantity;
@@ -179,7 +171,6 @@ export default function AssemblyDetailModal({
   );
 
   const dirty = opening.items.some((item) => parsedDraft(item) !== item.installedQuantity);
-  const locationValid = validateField(aisle) && validateField(row) && validateField(bay);
   const busy = saving || completing;
 
   // Mirrors the backend's completion gate exactly - every unit installed or condemned, and at least
@@ -190,8 +181,7 @@ export default function AssemblyDetailModal({
   const canComplete =
     allDraftsValid &&
     draftProgress.complete &&
-    (draftProgress.installed > 0 || opening.items.length === 0) &&
-    locationValid;
+    (draftProgress.installed > 0 || opening.items.length === 0);
 
   const progressPayload = useCallback(
     () =>
@@ -234,13 +224,10 @@ export default function AssemblyDetailModal({
       variables: {
         input: {
           openingId: opening.id,
-          aisle: aisle || null,
-          row: row || null,
-          bay: bay || null,
         },
       },
     });
-  }, [progressPayload, recordProgress, completeOpening, opening.id, aisle, row, bay]);
+  }, [progressPayload, recordProgress, completeOpening, opening.id]);
 
   // --- deficiency flagging -------------------------------------------------------------------
 
@@ -498,46 +485,11 @@ export default function AssemblyDetailModal({
             </Typography>
           )}
 
-          <Typography component="div" sx={{ ...microLabelSx, color: 'text.primary', mb: 0.5 }}>
-            Store completed Opening Item at
-          </Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ mb: 1.5, display: 'block' }}>
-            Leave blank for Unlocated
-          </Typography>
-
-          <Stack direction="row" spacing={2}>
-            <TextField
-              label="Aisle"
-              size="small"
-              sx={{ width: 128 }}
-              value={aisle}
-              onChange={(e) => setAisle(e.target.value)}
-              error={!validateField(aisle)}
-              helperText={!validateField(aisle) ? '1-20 characters' : ''}
-              inputProps={{ maxLength: 20 }}
-            />
-            <TextField
-              label="Row"
-              size="small"
-              sx={{ width: 128 }}
-              value={row}
-              onChange={(e) => setRow(e.target.value)}
-              error={!validateField(row)}
-              helperText={!validateField(row) ? '1-20 characters' : ''}
-              inputProps={{ maxLength: 20 }}
-            />
-            <TextField
-              label="Bay"
-              size="small"
-              sx={{ width: 128 }}
-              value={bay}
-              onChange={(e) => setBay(e.target.value)}
-              error={!validateField(bay)}
-              helperText={!validateField(bay) ? '1-20 characters' : ''}
-              inputProps={{ maxLength: 20 }}
-            />
-          </Stack>
-
+          {/* #498: no location fields here any more. The assembler was typing free-text
+              aisle/row/bay against no warehouse choice and no validation, so the "put-away location"
+              on a finished leaf was whatever they typed and warehouse staff could not correct it.
+              The leaf lands unlocated and joins the warehouse put-away queue, same as received
+              stock. */}
           {opening.items.length > 0 && !draftProgress.complete && (
             <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
               {draftProgress.remaining} unit(s) still unaccounted for - Mark Complete stays disabled

--- a/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssembleListPageModal.test.tsx
@@ -97,11 +97,9 @@ it('keeps the assembly modal open across a Save Progress from the Assemble List'
   const input = await screen.findByLabelText('Installed units: HG-100');
   fireEvent.change(input, { target: { value: '2' } });
 
-  // Local, unsaved modal state. A progress save never sends the put-away location, and the modal
-  // seeds it empty on mount - so if the dialog is torn down and rebuilt this is what is lost.
-  const aisle = screen.getByLabelText('Aisle') as HTMLInputElement;
-  fireEvent.change(aisle, { target: { value: 'A1' } });
-
+  // The typed installed count is the local, unsaved modal state: if the dialog is torn down and
+  // rebuilt it reverts to what the server last returned. #498 removed the put-away fields that
+  // used to stand in for this here, so the count carries the assertion on its own.
   fireEvent.click(screen.getByRole('button', { name: /save progress/i }));
 
   // The save resolves, the list refetches - and the modal is still on screen, still holding the
@@ -111,5 +109,4 @@ it('keeps the assembly modal open across a Save Progress from the Assemble List'
     expect(screen.getByLabelText('Installed units: HG-100')).toHaveValue(2)
   );
   expect(screen.getByText(/Shop Hardware Checklist/i)).toBeInTheDocument();
-  expect(screen.getByLabelText('Aisle')).toHaveValue('A1');
 });

--- a/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
+++ b/frontend/src/modules/shop-assembly/__tests__/AssemblyDetailModal.test.tsx
@@ -211,11 +211,10 @@ describe('AssemblyDetailModal progress editor', () => {
       request: {
         query: COMPLETE_OPENING,
         variables: {
+          // #498: completion no longer carries a location - the leaf lands unlocated and the
+          // warehouse puts it away.
           input: {
             openingId: 'o1',
-            aisle: null,
-            row: null,
-            bay: null,
           },
         },
       },

--- a/frontend/src/modules/warehouse/AssembledLeafPutAway.tsx
+++ b/frontend/src/modules/warehouse/AssembledLeafPutAway.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation, useQuery } from '@apollo/client/react';
+import { GET_UNLOCATED_OPENING_ITEMS } from '../../graphql/warehouse';
+import { ASSIGN_OPENING_ITEM_LOCATION } from '../../graphql/admin';
+import { GET_WAREHOUSES } from '../../graphql/shared';
+import { useToast } from '../../components/Toast';
+import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { leafSuffix } from '../../utils/leaf';
+import { parseServerDate } from '../../utils/serverDate';
+
+/**
+ * Assembled leaves waiting to be put away (#498).
+ *
+ * Completion used to take free-text aisle/row/bay from the assembler, against no warehouse choice
+ * and no validation that the place existed - so the "put-away location" on a finished leaf was
+ * whatever the person at the bench typed, and warehouse staff could not correct it. It was not
+ * actually a warehouse location.
+ *
+ * A finished leaf now lands unlocated and shows up here, which is the same route received stock
+ * takes. Putting it away is picking a warehouse and a bin within it.
+ */
+
+interface UnlocatedLeaf {
+  id: string;
+  projectId: string;
+  openingNumber: string;
+  leaf: number | null;
+  building: string | null;
+  floor: string | null;
+  location: string | null;
+  assemblyCompletedAt: string | null;
+  warehouseId: string | null;
+}
+
+interface Warehouse {
+  id: string;
+  code: string;
+  name: string;
+  isActive: boolean;
+}
+
+interface LocationDraft {
+  warehouseId: string;
+  aisle: string;
+  row: string;
+  bay: string;
+}
+
+const EMPTY: LocationDraft = { warehouseId: '', aisle: '', row: '', bay: '' };
+
+function validPart(value: string): boolean {
+  const v = value.trim();
+  return v.length >= 1 && v.length <= 20;
+}
+
+interface AssembledLeafPutAwayProps {
+  /** Empty string means all projects, matching the stock section above. */
+  projectFilter: string;
+}
+
+export default function AssembledLeafPutAway({ projectFilter }: AssembledLeafPutAwayProps) {
+  const { showToast } = useToast();
+  const [drafts, setDrafts] = useState<Record<string, LocationDraft>>({});
+  const [assigningId, setAssigningId] = useState<string | null>(null);
+
+  const { data, loading, error, refetch } = useQuery<{ unlocatedOpeningItems: UnlocatedLeaf[] }>(
+    GET_UNLOCATED_OPENING_ITEMS,
+    { variables: { projectId: projectFilter || undefined } },
+  );
+  const { data: whData } = useQuery<{ warehouses: Warehouse[] }>(GET_WAREHOUSES);
+  const [assign] = useMutation(ASSIGN_OPENING_ITEM_LOCATION);
+
+  const leaves = data?.unlocatedOpeningItems ?? [];
+  const warehouses = useMemo(
+    () => (whData?.warehouses ?? []).filter((w) => w.isActive),
+    [whData],
+  );
+
+  const draftFor = useCallback((id: string): LocationDraft => drafts[id] ?? EMPTY, [drafts]);
+
+  const update = useCallback((id: string, field: keyof LocationDraft, value: string) => {
+    setDrafts((prev) => ({ ...prev, [id]: { ...(prev[id] ?? EMPTY), [field]: value } }));
+  }, []);
+
+  const isValid = useCallback(
+    (id: string) => {
+      const d = draftFor(id);
+      return !!d.warehouseId && validPart(d.aisle) && validPart(d.row) && validPart(d.bay);
+    },
+    [draftFor],
+  );
+
+  const handleAssign = useCallback(
+    async (leaf: UnlocatedLeaf) => {
+      const d = draftFor(leaf.id);
+      setAssigningId(leaf.id);
+      try {
+        await assign({
+          variables: {
+            openingItemId: leaf.id,
+            warehouseId: d.warehouseId,
+            aisle: d.aisle.trim(),
+            row: d.row.trim(),
+            bay: d.bay.trim(),
+          },
+        });
+        showToast(
+          `${leaf.openingNumber}${leafSuffix(leaf.leaf)} put away`,
+          'success',
+        );
+        setDrafts((prev) => {
+          const next = { ...prev };
+          delete next[leaf.id];
+          return next;
+        });
+        await refetch();
+      } catch (e) {
+        showToast(e instanceof Error ? e.message : 'Could not put the leaf away', 'error');
+      } finally {
+        setAssigningId(null);
+      }
+    },
+    [assign, draftFor, refetch, showToast],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+  if (error) return <Alert severity="error">{error.message}</Alert>;
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography component="div" sx={{ ...microLabelSx, color: 'text.primary', mb: 0.5 }}>
+        Assembled leaves ({leaves.length})
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 1.5, display: 'block' }}>
+        Finished on the bench and waiting for a shelf. Until one is assigned, shipping shows the leaf
+        as not put away yet.
+      </Typography>
+
+      {leaves.length === 0 ? (
+        <Alert severity="success" variant="outlined">
+          Every assembled leaf has been put away.
+        </Alert>
+      ) : (
+        <Stack spacing={1.5}>
+          {leaves.map((leaf) => {
+            const d = draftFor(leaf.id);
+            const place = [leaf.building, leaf.floor, leaf.location].filter(Boolean).join(' / ');
+            return (
+              <Paper key={leaf.id} variant="outlined" sx={{ p: 1.5 }}>
+                <Stack
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={1.5}
+                  alignItems={{ md: 'center' }}
+                >
+                  <Box sx={{ minWidth: 220 }}>
+                    <Typography sx={{ ...monoSx, fontWeight: 600 }}>
+                      {leaf.openingNumber}
+                      {leafSuffix(leaf.leaf)}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                      {place || 'No place recorded'}
+                    </Typography>
+                    {leaf.assemblyCompletedAt && (
+                      <Typography variant="caption" color="text.secondary" sx={tabularSx}>
+                        Completed {parseServerDate(leaf.assemblyCompletedAt).toLocaleDateString()}
+                      </Typography>
+                    )}
+                  </Box>
+
+                  <TextField
+                    select
+                    label="Warehouse"
+                    size="small"
+                    sx={{ minWidth: 180 }}
+                    value={d.warehouseId}
+                    onChange={(e) => update(leaf.id, 'warehouseId', e.target.value)}
+                  >
+                    {warehouses.map((w) => (
+                      <MenuItem key={w.id} value={w.id}>
+                        {w.code} - {w.name}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+
+                  <TextField
+                    label="Aisle"
+                    size="small"
+                    sx={{ width: 110 }}
+                    value={d.aisle}
+                    onChange={(e) => update(leaf.id, 'aisle', e.target.value)}
+                    inputProps={{ maxLength: 20 }}
+                  />
+                  <TextField
+                    label="Row"
+                    size="small"
+                    sx={{ width: 110 }}
+                    value={d.row}
+                    onChange={(e) => update(leaf.id, 'row', e.target.value)}
+                    inputProps={{ maxLength: 20 }}
+                  />
+                  <TextField
+                    label="Bay"
+                    size="small"
+                    sx={{ width: 110 }}
+                    value={d.bay}
+                    onChange={(e) => update(leaf.id, 'bay', e.target.value)}
+                    inputProps={{ maxLength: 20 }}
+                  />
+
+                  <Button
+                    variant="contained"
+                    size="small"
+                    disabled={!isValid(leaf.id) || assigningId === leaf.id}
+                    onClick={() => handleAssign(leaf)}
+                  >
+                    {assigningId === leaf.id ? 'Assigning…' : 'Put away'}
+                  </Button>
+                </Stack>
+              </Paper>
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/modules/warehouse/FetchListPanel.tsx
+++ b/frontend/src/modules/warehouse/FetchListPanel.tsx
@@ -143,7 +143,9 @@ export default function FetchListPanel({ items, editable }: FetchListPanelProps)
                       {bin}
                     </Typography>
                   ) : (
-                    <Chip label="Unlocated" size="small" variant="outlined" />
+                    /* #498: an assembled leaf lands unlocated and stays that way until the
+                       warehouse puts it away, so say which it is rather than just "Unlocated". */
+                    <Chip label="Not put away yet" size="small" variant="outlined" color="warning" />
                   )}
                 </Box>
                 <Box component="td">

--- a/frontend/src/modules/warehouse/PutAwayTab.tsx
+++ b/frontend/src/modules/warehouse/PutAwayTab.tsx
@@ -26,6 +26,7 @@ import { useToast } from '../../components/Toast';
 import LocationAutocomplete from '../../components/LocationAutocomplete';
 import { GET_PROJECTS, ASSIGN_INVENTORY_LOCATION } from '../../graphql/shared';
 import { GET_UNLOCATED_INVENTORY, GET_LOCATION_DISTINCT_VALUES } from '../../graphql/warehouse';
+import AssembledLeafPutAway from './AssembledLeafPutAway';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
 import { StaggerItem, StaggerList } from '../../motion';
 import { parseServerDate } from '../../utils/serverDate';
@@ -340,6 +341,10 @@ export default function PutAwayTab() {
           );
         })}
       </StaggerList>
+
+      {/* #498: the other half of the queue. Assembled leaves arrive here unlocated because
+          completion no longer asks the assembler to invent a location. */}
+      <AssembledLeafPutAway projectFilter={projectFilter} />
     </Box>
   );
 }


### PR DESCRIPTION
closes #498

completion took free-text aisle/row/bay from the ASSEMBLER and stamped the primary warehouse itself. the put-away location on a finished leaf was whatever the person at the bench typed - no warehouse choice, no validation the place existed, no way for warehouse staff to correct it. it was not actually a warehouse location.

completed leaf -> IN_INVENTORY with no location -> warehouse put-away queue, the route received stock already takes. put-away picks an active warehouse and a bin within it.

- `complete_opening` drops its location arguments
- `CompleteOpeningInput` keeps aisle/row/bay deprecated and ignored until frontends stop sending them (#438 pattern)
- `AssemblyDetailModal` loses the three inputs and the `locationValid` gate on Mark Complete
- new `unlocatedOpeningItems` query - IN_INVENTORY leaves with no bin
- Assembled Leaves section on `PutAwayTab`, beside the unlocated-stock list
- `assignOpeningItemLocation` takes an optional `warehouseId`, validated as existing and active; omitting it moves the bin inside the leaf's current warehouse, which is what the admin correction path wants
- the PUT_AWAY audit row records the warehouse alongside the bin
- the shipping fetch list says "Not put away yet" rather than "Unlocated"

only IN_INVENTORY leaves are queued: one already pulled for shipping has left the rack, and asking someone to put it away would be asking them to find something that is not there.

no migration - `opening_items.warehouse_id`, `aisle`, `row`, `bay` all exist.

two shop-assembly tests updated:
- the completion mutation's variables lose the location
- the modal-persistence test drops the Aisle field it used as a stand-in for local unsaved state; the typed installed count already carries that assertion
