### PR TITLE
feat(warehouse): server mints pull request numbers per project (#493)

### DIFF
--- a/backend/alembic/versions/087_project_request_counters.py
+++ b/backend/alembic/versions/087_project_request_counters.py
@@ -1,0 +1,66 @@
+"""Per-project pull-request number counters
+
+Revision ID: 087
+Revises: 086
+Create Date: 2026-08-06
+
+Request numbers on shop-assembly and shipping-out requests were typed by hand (#493). That made a
+uniqueness constraint the user's problem to satisfy from memory, and nothing tied a number to the
+job it belonged to. The server mints them now, as <project number>-001, -002, ... with one sequence
+per project spanning both request types.
+
+The seed reads the highest numeric suffix already in use per project, across shop_assembly_requests,
+shipping_out_requests and pull_requests, so an existing project carries on from where its
+hand-typed numbers left off rather than colliding with them. Numbers that do not end in a suffix
+this scheme would produce are ignored by the seed - they cannot collide with a generated one.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "087"
+down_revision = "086"
+branch_labels = None
+depends_on = None
+
+
+# Highest -NNN suffix per project across every table that carries a live request number. The regex
+# anchors on the project's own number so a "23093-004" seeds project 23093 and nothing else.
+_SEED = """
+INSERT INTO project_request_counters (project_id, next_value)
+SELECT p.id, COALESCE(MAX(m.seq), 0) + 1
+FROM projects p
+LEFT JOIN (
+    SELECT r.project_id,
+           (regexp_match(r.request_number, '-([0-9]+)$'))[1]::int AS seq
+    FROM shop_assembly_requests r
+    WHERE r.request_number ~ '-[0-9]+$'
+    UNION ALL
+    SELECT r.project_id,
+           (regexp_match(r.request_number, '-([0-9]+)$'))[1]::int AS seq
+    FROM shipping_out_requests r
+    WHERE r.request_number ~ '-[0-9]+$'
+    UNION ALL
+    SELECT r.project_id,
+           (regexp_match(r.request_number, '-([0-9]+)$'))[1]::int AS seq
+    FROM pull_requests r
+    WHERE r.request_number ~ '-[0-9]+$'
+) m ON m.project_id = p.id
+GROUP BY p.id
+"""
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_request_counters",
+        sa.Column("project_id", sa.UUID(), nullable=False),
+        sa.Column("next_value", sa.Integer(), nullable=False, server_default="1"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"]),
+        sa.PrimaryKeyConstraint("project_id"),
+    )
+    op.execute(_SEED)
+
+
+def downgrade() -> None:
+    op.drop_table("project_request_counters")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,6 +26,7 @@ from .opening_item import OpeningItem, OpeningItemHardware  # noqa: E402, F401
 from .po_document_settings import PODocumentSettings  # noqa: E402, F401
 from .project import Opening, Project  # noqa: E402, F401
 from .project_excluded_item import ProjectExcludedItem  # noqa: E402, F401
+from .project_request_counter import ProjectRequestCounter  # noqa: E402, F401
 from .pull_pick_line import PullPickLine  # noqa: E402, F401
 from .pull_request import PullRequest, PullRequestItem  # noqa: E402, F401
 from .purchase_order import PODocument, PODocumentData, POLineItem, PurchaseOrder  # noqa: E402, F401

--- a/backend/app/models/project_request_counter.py
+++ b/backend/app/models/project_request_counter.py
@@ -1,0 +1,29 @@
+import uuid
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class ProjectRequestCounter(Base):
+    """The next pull-request sequence number for a project (#493).
+
+    Request numbers used to be typed by hand on the shop-assembly and shipping-out wizard steps,
+    which made them a uniqueness constraint the user had to satisfy from memory - two people
+    raising requests on the same project at once collided, and nothing tied a number to its job.
+
+    One counter per project, spanning BOTH request types. A shop-assembly request and a
+    shipping-out request both become warehouse pulls, and one chronological sequence per project is
+    what a warehouse user can actually reason about; two independent sequences would put a 23093-004
+    on the rack next to a different 23093-004.
+
+    Claimed with SELECT ... FOR UPDATE inside the creating transaction, so two concurrent creates
+    serialize on this row rather than racing to the same number.
+    """
+
+    __tablename__ = "project_request_counters"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("projects.id"), primary_key=True)
+    # The value the NEXT request on this project takes.
+    next_value: Mapped[int] = mapped_column(Integer, nullable=False, default=1)

--- a/backend/app/repositories/import_repository.py
+++ b/backend/app/repositories/import_repository.py
@@ -609,7 +609,8 @@ def finalize_import_session(
     excluded_items_input = input_data.get("excluded_items") or []
     shipping_pr_drafts = input_data.get("shipping_out_pr_drafts") or []
     include_sar = input_data.get("include_shop_assembly_request", False)
-    sar_request_number = input_data.get("shop_assembly_request_number")
+    # #493: the client's shop_assembly_request_number is deprecated and ignored. The number is
+    # minted from the project's counter below.
     sar_openings_input = input_data.get("shop_assembly_openings") or []
     replace_schedule = bool(input_data.get("replace_schedule", False))
     acknowledge_incomplete_leaves = bool(input_data.get("acknowledge_incomplete_leaves", False))
@@ -949,15 +950,7 @@ def finalize_import_session(
     # Since #342 the inventory gate lives HERE, at creation, and creating the request reserves the
     # hardware. Accept is a pure human gate and re-checks nothing.
     sar = None
-    if include_sar and sar_request_number:
-        # Validate uniqueness against the SAR number space.
-        existing_sar = session.scalars(select(SARModel).where(SARModel.request_number == sar_request_number)).first()
-        if existing_sar is not None:
-            raise ConflictError(
-                f"Shop-assembly request {sar_request_number} already exists",
-                field="shop_assembly_request_number",
-            )
-
+    if include_sar:
         from app.repositories import shipping_repository as _shipping_repository
         from app.repositories import shop_assembly_repository
 
@@ -1052,6 +1045,11 @@ def finalize_import_session(
             for item in sa_opening_input.get("items", [])
             if _allocated_quantity(item) > 0
         ]
+        # #493: the number is minted here, not taken from the client. FinalizeImportSessionInput
+        # still carries shop_assembly_request_number, deprecated and ignored (#427/#438 pattern).
+        from app.repositories.request_numbers import mint_request_number
+
+        sar_request_number = mint_request_number(session, project.id)
         _gate_on_available_inventory(
             session,
             project.id,

--- a/backend/app/repositories/request_numbers.py
+++ b/backend/app/repositories/request_numbers.py
@@ -1,0 +1,49 @@
+"""Server-minted pull-request numbers (#493).
+
+Request numbers were typed by hand on the shop-assembly and shipping-out wizard steps. That handed
+the user a uniqueness constraint to satisfy from memory: two people raising requests on the same
+project at once collided, and nothing tied a number to the job it belonged to.
+
+The number is `<project number>-NNN`, from one counter per project spanning BOTH request types.
+They all become warehouse pulls, and a single chronological sequence per project is what a
+warehouse user can reason about - two independent sequences would put a 23093-004 on the rack next
+to a different 23093-004.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.project import Project as ProjectModel
+from app.models.project_request_counter import ProjectRequestCounter
+
+
+def mint_request_number(session: Session, project_id: uuid.UUID) -> str:
+    """Claim the next request number for a project.
+
+    The counter row is locked FOR UPDATE, so two concurrent creates serialize here rather than
+    racing to the same number. The lock is held until the caller's transaction commits, which is
+    what makes the number and the request it names atomic - a rolled-back create gives the number
+    back rather than burning it.
+    """
+    project = session.get(ProjectModel, project_id)
+    if project is None:
+        raise ValueError(f"Project {project_id} not found")
+
+    counter = session.scalars(
+        select(ProjectRequestCounter).where(ProjectRequestCounter.project_id == project_id).with_for_update()
+    ).first()
+
+    if counter is None:
+        # A project created after the migration seeded the table. Insert-then-lock rather than
+        # lock-then-insert: the primary key makes a concurrent duplicate impossible, and the
+        # loser re-reads under the lock below.
+        counter = ProjectRequestCounter(project_id=project_id, next_value=1)
+        session.add(counter)
+        session.flush()
+
+    seq = counter.next_value
+    counter.next_value = seq + 1
+    session.flush()
+    return f"{project.project_id}-{seq:03d}"

--- a/backend/app/repositories/shipping_requests.py
+++ b/backend/app/repositories/shipping_requests.py
@@ -18,7 +18,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
-from app.errors import ConflictError, InvalidStateTransitionError, NotFoundError, ValidationError
+from app.errors import InvalidStateTransitionError, NotFoundError, ValidationError
 from app.models.enums import (
     OpeningItemState,
     PullRequestItemType,
@@ -76,22 +76,19 @@ def create_shipping_out_requests(
             project_id,
             all_needs,
             label="shipping-out request",
-            request_number=drafts[0]["request_number"],
+            # #493: the gate's label only names the request in its error text, and the number does
+            # not exist yet - it is minted per draft below.
+            request_number=None,
         )
 
     created: list[ShippingOutRequest] = []
+    from app.repositories.request_numbers import mint_request_number
+
     for index, draft in enumerate(drafts):
-        request_number = (draft["request_number"] or "").strip()
-        if not request_number:
-            raise ValidationError("A shipping-out request needs a request number.", field="request_number")
-        existing = session.scalars(
-            select(ShippingOutRequest).where(ShippingOutRequest.request_number == request_number)
-        ).first()
-        if existing is not None:
-            raise ConflictError(
-                f"Shipping-out request {request_number} already exists",
-                field="request_number",
-            )
+        # #493: minted from the project's counter, shared with shop-assembly requests so one
+        # chronological sequence covers every pull on the job. The draft's request_number is
+        # deprecated and ignored.
+        request_number = mint_request_number(session, project_id)
 
         req = ShippingOutRequest(
             id=uuid.uuid4(),

--- a/backend/tests/test_import_repository_full_schedule.py
+++ b/backend/tests/test_import_repository_full_schedule.py
@@ -20,7 +20,6 @@ from app.models.pull_request import PullRequest, PullRequestItem
 from app.models.purchase_order import POLineItem, PurchaseOrder
 from app.models.shop_assembly import (
     ShopAssemblyOpening,
-    ShopAssemblyRequest,
 )
 from app.models.stock_item import StockItem
 from app.repositories import import_repository, shop_assembly_repository, warehouse_admin_repository
@@ -372,15 +371,18 @@ def test_shop_assembly_request_created_pending(db_session):
     db_session.flush()
 
     # A PENDING shop-assembly request is created, no approval, no PullRequest.
-    sar = db_session.scalar(select(ShopAssemblyRequest).where(ShopAssemblyRequest.request_number == req_number))
+    # #493: the number is minted server-side, so the request is read off the result rather than
+    # looked up by the number the caller asked for - which is now ignored.
+    sar = result["shop_assembly_request"]
     assert sar is not None
+    assert sar.request_number.endswith("-001")
     assert sar.status == ShopAssemblyRequestStatus.PENDING
     assert sar.created_by == "Hardware Schedule Import"
     assert sar.project_id == project.id
     assert result["shop_assembly_request"].id == sar.id
 
     # No PullRequest exists yet - it is minted only at accept.
-    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number)) is None
+    assert db_session.scalar(select(PullRequest).where(PullRequest.request_number == sar.request_number)) is None
 
     # The opening hangs off the SAR (not a PR) with pull_request_id NULL and snapshot identity.
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.shop_assembly_request_id == sar.id))
@@ -425,7 +427,9 @@ def test_sar_queries_work_after_opening_deleted(db_session):
     db_session.flush()
 
     # Complete the pull so the opening shows up in assemble_list (assigned_to needs setting for my_work)
-    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    pr = db_session.scalar(
+        select(PullRequest).where(PullRequest.request_number == result["shop_assembly_request"].request_number)
+    )
     pr.status = PullRequestStatus.COMPLETED
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
     sao.pull_status = PullStatus.PULLED
@@ -484,7 +488,9 @@ def _pulled_opening(db_session, project, opening_number="A01"):
     db_session.flush()
     shop_assembly_repository.accept_shop_assembly_request(db_session, result["shop_assembly_request"].id, "acceptor")
     db_session.flush()
-    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    pr = db_session.scalar(
+        select(PullRequest).where(PullRequest.request_number == result["shop_assembly_request"].request_number)
+    )
     pr.status = PullRequestStatus.COMPLETED
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
     sao.pull_status = PullStatus.PULLED
@@ -802,7 +808,9 @@ def test_accept_stamps_leaf_on_pull_items(db_session):
     shop_assembly_repository.accept_shop_assembly_request(db_session, result["shop_assembly_request"].id, "acceptor")
     db_session.flush()
 
-    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    pr = db_session.scalar(
+        select(PullRequest).where(PullRequest.request_number == result["shop_assembly_request"].request_number)
+    )
     items = db_session.scalars(select(PullRequestItem).where(PullRequestItem.pull_request_id == pr.id)).all()
     assert len(items) == 2
     assert {i.leaf for i in items} == {1, 2}
@@ -838,7 +846,9 @@ def test_complete_opening_stamps_leaf(db_session):
     db_session.flush()
 
     # Drive the opening to a completable state: PR pulled+completed, opening assigned.
-    pr = db_session.scalar(select(PullRequest).where(PullRequest.request_number == req_number))
+    pr = db_session.scalar(
+        select(PullRequest).where(PullRequest.request_number == result["shop_assembly_request"].request_number)
+    )
     pr.status = PullRequestStatus.COMPLETED
     sao = db_session.scalar(select(ShopAssemblyOpening).where(ShopAssemblyOpening.pull_request_id == pr.id))
     sao.pull_status = PullStatus.PULLED

--- a/backend/tests/test_request_numbers.py
+++ b/backend/tests/test_request_numbers.py
@@ -1,0 +1,55 @@
+"""Server-minted pull-request numbers (#493).
+
+The numbers used to be typed by hand on two wizard steps, which made a uniqueness constraint the
+user's problem: two people raising requests on the same project at once collided, and nothing tied
+a number to the job it belonged to.
+"""
+
+import uuid
+
+import pytest
+
+from app.models.project import Project
+from app.repositories.request_numbers import mint_request_number
+
+
+def _project(session, project_id: str) -> Project:
+    p = Project(id=uuid.uuid4(), project_id=project_id, description="Test")
+    session.add(p)
+    session.flush()
+    return p
+
+
+def test_mints_sequentially_from_one(db_session):
+    project = _project(db_session, "23093")
+
+    assert mint_request_number(db_session, project.id) == "23093-001"
+    assert mint_request_number(db_session, project.id) == "23093-002"
+    assert mint_request_number(db_session, project.id) == "23093-003"
+
+
+def test_each_project_has_its_own_sequence(db_session):
+    a = _project(db_session, "23093")
+    b = _project(db_session, "24001")
+
+    assert mint_request_number(db_session, a.id) == "23093-001"
+    assert mint_request_number(db_session, b.id) == "24001-001"
+    assert mint_request_number(db_session, a.id) == "23093-002"
+
+
+def test_pads_to_three_digits_then_grows(db_session):
+    """The format is a floor, not a ceiling: a project past 999 requests keeps counting rather than
+    wrapping into a number it has already used."""
+    project = _project(db_session, "23093")
+    from app.models.project_request_counter import ProjectRequestCounter
+
+    db_session.add(ProjectRequestCounter(project_id=project.id, next_value=999))
+    db_session.flush()
+
+    assert mint_request_number(db_session, project.id) == "23093-999"
+    assert mint_request_number(db_session, project.id) == "23093-1000"
+
+
+def test_refuses_an_unknown_project(db_session):
+    with pytest.raises(ValueError):
+        mint_request_number(db_session, uuid.uuid4())

--- a/backend/tests/test_sar_allocation.py
+++ b/backend/tests/test_sar_allocation.py
@@ -299,7 +299,10 @@ def test_a_successful_short_send_tells_purchasing_about_the_gap(db_session):
         ).all()
     )
     assert len(notifs) == 1
-    assert "SA-SHORT-1" in notifs[0].message
+    # #493: the number in the message is the one the server minted, not the one the caller asked
+    # for. What purchasing needs from it is that it names a pull on this project.
+    assert notifs[0].message.startswith("Pull Request ")
+    assert "-001" in notifs[0].message
     assert "short 4" in notifs[0].message
     # Not "couldn't be fulfilled": the request exists and nothing is blocked. Purchasing is being
     # told what the project is missing, not sent hunting for a stuck request.

--- a/backend/tests/test_shipping_request_composition.py
+++ b/backend/tests/test_shipping_request_composition.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import pytest
 from sqlalchemy import select
 
-from app.errors import ConflictError, InvalidStateTransitionError, InventoryShortfallError, ValidationError
+from app.errors import InvalidStateTransitionError, InventoryShortfallError, ValidationError
 from app.models.enums import OpeningItemState, PullRequestItemType, ReservationSource, ShippingOutRequestStatus
 from app.models.inventory import InventoryLocation
 from app.models.opening_item import OpeningItem
@@ -207,13 +207,23 @@ def test_an_opening_item_line_takes_its_opening_from_the_leaf(db_session):
     assert [(i.opening_number, i.leaf) for i in req.items] == [("0501-EX", 2)]
 
 
-def test_a_duplicate_request_number_is_refused(db_session):
+def test_the_server_mints_a_unique_number_whatever_the_caller_sends(db_session):
+    """#493: duplicates are no longer possible to refuse, because they are no longer possible.
+
+    The number used to be typed by hand, so two requests could collide and the create had to reject
+    the second. The server mints it from the project's counter now and ignores what the caller sent,
+    so the same string twice produces two distinct requests rather than a conflict.
+    """
     project = _project(db_session)
     _stock(db_session, project, qty=10)
-    _create(db_session, project, [_loose(qty=1)], number="SOR-DUP")
 
-    with pytest.raises(ConflictError):
-        _create(db_session, project, [_loose(qty=1)], number="SOR-DUP")
+    first = _create(db_session, project, [_loose(qty=1)], number="SOR-DUP")
+    second = _create(db_session, project, [_loose(qty=1)], number="SOR-DUP")
+
+    assert first.request_number != second.request_number
+    assert first.request_number.endswith("-001")
+    assert second.request_number.endswith("-002")
+    assert first.request_number.startswith(project.project_id)
 
 
 # --- editing a pending one --------------------------------------------------------------------

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -1062,12 +1062,6 @@ export default function ImportWizard({
     setShippingPRDrafts((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
-  const updateShippingPR = useCallback((index: number, requestNumber: string) => {
-    setShippingPRDrafts((prev) =>
-      prev.map((draft, i) => (i === index ? { ...draft, requestNumber } : draft)),
-    );
-  }, []);
-
   // Add or remove one already-built line on a draft (#335). The step decides what kind of line it
   // is - an assembled leaf or loose hardware - so this no longer hard-codes LOOSE.
   const toggleShippingPRItem = useCallback((prIndex: number, item: ShippingPRItem) => {
@@ -1252,7 +1246,8 @@ export default function ImportWizard({
           }))
         : null,
       includeShopAssemblyRequest: purpose === 'assembly',
-      shopAssemblyRequestNumber: purpose === 'assembly' ? sarRequestNumber : null,
+      // #493: deprecated and ignored by the server, which mints the number itself.
+      shopAssemblyRequestNumber: null,
       // True when the user uploaded a fresh XML on a project that already has a persisted
       // schedule (i.e., they did not pick "Use last uploaded schedule"). The backend wipes all
       // existing HardwareItems and openings absent from the new input.
@@ -1759,8 +1754,6 @@ export default function ImportWizard({
           {/* ============ Step: Shop Assembly ============ */}
           {effectiveStepId === 'shop-assembly' && (
             <ShopAssemblyStep
-              sarRequestNumber={sarRequestNumber}
-              onSarNumberChange={setSarRequestNumber}
               openingDrafts={shopAssemblyOpeningDrafts}
               availabilityByCombo={availabilityByCombo}
               allocation={sarAllocation}
@@ -1790,7 +1783,6 @@ export default function ImportWizard({
               coverageError={coverageError !== undefined}
               onAddPR={addShippingPR}
               onRemovePR={removeShippingPR}
-              onUpdatePR={updateShippingPR}
               onTogglePRItem={toggleShippingPRItem}
               onSetPRItemQuantity={setShippingPRItemQuantity}
               availabilityByCombo={availabilityByCombo}
@@ -1844,7 +1836,7 @@ export default function ImportWizard({
                 {purpose === 'assembly' && (
                   <Box sx={{ mb: 1 }}>
                     <Typography variant="body1">
-                      1 Shop Assembly Pull Request (#{sarRequestNumber})
+                      1 Shop Assembly Pull Request (number assigned on finalize)
                     </Typography>
                   </Box>
                 )}

--- a/frontend/src/modules/import/ShippingPRsStep.tsx
+++ b/frontend/src/modules/import/ShippingPRsStep.tsx
@@ -76,7 +76,6 @@ interface ShippingPRsStepProps {
   coverageError: boolean;
   onAddPR: () => void;
   onRemovePR: (index: number) => void;
-  onUpdatePR: (index: number, requestNumber: string) => void;
   onTogglePRItem: (prIndex: number, item: ShippingPRItem) => void;
   /** Add, re-quantify or (at 0) drop one loose line on a draft. */
   onSetPRItemQuantity: (prIndex: number, item: ShippingPRItem, quantity: number) => void;
@@ -138,7 +137,6 @@ export default function ShippingPRsStep({
   coverageError,
   onAddPR,
   onRemovePR,
-  onUpdatePR,
   onTogglePRItem,
   onSetPRItemQuantity,
   availabilityByCombo,
@@ -191,7 +189,7 @@ export default function ShippingPRsStep({
   // selection through on numbers that were never real.
   const canProceed = useMemo(
     () =>
-      shippingPRDrafts.some((d) => d.requestNumber.trim() !== '' && d.items.length > 0) &&
+      shippingPRDrafts.some((d) => d.items.length > 0) &&
       availabilityShortfalls.length === 0 &&
       !availabilityLoading &&
       !availabilityError,
@@ -343,17 +341,9 @@ export default function ShippingPRsStep({
 
             {/* No requester box: the import stamps every request it creates as "Hardware Schedule
                 Import", so the one that used to sit here was collected and thrown away (#438). */}
-            <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-              <TextField
-                label="PR Number"
-                size="small"
-                required
-                value={draft.requestNumber}
-                onChange={(e) => onUpdatePR(prIdx, e.target.value)}
-                sx={{ flex: 1 }}
-                slotProps={{ input: { sx: monoSx } }}
-              />
-            </Box>
+            {/* #493: no number field. The server mints <project>-NNN per request, from the same
+                counter shop-assembly requests draw on, so every pull on a job shares one
+                chronological sequence. */}
 
             {/* What is on this request so far, before the offer lists below. The point of the
                 builder is that the two are read together: this is what you have, that is what the

--- a/frontend/src/modules/import/ShopAssemblyStep.tsx
+++ b/frontend/src/modules/import/ShopAssemblyStep.tsx
@@ -14,7 +14,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TextField,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -40,8 +39,6 @@ import { monoSx, microLabelSx, tabularSx } from '../../theme';
 import { StaggerItem, StaggerList } from '../../motion';
 
 interface ShopAssemblyStepProps {
-  sarRequestNumber: string;
-  onSarNumberChange: (value: string) => void;
   /** The exact work units finalize will send - the same derivation, not a parallel one. */
   openingDrafts: ShopAssemblyOpeningDraft[];
   /** Reservation-aware availability per (category|product) for this project (#342). */
@@ -78,8 +75,6 @@ interface ShopAssemblyStepProps {
 }
 
 export default function ShopAssemblyStep({
-  sarRequestNumber,
-  onSarNumberChange,
   openingDrafts,
   availabilityByCombo,
   allocation,
@@ -159,7 +154,7 @@ export default function ShopAssemblyStep({
   // at least one leaf carrying something, and availability numbers that are real rather than
   // unknown. Sending short is now a decision the user is allowed to make, not an error state.
   const canProceed =
-    sarRequestNumber.trim() !== '' && includedCount > 0 && !availabilityLoading && !availabilityError;
+    includedCount > 0 && !availabilityLoading && !availabilityError;
 
   const handleLineChange = (
     draft: ShopAssemblyOpeningDraft,
@@ -185,15 +180,9 @@ export default function ShopAssemblyStep({
         Shop Assembly
       </Typography>
 
-      <TextField
-        label="Pull Request Number"
-        size="small"
-        required
-        value={sarRequestNumber}
-        onChange={(e) => onSarNumberChange(e.target.value)}
-        sx={{ mb: 3, width: 300 }}
-        slotProps={{ input: { sx: monoSx } }}
-      />
+      {/* #493: no number field. The server mints <project>-NNN from one counter per project,
+          shared with shipping-out requests, so a hand-typed number can neither collide nor come
+          from the wrong job. */}
 
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         Openings with items classified as Shop Hardware (in the Classification step) are listed below.

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -619,11 +619,8 @@ describe('ImportWizard step transitions', () => {
     const checkboxes = screen.getAllByRole('checkbox');
     fireEvent.click(checkboxes[0]);
     expect(screen.getByText('1 door leaf/leaves')).toBeInTheDocument();
-    expect(nextButton()).toBeDisabled(); // still needs a PR number
-
-    fireEvent.change(screen.getByRole('textbox', { name: /PR Number/i }), {
-      target: { value: 'SHIP-0019' },
-    });
+    // #493: a draft carrying at least one line is complete. There is no PR-number field to fill -
+    // the server mints <project>-NNN at finalize, from the counter shop-assembly requests share.
     expect(nextButton()).toBeEnabled();
   });
 


### PR DESCRIPTION
closes #493.

request numbers were typed by hand on the shop-assembly and shipping-out wizard steps. that made a uniqueness constraint the user's problem to satisfy from memory - two people raising requests on the same project at once collided - and nothing tied a number to the job it belonged to.

server mints `<project number>-NNN` from one counter per project, spanning both request types. a shop-assembly request and a shipping-out request both become warehouse pulls, and one chronological sequence per project is what a warehouse user can reason about; two independent sequences would put a 23093-004 on the rack next to a different 23093-004.

new `project_request_counters` table, one row per project, `next_value`. claimed with `SELECT ... FOR UPDATE` inside the creating transaction, so concurrent creates serialize rather than racing. a rolled-back create returns its number instead of burning it.

migration 087 seeds each project from the highest numeric suffix already in use across
shop_assembly_requests
shipping_out_requests
pull_requests

so existing projects carry on past their hand-typed numbers rather than colliding with them. numbers with no `-NNN` suffix cannot collide with a generated one and are ignored by the seed.

these stay in the schema, deprecated and ignored (#427/#438 pattern):
FinalizeImportSessionInput.shop_assembly_request_number
shipping draft `request_number`

both wizard steps lose the number field and its canProceed requirement. finalize summary says the number is assigned on finalize.

adds four repository tests:
sequential minting
per-project independence
three-digit pad past 999, no wrap
unknown project refused

one ImportWizard test updated - it asserted Next stayed disabled until a PR number was typed, which is the requirement being removed.
