### PR TITLE
feat(warehouse): the receive draft is a count, put-away follows approval (#501)

### DIFF
--- a/backend/app/auth_policy.py
+++ b/backend/app/auth_policy.py
@@ -305,6 +305,7 @@ ROOT_FIELD_POLICY: dict[str, str | frozenset[str]] = {
     # requirement can express.
     "approveReceiveDraft": frozenset({ADMIN_ROLE, WAREHOUSE_MANAGER_ROLE}),
     "assignInventoryLocation": SIGNED_IN,
+    "splitInventoryLocation": SIGNED_IN,
     "assignOpeningItemLocation": SIGNED_IN,
     "cancelPullRequest": SIGNED_IN,
     "completePullRequest": SIGNED_IN,

--- a/backend/app/repositories/warehouse/__init__.py
+++ b/backend/app/repositories/warehouse/__init__.py
@@ -37,6 +37,7 @@ from .locations import (
     move_inventory_location,
     move_opening_item_location,
     normalize_location_value,
+    split_inventory_location,
 )
 from .progress import (
     PLACED_PO_STATUSES,
@@ -143,6 +144,7 @@ __all__ = [
     "_normalize_and_validate_location_fields",
     "adjust_inventory_quantity",
     "assign_inventory_location",
+    "split_inventory_location",
     "assign_opening_item_location",
     "cancel_pull_request",
     "check_inventory_sufficiency",

--- a/backend/app/repositories/warehouse/locations.py
+++ b/backend/app/repositories/warehouse/locations.py
@@ -476,6 +476,67 @@ def assign_inventory_location(
     return il
 
 
+def split_inventory_location(
+    session: Session, inv_id: uuid.UUID, quantity: int, *, performed_by: str
+) -> tuple[InventoryLocationModel, InventoryLocationModel]:
+    """Break `quantity` units off an inventory row into a second row (#501).
+
+    Put-away moved after approval, so a receive books one row per PO line and the warehouse decides
+    where it goes afterwards. Ten hinges rarely go in one bin: six in A-1-1 and four in B-2-2 is the
+    normal case, and it needs two rows because a row carries exactly one aisle/row/bay.
+
+    The new row copies the origin FKs and `received_at` verbatim. Those are what make the units
+    traceable back to the receipt that booked them and what FIFO orders picks by - a split is a
+    change of shelf, not of provenance, so inventing new values would quietly reorder the pick queue
+    and orphan the audit trail.
+
+    Deficient units stay with the original row. They are not on a shelf; they are a claim against
+    the vendor, and moving a fraction of them to a bin nobody put them in would be a lie.
+    """
+    il = session.get(InventoryLocationModel, inv_id)
+    if il is None:
+        raise NotFoundError(f"Inventory location {inv_id} not found")
+    if quantity < 1:
+        raise ValidationError("Split quantity must be at least 1", field="quantity")
+    if quantity >= il.quantity:
+        # Equal is refused too: splitting off everything is a no-op that leaves an empty row behind.
+        raise ValidationError(
+            f"Cannot split {quantity} off a row holding {il.quantity}; leave at least one unit behind",
+            field="quantity",
+        )
+
+    remainder = InventoryLocationModel(
+        project_id=il.project_id,
+        po_line_item_id=il.po_line_item_id,
+        receive_line_item_id=il.receive_line_item_id,
+        stock_item_id=il.stock_item_id,
+        shipment_return_item_id=il.shipment_return_item_id,
+        warehouse_id=il.warehouse_id,
+        hardware_category=il.hardware_category,
+        product_code=il.product_code,
+        quantity=quantity,
+        deficient_quantity=0,
+        aisle=None,
+        row=None,
+        bay=None,
+        received_at=il.received_at,
+    )
+    il.quantity -= quantity
+    session.add(remainder)
+    session.flush()
+
+    _log_audit_event(
+        session,
+        project_id=il.project_id,
+        entity_type=AuditEntityType.INVENTORY_LOCATION,
+        entity_id=remainder.id,
+        action=AuditAction.PUT_AWAY,
+        performed_by=performed_by,
+        detail={"splitFrom": str(il.id), "quantity": quantity},
+    )
+    return il, remainder
+
+
 def move_opening_item_location(
     session: Session,
     oi_id: uuid.UUID,

--- a/backend/app/schemas/inputs.py
+++ b/backend/app/schemas/inputs.py
@@ -504,6 +504,9 @@ class ReconciliationItemInput:
 class ReceiveLineItemInput:
     po_line_item_id: strawberry.ID
     quantity_received: int
+    # Empty since #501: a draft is a count, and where the units go is chosen on the Put Away queue
+    # after the warehouse manager approves. The field stays because drafts counted before that
+    # change still carry their rack rows and the booking still honours them.
     locations: list["LocationInput"] = strawberry.field(default_factory=list)
 
 

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -134,17 +134,34 @@ def _load_receive_type(receive_id: uuid.UUID) -> ReceiveRecord:
         return receive_record_to_type(rec)
 
 
-def _prepare_create_receive(*, po_id, received_by, line_items_data) -> tuple[str, dict]:
+def _prepare_create_receive(*, po_id, received_by, line_items_data, warehouse_id=None) -> tuple[str, dict]:
     """Read-only: validate the receive is eligible (before the GP receipt is posted) and build the relay
-    create_receipt payload. Returns (gp_company, payload)."""
+    create_receipt payload. Returns (gp_company, payload).
+
+    The warehouse code rides along because put-away happens after approval now (#501): a line
+    normally has no bin yet, and the warehouse is what GP gets told instead of nothing."""
     with SessionLocal() as session:
         po_number, gp_company, receipt_line_items = warehouse_repository.validate_receive_eligibility(
             session, po_id, received_by, line_items_data
         )
+        warehouse_code = _warehouse_code(session, warehouse_id)
     payload = gp_po.build_create_receipt_payload(
-        po_number=po_number, received_by=received_by, line_items=receipt_line_items
+        po_number=po_number,
+        received_by=received_by,
+        line_items=receipt_line_items,
+        warehouse_code=warehouse_code,
     )
     return gp_company, payload
+
+
+def _warehouse_code(session, warehouse_id) -> str | None:
+    """The receiving warehouse's code, falling back to the primary one the booking will use."""
+    from app.models.warehouse import Warehouse as WarehouseModel
+
+    if warehouse_id is None:
+        warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    warehouse = session.get(WarehouseModel, warehouse_id)
+    return warehouse.code if warehouse else None
 
 
 def _receive_outbox_identity(po_id: uuid.UUID) -> tuple[uuid.UUID | None, str]:
@@ -1104,6 +1121,7 @@ class WarehouseMutations:
                     po_id=ctx.po_id,
                     received_by=ctx.author_name,
                     line_items_data=ctx.line_items_data,
+                    warehouse_id=ctx.warehouse_id,
                 )
             except Exception:
                 # Nothing reached GP, so the draft belongs back in the queue with the reason surfaced
@@ -1555,6 +1573,29 @@ class WarehouseMutations:
             session.commit()
             session.refresh(result)
             return inventory_location_to_type(result)
+
+    @strawberry.mutation
+    def split_inventory_location(
+        self,
+        info: strawberry.Info,
+        inventory_location_id: strawberry.ID,
+        quantity: int,
+    ) -> list[InventoryLocation]:
+        """Break units off an inventory row so they can go on a different shelf (#501).
+
+        Put-away happens after approval now, so a receive books one row per PO line and ten hinges
+        arriving as one row routinely go to two bins. Returns [original, new] - the new row is
+        unlocated and is what the caller then assigns."""
+        auth = current_user(info)
+        actor = resolve_display_name(auth["user_id"])
+        with SessionLocal() as session:
+            original, remainder = warehouse_repository.split_inventory_location(
+                session, uuid.UUID(str(inventory_location_id)), quantity, performed_by=actor
+            )
+            session.commit()
+            session.refresh(original)
+            session.refresh(remainder)
+            return [inventory_location_to_type(original), inventory_location_to_type(remainder)]
 
     @strawberry.mutation
     def move_opening_item_location(

--- a/backend/app/services/gp_po.py
+++ b/backend/app/services/gp_po.py
@@ -131,10 +131,18 @@ def build_create_receipt_payload(
     po_number: str,
     received_by: str,
     line_items: list[dict],
+    warehouse_code: str | None = None,
 ) -> dict:
     """line_items: each with gp_line_ord, quantity, and locations (the same aisle/row/bay dicts the
     createReceive input carries for the UC Nexus put-away) - rack_location composes the distinct
-    locations a line's units were placed in, same convention the browser used to build it."""
+    locations a line's units were placed in, same convention the browser used to build it.
+
+    Since #501 put-away happens AFTER the warehouse manager approves, so a line usually reaches this
+    point with no locations at all. `warehouse_code` is what GP gets told instead: the building the
+    units are in, which is true at receipt time and is the most specific thing anybody knows yet.
+    Sending an empty rack_location would lose even that. Lines that DO carry locations - drafts
+    counted before #501 shipped - still compose the bins.
+    """
     lines = []
     for li in line_items:
         racks: list[str] = []
@@ -144,11 +152,12 @@ def build_create_receipt_payload(
             if key not in seen:
                 seen.add(key)
                 racks.append(key)
+        rack_location = ", ".join(racks) if racks else (warehouse_code or "")
         lines.append(
             {
                 "po_line_ord": li["gp_line_ord"],
                 "quantity": li["quantity"],
-                "rack_location": ", ".join(racks)[:_MAX_RACK_LOCATION],
+                "rack_location": rack_location[:_MAX_RACK_LOCATION],
             }
         )
 

--- a/backend/tests/test_gp_po.py
+++ b/backend/tests/test_gp_po.py
@@ -153,6 +153,39 @@ def test_build_create_receipt_payload_dedupes_and_joins_rack_locations():
     assert line["rack_location"] == "A1-B1-C1, A2-B2-C2"
 
 
+def test_a_line_with_no_locations_tells_gp_the_warehouse():
+    """#501: put-away happens after approval, so a line normally reaches GP with no bin yet. The
+    warehouse is true at receipt time and is the most specific thing anybody knows - an empty
+    rack_location would throw even that away."""
+    payload = gp_po.build_create_receipt_payload(
+        po_number="PO0000001",
+        received_by="Jane Doe",
+        line_items=[{"gp_line_ord": 16384, "quantity": 5, "locations": []}],
+        warehouse_code="MAIN",
+    )
+    assert payload["lines"][0]["rack_location"] == "MAIN"
+
+
+def test_a_legacy_draft_that_still_carries_bins_keeps_composing_them():
+    """Drafts counted before #501 shipped still have rack rows; those win over the warehouse."""
+    payload = gp_po.build_create_receipt_payload(
+        po_number="PO0000001",
+        received_by="Jane Doe",
+        line_items=[{"gp_line_ord": 16384, "quantity": 5, "locations": [{"aisle": "A1", "row": "B1", "bay": "C1"}]}],
+        warehouse_code="MAIN",
+    )
+    assert payload["lines"][0]["rack_location"] == "A1-B1-C1"
+
+
+def test_no_locations_and_no_warehouse_sends_an_empty_rack_location():
+    payload = gp_po.build_create_receipt_payload(
+        po_number="PO0000001",
+        received_by="Jane Doe",
+        line_items=[{"gp_line_ord": 16384, "quantity": 5, "locations": []}],
+    )
+    assert payload["lines"][0]["rack_location"] == ""
+
+
 # --- validate_create_po_inputs: pre-relay field checks (issue #202 #1) --------------------------------
 
 

--- a/backend/tests/test_inventory_split.py
+++ b/backend/tests/test_inventory_split.py
@@ -1,0 +1,140 @@
+"""Splitting an unlocated inventory row at put-away (#501).
+
+Put-away moved after the warehouse manager's approval, so a receive books ONE row per PO line and
+the warehouse decides afterwards where the units go. Ten hinges rarely land in one bin, and a row
+carries exactly one aisle/row/bay - so the queue needs a way to break a row in two.
+
+What the split must not do is launder provenance. The origin FKs and `received_at` are what tie the
+units back to the receipt that booked them and what FIFO orders picks by; a split is a change of
+shelf, not of history.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.errors import ValidationError
+from app.models.audit_log import InventoryAuditLog
+from app.models.enums import AuditAction
+from app.models.inventory import InventoryLocation
+from app.models.project import Project
+from app.models.stock_item import StockItem
+from app.repositories import warehouse as warehouse_repository
+from app.repositories import warehouse_admin_repository
+
+
+def _row(session, *, quantity=10, deficient=0):
+    project = Project(id=uuid.uuid4(), project_id=f"PROJ-{uuid.uuid4().hex[:8]}", description="Split")
+    session.add(project)
+    session.flush()
+    warehouse_id = warehouse_admin_repository.get_primary_warehouse_id(session)
+    stock = StockItem(
+        id=uuid.uuid4(),
+        warehouse_id=warehouse_id,
+        hardware_category="HINGE",
+        product_code="HG-100",
+        quantity=quantity,
+        deficient_quantity=0,
+        received_at=datetime.utcnow(),
+    )
+    session.add(stock)
+    session.flush()
+    received_at = datetime.utcnow() - timedelta(days=3)
+    il = InventoryLocation(
+        id=uuid.uuid4(),
+        project_id=project.id,
+        stock_item_id=stock.id,
+        warehouse_id=warehouse_id,
+        hardware_category="HINGE",
+        product_code="HG-100",
+        quantity=quantity,
+        deficient_quantity=deficient,
+        aisle=None,
+        row=None,
+        bay=None,
+        received_at=received_at,
+    )
+    session.add(il)
+    session.flush()
+    return project, il
+
+
+def test_a_split_conserves_quantity_and_copies_the_origin(db_session):
+    project, il = _row(db_session, quantity=10)
+    original_received_at = il.received_at
+
+    kept, moved = warehouse_repository.split_inventory_location(db_session, il.id, 4, performed_by="picker")
+    db_session.flush()
+
+    assert kept.id == il.id
+    assert kept.quantity == 6
+    assert moved.quantity == 4
+    assert kept.quantity + moved.quantity == 10
+
+    # A split is a change of shelf, not of history: FIFO and the audit trail both key off these.
+    assert moved.stock_item_id == il.stock_item_id
+    assert moved.po_line_item_id == il.po_line_item_id
+    assert moved.receive_line_item_id == il.receive_line_item_id
+    assert moved.warehouse_id == il.warehouse_id
+    assert moved.project_id == project.id
+    assert moved.received_at == original_received_at
+
+    # The new row is what the caller then assigns, so it starts unlocated.
+    assert moved.aisle is None and moved.row is None and moved.bay is None
+
+
+def test_the_split_writes_a_put_away_audit_row_naming_the_caller(db_session):
+    project, il = _row(db_session, quantity=10)
+
+    _kept, moved = warehouse_repository.split_inventory_location(db_session, il.id, 3, performed_by="Wendy Warehouse")
+    db_session.flush()
+
+    logs = list(
+        db_session.scalars(
+            select(InventoryAuditLog).where(
+                InventoryAuditLog.project_id == project.id,
+                InventoryAuditLog.entity_id == moved.id,
+            )
+        ).all()
+    )
+    assert len(logs) == 1
+    assert logs[0].action == AuditAction.PUT_AWAY
+    assert logs[0].performed_by == "Wendy Warehouse"
+    assert logs[0].detail["splitFrom"] == str(il.id)
+    assert logs[0].detail["quantity"] == 3
+
+
+def test_deficient_units_stay_with_the_original_row(db_session):
+    """They are not on a shelf - they are a claim against the vendor. Moving a fraction of them to a
+    bin nobody put them in would be a lie."""
+    _project, il = _row(db_session, quantity=10, deficient=2)
+
+    kept, moved = warehouse_repository.split_inventory_location(db_session, il.id, 4, performed_by="picker")
+    db_session.flush()
+
+    assert kept.deficient_quantity == 2
+    assert moved.deficient_quantity == 0
+
+
+@pytest.mark.parametrize("bad", [0, -1, 10, 11])
+def test_a_split_that_would_empty_or_overdraw_the_row_is_refused(db_session, bad):
+    _project, il = _row(db_session, quantity=10)
+
+    with pytest.raises(ValidationError):
+        warehouse_repository.split_inventory_location(db_session, il.id, bad, performed_by="picker")
+
+
+def test_splitting_twice_leaves_three_rows_that_still_sum(db_session):
+    """The normal case is more than two bins: 5 here, 3 there, 2 left."""
+    _project, il = _row(db_session, quantity=10)
+
+    _kept, first = warehouse_repository.split_inventory_location(db_session, il.id, 5, performed_by="picker")
+    _kept2, second = warehouse_repository.split_inventory_location(db_session, il.id, 3, performed_by="picker")
+    db_session.flush()
+
+    assert il.quantity == 2
+    assert first.quantity == 5
+    assert second.quantity == 3
+    assert il.quantity + first.quantity + second.quantity == 10

--- a/frontend/src/graphql/shared.ts
+++ b/frontend/src/graphql/shared.ts
@@ -145,6 +145,21 @@ export const ASSIGN_INVENTORY_LOCATION = gql`
   }
 `;
 
+/**
+ * Break units off an unlocated row so they can go on a different shelf (#501).
+ *
+ * Put-away happens after the warehouse manager approves now, so a receive books one row per PO
+ * line. Ten hinges arriving as one row routinely go to two bins, and a row carries exactly one
+ * aisle/row/bay. Returns [original, new]; the new row is unlocated and is what gets assigned next.
+ */
+export const SPLIT_INVENTORY_LOCATION = gql`
+  mutation SplitInventoryLocation($inventoryLocationId: ID!, $quantity: Int!) {
+    splitInventoryLocation(inventoryLocationId: $inventoryLocationId, quantity: $quantity) {
+      id projectId poLineItemId receiveLineItemId hardwareCategory productCode quantity aisle row bay receivedAt createdAt updatedAt
+    }
+  }
+`;
+
 export const MOVE_OPENING_ITEM_LOCATION = gql`
   mutation MoveOpeningItemLocation($openingItemId: ID!, $aisle: String!, $row: String!, $bay: String!, $warehouseId: ID) {
     moveOpeningItemLocation(openingItemId: $openingItemId, aisle: $aisle, row: $row, bay: $bay, warehouseId: $warehouseId) {

--- a/frontend/src/modules/warehouse/PutAwayTab.tsx
+++ b/frontend/src/modules/warehouse/PutAwayTab.tsx
@@ -19,12 +19,18 @@ import {
   TableHead,
   TableRow,
   Paper,
+  TextField,
+  Tooltip,
 } from '@mui/material';
 import { ChevronDown } from 'lucide-react';
 import { useQuery, useMutation } from '@apollo/client/react';
 import { useToast } from '../../components/Toast';
 import LocationAutocomplete from '../../components/LocationAutocomplete';
-import { GET_PROJECTS, ASSIGN_INVENTORY_LOCATION } from '../../graphql/shared';
+import {
+  GET_PROJECTS,
+  ASSIGN_INVENTORY_LOCATION,
+  SPLIT_INVENTORY_LOCATION,
+} from '../../graphql/shared';
 import { GET_UNLOCATED_INVENTORY, GET_LOCATION_DISTINCT_VALUES } from '../../graphql/warehouse';
 import AssembledLeafPutAway from './AssembledLeafPutAway';
 import { microLabelSx, monoSx, tabularSx } from '../../theme';
@@ -95,6 +101,8 @@ export default function PutAwayTab() {
   const [projectFilter, setProjectFilter] = useState<string>('');
   const [locationInputs, setLocationInputs] = useState<Record<string, LocationInput>>({});
   const [assigningId, setAssigningId] = useState<string | null>(null);
+  // Per-row "put N of these somewhere else" entry. Empty means the whole row goes to one bin.
+  const [splitQty, setSplitQty] = useState<Record<string, string>>({});
 
   // Queries
   const { data: projectsData } = useQuery<{ projects: Project[] }>(GET_PROJECTS);
@@ -117,6 +125,7 @@ export default function PutAwayTab() {
 
   // Mutation
   const [assignLocation] = useMutation(ASSIGN_INVENTORY_LOCATION);
+  const [splitLocation] = useMutation(SPLIT_INVENTORY_LOCATION);
 
   // Derived
   const projects = projectsData?.projects ?? [];
@@ -154,20 +163,54 @@ export default function PutAwayTab() {
     [getLocationInput],
   );
 
+  const splitIsValid = useCallback(
+    (id: string, rowQuantity: number): boolean => {
+      const raw = (splitQty[id] ?? '').trim();
+      if (raw === '') return true;
+      const n = Number(raw);
+      return Number.isInteger(n) && n >= 1 && n <= rowQuantity;
+    },
+    [splitQty],
+  );
+
   const handleAssign = useCallback(
-    async (id: string, productCode: string) => {
+    async (id: string, productCode: string, rowQuantity: number) => {
       const loc = getLocationInput(id);
+      const wanted = Number(splitQty[id] ?? '');
+      // A partial put-away splits first, then assigns the piece that was broken off - so the bin
+      // gets exactly the units the user said and the rest stays in the queue for its own shelf.
+      const partial = Number.isFinite(wanted) && wanted > 0 && wanted < rowQuantity;
       setAssigningId(id);
       try {
+        let targetId = id;
+        if (partial) {
+          const res = await splitLocation({
+            variables: { inventoryLocationId: id, quantity: wanted },
+          });
+          const rows = (res.data as { splitInventoryLocation?: { id: string }[] } | null | undefined)
+            ?.splitInventoryLocation;
+          if (!rows || rows.length < 2) throw new Error('Split did not return the new row');
+          targetId = rows[1].id;
+        }
         await assignLocation({
           variables: {
-            inventoryLocationId: id,
+            inventoryLocationId: targetId,
             aisle: loc.aisle.trim(),
             row: loc.row.trim(),
             bay: loc.bay.trim(),
           },
         });
-        showToast(`Location assigned for ${productCode}`, 'success');
+        showToast(
+          partial
+            ? `${wanted} of ${productCode} put away; the rest stays in the queue`
+            : `Location assigned for ${productCode}`,
+          'success',
+        );
+        setSplitQty((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
         setLocationInputs((prev) => {
           const next = { ...prev };
           delete next[id];
@@ -181,7 +224,7 @@ export default function PutAwayTab() {
         setAssigningId(null);
       }
     },
-    [getLocationInput, assignLocation, showToast, refetch],
+    [getLocationInput, assignLocation, splitLocation, splitQty, showToast, refetch],
   );
 
   // ---- Render ----
@@ -273,6 +316,9 @@ export default function PutAwayTab() {
                               now carry their own Aisle/Row/Bay labels rather than relying on a
                               header three rows up. */}
                           <TableCell sx={{ minWidth: 300 }}>Destination</TableCell>
+                          <TableCell align="right" sx={{ minWidth: 110 }}>
+                            Qty to put away
+                          </TableCell>
                           <TableCell />
                         </TableRow>
                       </TableHead>
@@ -317,13 +363,39 @@ export default function PutAwayTab() {
                                   />
                                 </Box>
                               </TableCell>
+                              <TableCell align="right">
+                                {/* Blank means the whole row. A number under the row quantity
+                                    splits it: that many go to this bin, the remainder comes back
+                                    to the queue for a shelf of its own. */}
+                                <Tooltip title="Leave blank to put the whole row away here.">
+                                  <TextField
+                                    size="small"
+                                    type="number"
+                                    placeholder={String(item.inventoryLocation.quantity)}
+                                    value={splitQty[id] ?? ''}
+                                    onChange={(e) =>
+                                      setSplitQty((prev) => ({ ...prev, [id]: e.target.value }))
+                                    }
+                                    inputProps={{
+                                      min: 1,
+                                      max: item.inventoryLocation.quantity,
+                                      'aria-label': `Quantity of ${item.inventoryLocation.productCode} to put away`,
+                                    }}
+                                    sx={{ width: 96 }}
+                                  />
+                                </Tooltip>
+                              </TableCell>
                               <TableCell>
                                 <Button
                                   variant="contained"
                                   size="small"
-                                  disabled={!valid || isAssigning}
+                                  disabled={!valid || isAssigning || !splitIsValid(id, item.inventoryLocation.quantity)}
                                   onClick={() =>
-                                    handleAssign(id, item.inventoryLocation.productCode)
+                                    handleAssign(
+                                      id,
+                                      item.inventoryLocation.productCode,
+                                      item.inventoryLocation.quantity,
+                                    )
                                   }
                                 >
                                   {isAssigning ? <CircularProgress size={20} /> : 'Assign'}

--- a/frontend/src/modules/warehouse/ReceiveDraftEditModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveDraftEditModal.tsx
@@ -14,8 +14,6 @@ import ReceiveLinesEditor from './ReceiveLinesEditor';
 import {
   buildReceiveLineItemsInput,
   draftToEditorState,
-  validatePutAway,
-  type LocationDraft,
   type PODetailLineItem,
   type PODetails,
 } from './receiveLines';
@@ -39,7 +37,6 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
   const client = useApolloClient();
 
   const [receiveQuantities, setReceiveQuantities] = useState<Record<string, number>>({});
-  const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
   const [submitting, setSubmitting] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -62,7 +59,6 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
     const state = draftToEditorState(draft.lineItems);
     // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate the editor from the draft
     setReceiveQuantities(state.receiveQuantities);
-    setLineLocations(state.lineLocations);
     setMutationError(null);
   }, [open, draft]);
 
@@ -87,10 +83,6 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
     );
   }, [poDetails, receiveQuantities]);
 
-  const putAwayValid = useMemo(
-    () => validatePutAway(lineItemsToReceive, receiveQuantities, lineLocations),
-    [lineItemsToReceive, receiveQuantities, lineLocations],
-  );
 
   const isRejected = draft?.status === 'REJECTED';
 
@@ -104,7 +96,7 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
           input: {
             draftId: draft.id,
             warehouseId: draft.warehouseId,
-            lineItems: buildReceiveLineItemsInput(lineItemsToReceive, receiveQuantities, lineLocations),
+            lineItems: buildReceiveLineItemsInput(lineItemsToReceive, receiveQuantities),
           },
         },
       });
@@ -127,7 +119,6 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
     updateDraft,
     lineItemsToReceive,
     receiveQuantities,
-    lineLocations,
     isRejected,
     resubmitDraft,
     showToast,
@@ -148,7 +139,7 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
           <Button onClick={onClose}>Cancel</Button>
           <Button
             variant="contained"
-            disabled={totalUnits === 0 || hasQuantityErrors || !putAwayValid || submitting}
+            disabled={totalUnits === 0 || hasQuantityErrors || submitting}
             onClick={handleSave}
           >
             {submitting ? (
@@ -189,9 +180,6 @@ export default function ReceiveDraftEditModal({ open, draft, onClose }: ReceiveD
           poDetailsList={[poDetails]}
           receiveQuantities={receiveQuantities}
           onQuantityChange={handleQuantityChange}
-          lineLocations={lineLocations}
-          onLineLocationsChange={setLineLocations}
-          lineItemsToReceive={lineItemsToReceive}
           showPoHeaders={false}
         />
       )}

--- a/frontend/src/modules/warehouse/ReceiveDraftReviewModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveDraftReviewModal.tsx
@@ -37,8 +37,6 @@ import { PostedReceiptLines, type PostedReceipt } from './ReceiveOutcomePanels';
 import {
   buildReceiveLineItemsInput,
   draftToEditorState,
-  validatePutAway,
-  type LocationDraft,
   type PODetailLineItem,
   type PODetails,
 } from './receiveLines';
@@ -79,7 +77,6 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
   const client = useApolloClient();
 
   const [receiveQuantities, setReceiveQuantities] = useState<Record<string, number>>({});
-  const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
   const [warehouseId, setWarehouseId] = useState<string>('');
   const [initialSignature, setInitialSignature] = useState<string>('');
 
@@ -138,9 +135,8 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
     const state = draftToEditorState(draft.lineItems);
     // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate the editor from the draft
     setReceiveQuantities(state.receiveQuantities);
-    setLineLocations(state.lineLocations);
     setWarehouseId(draft.warehouseId ?? '');
-    setInitialSignature(JSON.stringify([state.receiveQuantities, state.lineLocations, draft.warehouseId ?? '']));
+    setInitialSignature(JSON.stringify([state.receiveQuantities, draft.warehouseId ?? '']));
     setMutationError(null);
     setGpError(null);
     setPosted(null);
@@ -188,14 +184,10 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
     );
   }, [poDetails, receiveQuantities]);
 
-  const putAwayValid = useMemo(
-    () => validatePutAway(lineItemsToReceive, receiveQuantities, lineLocations),
-    [lineItemsToReceive, receiveQuantities, lineLocations],
-  );
 
   const isDirty = useMemo(
-    () => JSON.stringify([receiveQuantities, lineLocations, warehouseId]) !== initialSignature,
-    [receiveQuantities, lineLocations, warehouseId, initialSignature],
+    () => JSON.stringify([receiveQuantities, warehouseId]) !== initialSignature,
+    [receiveQuantities, warehouseId, initialSignature],
   );
 
   // ---- Actions ----
@@ -222,11 +214,11 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
             input: {
               draftId: draft.id,
               warehouseId: warehouseId || null,
-              lineItems: buildReceiveLineItemsInput(lineItemsToReceive, receiveQuantities, lineLocations),
+              lineItems: buildReceiveLineItemsInput(lineItemsToReceive, receiveQuantities),
             },
           },
         });
-        setInitialSignature(JSON.stringify([receiveQuantities, lineLocations, warehouseId]));
+        setInitialSignature(JSON.stringify([receiveQuantities, warehouseId]));
       }
 
       const idempotencyKey = (idempotencyKeyRef.current[draft.id] ??= crypto.randomUUID());
@@ -278,7 +270,6 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
     warehouseId,
     lineItemsToReceive,
     receiveQuantities,
-    lineLocations,
     approveDraft,
     totalUnits,
     showToast,
@@ -323,7 +314,7 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
           drain into the same eConnect rejection. */}
       <Button
         variant="contained"
-        disabled={totalUnits === 0 || hasQuantityErrors || !putAwayValid || quarantined || submitting}
+        disabled={totalUnits === 0 || hasQuantityErrors || quarantined || submitting}
         onClick={() => setConfirmOpen(true)}
       >
         {submitting ? <CircularProgress size={24} /> : 'Approve & Post to GP'}
@@ -428,9 +419,6 @@ export default function ReceiveDraftReviewModal({ open, draft, onClose }: Receiv
                 poDetailsList={[poDetails]}
                 receiveQuantities={receiveQuantities}
                 onQuantityChange={handleQuantityChange}
-                lineLocations={lineLocations}
-                onLineLocationsChange={setLineLocations}
-                lineItemsToReceive={lineItemsToReceive}
                 showPoHeaders={false}
               />
             )}

--- a/frontend/src/modules/warehouse/ReceiveLinesEditor.tsx
+++ b/frontend/src/modules/warehouse/ReceiveLinesEditor.tsx
@@ -1,18 +1,9 @@
-import { useCallback, useMemo } from 'react';
-import { Typography, Box, Button, TextField, Paper, Stack, IconButton } from '@mui/material';
-import { Plus, Trash2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { Typography, Box, Paper, TextField } from '@mui/material';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { poVendorName } from '../po/poVendorName';
-import { microLabelSx, monoSx } from '../../theme';
-import {
-  MAX_LOC_LEN,
-  draftsForLine,
-  emptyDraft,
-  locationIncomplete,
-  type LocationDraft,
-  type PODetailLineItem,
-  type PODetails,
-} from './receiveLines';
+import { monoSx } from '../../theme';
+import { type PODetails } from './receiveLines';
 
 /**
  * What a receive says was counted, and where it goes - the one editor behind every screen that
@@ -26,6 +17,10 @@ import {
  *
  * Fully controlled, so each parent gates its own submit off the shared validators in receiveLines.ts
  * rather than this component deciding when it is "done".
+ *
+ * Since #501 it is quantities only. Rack rows and deficient counts left the draft: a count is what
+ * came off the truck, and where it goes is decided on the Put Away queue after the warehouse
+ * manager has approved the numbers.
  */
 export interface ReceiveLinesEditorProps {
   /** One entry per PO being received. The review screens pass exactly one. */
@@ -33,11 +28,6 @@ export interface ReceiveLinesEditorProps {
   /** Units to receive now, keyed by PO line item id. */
   receiveQuantities: Record<string, number>;
   onQuantityChange: (lineId: string, value: number) => void;
-  /** Rack rows per line, keyed the same way. */
-  lineLocations: Record<string, LocationDraft[]>;
-  onLineLocationsChange: (next: Record<string, LocationDraft[]>) => void;
-  /** The lines the put-away section covers - the ones with a quantity entered. */
-  lineItemsToReceive: PODetailLineItem[];
   /** Name each PO above its grid. On for a multi-PO batch, off when there is only one. */
   showPoHeaders: boolean;
 }
@@ -46,51 +36,8 @@ export default function ReceiveLinesEditor({
   poDetailsList,
   receiveQuantities,
   onQuantityChange,
-  lineLocations,
-  onLineLocationsChange,
-  lineItemsToReceive,
   showPoHeaders,
 }: ReceiveLinesEditorProps) {
-  const draftsFor = useCallback(
-    (lineId: string, receiveNow: number) => draftsForLine(lineLocations, lineId, receiveNow),
-    [lineLocations],
-  );
-
-  const setDrafts = useCallback(
-    (lineId: string, drafts: LocationDraft[]) => {
-      onLineLocationsChange({ ...lineLocations, [lineId]: drafts });
-    },
-    [lineLocations, onLineLocationsChange],
-  );
-
-  const updateLocation = useCallback(
-    (lineId: string, receiveNow: number, idx: number, field: keyof LocationDraft, value: string) => {
-      const v = field === 'aisle' || field === 'row' || field === 'bay' ? value.slice(0, MAX_LOC_LEN) : value;
-      setDrafts(
-        lineId,
-        draftsFor(lineId, receiveNow).map((d, i) => (i === idx ? { ...d, [field]: v } : d)),
-      );
-    },
-    [draftsFor, setDrafts],
-  );
-
-  const addLocation = useCallback(
-    (lineId: string, receiveNow: number) => {
-      setDrafts(lineId, [...draftsFor(lineId, receiveNow), emptyDraft(0)]);
-    },
-    [draftsFor, setDrafts],
-  );
-
-  const removeLocation = useCallback(
-    (lineId: string, receiveNow: number, idx: number) => {
-      setDrafts(
-        lineId,
-        draftsFor(lineId, receiveNow).filter((_, i) => i !== idx),
-      );
-    },
-    [draftsFor, setDrafts],
-  );
-
   const quantityColumns: GridColDef[] = useMemo(
     () => [
       {
@@ -217,134 +164,9 @@ export default function ReceiveLinesEditor({
     );
   };
 
-  const renderLineLocations = (li: PODetailLineItem) => {
-    const receiveNow = receiveQuantities[li.id] ?? 0;
-    const drafts = draftsFor(li.id, receiveNow);
-    const placed = drafts.reduce((s, d) => s + (Number(d.quantity) || 0), 0);
-    const remaining = receiveNow - placed;
-    // "all placed" only when the line would actually pass validatePutAway's location check -
-    // quantities that add up with Aisle/Row/Bay still blank used to claim done while submit stayed
-    // disabled with nothing saying why (#474).
-    const needsLocation = remaining === 0 && drafts.some(locationIncomplete);
-    return (
-      <Paper key={li.id} variant="outlined" sx={{ p: 1.5 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'baseline',
-            mb: 1,
-            gap: 1,
-            pb: 0.75,
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="body2" sx={{ ...monoSx, fontWeight: 600 }}>
-            {li.productCode} · {li.hardwareCategory} (placing {receiveNow})
-          </Typography>
-          <Typography
-            variant="caption"
-            sx={{ ...microLabelSx, color: remaining === 0 && !needsLocation ? 'success.main' : 'error.main' }}
-          >
-            {remaining !== 0 ? `${remaining} unplaced` : needsLocation ? 'needs aisle · row · bay' : 'all placed'}
-          </Typography>
-        </Box>
-        <Stack spacing={1}>
-          {drafts.map((d, idx) => {
-            const q = Number(d.quantity);
-            const def = Number(d.deficient || '0');
-            const defError = !Number.isInteger(def) || def < 0 || def > (Number.isInteger(q) ? q : 0);
-            return (
-              <Stack key={idx} direction="row" spacing={1} alignItems="flex-start" sx={{ flexWrap: 'wrap' }}>
-                <TextField
-                  label="Aisle"
-                  size="small"
-                  value={d.aisle}
-                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'aisle', e.target.value)}
-                  sx={{ width: 90 }}
-                />
-                <TextField
-                  label="Row"
-                  size="small"
-                  value={d.row}
-                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'row', e.target.value)}
-                  sx={{ width: 90 }}
-                />
-                <TextField
-                  label="Bay"
-                  size="small"
-                  value={d.bay}
-                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'bay', e.target.value)}
-                  sx={{ width: 90 }}
-                />
-                <TextField
-                  label="Qty"
-                  type="number"
-                  size="small"
-                  value={d.quantity}
-                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'quantity', e.target.value)}
-                  slotProps={{ htmlInput: { min: 1 } }}
-                  sx={{ width: 80 }}
-                />
-                <TextField
-                  label="Deficient"
-                  type="number"
-                  size="small"
-                  value={d.deficient}
-                  error={defError}
-                  onChange={(e) => updateLocation(li.id, receiveNow, idx, 'deficient', e.target.value)}
-                  slotProps={{ htmlInput: { min: 0, max: Number.isInteger(q) ? q : undefined } }}
-                  sx={{ width: 100 }}
-                />
-                <IconButton
-                  size="small"
-                  aria-label="Remove location"
-                  disabled={drafts.length <= 1}
-                  onClick={() => removeLocation(li.id, receiveNow, idx)}
-                  sx={{ mt: 0.5 }}
-                >
-                  <Trash2 size={18} strokeWidth={1.75} />
-                </IconButton>
-              </Stack>
-            );
-          })}
-          <Button
-            size="small"
-            startIcon={<Plus size={18} strokeWidth={1.75} />}
-            onClick={() => addLocation(li.id, receiveNow)}
-            sx={{ alignSelf: 'flex-start' }}
-          >
-            Add location
-          </Button>
-        </Stack>
-      </Paper>
-    );
-  };
-
   return (
     <>
       {poDetailsList.map(renderPOSection)}
-      {lineItemsToReceive.length > 0 && (
-        <Box sx={{ mt: 1 }}>
-          <Typography
-            component="div"
-            sx={{
-              ...microLabelSx,
-              pb: 0.75,
-              borderBottom: '2px solid',
-              borderColor: 'text.primary',
-            }}
-          >
-            Assign locations & flag deficient units
-          </Typography>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1, mb: 1 }}>
-            Place every received unit in a row (the GP receipt records a rack location per line) and
-            optionally record how many of each arrived deficient.
-          </Typography>
-          <Stack spacing={2}>{lineItemsToReceive.map(renderLineLocations)}</Stack>
-        </Box>
-      )}
     </>
   );
 }

--- a/frontend/src/modules/warehouse/ReceiveModal.tsx
+++ b/frontend/src/modules/warehouse/ReceiveModal.tsx
@@ -28,8 +28,6 @@ import PackingSlipPicker from './PackingSlipPicker';
 import {
   buildReceiveLineItemsInput,
   isPoGpRegistered,
-  validatePutAway,
-  type LocationDraft,
   type PODetailLineItem,
   type PODetails,
 } from './receiveLines';
@@ -92,7 +90,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
   const [poDetailsError, setPoDetailsError] = useState<string | null>(null);
   // Put-away is entered here rather than later: the GP receipt the approval posts needs a rack
   // location per line, and the person who unloaded the truck is the one who knows where it went.
-  const [lineLocations, setLineLocations] = useState<Record<string, LocationDraft[]>>({});
   const [submitting, setSubmitting] = useState(false);
   // #504: one packing slip per PO, because one draft is created per PO. Held as the chosen File
   // until submit - uploading on pick would leave orphan documents on every abandoned count.
@@ -165,7 +162,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
       setReceiveQuantities({});
       setMutationError(null);
       setSucceeded(false);
-      setLineLocations({});
       // Fresh open = fresh action set; drop any keys held from a prior batch.
       idempotencyKeysRef.current = {};
       fetchPODetails(poIds);
@@ -261,10 +257,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
       .filter((x) => x.drafts.length > 0);
   }, [poDetailsList, pendingDraftsByPoId]);
 
-  const putAwayValid = useMemo(
-    () => validatePutAway(lineItemsToReceive, receiveQuantities, lineLocations),
-    [lineItemsToReceive, receiveQuantities, lineLocations],
-  );
 
   // ---- Handlers ----
 
@@ -321,7 +313,7 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
           warehouseId: warehouseId || null,
           idempotencyKey,
           packingSlipDocumentId,
-          lineItems: buildReceiveLineItemsInput(poLineItems, receiveQuantities, lineLocations),
+          lineItems: buildReceiveLineItemsInput(poLineItems, receiveQuantities),
         };
 
         try {
@@ -373,7 +365,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
     uploadPoDocument,
     lineItemsToReceive,
     receiveQuantities,
-    lineLocations,
     createReceiveDraft,
     client,
     showToast,
@@ -388,7 +379,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
     setMutationError(null);
     setSucceeded(false);
     setConfirmOpen(false);
-    setLineLocations({});
     setPackingSlips({});
     onClose();
   }, [onClose]);
@@ -425,7 +415,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
         disabled={
           !hasAnyReceiveQuantity ||
           hasQuantityErrors ||
-          !putAwayValid ||
           !allPackingSlipsAttached ||
           blockedPos.length > 0 ||
           submitting
@@ -439,7 +428,7 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
 
   // Escape is a dismissal, not a discard: once counts or rack rows have been typed in, the key is
   // swallowed and the user has to use Cancel. Nothing here is recoverable once handleClose resets it.
-  const hasUnsavedEntry = !succeeded && (hasAnyReceiveQuantity || Object.keys(lineLocations).length > 0);
+  const hasUnsavedEntry = !succeeded && (hasAnyReceiveQuantity || false);
   const showForm = !poDetailsLoading && !poDetailsError && !succeeded;
 
   return (
@@ -535,9 +524,6 @@ export default function ReceiveModal({ open, onClose, poIds, pendingDraftsByPoId
             poDetailsList={poDetailsList}
             receiveQuantities={receiveQuantities}
             onQuantityChange={handleQuantityChange}
-            lineLocations={lineLocations}
-            onLineLocationsChange={setLineLocations}
-            lineItemsToReceive={lineItemsToReceive}
             showPoHeaders={poIds.length > 1}
           />
         )}

--- a/frontend/src/modules/warehouse/__tests__/ReceiveDraftReviewModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveDraftReviewModal.test.tsx
@@ -206,15 +206,16 @@ async function approveViaConfirm() {
 vi.setConfig({ testTimeout: 60_000 });
 
 describe('ReceiveDraftReviewModal', () => {
-  it('prefills the counted quantities and rack rows from the draft', async () => {
+  it('prefills the counted quantities and shows no rack rows to review', async () => {
+    // #501: the reviewer is checking a count against a packing slip, not a put-away. Even a draft
+    // that still carries rack rows from before the change renders none - they are not the
+    // manager's decision any more, and the shelf is chosen on the Put Away queue after approval.
     await openModal();
 
     expect(screen.getByText(/Counted by/)).toHaveTextContent('Wendy Warehouse');
     expect(within(screen.getByRole('grid')).getByRole('spinbutton')).toHaveValue(2);
-    expect(screen.getByLabelText('Aisle')).toHaveValue('A1');
-    expect(screen.getByLabelText('Row')).toHaveValue('B2');
-    expect(screen.getByLabelText('Bay')).toHaveValue('C3');
-    expect(screen.getByText('all placed')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Aisle')).toBeNull();
+    expect(screen.queryByLabelText('Bay')).toBeNull();
   });
 
   it('approves an unedited draft without saving it first', async () => {
@@ -255,7 +256,6 @@ describe('ReceiveDraftReviewModal', () => {
 
     // The count was two; the reviewer makes it three, which is exactly the PO's pending quantity.
     fireEvent.change(within(screen.getByRole('grid')).getByRole('spinbutton'), { target: { value: '3' } });
-    fireEvent.change(screen.getByLabelText('Qty'), { target: { value: '3' } });
     await approveViaConfirm();
 
     await screen.findByText(/Approved\. 3 items added to inventory/, undefined, SLOW);
@@ -267,7 +267,7 @@ describe('ReceiveDraftReviewModal', () => {
           {
             poLineItemId: 'li-1',
             quantityReceived: 3,
-            locations: [{ aisle: 'A1', row: 'B2', bay: 'C3', quantity: 3, deficientQuantity: 0 }],
+            locations: [],
           },
         ],
       },
@@ -410,7 +410,6 @@ describe('ReceiveDraftReviewModal', () => {
     await openModal([updateMock, ...failThenPass]);
 
     fireEvent.change(within(screen.getByRole('grid')).getByRole('spinbutton'), { target: { value: '3' } });
-    fireEvent.change(screen.getByLabelText('Qty'), { target: { value: '3' } });
     await approveViaConfirm();
     await screen.findByText(/Approving this receive failed/, undefined, SLOW);
 
@@ -427,18 +426,6 @@ describe('ReceiveDraftReviewModal', () => {
 
     fireEvent.change(within(screen.getByRole('grid')).getByRole('spinbutton'), { target: { value: '4' } });
     expect(screen.getByText('Max: 3')).toBeInTheDocument();
-    expect(approveButton()).toBeDisabled();
-  });
-
-  it('names what put-away still needs instead of claiming all placed over blank rack fields', async () => {
-    // Quantities that sum correctly used to be the whole of "all placed" - blank the Aisle and the
-    // caption kept claiming done while approval stayed disabled with nothing saying why (#474).
-    await openModal();
-
-    fireEvent.change(screen.getByLabelText('Aisle'), { target: { value: '' } });
-
-    expect(screen.getByText('needs aisle · row · bay')).toBeInTheDocument();
-    expect(screen.queryByText('all placed')).toBeNull();
     expect(approveButton()).toBeDisabled();
   });
 

--- a/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
+++ b/frontend/src/modules/warehouse/__tests__/ReceiveModal.test.tsx
@@ -242,8 +242,8 @@ async function openModal(extraMocks: MockedResponse[] = []) {
   return result;
 }
 
-// the Receive Now cell input is the only spinbutton inside the grid (the fully received
-// line renders text, and the put-away Qty/Deficient inputs live outside the grid)
+// the Receive Now cell input is the only spinbutton inside the grid (the fully received line
+// renders text). Since #501 there are no put-away inputs on this screen at all.
 function receiveNowInput() {
   return within(screen.getByRole('grid')).getByRole('spinbutton');
 }
@@ -254,15 +254,6 @@ function submitButton() {
 
 function setReceiveQty(value: string) {
   fireEvent.change(receiveNowInput(), { target: { value } });
-}
-
-function fillLocation(idx: number, aisle: string, row: string, bay: string, qty?: string) {
-  fireEvent.change(screen.getAllByLabelText('Aisle')[idx], { target: { value: aisle } });
-  fireEvent.change(screen.getAllByLabelText('Row')[idx], { target: { value: row } });
-  fireEvent.change(screen.getAllByLabelText('Bay')[idx], { target: { value: bay } });
-  if (qty !== undefined) {
-    fireEvent.change(screen.getAllByLabelText('Qty')[idx], { target: { value: qty } });
-  }
 }
 
 async function submitViaConfirm() {
@@ -304,22 +295,18 @@ describe('ReceiveModal', () => {
     expect(screen.queryByText(/queued/i)).toBeNull();
   });
 
-  it('enables submit only after a quantity is entered and every unit is placed in a row', async () => {
+  it('enables submit once a quantity and a packing slip are in, with no rack rows to fill', async () => {
+    // #501: a draft is a count. Where the units go is decided on the Put Away queue after the
+    // warehouse manager approves, so nothing here asks for an aisle, row or bay.
     await openModal([poDetailsMock()]);
 
     expect(submitButton()).toBeDisabled();
 
     setReceiveQty('3');
-    expect(screen.getByText(/placing 3/)).toBeInTheDocument();
-    // Row fields still blank, so put-away is incomplete - and the caption says so. The quantity
-    // defaults to the full count, so this used to read "all placed" while submit stayed disabled
-    // with nothing naming what was missing (#474).
-    expect(screen.getByText('needs aisle · row · bay')).toBeInTheDocument();
-    expect(screen.queryByText('all placed')).toBeNull();
-    expect(submitButton()).toBeDisabled();
+    expect(screen.queryByLabelText('Aisle')).toBeNull();
+    expect(screen.queryByLabelText('Bay')).toBeNull();
+    expect(screen.queryByText(/deficient/i)).toBeNull();
 
-    fillLocation(0, 'A1', 'B2', 'C3');
-    expect(screen.getByText('all placed')).toBeInTheDocument();
     attachPackingSlips();
     expect(submitButton()).toBeEnabled();
   });
@@ -329,28 +316,10 @@ describe('ReceiveModal', () => {
 
     setReceiveQty('5'); // pending is only 3
     expect(screen.getByText('Max: 3')).toBeInTheDocument();
-    fillLocation(0, 'A1', 'B2', 'C3'); // put-away itself is valid at 5 placed
     expect(submitButton()).toBeDisabled();
 
-    // dropping back within pending (and matching the row qty) makes it submittable
     setReceiveQty('3');
-    fireEvent.change(screen.getByLabelText('Qty'), { target: { value: '3' } });
     expect(screen.queryByText('Max: 3')).toBeNull();
-    attachPackingSlips();
-    expect(submitButton()).toBeEnabled();
-  });
-
-  it('requires the row split to sum to the received quantity', async () => {
-    await openModal([poDetailsMock()]);
-
-    setReceiveQty('3');
-    fillLocation(0, 'A1', 'B2', 'C3', '2');
-    expect(screen.getByText('1 unplaced')).toBeInTheDocument();
-    expect(submitButton()).toBeDisabled();
-
-    fireEvent.click(screen.getByRole('button', { name: /add location/i }));
-    fillLocation(1, 'A2', 'B2', 'C4', '1');
-    expect(screen.getByText('all placed')).toBeInTheDocument();
     attachPackingSlips();
     expect(submitButton()).toBeEnabled();
   });
@@ -370,8 +339,6 @@ describe('ReceiveModal', () => {
     await screen.findByText(/Main \(MAIN\)/, undefined, SLOW); // default warehouse selected
 
     setReceiveQty('2');
-    fillLocation(0, 'A1', 'B2', 'C3'); // row qty defaults to the received 2
-    fireEvent.change(screen.getByLabelText('Deficient'), { target: { value: '1' } });
     await submitViaConfirm();
 
     await screen.findByText(/Submitted for approval\. 2 items across 1 PO/, undefined, SLOW);
@@ -386,7 +353,7 @@ describe('ReceiveModal', () => {
           {
             poLineItemId: 'li-1',
             quantityReceived: 2,
-            locations: [{ aisle: 'A1', row: 'B2', bay: 'C3', quantity: 2, deficientQuantity: 1 }],
+            locations: [],
           },
         ],
       },
@@ -406,7 +373,6 @@ describe('ReceiveModal', () => {
     const { onClose } = await openModal([poDetailsMock(), draftMock]);
 
     setReceiveQty('3');
-    fillLocation(0, 'A1', 'B2', 'C3');
     await submitViaConfirm();
 
     await screen.findByText(/Submitting PO-123 failed/, undefined, SLOW);
@@ -440,7 +406,6 @@ describe('ReceiveModal', () => {
     await openModal([poDetailsMock(), failMock, successMock]);
 
     setReceiveQty('3');
-    fillLocation(0, 'A1', 'B2', 'C3');
     await submitViaConfirm();
     await screen.findByText(/Submitting PO-123 failed/, undefined, SLOW);
 
@@ -462,7 +427,6 @@ describe('ReceiveModal', () => {
     expect(screen.getByText(/already has a receive awaiting approval \(2 units\)/)).toBeInTheDocument();
 
     setReceiveQty('3');
-    fillLocation(0, 'A1', 'B2', 'C3');
     attachPackingSlips();
     expect(submitButton()).toBeEnabled();
   });
@@ -476,7 +440,6 @@ describe('ReceiveModal', () => {
 
     // even a fully valid receive stays blocked
     setReceiveQty('3');
-    fillLocation(0, 'A1', 'B2', 'C3');
     expect(submitButton()).toBeDisabled();
   });
 
@@ -497,8 +460,6 @@ describe('ReceiveModal', () => {
     const [firstQty, secondQty] = screen.getAllByRole('grid').map((g) => within(g).getByRole('spinbutton'));
     fireEvent.change(firstQty, { target: { value: '3' } });
     fireEvent.change(secondQty, { target: { value: '4' } });
-    fillLocation(0, 'A1', 'B2', 'C3');
-    fillLocation(1, 'A2', 'B3', 'C4');
     await submitViaConfirm();
 
     await screen.findByText(/Submitted for approval\. 7 items across 2 POs/, undefined, SLOW);

--- a/frontend/src/modules/warehouse/receiveLines.ts
+++ b/frontend/src/modules/warehouse/receiveLines.ts
@@ -72,35 +72,9 @@ export function draftsForLine(
 }
 
 /** A row without all three rack coordinates cannot be put away. Shared with the editor's per-line
- *  status caption, so what the caption calls done is exactly what validatePutAway will accept. */
+ *  status caption. Only drafts counted before #501 carry rack rows at all. */
 export function locationIncomplete(d: LocationDraft): boolean {
   return !d.aisle.trim() || !d.row.trim() || !d.bay.trim();
-}
-
-/**
- * Put-away is mandatory: every received unit must land in a valid row and each row's deficient count
- * must be within its quantity. Mirrors the backend contract in warehouse_repository.create_receive
- * and gives the GP receipt a non-empty rack location per line.
- */
-export function validatePutAway(
-  lineItems: PODetailLineItem[],
-  receiveQuantities: Record<string, number>,
-  lineLocations: Record<string, LocationDraft[]>,
-): boolean {
-  for (const li of lineItems) {
-    const receiveNow = receiveQuantities[li.id] ?? 0;
-    let placed = 0;
-    for (const d of draftsForLine(lineLocations, li.id, receiveNow)) {
-      const q = Number(d.quantity);
-      const def = Number(d.deficient || '0');
-      if (locationIncomplete(d)) return false;
-      if (!Number.isInteger(q) || q < 1) return false;
-      if (!Number.isInteger(def) || def < 0 || def > q) return false;
-      placed += q;
-    }
-    if (placed !== receiveNow) return false;
-  }
-  return true;
 }
 
 export interface ReceiveLineItemInput {
@@ -116,26 +90,21 @@ export interface ReceiveLineItemInput {
 }
 
 /** The `lineItems` payload every receive mutation takes - draft create, draft update, and the
- *  approval that eventually posts them to GP all speak this one shape. */
+ *  approval that eventually posts them to GP all speak this one shape.
+ *
+ *  `locations` is always empty since #501. A draft is a count, not a put-away: the warehouse
+ *  manager approves the numbers, the receipt books one unlocated row per line, and the shelf is
+ *  chosen afterwards on the Put Away queue. The field stays on the input because drafts counted
+ *  before that change still carry theirs and the backend still reads them. */
 export function buildReceiveLineItemsInput(
   lineItems: PODetailLineItem[],
   receiveQuantities: Record<string, number>,
-  lineLocations: Record<string, LocationDraft[]>,
 ): ReceiveLineItemInput[] {
-  return lineItems.map((li) => {
-    const receiveNow = receiveQuantities[li.id] ?? 0;
-    return {
-      poLineItemId: li.id,
-      quantityReceived: receiveNow,
-      locations: draftsForLine(lineLocations, li.id, receiveNow).map((d) => ({
-        aisle: d.aisle.trim(),
-        row: d.row.trim(),
-        bay: d.bay.trim(),
-        quantity: Number(d.quantity),
-        deficientQuantity: Number(d.deficient || '0'),
-      })),
-    };
-  });
+  return lineItems.map((li) => ({
+    poLineItemId: li.id,
+    quantityReceived: receiveQuantities[li.id] ?? 0,
+    locations: [],
+  }));
 }
 
 /** A persisted draft's line, as the backend returns it. */


### PR DESCRIPTION
closes #501.

location capture and deficient flagging move out of the receive draft, past warehouse manager approval.

a draft is a count against a packing slip. rack rows and deficient inputs gone from ReceiveLinesEditor, so all three draft-editing screens show quantities only:
- counter's ReceiveModal
- manager's review
- author's post-rejection edit

buildReceiveLineItemsInput always emits an empty locations list. validatePutAway and the "all placed / needs aisle - row - bay" caption deleted with the section they gated.

the input field survives because drafts counted before this change still carry their rack rows, and create_receive still reads them when present, so nothing in flight at deploy breaks. InventoryLocation.aisle/row/bay already nullable, create_receive already had the unlocated branch -> approval books one row per line with no location, no migration.

build_create_receipt_payload composed rack_location from the aisle/row/bay triples; with none at approval it sends the warehouse code, which is true at receipt time and the most specific thing anybody knows yet. a line that does carry locations still composes the bins. purchasing to confirm GP's rack_location carrying just the warehouse is acceptable - one line to change if not.

put-away queue already shipped as unlocatedInventory + assignInventoryLocation on PutAwayTab. what it was missing is splitting. new split_inventory_location breaks N units off a row into a second row, copying the origin FKs and received_at verbatim - a split is a change of shelf, not of provenance, and those are what FIFO orders picks by. deficient units stay with the original row; they are a claim against the vendor, not something on a shelf. the Put Away row grows "Qty to put away" - blank is the whole row, a smaller number splits first and assigns the piece.

deficient flagging after approval needed nothing new. reportInventoryDeficiency already exists, and #506 kept "Flag Deficient" as a row action on the inventory table.

tests cover:
- split conserves quantity and copies the origin
- writes a PUT_AWAY audit row naming the caller
- leaves deficient units behind
- refuses a split that would empty or overdraw the row
- splitting twice still sums
- GP payload sends the warehouse with no bins, composes bins when there are, sends empty with neither
- three receive modal test files rewritten for the count-only contract

not e2e tested on a PR environment yet.
