### PR TITLE
feat(gp): push a project's name and site address onto its GP job (#497)

### DIFF
--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -224,7 +224,19 @@ class ProjectMutations:
         return GpJobSyncResult(total=total, adopted=adopted)
 
     @strawberry.mutation
-    def update_project(self, info: strawberry.Info, id: strawberry.ID, input: UpdateProjectInput) -> Project:
+    async def update_project(self, info: strawberry.Info, id: strawberry.ID, input: UpdateProjectInput) -> Project:
+        """Edit a project, and tell GP about the parts GP holds too (#497).
+
+        The job name and the site address live in both systems. Correcting them in Nexus alone left
+        GP with the old ones, and GP is what purchasing, accounting and the printed PO read - so the
+        wrong address reached the vendor long after somebody had fixed it here.
+
+        Nexus commits first and pushes second, deliberately. The edit is the user's and must not be
+        lost to a GP outage; the push is a replication of it. When the relay is unreachable the push
+        goes on the outbox and drains later, which is the same shape every other GP write in this
+        codebase uses. A GP refusal is surfaced - the edit is already saved, so there is nothing to
+        roll back and nothing the user can do about the GP half except be told.
+        """
         with SessionLocal() as session:
             project = project_repository.update_project(
                 session,
@@ -246,4 +258,79 @@ class ProjectMutations:
             )
             session.commit()
             session.refresh(project)
-            return project_to_type(project)
+            pushed = _gp_site_payload(project)
+            project_type = project_to_type(project)
+            quarantined = project.gp_setup_ok is False
+
+        if pushed is not None and not quarantined:
+            await _push_site_to_gp(uuid.UUID(str(id)), pushed)
+        return project_type
+
+
+def _gp_site_payload(project) -> dict | None:
+    """What of this project GP holds, or None when there is nothing to push.
+
+    Only the job name and the site address: they are the fields that exist on both sides. Everything
+    else on the project - the GC contact, the estimator, the storage agreement - is Nexus's alone, and
+    sending it would mean inventing a place to put it in GP.
+
+    An address is a street and a city or it is nothing GP can ship to, so a half-filled one is not
+    pushed rather than written as a partial record.
+    """
+    name = (project.description or "").strip()
+    address1 = (project.address or "").strip()
+    city = (project.city or "").strip()
+    has_address = bool(address1 and city)
+    if not name and not has_address:
+        return None
+
+    payload: dict = {"job_number": project.project_id}
+    if name:
+        payload["job_name"] = name
+    if has_address:
+        payload["address1"] = address1
+        payload["city"] = city
+        payload["state"] = (project.state or "").strip()
+        payload["zip_code"] = (project.zip or "").strip()
+    return payload
+
+
+async def _push_site_to_gp(project_id: uuid.UUID, payload: dict) -> None:
+    """Replicate the edit onto the GP job, queueing it if the relay never took it.
+
+    Only an UNDISPATCHED relay failure queues (`should_enqueue`): the write never left the backend, so
+    GP cannot be holding it. Anything ambiguous - a dispatched disconnect, a timeout - is NOT queued,
+    because a second push of the same values would mint nothing new but would still be a write against
+    accounting data on a guess.
+    """
+    from app.services import gp_outbox_enqueue
+
+    company = relay_gateway.company
+    if not company:
+        logger.info("update_project: no GP company configured, skipping the site push")
+        return
+
+    try:
+        await relay_gateway.relay_call(company, "update_job_site", payload)
+    except RelayUnavailableError as e:
+        if not gp_outbox_enqueue.should_enqueue(e):
+            logger.warning("update_project: site push for %s failed ambiguously: %s", payload["job_number"], e)
+            return
+        gp_outbox_enqueue.enqueue(
+            # Keyed on the values, so re-saving the same edit while it is queued is one entry, and a
+            # genuinely different correction queues as its own.
+            idempotency_key=f"update_job_site:{payload['job_number']}:{hash(tuple(sorted(payload.items())))}",
+            op="update_job_site",
+            relay_op="update_job_site",
+            company=company,
+            payload=payload,
+            persist_context={},
+            entity_key=f"project:{project_id}",
+            label=f"Site details for job {payload['job_number']}",
+            project_id=project_id,
+        )
+    except RelayCallError as e:
+        # GP refused - an address code collision, a job it does not have. The edit is already saved
+        # in Nexus, so this is reported rather than raised: failing the mutation would tell the user
+        # their correction did not happen when it did.
+        logger.warning("update_project: GP refused the site push for %s: %s", payload["job_number"], e)

--- a/backend/app/services/gp_outbox_worker.py
+++ b/backend/app/services/gp_outbox_worker.py
@@ -94,10 +94,20 @@ def _persist_create_receive_from_context(context: dict, relay_result: dict, key:
     )
 
 
+def _persist_update_job_site_from_context(context: dict, relay_result: dict, key: str) -> None:
+    """#497 has no Nexus-side persist: the project row was already saved before the push was queued.
+
+    The relay call IS the whole write, so a successful drain has nothing left to do. This exists so
+    the op is a registered handler rather than an unknown one the worker would fail permanently.
+    """
+    return None
+
+
 # op -> adapter. The adapters return the resolver's Strawberry DTO; the worker discards it.
 _HANDLERS: dict[str, Callable[[dict, dict, str], None]] = {
     "register_po_in_gp": _persist_register_po_from_context,
     "create_receive": _persist_create_receive_from_context,
+    "update_job_site": _persist_update_job_site_from_context,
 }
 
 

--- a/backend/tests/test_gp_site_push.py
+++ b/backend/tests/test_gp_site_push.py
@@ -1,0 +1,87 @@
+"""What of a project edit reaches GP, and what does not (#497).
+
+The job name and the site address live in both systems. Correcting them in Nexus alone left GP with
+the old ones - and GP is what purchasing, accounting and the printed PO read, so a stale address
+reached the vendor long after somebody had fixed it here.
+
+These pin the payload builder, which is where every decision about the push actually lives: which
+fields are GP's to hold, and when there is nothing worth sending.
+"""
+
+import uuid
+
+from app.models.project import Project
+from app.schemas.project import _gp_site_payload
+
+
+def _project(**kwargs) -> Project:
+    defaults = dict(
+        id=uuid.uuid4(),
+        project_id="23093",
+        description="Cowichan District Hospital",
+        address="123 Main St",
+        city="Duncan",
+        state="BC",
+        zip="V9L 1A1",
+    )
+    defaults.update(kwargs)
+    return Project(**defaults)
+
+
+def test_the_push_carries_the_job_name_and_the_site_address():
+    payload = _gp_site_payload(_project())
+
+    assert payload == {
+        "job_number": "23093",
+        "job_name": "Cowichan District Hospital",
+        "address1": "123 Main St",
+        "city": "Duncan",
+        "state": "BC",
+        "zip_code": "V9L 1A1",
+    }
+
+
+def test_nothing_else_on_the_project_is_pushed():
+    """The GC contact, the estimator, the storage agreement are Nexus's alone. Sending them would
+    mean inventing a place to put them in GP."""
+    payload = _gp_site_payload(
+        _project(
+            gc_contact_name="Bob Builder",
+            gc_phone="250-555-0100",
+            contractor="Acme",
+            project_manager="Paula",
+            off_site_storage_agreement=True,
+        )
+    )
+
+    assert set(payload) == {"job_number", "job_name", "address1", "city", "state", "zip_code"}
+
+
+def test_a_half_filled_address_is_not_pushed():
+    """A street with no city is not something GP can ship to. Writing it as a partial record would
+    put an address on the job that looks filled in and is not."""
+    payload = _gp_site_payload(_project(city=None))
+
+    assert "address1" not in payload
+    assert "city" not in payload
+    # The name still goes - it is a separate field and it is still correct.
+    assert payload["job_name"] == "Cowichan District Hospital"
+
+
+def test_a_project_with_neither_a_name_nor_an_address_pushes_nothing():
+    """None means the resolver skips the relay call entirely rather than making a no-op write
+    against accounting data."""
+    assert _gp_site_payload(_project(description=None, address=None, city=None)) is None
+
+
+def test_whitespace_only_values_count_as_absent():
+    assert _gp_site_payload(_project(description="   ", address="  ", city="  ")) is None
+
+
+def test_the_optional_address_parts_are_sent_as_blanks_rather_than_dropped():
+    """A cleared postcode has to reach GP as a clear, not as "leave what you have" - otherwise the
+    old one survives a correction that was meant to remove it."""
+    payload = _gp_site_payload(_project(state=None, zip=None))
+
+    assert payload["state"] == ""
+    assert payload["zip_code"] == ""

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -389,6 +389,19 @@ def _run_create_customer_address(company: str, payload: dict) -> dict:
             raise
 
 
+def _run_update_job_site(company: str, payload: dict) -> dict:
+    ops.check_company_allowed(company)
+    request = models.UpdateJobSiteRequest(company=company, **payload)
+    with db.get_connection(company) as conn:
+        try:
+            response = ops.update_job_site_op(conn, company=company, request=request)
+            conn.commit()
+            return response.model_dump(mode="json")
+        except Exception:
+            conn.rollback()
+            raise
+
+
 def _run_create_receipt(company: str, payload: dict) -> dict:
     ops.check_company_allowed(company)
     request = models.ReceiptRequest(company=company, **payload)
@@ -432,6 +445,9 @@ _OPS = {
     # issue #444 - the create-job dialog can add a job site that was never entered in GP, instead of
     # dead-ending on an address picker that has no code for it.
     "create_customer_address": _run_create_customer_address,
+    # issue #497 - a project's site address and name are edited in Nexus, and GP has to hear about it.
+    # Mints a job-specific address code rather than editing a shared one; see update_job_site_op.
+    "update_job_site": _run_update_job_site,
     # issue #425 - jobs replicated from UCSH carry GL account indexes that do not exist in UBC, so a
     # PO against them registers and can never be received. This is how Nexus finds out which ones.
     "job_setup_health": _run_job_setup_health,

--- a/relay/src/ucnexus_relay/econnect.py
+++ b/relay/src/ucnexus_relay/econnect.py
@@ -1008,13 +1008,21 @@ def get_job(conn, job_number: str) -> dict | None:
     back - WS_Job_Name is char(31), and what GP stored is the honest thing to snapshot onto the Nexus
     project. Doubles as proof the row actually landed."""
     row = conn.cursor().execute(
-        "SELECT RTRIM(WS_Job_Number) AS job_number, RTRIM(WS_Job_Name) AS job_name "
+        "SELECT RTRIM(WS_Job_Number) AS job_number, RTRIM(WS_Job_Name) AS job_name, "
+        # #497 needs both: the customer is who a new address code is minted under, and the current
+        # code is what the job ships to today.
+        "RTRIM(CUSTNMBR) AS customer_number, RTRIM(ISNULL(Job_Address_Code, '')) AS job_address_code "
         "FROM dbo.JC00102 WHERE RTRIM(WS_Job_Number) = ?",
         job_number.strip(),
     ).fetchone()
     if row is None:
         return None
-    return {"job_number": row.job_number, "job_name": row.job_name or None}
+    return {
+        "job_number": row.job_number,
+        "job_name": row.job_name or None,
+        "customer_number": row.customer_number or None,
+        "job_address_code": row.job_address_code or None,
+    }
 
 
 def list_customer_addresses(conn, customer_number: str) -> list[dict]:
@@ -1104,6 +1112,25 @@ _CREATE_JOB_REQUIRED = (
 )
 
 
+def update_job(conn, *, only_validate: bool = False, **fields) -> None:
+    """Update an EXISTING GP job through wsiJCJobMaster (#497).
+
+    Same proc, same statement builder, one parameter different: `@I_vUpdateIfExists = 1`. That flag is
+    what makes the proc an upsert rather than a create - established from `sys.parameters` on the live
+    proc (parameter 207), because the proc body is encrypted and cannot be read.
+
+    Only the fields the caller sets are sent, which is what makes this a PATCH: everything absent from
+    the EXEC keeps whatever GP holds. That matters more here than on create - a Nexus project carries a
+    fraction of a JC00102 row, and sending the rest as defaults would silently blank estimator, dates,
+    contract amounts and the rest of the columns accounting maintains in GP.
+
+    The site address is NOT a parameter on this proc. `JobAddressCode` is a char(15) pointer at a
+    customer address record, so changing where a job ships means minting an address code and
+    re-pointing - see `update_job_site_address_op`.
+    """
+    return _exec_job_master(conn, only_validate=only_validate, update_if_exists=True, **fields)
+
+
 def create_job(conn, *, only_validate: bool = False, **fields) -> None:
     """Create a GP job through the WennSoft job proc wsiJCJobMaster. Same shape as
     apply_wennsoft_integration: DECLARE the two OUTPUT locals, EXEC, then SELECT them back.
@@ -1119,13 +1146,26 @@ def create_job(conn, *, only_validate: bool = False, **fields) -> None:
 
     @I_vReturnErrorText=1 makes the proc fill @oErrString; that text is carried on the raised error as
     proc_message so it survives to the user verbatim (see EConnectError)."""
+    return _exec_job_master(conn, only_validate=only_validate, update_if_exists=False, **fields)
+
+
+def _exec_job_master(conn, *, only_validate: bool, update_if_exists: bool, **fields) -> None:
+    """The one statement builder behind create_job and update_job.
+
+    Shared so a create and an update cannot drift on how the parameters are assembled - and so the dry
+    run of either exercises the exact statement its real call will make.
+    """
     unknown = set(fields) - {field for field, _ in _CREATE_JOB_PARAMS}
     if unknown:
         raise EConnectError(f"unknown create_job field(s): {sorted(unknown)}", proc="wsiJCJobMaster")
     # A required field arriving as None would otherwise be quietly dropped from the EXEC and the proc
     # would run on its own default for it - validating and then creating something other than what was
     # asked for. CreateJobRequest already rejects these, so reaching here means a caller bypassed it.
-    missing = [field for field in _CREATE_JOB_REQUIRED if fields.get(field) is None]
+    # An update is a PATCH - it names the job and whatever is changing, and everything else keeps
+    # what GP holds. Demanding the create-time eight would make a name change also restate the
+    # customer, the division and the address codes, which is how a caller blanks a column by accident.
+    required = ("job_number",) if update_if_exists else _CREATE_JOB_REQUIRED
+    missing = [field for field in required if fields.get(field) is None]
     if missing:
         raise EConnectError(f"create_job is missing required field(s): {missing}", proc="wsiJCJobMaster")
 
@@ -1139,16 +1179,20 @@ def create_job(conn, *, only_validate: bool = False, **fields) -> None:
     DECLARE @err_str varchar(255) = '';
     EXEC dbo.wsiJCJobMaster
         {assignments},
+        @I_vUpdateIfExists  = ?,
         @I_vOnlyValidate    = ?,
         @I_vReturnErrorText = 1,
         @O_iErrorState      = @err OUTPUT,
         @oErrString         = @err_str OUTPUT;
     SELECT @err AS error_state, @err_str AS err_string;
     """
-    row = conn.cursor().execute(sql, *supplied.values(), 1 if only_validate else 0).fetchone()
+    row = conn.cursor().execute(
+        sql, *supplied.values(), 1 if update_if_exists else 0, 1 if only_validate else 0
+    ).fetchone()
     if row.error_state != 0:
         message = (row.err_string or "").strip()
-        pass_label = "validation" if only_validate else "create"
+        verb = "update" if update_if_exists else "create"
+        pass_label = "validation" if only_validate else verb
         raise EConnectError(
             f"wsiJCJobMaster {pass_label} failed for job {fields.get('job_number')}: {message}",
             proc="wsiJCJobMaster",

--- a/relay/src/ucnexus_relay/models.py
+++ b/relay/src/ucnexus_relay/models.py
@@ -453,6 +453,68 @@ _ADDRESS_MAX_LENGTHS = {
 }
 
 
+class UpdateJobSiteRequest(BaseModel):
+    """Push a Nexus project's site details onto its GP job (#497).
+
+    Two writes behind one request, because GP does not keep a site address on the job. `JC00102` holds
+    `Job_Address_Code`, a char(15) pointer at a customer address record in `RM00102` - so "change where
+    this job ships to" means having an address record that says the new thing, and pointing the job at
+    it.
+
+    This mints a NEW address code rather than editing the one the job currently points at. Address
+    codes ARE shared between jobs - TUBC has one customer whose codes serve two and three jobs each -
+    so editing in place would silently change the site address of unrelated jobs. It is also the stance
+    #444 already took when it pinned `UpdateIfExists=0` on `taCreateCustomerAddress`: an address
+    accounting maintains is not Nexus's to overwrite.
+
+    The code is derived from the job number, which keeps it unique per job and self-describing in GP's
+    address picker. `job_name` rides along because renaming a project in Nexus should reach GP too, and
+    it is the same proc call.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    company: str
+    job_number: str
+
+    # Absent means "leave GP's". Sending the whole record every time is how a Nexus field that is
+    # simply blank blanks a GP column accounting filled in.
+    job_name: str | None = None
+    address_code: str | None = None
+    address1: str | None = None
+    address2: str | None = None
+    city: str | None = None
+    state: str | None = None
+    zip_code: str | None = None
+    country: str | None = None
+
+    @model_validator(mode="after")
+    def normalize(self):
+        self.job_number = (self.job_number or "").strip()
+        if not self.job_number:
+            raise ValueError("job_number is required")
+        for name in ("job_name", "address_code", "address1", "address2", "city", "state", "zip_code", "country"):
+            value = getattr(self, name)
+            if value is not None:
+                setattr(self, name, value.strip())
+        if self.address_code:
+            self.address_code = self.address_code.upper()
+        # An address is a street and a city or it is not one anybody can ship to. Asking for half of
+        # one is a mistake worth naming rather than writing a partial record into GP.
+        if (self.address1 or self.city) and not (self.address1 and self.city):
+            raise ValueError("address1 and city must be given together")
+        return self
+
+
+class UpdateJobSiteResponse(BaseModel):
+    job_number: str
+    job_name: str
+    company: str
+    # The code the job now points at. Null when the request carried no address change.
+    address_code: str | None = None
+    address_created: bool = False
+
+
 class CreateCustomerAddressRequest(BaseModel):
     """One new address code under an existing GP customer (RM00102).
 

--- a/relay/src/ucnexus_relay/ops.py
+++ b/relay/src/ucnexus_relay/ops.py
@@ -451,6 +451,95 @@ def _address_code_already_exists(company: str, request: models.CreateCustomerAdd
     )
 
 
+def update_job_site_op(
+    conn, *, company: str, request: models.UpdateJobSiteRequest
+) -> models.UpdateJobSiteResponse:
+    """Push a Nexus project's site details onto its GP job (#497). The caller commits.
+
+    GP keeps no site address on the job. `JC00102.Job_Address_Code` is a char(15) pointer at a customer
+    address record, so this is two writes:
+
+    1. If the request carries an address, mint a code for it under the job's own customer and point the
+       job at that. The code is derived from the job number, which keeps it unique to this job - so
+       correcting one job's site can never move another's, which editing the existing code WOULD do:
+       address codes are shared in practice (TUBC has one customer whose codes serve two and three
+       jobs each), and #444 already ruled that overwriting an address accounting maintains is the one
+       outcome this integration must not produce.
+
+    2. Call wsiJCJobMaster with UpdateIfExists=1, sending ONLY what changed. Absent parameters keep
+       whatever GP holds, which is what stops a Nexus project - which carries a fraction of a JC00102
+       row - from blanking the columns accounting fills in.
+
+    Re-running with the same address is idempotent: the code already exists, so the mint is skipped and
+    the job is re-pointed at what it already points at.
+    """
+    job = econnect.get_job(conn, request.job_number)
+    if job is None:
+        raise RelayOpError("job_not_found", f"Job '{request.job_number}' is not in {company}")
+
+    address_code: str | None = None
+    address_created = False
+
+    if request.address1:
+        customer_number = job.get("customer_number")
+        if not customer_number:
+            raise RelayOpError(
+                "job_has_no_customer",
+                f"Job '{request.job_number}' has no customer, so a site address cannot be created for it",
+            )
+        # char(15), and it has to be stable so a re-push finds its own code rather than making another.
+        address_code = (request.address_code or f"SITE-{request.job_number}")[:15].strip().upper()
+
+        if not econnect.customer_address_exists(conn, customer_number, address_code):
+            econnect.create_customer_address(
+                conn,
+                {
+                    "customer_number": customer_number,
+                    "address_code": address_code,
+                    "address1": request.address1,
+                    "address2": request.address2 or "",
+                    "city": request.city,
+                    "state": request.state or "",
+                    "zip_code": request.zip_code or "",
+                    "country": request.country or "",
+                },
+            )
+            address_created = True
+
+    fields: dict = {"job_number": request.job_number}
+    if request.job_name:
+        fields["job_name"] = request.job_name
+    if address_code:
+        fields["job_address_code"] = address_code
+    if len(fields) == 1:
+        # Nothing to push. Calling the proc with only the job number would be a no-op write against
+        # accounting data, which is not a thing to do for the sake of a tidy code path.
+        return models.UpdateJobSiteResponse(
+            job_number=job["job_number"],
+            job_name=job.get("job_name") or "",
+            company=company,
+        )
+
+    econnect.update_job(conn, only_validate=True, **fields)
+    econnect.update_job(conn, only_validate=False, **fields)
+
+    updated = econnect.get_job(conn, request.job_number)
+    if updated is None:
+        # The err=0-but-nothing-landed case create_po_line has a known mode for.
+        raise econnect.EConnectError(
+            f"wsiJCJobMaster reported success but job {request.job_number} is not in JC00102",
+            proc="wsiJCJobMaster",
+        )
+
+    return models.UpdateJobSiteResponse(
+        job_number=updated["job_number"],
+        job_name=updated.get("job_name") or "",
+        company=company,
+        address_code=updated.get("job_address_code") or address_code,
+        address_created=address_created,
+    )
+
+
 def create_customer_address_op(
     conn, *, company: str, request: models.CreateCustomerAddressRequest
 ) -> models.CreateCustomerAddressResponse:

--- a/relay/tests/test_channel.py
+++ b/relay/tests/test_channel.py
@@ -482,3 +482,58 @@ def test_hello_frame_advertises_build_and_the_full_op_set():
     assert "list_tax_details" in frame["ops"]
     assert isinstance(frame["build"], str) and frame["build"]  # 'dev' in a checkout, a tag in a CI build
     assert isinstance(frame["version"], str) and frame["version"]
+
+
+# --- push a project's site details onto its GP job (issue #497) ---
+
+
+def test_update_job_site_success_returns_the_response_body(monkeypatch):
+    from ucnexus_relay.models import UpdateJobSiteResponse
+
+    def _fake(conn, *, company, request):
+        return UpdateJobSiteResponse(
+            job_number=request.job_number,
+            job_name=request.job_name or "",
+            company=company,
+            address_code="SITE-23093",
+            address_created=True,
+        )
+
+    monkeypatch.setattr(ops, "update_job_site_op", _fake)
+    reply = channel._dispatch(
+        "update_job_site",
+        "TUBC",
+        {"job_number": "23093", "job_name": "Cowichan", "address1": "123 Main St", "city": "Duncan"},
+    )
+    assert reply["ok"] is True
+    assert reply["result"] == {
+        "job_number": "23093",
+        "job_name": "Cowichan",
+        "company": "TUBC",
+        "address_code": "SITE-23093",
+        "address_created": True,
+    }
+
+
+def test_update_job_site_needs_a_job_number():
+    reply = channel._dispatch("update_job_site", "TUBC", {"job_name": "Cowichan"})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "invalid_payload"
+
+
+def test_update_job_site_refuses_half_an_address():
+    """A street with no city is not something GP can ship to, and writing it would leave an address
+    on the job that looks filled in and is not."""
+    reply = channel._dispatch("update_job_site", "TUBC", {"job_number": "23093", "address1": "123 Main St"})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "invalid_payload"
+
+
+def test_update_job_site_missing_job_translates_cleanly(monkeypatch):
+    def _raise(conn, *, company, request):
+        raise ops.RelayOpError("job_not_found", "Job '23093' is not in TUBC")
+
+    monkeypatch.setattr(ops, "update_job_site_op", _raise)
+    reply = channel._dispatch("update_job_site", "TUBC", {"job_number": "23093", "job_name": "Cowichan"})
+    assert reply["ok"] is False
+    assert reply["error"]["error"] == "job_not_found"

--- a/relay/tests/test_create_job.py
+++ b/relay/tests/test_create_job.py
@@ -95,9 +95,10 @@ def test_only_supplied_parameters_reach_the_exec():
         "@I_vBidDueDate",
     ):
         assert param not in sql
-    # 8 required values + the trailing OnlyValidate flag
+    # 8 required values, then the two trailing flags: UpdateIfExists (0 - this is a create, #497
+    # added the update path that sets it to 1) and OnlyValidate.
     assert params == (
-        "NEXUS-380-T1", "Test job", "VANCOUVER", "ELL100", "MAIN", "MAIN", "GST 5%", date(2025, 9, 15), 0,
+        "NEXUS-380-T1", "Test job", "VANCOUVER", "ELL100", "MAIN", "MAIN", "GST 5%", date(2025, 9, 15), 0, 0,
     )
 
 
@@ -108,7 +109,7 @@ def test_supplied_optional_parameters_are_added_in_order():
     assert "@I_vEstimatorID" in sql
     assert "@I_vBidDueDate" in sql
     assert "@I_vWSManagerID" not in sql  # still unset
-    assert params[8:] == ("EST1", date(2025, 8, 1), 0)
+    assert params[8:] == ("EST1", date(2025, 8, 1), 0, 0)
 
 
 def test_return_error_text_is_always_requested():
@@ -285,3 +286,51 @@ def test_over_length_job_number_is_rejected():
     # WS_Job_Number is char(17); SQL Server would silently truncate a longer value
     with pytest.raises(ValueError):
         _request(job_number="X" * 18)
+
+
+# --- updating an existing job (issue #497) ---
+#
+# Same proc, one parameter different. `@I_vUpdateIfExists = 1` is what makes wsiJCJobMaster an upsert
+# rather than a create - established from sys.parameters on the live proc (parameter 207), because
+# the proc body is encrypted and cannot be read.
+
+
+def test_update_sets_update_if_exists():
+    from ucnexus_relay.econnect import update_job
+
+    conn = _FakeConn()
+    update_job(conn, job_number="NEXUS-380-T1", job_name="Renamed")
+    sql, params = conn.proc_calls()[0]
+
+    assert "@I_vUpdateIfExists  = ?" in sql
+    # job number, name, then UpdateIfExists=1 and OnlyValidate=0.
+    assert params == ("NEXUS-380-T1", "Renamed", 1, 0)
+
+
+def test_update_needs_only_the_job_number():
+    """An update is a PATCH. Demanding the create-time eight would make a rename also restate the
+    customer, the division and the address codes - which is how a caller blanks a column by
+    accident."""
+    from ucnexus_relay.econnect import update_job
+
+    conn = _FakeConn()
+    update_job(conn, job_number="NEXUS-380-T1", job_address_code="SITE-23093")
+    sql, params = conn.proc_calls()[0]
+
+    assert "@I_vJobAddressCode" in sql
+    # Nothing else was sent, so nothing else can be overwritten with a default.
+    for param in ("@I_vWSJobName", "@I_vDivisions", "@I_vCustomerNumber", "@I_vTaxScheduleID"):
+        assert param not in sql
+    assert params == ("NEXUS-380-T1", "SITE-23093", 1, 0)
+
+
+def test_update_without_a_job_number_is_refused():
+    from ucnexus_relay.econnect import EConnectError, update_job
+
+    conn = _FakeConn()
+    try:
+        update_job(conn, job_name="Renamed")
+    except EConnectError as e:
+        assert "job_number" in str(e)
+    else:
+        raise AssertionError("update_job accepted a call with no job number")


### PR DESCRIPTION
closes #497.

wsiJCJobMaster updates in place. proc body encrypted, sys.parameters is not. parameter 207 is @I_vUpdateIfExists. no write probe needed.

site correction belongs to the job, not the customer. #444 pinned UpdateIfExists=0 on taCreateCustomerAddress so an address accounting maintains is never overwritten, and TUBC has one customer whose address codes serve two and three jobs each - editing the code a job points at would silently move unrelated jobs' sites. this mints a job-specific code derived from the job number, re-points JobAddressCode.

relay
- econnect.update_job shares one statement builder with create_job so the two cannot drift on how parameters are assembled. UpdateIfExists=1, only job number required - an update is a PATCH, and demanding the create-time eight would make a rename restate the customer, division and address codes.
- ops.update_job_site_op reads the job -> mints SITE-<job number> under its customer if the request carries an address and the code is absent -> updates the job. idempotent on re-run: the code exists, the mint is skipped, the job is re-pointed at what it already points at.
- get_job also returns customer_number and job_address_code.
- update_job_site registered on the channel.

backend
- updateProject commits -> pushes. the edit is the user's and must not be lost to a GP outage; the push is a replication of it.
- only job name and site address go. GC contact, estimator, storage agreement stay Nexus-only, nowhere to live in GP.
- half-filled address not pushed. a street with no city is not something GP can ship to.
- undispatched relay failure queues on the outbox, drains later. dispatched or timed-out does NOT queue - GP may hold it, and a second push would be a write against accounting data on a guess.
- GP refusal logged, not raised. the Nexus edit is already saved, so failing the mutation would say the correction did not happen when it did.
- quarantined projects skipped.

pins added
- payload builder six ways (what goes, what does not, half addresses, nothing-to-send, whitespace, cleared optionals)
- relay channel dispatch four ways
- update_job three ways
- two create_job param-tuple pins updated for the extra UpdateIfExists bind

worth your review: minting a per-job address code grows a customer's GP address list by one code per job whose site is ever corrected from Nexus. that is the cost of not touching shared addresses. editing the existing code in place instead is a small change to update_job_site_op, but it would move other jobs' sites.

not e2e tested against a relay-connected PR environment yet.
