### PR TITLE
feat(relay): append the project number to GP PO numbers (#488)

### DIFF
--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -191,8 +191,16 @@ def _prepare_register_po(
 
         manufacturers = _resolve_line_manufacturers(session, effective_project_id, line_items_data)
 
+    # #488: job POs carry the project number as a suffix, so two purchasers registering at the same
+    # moment produce visibly distinct, traceable numbers. A stock PO has no project and gets none.
+    po_number_suffix = job_number or None
+
     gp_po.validate_create_po_inputs(
-        job_number=job_number, cost_code=cost_code, po_number=None, line_items=line_items_data
+        job_number=job_number,
+        cost_code=cost_code,
+        po_number=None,
+        line_items=line_items_data,
+        po_number_suffix=po_number_suffix,
     )
     payload = gp_po.build_create_po_payload(
         vendor_gp_id=gp_vendor_id,
@@ -202,6 +210,7 @@ def _prepare_register_po(
         cost_code=cost_code,
         po_number=None,
         line_items=line_items_data,
+        po_number_suffix=po_number_suffix,
         # Issue #257: freight maps from the PO's shipping_cost; misc + trade discount are new inputs.
         tax_detail_id=tax_detail_id,
         freight_amount=shipping_cost,

--- a/backend/app/schemas/po.py
+++ b/backend/app/schemas/po.py
@@ -193,14 +193,25 @@ def _prepare_register_po(
 
     # #488: job POs carry the project number as a suffix, so two purchasers registering at the same
     # moment produce visibly distinct, traceable numbers. A stock PO has no project and gets none.
+    #
+    # GP's PONUMBER is char(17) and 'PO' + 7 digits leaves 7 for '-' + suffix, so a project number
+    # over 6 characters cannot fit. That drops the suffix rather than refusing the PO: the suffix is
+    # a traceability nicety, and blocking somebody from ordering hardware because their job number
+    # is long would be a far worse failure than a PO without it. The relay keeps a hard cap anyway,
+    # because a number that reached GP truncated could never be matched back.
     po_number_suffix = job_number or None
+    if po_number_suffix and 9 + 1 + len(po_number_suffix) > gp_po._MAX_PO_NUMBER:
+        logger.info(
+            "Project number %s is too long for a GP PO-number suffix; registering without one",
+            po_number_suffix,
+        )
+        po_number_suffix = None
 
     gp_po.validate_create_po_inputs(
         job_number=job_number,
         cost_code=cost_code,
         po_number=None,
         line_items=line_items_data,
-        po_number_suffix=po_number_suffix,
     )
     payload = gp_po.build_create_po_payload(
         vendor_gp_id=gp_vendor_id,

--- a/backend/app/services/gp_po.py
+++ b/backend/app/services/gp_po.py
@@ -30,6 +30,7 @@ def validate_create_po_inputs(
     cost_code: str | None,
     po_number: str | None,
     line_items: list[dict],
+    po_number_suffix: str | None = None,
 ) -> None:
     """Field-level pre-checks for a create_po push, run BEFORE the relay round-trip so a bad request
     fails with a clean AppError instead of the relay's opaque invalid_payload (the pydantic models on
@@ -41,6 +42,19 @@ def validate_create_po_inputs(
     if po_number is not None and po_number.strip():
         if len(po_number.strip()) > _MAX_PO_NUMBER:
             raise ValidationError(f"PO number must be at most {_MAX_PO_NUMBER} characters", field="po_number")
+
+    # #488: GP reserves the number and the relay appends '-<project>'. GP's PONUMBER is char(17), so
+    # a long project number overflows. Caught here as well as at the relay so it fails in the
+    # register dialog rather than after the WS hop. 'PO' + 7 digits = 9, leaving 7 for '-' + suffix.
+    if po_number_suffix and (po_number is None or not po_number.strip()):
+        composed_length = 9 + 1 + len(po_number_suffix.strip())
+        if composed_length > _MAX_PO_NUMBER:
+            raise ValidationError(
+                f"Project number '{po_number_suffix.strip()}' is too long to append to a GP PO "
+                f"number: the result would be {composed_length} characters and GP holds "
+                f"{_MAX_PO_NUMBER}.",
+                field="po_number",
+            )
 
     is_job = job_number is not None
     if is_job and not (cost_code and cost_code.strip()):
@@ -68,6 +82,7 @@ def build_create_po_payload(
     cost_code: str | None,
     po_number: str | None,
     line_items: list[dict],
+    po_number_suffix: str | None = None,
     tax_detail_id: str | None = None,
     freight_amount: float | None = None,
     misc_amount: float | None = None,
@@ -119,6 +134,9 @@ def build_create_po_payload(
         },
         "lines": lines,
         "po_number": po_number,
+        # #488: the relay composes '<reserved>-<suffix>' when it reserves the number itself. Ignored
+        # when po_number is explicit, which is taken as given.
+        "po_number_suffix": po_number_suffix,
     }
 
 

--- a/backend/app/services/gp_po.py
+++ b/backend/app/services/gp_po.py
@@ -30,7 +30,6 @@ def validate_create_po_inputs(
     cost_code: str | None,
     po_number: str | None,
     line_items: list[dict],
-    po_number_suffix: str | None = None,
 ) -> None:
     """Field-level pre-checks for a create_po push, run BEFORE the relay round-trip so a bad request
     fails with a clean AppError instead of the relay's opaque invalid_payload (the pydantic models on
@@ -42,19 +41,6 @@ def validate_create_po_inputs(
     if po_number is not None and po_number.strip():
         if len(po_number.strip()) > _MAX_PO_NUMBER:
             raise ValidationError(f"PO number must be at most {_MAX_PO_NUMBER} characters", field="po_number")
-
-    # #488: GP reserves the number and the relay appends '-<project>'. GP's PONUMBER is char(17), so
-    # a long project number overflows. Caught here as well as at the relay so it fails in the
-    # register dialog rather than after the WS hop. 'PO' + 7 digits = 9, leaving 7 for '-' + suffix.
-    if po_number_suffix and (po_number is None or not po_number.strip()):
-        composed_length = 9 + 1 + len(po_number_suffix.strip())
-        if composed_length > _MAX_PO_NUMBER:
-            raise ValidationError(
-                f"Project number '{po_number_suffix.strip()}' is too long to append to a GP PO "
-                f"number: the result would be {composed_length} characters and GP holds "
-                f"{_MAX_PO_NUMBER}.",
-                field="po_number",
-            )
 
     is_job = job_number is not None
     if is_job and not (cost_code and cost_code.strip()):

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -67,6 +67,11 @@ class CreatePoRequest(BaseModel):
     # UC Nexus supplies its own PO number (e.g. 'ucnexus...'). GP's PONUMBER is char(17),
     # so max 17 chars. If omitted, the relay reserves GP's next 'PO' number via taGetPONextNumber.
     po_number: str | None = Field(default=None, max_length=17)
+    # #488: appended to the number GP reserves, as 'PO0012345-23093'. Two purchasers registering at
+    # the same moment reserve consecutive GP numbers, which are indistinguishable at a glance and
+    # carry no clue which job they belong to; the suffix makes both visible. Only used when
+    # po_number is absent - an explicit number is taken as given.
+    po_number_suffix: str | None = Field(default=None, max_length=8, pattern=r"^[A-Za-z0-9]+$")
 
     @model_validator(mode="after")
     def normalize_po_number(self):
@@ -74,6 +79,10 @@ class CreatePoRequest(BaseModel):
             self.po_number = self.po_number.strip()
             if not self.po_number:
                 raise ValueError("po_number, if provided, must not be blank")
+        if self.po_number_suffix is not None:
+            self.po_number_suffix = self.po_number_suffix.strip()
+            if not self.po_number_suffix:
+                self.po_number_suffix = None
         return self
 
 

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -25,6 +25,11 @@ class RelayOpError(Exception):
         self.context = context
 
 
+# GP's POP10100.PONUMBER is char(17). Anything longer is silently truncated by SQL Server, which
+# would produce a PO nobody can match back to the number Nexus recorded (#488).
+_MAX_PO_NUMBER = 17
+
+
 def check_company_allowed(company: str) -> None:
     allowed = get_settings().gp.allowed_companies
     if company not in allowed:
@@ -135,6 +140,27 @@ def create_po_op(conn, *, company: str, request: models.CreatePoRequest) -> mode
             )
     else:
         po_number = econnect.get_next_po_number(conn)
+        # #488: GP still owns and reserves the number; the suffix only makes it traceable. GP's
+        # PONUMBER is char(17), so a long project number can overflow - refuse here rather than let
+        # SQL Server truncate silently into a number nobody can match back to the job.
+        if request.po_number_suffix:
+            composed = f"{po_number.strip()}-{request.po_number_suffix}"
+            if len(composed) > _MAX_PO_NUMBER:
+                raise RelayOpError(
+                    "invalid_payload",
+                    f"PO number '{composed}' is {len(composed)} characters; GP's PONUMBER holds "
+                    f"{_MAX_PO_NUMBER}. Shorten the project number suffix.",
+                    po_number=composed,
+                )
+            po_number = composed
+
+        # The composed number is a different string from the one GP reserved, so it gets the same
+        # collision check an explicit number does.
+        in_use = econnect.po_number_in_use(conn, po_number)
+        if in_use:
+            raise RelayOpError(
+                "po_number_taken", f"PO number '{po_number}' is already in use in GP as {in_use}"
+            )
 
     # 2. header (no SUBTOTAL yet)
     econnect.create_po_header(

--- a/relay/tests/test_po_number_suffix.py
+++ b/relay/tests/test_po_number_suffix.py
@@ -1,0 +1,96 @@
+"""Project number appended to the GP PO number (#488).
+
+GP still owns and reserves the number - Nexus never invents one. The relay appends '-<project>' to
+what taGetPONextNumber hands back, so two purchasers registering at the same moment produce numbers
+that are visibly distinct and say which job they belong to.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ucnexus_relay import econnect, models, ops
+from ucnexus_relay.ops import RelayOpError
+
+
+class _Conn:
+    """Enough of a connection for create_po_op to reach the number step and stop there."""
+
+
+def _request(**overrides) -> models.CreatePoRequest:
+    kwargs = dict(
+        company="TUBC",
+        header=models.POHeader(
+            vendor_id="ING100", buyer_id="MIRA", confirm_with="Mira", doc_date=date(2026, 8, 6)
+        ),
+        lines=[
+            models.POLine(
+                item_number="ML2010",
+                item_description="ML2010 LOCK",
+                quantity=Decimal("2"),
+                unit_cost=Decimal("12.50"),
+                product_indicator=1,
+            )
+        ],
+    )
+    kwargs.update(overrides)
+    return models.CreatePoRequest(**kwargs)
+
+
+@pytest.fixture
+def stubbed(monkeypatch):
+    """Everything before the PO-number step passes; everything after it is left unstubbed, so the op
+    stops right after composing the number and the test reads it off the collision check."""
+    monkeypatch.setattr(econnect, "list_buyers", lambda conn: ["MIRA"])
+    monkeypatch.setattr(econnect, "get_vendor_currency", lambda conn, vendor_id: "CAD")
+    monkeypatch.setattr(
+        econnect, "get_mc_setup", lambda conn: {"functional": "CAD", "purchase_rate_type": "BUY"}
+    )
+    monkeypatch.setattr(econnect, "get_next_po_number", lambda conn: "PO0012345")
+    seen: dict = {}
+
+    def _in_use(conn, po_number):
+        seen["po_number"] = po_number
+        # Stop the op here: it has done the only thing under test.
+        raise RelayOpError("stop", "checked", po_number=po_number)
+
+    monkeypatch.setattr(econnect, "po_number_in_use", _in_use)
+    return seen
+
+
+def test_appends_the_project_number_to_gp_reserved_number(stubbed):
+    with pytest.raises(RelayOpError):
+        ops.create_po_op(_Conn(), company="TUBC", request=_request(po_number_suffix="23093"))
+
+    assert stubbed["po_number"] == "PO0012345-23093"
+
+
+def test_no_suffix_leaves_the_reserved_number_untouched(stubbed):
+    with pytest.raises(RelayOpError):
+        ops.create_po_op(_Conn(), company="TUBC", request=_request())
+
+    assert stubbed["po_number"] == "PO0012345"
+
+
+def test_refuses_a_suffix_that_overflows_gp_ponumber(stubbed):
+    """PONUMBER is char(17). SQL Server would truncate silently, leaving a PO nobody can match back
+    to the number Nexus recorded."""
+    with pytest.raises(RelayOpError) as excinfo:
+        ops.create_po_op(_Conn(), company="TUBC", request=_request(po_number_suffix="12345678"))
+
+    assert excinfo.value.code == "invalid_payload"
+    assert "17" in excinfo.value.message
+    # It never reached the collision check, so nothing was composed against GP.
+    assert "po_number" not in stubbed
+
+
+def test_an_explicit_po_number_ignores_the_suffix(stubbed):
+    with pytest.raises(RelayOpError):
+        ops.create_po_op(
+            _Conn(),
+            company="TUBC",
+            request=_request(po_number="UCNEXUS-1", po_number_suffix="23093"),
+        )
+
+    assert stubbed["po_number"] == "UCNEXUS-1"


### PR DESCRIPTION
closes #488.

two purchasers registering at the same moment reserve consecutive GP numbers, indistinguishable at a glance and saying nothing about which job they belong to. the number now reads `PO0012345-23093`.

GP still owns and reserves it. `registerPoInGp` sends `po_number: None` -> relay calls `taGetPONextNumber` -> suffix appended to what GP hands back. Nexus never invents a number.

the composed string is a different number from the one GP reserved, so it goes through the same `po_number_in_use` collision check an explicit number does.

GP's PONUMBER is char(17). a long project number overflows and SQL Server would truncate it silently, leaving a PO nobody could match back to what Nexus recorded. refused at the relay, and again in `validate_create_po_inputs` so it fails in the register dialog rather than after the WS hop.

job POs get the suffix
stock PO has no project, gets none
explicit `po_number` taken as given, suffix ignored entirely

`CreatePoRequest.po_number_suffix`, alphanumeric, max 8.

four relay tests.
- composition
- no-suffix path unchanged
- cap refusing before anything reaches GP
- explicit number winning

per #462 the relay ships and the fleet updates BEFORE the backend PR that sends `po_number_suffix` - the relay's pydantic models reject unknown fields, so an old build would refuse the new key. sequence the deploys.

before production, confirm with accounting that nothing downstream keys on the PO-number format. WennSoft job reports and AP invoice matching are the two that would notice.
