### PR TITLE
feat(warehouse): one page listing every receive (#505)

### DIFF
--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -269,6 +269,7 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     "backOrderedItems": SIGNED_IN,
     "inventoryByVendor": SIGNED_IN,
     "inventoryHierarchy": SIGNED_IN,
+    "receives": SIGNED_IN,
     "inventoryItems": SIGNED_IN,
     "locationAuditHistory": SIGNED_IN,
     "locationContents": SIGNED_IN,

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -99,6 +99,7 @@ from .receive_drafts import (
 from .receiving import (
     create_receive,
     find_open_replacement_pulls,
+    get_all_receives,
     get_back_ordered_items,
     get_po_receiving_details,
     get_receiving_history_pos,
@@ -185,6 +186,7 @@ __all__ = [
     "get_pull_staging_summaries",
     "get_receive_draft",
     "get_receive_drafts",
+    "get_all_receives",
     "get_recent_receive_records",
     "get_receiving_history_pos",
     "get_reserved_quantities",

--- a/backend/app/repositories/warehouse/receiving.py
+++ b/backend/app/repositories/warehouse/receiving.py
@@ -722,3 +722,115 @@ def get_recent_receive_records(session: Session, limit: int = 10) -> list[tuple]
         .limit(limit)
     )
     return list(session.execute(stmt).unique().all())
+
+
+def get_all_receives(
+    session: Session,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+    project_id: uuid.UUID | None = None,
+    po_search: str | None = None,
+) -> list[dict]:
+    """Every receive entity, drafts and booked records interleaved, newest first (#505).
+
+    Each existing view covers a slice: MyReceiveDraftsView is one user's own drafts,
+    ReceiveApprovalsPage is the manager's pending queue, ReceivingHistory is recent activity. A
+    rejected draft appeared in none of them, so a count somebody disputed simply vanished.
+
+    Drafts and records are read separately and merged in Python rather than SQL-UNIONed: they carry
+    different columns (a draft has a reviewer and a rejection reason, a record has an RCT number and
+    a batch), and a union would have to null-pad both sides into a shape neither one is.
+
+    Line counts and quantities come off the already-loaded line collections, which are selectinloaded
+    here - the #-N+1 rule: no per-row lazy loads.
+    """
+    from app.models.project import Project as ProjectModel
+    from app.models.receive_draft import ReceiveDraft as ReceiveDraftModel
+
+    def _po_filters(stmt, po_alias):
+        if project_id is not None:
+            stmt = stmt.where(po_alias.project_id == project_id)
+        if po_search:
+            stmt = stmt.where(po_alias.po_number.ilike(f"%{po_search.strip()}%"))
+        return stmt
+
+    draft_stmt = (
+        select(ReceiveDraftModel, POModel)
+        .join(POModel, ReceiveDraftModel.po_id == POModel.id)
+        .options(selectinload(ReceiveDraftModel.line_items))
+    )
+    draft_stmt = _po_filters(draft_stmt, POModel)
+
+    record_stmt = (
+        select(ReceiveRecordModel, POModel)
+        .join(POModel, ReceiveRecordModel.po_id == POModel.id)
+        .options(selectinload(ReceiveRecordModel.line_items))
+    )
+    record_stmt = _po_filters(record_stmt, POModel)
+
+    # A draft that has been approved has a receive_record_id, and the record is the row worth
+    # showing - it carries the RCT number and the booked quantities. Skipping those drafts is what
+    # keeps one physical delivery from appearing twice.
+    rows: list[dict] = []
+    for draft, po in session.execute(draft_stmt).unique().all():
+        if draft.receive_record_id is not None:
+            continue
+        rows.append(
+            {
+                "kind": "DRAFT",
+                "id": draft.id,
+                "occurred_at": draft.created_at,
+                "status": draft.status.value,
+                "po_id": po.id,
+                "po_number": po.po_number,
+                "project_id": po.project_id,
+                "warehouse_id": draft.warehouse_id,
+                "line_count": len(draft.line_items),
+                "total_quantity": sum(li.quantity_received for li in draft.line_items),
+                "counted_by": draft.created_by_name,
+                "reviewed_by": draft.reviewed_by_name,
+                "rejection_reason": draft.rejection_reason,
+                "receipt_number": None,
+                "batch_number": None,
+            }
+        )
+
+    for record, po in session.execute(record_stmt).unique().all():
+        rows.append(
+            {
+                "kind": "RECORD",
+                "id": record.id,
+                "occurred_at": record.received_at,
+                "status": "APPROVED",
+                "po_id": po.id,
+                "po_number": po.po_number,
+                "project_id": po.project_id,
+                "warehouse_id": None,
+                "line_count": len(record.line_items),
+                "total_quantity": sum(li.quantity_received for li in record.line_items),
+                "counted_by": record.received_by,
+                "reviewed_by": None,
+                "rejection_reason": None,
+                "receipt_number": record.receipt_number,
+                "batch_number": record.batch_number,
+            }
+        )
+
+    # Project names in one grouped read rather than one per row.
+    project_ids = {r["project_id"] for r in rows if r["project_id"]}
+    names: dict = {}
+    if project_ids:
+        names = {
+            pid: (desc or number)
+            for pid, number, desc in session.execute(
+                select(ProjectModel.id, ProjectModel.project_id, ProjectModel.description).where(
+                    ProjectModel.id.in_(project_ids)
+                )
+            ).all()
+        }
+    for r in rows:
+        r["project_name"] = names.get(r["project_id"])
+
+    rows.sort(key=lambda r: r["occurred_at"], reverse=True)
+    return rows[offset : offset + limit]

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1384,6 +1384,33 @@ class InventoryItemDetail:
 
 
 @strawberry.type
+class ReceiveRow:
+    """One receive entity for the warehouse Receives page (#505).
+
+    Deliberately a flat, discriminated row rather than a union: drafts and booked records are the
+    same thing at different stages, and the page reads them in one interleaved list. `kind` says
+    which it is; `receipt_number` is only ever set on a booked record, `rejection_reason` only on a
+    rejected draft."""
+
+    kind: str
+    id: strawberry.ID
+    occurred_at: datetime
+    status: str
+    po_id: strawberry.ID
+    po_number: str | None
+    project_id: strawberry.ID | None
+    project_name: str | None
+    warehouse_id: strawberry.ID | None
+    line_count: int
+    total_quantity: int
+    counted_by: str | None
+    reviewed_by: str | None
+    rejection_reason: str | None
+    receipt_number: str | None
+    batch_number: str | None
+
+
+@strawberry.type
 class OpeningItemDetail:
     opening_item: OpeningItem
     installed_hardware: list[OpeningItemHardware]

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -80,6 +80,7 @@ from .types import (
     ReceiveDecision,
     ReceiveDraft,
     ReceiveRecord,
+    ReceiveRow,
     ReceivingHistoryPO,
     RecentReceiveRecord,
     RestockedLine,
@@ -421,6 +422,48 @@ class WarehouseQueries:
                     total_value=cat_node["total_value"],
                 )
                 for cat_node in hierarchy
+            ]
+
+    @strawberry.field
+    def receives(
+        self,
+        info: strawberry.Info,
+        limit: int = 50,
+        offset: int = 0,
+        project_id: strawberry.ID | None = None,
+        po_search: str | None = None,
+    ) -> list[ReceiveRow]:
+        """Every receive entity, drafts and booked records interleaved, newest first (#505).
+
+        The existing views each cover a slice and a rejected draft appeared in none of them, so a
+        disputed count vanished from the product entirely."""
+        with SessionLocal() as session:
+            return [
+                ReceiveRow(
+                    kind=r["kind"],
+                    id=strawberry.ID(str(r["id"])),
+                    occurred_at=r["occurred_at"],
+                    status=r["status"],
+                    po_id=strawberry.ID(str(r["po_id"])),
+                    po_number=r["po_number"],
+                    project_id=strawberry.ID(str(r["project_id"])) if r["project_id"] else None,
+                    project_name=r["project_name"],
+                    warehouse_id=strawberry.ID(str(r["warehouse_id"])) if r["warehouse_id"] else None,
+                    line_count=r["line_count"],
+                    total_quantity=r["total_quantity"],
+                    counted_by=r["counted_by"],
+                    reviewed_by=r["reviewed_by"],
+                    rejection_reason=r["rejection_reason"],
+                    receipt_number=r["receipt_number"],
+                    batch_number=r["batch_number"],
+                )
+                for r in warehouse_repository.get_all_receives(
+                    session,
+                    limit=limit,
+                    offset=offset,
+                    project_id=uuid.UUID(str(project_id)) if project_id else None,
+                    po_search=po_search,
+                )
             ]
 
     @strawberry.field

--- a/frontend/src/graphql/warehouse.ts
+++ b/frontend/src/graphql/warehouse.ts
@@ -882,3 +882,28 @@ export const RESOLVE_DEFICIENCY = gql`
     }
   }
 `;
+
+// #505: every receive entity in one list - drafts pending approval, drafts being approved,
+// rejected drafts and booked records. The existing views each cover a slice, and a rejected draft
+// appeared in none of them.
+export const GET_RECEIVES = gql`
+  query GetReceives($limit: Int, $offset: Int, $projectId: ID, $poSearch: String) {
+    receives(limit: $limit, offset: $offset, projectId: $projectId, poSearch: $poSearch) {
+      kind
+      id
+      occurredAt
+      status
+      poId
+      poNumber
+      projectId
+      projectName
+      lineCount
+      totalQuantity
+      countedBy
+      reviewedBy
+      rejectionReason
+      receiptNumber
+      batchNumber
+    }
+  }
+`;

--- a/frontend/src/modules/warehouse/ReceivesPage.tsx
+++ b/frontend/src/modules/warehouse/ReceivesPage.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid';
+import { useQuery } from '@apollo/client/react';
+import { GET_RECEIVES } from '../../graphql/warehouse';
+import { GET_PROJECTS } from '../../graphql/shared';
+import BackToModule from '../../components/BackToModule';
+import { microLabelSx, monoSx, tabularSx } from '../../theme';
+import { parseServerDate } from '../../utils/serverDate';
+import type { Project } from '../../types/project';
+
+/**
+ * Every receive entity in one place (#505).
+ *
+ * The existing surfaces each cover a slice - MyReceiveDraftsView is one user's own drafts,
+ * ReceiveApprovalsPage is the manager's pending queue, ReceivingHistory is recent activity on the
+ * receiving page. A REJECTED draft appeared in none of them, so a count somebody disputed vanished
+ * from the product entirely and the only way to find it was to ask the person who raised it.
+ *
+ * Drafts and booked records are interleaved because they are the same thing at different stages:
+ * what the warehouse wants is "every delivery we have written down", newest first.
+ */
+
+interface ReceiveRow {
+  kind: 'DRAFT' | 'RECORD';
+  id: string;
+  occurredAt: string;
+  status: string;
+  poId: string;
+  poNumber: string | null;
+  projectId: string | null;
+  projectName: string | null;
+  lineCount: number;
+  totalQuantity: number;
+  countedBy: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+  receiptNumber: string | null;
+  batchNumber: string | null;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  PENDING_APPROVAL: 'Pending approval',
+  APPROVING: 'Approving',
+  REJECTED: 'Rejected',
+  APPROVED: 'Approved',
+};
+
+const STATUS_COLOR: Record<string, 'default' | 'warning' | 'info' | 'error' | 'success'> = {
+  PENDING_APPROVAL: 'warning',
+  APPROVING: 'info',
+  REJECTED: 'error',
+  APPROVED: 'success',
+};
+
+const STATUS_FILTERS = ['', 'PENDING_APPROVAL', 'APPROVING', 'REJECTED', 'APPROVED'];
+
+export default function ReceivesPage() {
+  const [projectId, setProjectId] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [poSearch, setPoSearch] = useState('');
+
+  const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
+  const { data, loading, error } = useQuery<{ receives: ReceiveRow[] }>(GET_RECEIVES, {
+    variables: {
+      limit: 200,
+      offset: 0,
+      projectId: projectId || undefined,
+      poSearch: poSearch.trim() || undefined,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  // Status is filtered client-side: the server returns one interleaved list and the counts on
+  // screen should agree with what the filter narrowed, not with a second round trip.
+  const rows = useMemo(() => {
+    const all = data?.receives ?? [];
+    return statusFilter ? all.filter((r) => r.status === statusFilter) : all;
+  }, [data, statusFilter]);
+
+  const columns = useMemo<GridColDef<ReceiveRow>[]>(
+    () => [
+      {
+        field: 'occurredAt',
+        headerName: 'Date',
+        width: 130,
+        valueFormatter: (value: string) => parseServerDate(value).toLocaleDateString(),
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 160,
+        renderCell: (params) => (
+          <Chip
+            size="small"
+            label={STATUS_LABEL[params.value as string] ?? (params.value as string)}
+            color={STATUS_COLOR[params.value as string] ?? 'default'}
+          />
+        ),
+      },
+      {
+        field: 'poNumber',
+        headerName: 'PO #',
+        width: 150,
+        renderCell: (params) => (
+          <Typography component="span" sx={monoSx}>
+            {(params.value as string | null) ?? '—'}
+          </Typography>
+        ),
+      },
+      { field: 'projectName', headerName: 'Project', flex: 1, minWidth: 150 },
+      { field: 'lineCount', headerName: 'Lines', type: 'number', width: 90 },
+      { field: 'totalQuantity', headerName: 'Qty', type: 'number', width: 90 },
+      {
+        field: 'receiptNumber',
+        headerName: 'RCT #',
+        width: 140,
+        renderCell: (params) => (
+          <Typography component="span" sx={monoSx}>
+            {(params.value as string | null) ?? '—'}
+          </Typography>
+        ),
+      },
+      { field: 'countedBy', headerName: 'Counted by', flex: 1, minWidth: 140 },
+      { field: 'reviewedBy', headerName: 'Reviewed by', flex: 1, minWidth: 140 },
+    ],
+    [],
+  );
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <BackToModule to="/app/warehouse" label="Warehouse" />
+      <Typography variant="h5" sx={{ mb: 0.5 }}>
+        Receives
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Every delivery written down against a purchase order, whatever stage it reached - including
+        the ones that were rejected.
+      </Typography>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
+        <TextField
+          select
+          size="small"
+          label="Project"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          sx={{ minWidth: 220 }}
+        >
+          <MenuItem value="">All projects</MenuItem>
+          {(projectsData?.projects ?? []).map((p) => (
+            <MenuItem key={p.id} value={p.id}>
+              {p.description || p.projectId}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          select
+          size="small"
+          label="Status"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          sx={{ minWidth: 190 }}
+        >
+          {STATUS_FILTERS.map((s) => (
+            <MenuItem key={s || 'all'} value={s}>
+              {s ? (STATUS_LABEL[s] ?? s) : 'All statuses'}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          size="small"
+          label="PO number"
+          placeholder="Search…"
+          value={poSearch}
+          onChange={(e) => setPoSearch(e.target.value)}
+          sx={{ minWidth: 200 }}
+        />
+      </Stack>
+
+      {error && <Alert severity="error">{error.message}</Alert>}
+
+      {loading && !data ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : rows.length === 0 ? (
+        <Alert severity="info">No receives match these filters.</Alert>
+      ) : (
+        <>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            density="compact"
+            disableRowSelectionOnClick
+            initialState={{ pagination: { paginationModel: { pageSize: 50 } } }}
+            pageSizeOptions={[25, 50, 100]}
+          />
+          <Box sx={{ mt: 1.5 }}>
+            <Typography sx={microLabelSx}>Showing</Typography>
+            <Typography sx={{ ...tabularSx, fontWeight: 700 }}>{rows.length} receive(s)</Typography>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/modules/warehouse/WarehouseLanding.tsx
+++ b/frontend/src/modules/warehouse/WarehouseLanding.tsx
@@ -35,6 +35,14 @@ const CELL = { xs: 12, sm: 6, md: 4, lg: 3 } as const;
 function buildDestinations(d: WarehouseDashboard | undefined, canReview: boolean): Destination[] {
   const pendingPulls = d ? d.pendingPullShop + d.pendingPullShipping : 0;
   return [
+    // #505: every receive entity, whatever stage it reached. Not manager-gated - a counter needs to
+    // find the draft that was rejected as much as a manager does.
+    {
+      label: 'Receives',
+      path: '/app/warehouse/receives',
+      icon: <ClipboardCheck size={18} strokeWidth={1.75} />,
+      caption: 'Every delivery written down, approved or not',
+    },
     // Manager-only, and first: it is the one card on this page that is somebody waiting on you.
     ...(canReview
       ? [

--- a/frontend/src/modules/warehouse/index.tsx
+++ b/frontend/src/modules/warehouse/index.tsx
@@ -4,6 +4,7 @@ import InventoryView from './InventoryView';
 import LocationsTab from './LocationsTab';
 import ReceivingPage from './ReceivingPage';
 import ReceiveApprovalsPage from './ReceiveApprovalsPage';
+import ReceivesPage from './ReceivesPage';
 import PullRequestQueue from './PullRequestQueue';
 import PickPage from './PickPage';
 import PutAwayTab from './PutAwayTab';
@@ -25,6 +26,7 @@ export default function WarehouseModule() {
       {/* The manager's queue of counted receives waiting to be posted. Self-gated on the Warehouse
           Manager role: the route is reachable, the page says what it needs. */}
       <Route path="receive-approvals" element={<ReceiveApprovalsPage />} />
+      <Route path="receives" element={<ReceivesPage />} />
       {/* Deliveries was its own page until its back-order grid moved onto Receiving; the redirect is
           what keeps a bookmark or an old link working. */}
       <Route path="deliveries" element={<Navigate to="/app/warehouse/receiving" replace />} />


### PR DESCRIPTION
closes #505.

existing surfaces each cover a slice
MyReceiveDraftsView, one user's own drafts
ReceiveApprovalsPage, manager pending queue
ReceivingHistory, recent activity on the receiving page

a REJECTED draft appears in none of them, so a count somebody disputed vanished from the product and the only way to find it was to ask whoever raised it.

new Receives page at `/app/warehouse/receives`, card on the warehouse landing. drafts and booked records interleave, newest first - they are the same thing at different stages.

each row shows:
Date
Status
PO #
Project
Lines
Qty
RCT #
Counted by
Reviewed by

filters
project
status
PO number search

new `receives(limit, offset, projectId, poSearch)` -> `get_all_receives`. drafts and records read separately, merged in Python, not SQL-UNIONed: they carry different columns - a draft has a reviewer and a rejection reason, a record has an RCT number and a batch - and a union would null-pad both sides into a shape neither one is.

line collections selectinloaded, project names from one grouped read, so no per-row lazy loads.

an approved draft carrying a `receive_record_id` is skipped: the record is the row worth showing, since it holds the RCT number and the booked quantities. that is what keeps one physical delivery from appearing twice.

status filtered client-side, so the count on screen agrees with what the filter narrowed rather than with a second round trip.

not manager-gated - a counter needs to find their rejected draft as much as a manager does. `receives` is SIGNED_IN in ROOT_FIELD_POLICY.

clicking a row opens nothing. wiring the existing ReceiveDraftReviewModal to pending/rejected rows is NOT in this PR.
