### PR TITLE
fix(relay): dictate PO line ORD so colliding item numbers can't collapse (#538)

### DIFF
--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -156,6 +156,7 @@ def create_po_line(
     item_description: str,
     quantity: Decimal,
     unit_cost: Decimal,
+    line_ord: int,
     location_code: str = "VANCOUVER",
     uofm: str = "Each",
     manufacturer: str | None = None,
@@ -164,6 +165,17 @@ def create_po_line(
     """Create one non-inventoried PO line. For job-cost lines, follow with
     apply_wennsoft_job_cost(). Do NOT pass ProjNum/CostCatID — they fail silently
     here (PA42201 absent; Project Accounting not configured).
+
+    line_ord is REQUIRED and is bound to @I_vORD (issue #538). Left unset, eConnect resolves the
+    line by item number instead, so two lines sharing an ITEMNMBR update each other rather than both
+    landing: the second silently overwrites the first (err=0, wrong quantity and description), and a
+    third fails with 9191 "the line item cannot be manually released". That is reachable from normal
+    data because gp_po.py truncates the item number to GP's 30-char ITEMNMBR, and hardware part
+    numbers carry their handing as a suffix - three codes differing only past character 30 collapse
+    into one. GP itself is happy to hold repeated item numbers on a PO (UCSH has 33,184 such POs);
+    only the implicit-ORD path cannot produce them. Passing ORD also makes the ordinal ours rather
+    than a value we hope eConnect agrees on, which is what ops.py's WennSoft step and UC Nexus's
+    stored gp_line_ord both already assume.
 
     manufacturer (when captured) is written to USRDEFND1 on POP10110 - the free user-defined
     line field this customer uses for it (issue #233)."""
@@ -181,6 +193,7 @@ def create_po_line(
         @I_vNONINVEN       = 1,
         @I_vPOLNESTA       = 2,
         @I_vUpdateIfExists = 1,
+        @I_vORD            = ?,
         @I_vLOCNCODE       = ?,
         @I_vITEMNMBR       = ?,
         @I_vITEMDESC       = ?,
@@ -195,21 +208,25 @@ def create_po_line(
     row = conn.cursor().execute(
         sql,
         po_type, po_number, doc_date, vendor_id,
-        location_code, item_number, item_description, quantity, uofm, unit_cost, usrdefnd1,
+        line_ord, location_code, item_number, item_description, quantity, uofm, unit_cost, usrdefnd1,
     ).fetchone()
     if row.error_state != 0:
         raise EConnectError(
-            f"taPoLine failed for {item_number}: {row.err_string.strip()}",
+            f"taPoLine failed for {item_number} at ORD {line_ord}: {row.err_string.strip()}",
             proc="taPoLine", error_state=row.error_state,
         )
-    # Defensive read-back: taPoLine has a known err=0-but-no-row silent-failure mode.
+    # Defensive read-back: taPoLine has a known err=0-but-no-row silent-failure mode. Keyed on ORD,
+    # NOT on ITEMNMBR (issue #538): item numbers repeat legitimately once GP's 30-char limit truncates
+    # two part numbers to the same string, so an ITEMNMBR read-back is satisfied by the OTHER line and
+    # waves through exactly the overwrite this function now exists to prevent. ORD is unique per line.
     verify = conn.cursor().execute(
-        "SELECT COUNT(*) AS n FROM dbo.POP10110 WHERE PONUMBER = ? AND ITEMNMBR = ?",
-        po_number, item_number,
+        "SELECT COUNT(*) AS n FROM dbo.POP10110 WHERE PONUMBER = ? AND ORD = ?",
+        po_number, line_ord,
     ).fetchone()
     if verify.n == 0:
         raise EConnectError(
-            f"taPoLine returned err=0 but no row inserted for {item_number} (silent failure)",
+            f"taPoLine returned err=0 but no row inserted for {item_number} at ORD {line_ord} "
+            f"(silent failure)",
             proc="taPoLine", error_state=0,
         )
 

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -14,6 +14,13 @@ from . import buyers, econnect, models
 from .config import get_settings
 
 
+# GP spaces PO line ordinals by 16384 so lines can be inserted between existing ones. The relay
+# dictates the ordinal rather than letting eConnect derive it (issue #538), and UC Nexus mirrors the
+# same arithmetic when it stores gp_line_ord - a receipt targets a line by that number, so the two
+# sides have to agree. PAIRED EDIT: backend/app/repositories/po_repository.py's gp_line_ord.
+GP_LINE_ORD_STEP = 16384
+
+
 class RelayOpError(Exception):
     """A pre-check / validation failure, distinct from an eConnect error. The transport layer maps
     this to its own error shape (HTTPException for main.py, {ok: false, error: ...} for channel.py)."""
@@ -152,8 +159,8 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
         null_tax_schedule=is_foreign,
     )
 
-    # 3. lines
-    for line in request.lines:
+    # 3. lines. ORD is dictated here rather than left to eConnect (issue #538) - see create_po_line.
+    for idx, line in enumerate(request.lines, start=1):
         econnect.create_po_line(
             conn,
             po_number=po_number,
@@ -163,18 +170,19 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
             item_description=line.item_description,
             quantity=line.quantity,
             unit_cost=line.unit_cost,
+            line_ord=idx * GP_LINE_ORD_STEP,
             location_code=line.location_code,
             uofm=line.uofm,
             manufacturer=line.manufacturer,
         )
 
     # 4. WennSoft integration for EVERY line - this is what sets Product_Indicator (1 non-inv / 2
-    #    job cost); taPoLine can't.
+    #    job cost); taPoLine can't. Same ORD step 3 wrote, so the two can no longer disagree.
     for idx, line in enumerate(request.lines, start=1):
         econnect.apply_wennsoft_integration(
             conn,
             po_number=po_number,
-            line_ord=idx * 16384,
+            line_ord=idx * GP_LINE_ORD_STEP,
             product_indicator=line.product_indicator,
             job_number=line.job_number,
             cost_code=line.cost_code,

--- a/relay/tests/test_create_po_line.py
+++ b/relay/tests/test_create_po_line.py
@@ -1,7 +1,8 @@
-"""create_po_line writes the captured manufacturer onto taPoLine USRDEFND1 (issue #233). No real GP:
-a fake cursor records each EXEC's SQL + params and answers the defensive read-back COUNT, so the tests
-assert USRDEFND1 is bound (RTRIM + capped at 50), blank when no manufacturer is sent, and that the
-err=0-but-no-row read-back guard still fires."""
+"""create_po_line writes the captured manufacturer onto taPoLine USRDEFND1 (issue #233) and binds an
+explicit @I_vORD (issue #538). No real GP: a fake cursor records each EXEC's SQL + params and answers
+the defensive read-back COUNT, so the tests assert USRDEFND1 is bound (RTRIM + capped at 50), blank
+when no manufacturer is sent, that ORD is bound and the read-back is keyed on it rather than on the
+item number, and that the err=0-but-no-row read-back guard still fires."""
 
 from collections import namedtuple
 from datetime import date
@@ -47,6 +48,9 @@ class _FakeConn:
     def tapoline_call(self):
         return next(c for c in self.calls if "taPoLine" in c[0])
 
+    def readback_call(self):
+        return next(c for c in self.calls if "COUNT(*)" in c[0])
+
 
 def _create(conn, **overrides):
     kwargs = dict(
@@ -57,6 +61,7 @@ def _create(conn, **overrides):
         item_description="AB123 HINGE",
         quantity=Decimal("2"),
         unit_cost=Decimal("12.50"),
+        line_ord=16384,
     )
     kwargs.update(overrides)
     create_po_line(conn, **kwargs)
@@ -98,3 +103,48 @@ def test_read_back_guard_still_fires_on_silent_failure():
     conn = _FakeConn(verify_count=0)
     with pytest.raises(EConnectError):
         _create(conn, manufacturer="SCHLAGE")
+
+
+def test_line_ord_is_bound_to_the_ord_parameter():
+    # issue #538: without @I_vORD, eConnect resolves the line by item number and a repeated ITEMNMBR
+    # overwrites the previous line instead of adding one.
+    conn = _FakeConn()
+    _create(conn, line_ord=49152)
+    sql, params = conn.tapoline_call()
+    assert "@I_vORD" in sql
+    assert 49152 in params
+
+
+def test_read_back_is_keyed_on_ord_not_item_number():
+    # keying the read-back on ITEMNMBR lets the OTHER line of a truncation collision satisfy it, which
+    # is precisely the overwrite #538 is about. ORD is unique per line, so the guard has to use it.
+    conn = _FakeConn()
+    _create(conn, line_ord=32768, item_number="DUPLICATE")
+    sql, params = conn.readback_call()
+    assert "ORD = ?" in sql
+    assert "ITEMNMBR" not in sql
+    assert params == ("PO0000001", 32768)
+
+
+def test_lines_sharing_an_item_number_get_distinct_ords():
+    # the PO-REQ-053 shape: three part numbers that truncate to one ITEMNMBR must still be three lines.
+    conn = _FakeConn()
+    for idx in (1, 2, 3):
+        _create(conn, line_ord=idx * 16384, item_number="56 LC LX SG 36 8204 LSJ US32D ")
+    ords = [params[4] for sql, params in conn.calls if "taPoLine" in sql]
+    assert ords == [16384, 32768, 49152]
+
+
+def test_line_ord_is_required():
+    conn = _FakeConn()
+    with pytest.raises(TypeError):
+        create_po_line(
+            conn,
+            po_number="PO0000001",
+            doc_date=date(2026, 7, 13),
+            vendor_id="ING100",
+            item_number="ML2010",
+            item_description="AB123 HINGE",
+            quantity=Decimal("2"),
+            unit_cost=Decimal("12.50"),
+        )

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -232,8 +232,11 @@ click produces no network request at all, that is what happened. Fix it properly
 -> Add Buyer (pick the GP buyer your account is linked to, add the project), not by scripting the
 mutation.
 
-**A MULTI-LINE PO fails GP registration with eConnect 9191. A single-line one succeeds.** Isolated
-2026-08-03 on pr-463 against TUBC:
+**A PO whose lines share a GP item number used to fail with eConnect 9191. It is the item numbers,
+not the line count** (issue #538, fixed). An earlier revision of this file blamed the line count and
+told you to seed inventory one product at a time. That was wrong: TUBC holds relay-created four-line
+POs that registered cleanly (`PO0000093`, `PO0000094`), and one of them carries the very product set
+recorded here as failing.
 
 ```
 GP PROC   taPoLine
@@ -241,23 +244,16 @@ ERROR STATE 9191
 DESCRIPTION Invalid PO Status (POLNESTA), the line item cannot be manually released
 ```
 
-Four registrations, same dialog, same vendor / cost code / tax detail, relay connected throughout:
+What actually happened: `create_po_line` called `taPoLine` with no `@I_vORD`, so eConnect resolved
+each line by item number. Two lines sharing an `ITEMNMBR` updated each other instead of both landing
+- the second silently overwrote the first with `err=0`, and a third raised 9191. Because
+`gp_po.py` truncates the item number to GP's 30-character `ITEMNMBR` and hardware part numbers carry
+their handing as a suffix, three codes differing only past character 30 collapse into one. The
+registrations logged here as "3 lines, short clean codes" were sharing a truncated item number.
 
-| Lines | Product codes | Result |
-| --- | --- | --- |
-| 5 | Pemko, all with embedded `"` | 9191 |
-| 3 | SARGENT, one code 35 chars | 9191 |
-| 1 | `6042 112 US32D` | **PO0000084** |
-| 3 | `MKA` / `M62BD` / `AQD2`, all short and clean | 9191 |
-| 1 | `MKA` | **PO0000085** |
-
-So it is neither the item codes nor their length - **it is the line count**, which points at the
-relay's `taPoLine` sequencing rather than at GP data or at the schedule. Worth a bug of its own; the
-register dialog's own Remove-line-item buttons are the workaround, and receiving is unaffected.
-
-Until that is fixed, seed inventory one product at a time: register a single-line PO, receive it,
-approve it, repeat. Two of those took about ten minutes end to end and were enough to drive a
-shop-assembly request, an assembled leaf and two shipping-out requests.
+The relay now dictates `ORD = idx * 16384`, so this shape registers correctly and you can seed
+inventory with a multi-line PO. If you see 9191 again, look at what the four lines truncate to at 30
+characters before suspecting anything else.
 
 Two other things worth knowing when GP is refusing outright:
 


### PR DESCRIPTION
Closes #538.

`taPoLine` ran without `@I_vORD`, eConnect resolved each line by item number. two lines sharing an ITEMNMBR updated each other - second overwrote first with err=0, third failed 9191 "Invalid PO Status (POLNESTA), the line item cannot be manually released".

backend/app/services/gp_po.py truncates item_number to GP's 30-char ITEMNMBR, hardware part numbers carry handing as a suffix, codes differing only past character 30 collapse into one. production draft PO-REQ-053's four codes collapse three-to-one.

- `create_po_line` takes a required `line_ord`, bound to `@I_vORD`
- read-back keys on ORD instead of ITEMNMBR. an ITEMNMBR read-back is satisfied by the other line of a collision, so it waved through exactly the overwrite it exists to catch
- ops.py owns `GP_LINE_ORD_STEP`, used for both the line insert and the WennSoft step, so those two and the gp_line_ord UC Nexus stores can no longer disagree
- testing/CLAUDE.md corrected, it blamed line count and told readers to seed inventory one product at a time

truncation unchanged. the three colliding lines still carry one ITEMNMBR in GP, distinguished by ORD and by ITEMDESC (char(101), holds the full code). whether the GP item number should stay meaningful is a separate decision.

verified against TUBC with the PO-REQ-053 payload, transaction rolled back both times, re-run through the patched relay functions.
before, 2 of 4 lines landed, L3 overwrote L2 (quantity 1 -> 2, description switched), L4 err=9191.
after, 4 of 4 lines, ORD 16384/32768/49152/65536, quantities 1/1/2/1, descriptions intact.

470 relay tests pass, ruff clean.
