### PR TITLE
fix(po): cancel is draft-only, and the always-zero Cancelled tile comes off

### DIFF
--- a/backend/app/repositories/po_repository.py
+++ b/backend/app/repositories/po_repository.py
@@ -649,10 +649,16 @@ def update_po(
 def cancel_po(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     """
     - Validate exists + not soft-deleted (NotFoundError)
-    - Validate status in (Draft, GP_Registered, Vendor_Confirmed) (InvalidStateTransitionError)
+    - Validate status is DRAFT (InvalidStateTransitionError)
     - Set status=Cancelled, deleted_at=datetime.utcnow()
     - Release the PO's hardware-schedule rows back to AVAILABLE
     - Return updated PO
+
+    DRAFT only. Cancelling used to be legal at GP_REGISTERED and VENDOR_CONFIRMED too, and nothing
+    here ever told GP: the cancel is a local write with no relay call, so GP kept a live PO against
+    the job that Nexus had forgotten. That is a phantom commitment on the job cost, and the warehouse
+    can still receive against it on the GP side. A registered PO is GP's record now, so unwinding one
+    starts there and syncs back, rather than being something Nexus can decide on its own.
     """
     from app.models.hardware import HardwareItem
 
@@ -660,8 +666,11 @@ def cancel_po(session: Session, po_id: uuid.UUID) -> PurchaseOrder:
     if po is None:
         raise NotFoundError(f"Purchase order {po_id} not found")
 
-    if po.status not in (POStatus.DRAFT, POStatus.GP_REGISTERED, POStatus.VENDOR_CONFIRMED):
-        raise InvalidStateTransitionError(f"Cannot cancel PO in {po.status.value} status")
+    if po.status is not POStatus.DRAFT:
+        raise InvalidStateTransitionError(
+            f"Cannot cancel PO in {po.status.value} status - only a draft can be cancelled. "
+            "Once a PO is registered in GP, cancel it there."
+        )
 
     po.status = POStatus.CANCELLED
     po.deleted_at = datetime.utcnow()

--- a/backend/tests/test_po_cancel_release.py
+++ b/backend/tests/test_po_cancel_release.py
@@ -100,3 +100,27 @@ def test_cancel_po_refused_after_receiving_started(db_session):
         po_repository.cancel_po(db_session, po.id)
     db_session.refresh(hi)
     assert hi.state == HardwareItemState.IN_PO
+
+
+@pytest.mark.parametrize("status", [POStatus.GP_REGISTERED, POStatus.VENDOR_CONFIRMED])
+def test_cancel_po_refused_once_gp_holds_it(db_session, status):
+    """Cancelling is DRAFT-only, because cancelling never told GP anything.
+
+    `cancel_po` makes no relay call, so cancelling a registered PO left GP holding a live PO against
+    the job while Nexus dropped it from every list - a phantom commitment on the job cost that the
+    warehouse could still receive against on the GP side. The schedule rows must stay IN_PO too: the
+    PO they were stamped against is still real in GP, so releasing them would invite a second order
+    for hardware already on one.
+    """
+    project = _make_project(db_session)
+    po, _line, hi = _po_with_schedule_item(db_session, project, status=status)
+
+    with pytest.raises(InvalidStateTransitionError):
+        po_repository.cancel_po(db_session, po.id)
+
+    db_session.refresh(po)
+    db_session.refresh(hi)
+    assert po.status is status
+    assert po.deleted_at is None
+    assert hi.state == HardwareItemState.IN_PO
+    assert hi.po_line_item_id is not None

--- a/frontend/src/graphql/po.ts
+++ b/frontend/src/graphql/po.ts
@@ -9,7 +9,6 @@ export const GET_PO_STATISTICS = gql`
       vendorConfirmed
       partiallyReceived
       closed
-      cancelled
     }
   }
 `;

--- a/frontend/src/modules/admin/AdminLanding.tsx
+++ b/frontend/src/modules/admin/AdminLanding.tsx
@@ -107,7 +107,10 @@ export default function AdminLanding() {
               <StatCard icon={<Users {...TILE_ICON} />} label="Users" value={s.userCount} />
             </StaggerItem>
             <StaggerItem style={{ flex: '1 1 0', minWidth: 130, display: 'flex' }}>
-              <StatCard icon={<Boxes {...TILE_ICON} />} label="Hardware Items" value={s.hardwareItemCount} />
+              {/* Distinct (category, product code) pairs, not a row count - `get_admin_stats` groups
+                  before counting. Labelled "Hardware Items" it sat next to a raw Openings count and
+                  read as though the schedule had imported short (1,122 against 29,126 actual rows). */}
+              <StatCard icon={<Boxes {...TILE_ICON} />} label="Distinct Products" value={s.hardwareItemCount} />
             </StaggerItem>
             <StaggerItem style={{ flex: '1 1 0', minWidth: 130, display: 'flex' }}>
               <StatCard icon={<DoorOpen {...TILE_ICON} />} label="Openings" value={s.openingCount} />

--- a/frontend/src/modules/import/ClassificationGrid.tsx
+++ b/frontend/src/modules/import/ClassificationGrid.tsx
@@ -89,10 +89,22 @@ function siteShopEligibleKeys(rows: ClassificationRow[], exemptValue?: string): 
   return uniqueClassificationKeys(rows.filter((r) => !exemptValue || r.classification !== exemptValue));
 }
 
+// TITAN writes Vendor_Discount against List_Price, and when it has no list price it writes a $0.01
+// placeholder instead of nothing. The discount it then derives is arithmetically meaningless - a real
+// export carries rows reading -1199%, -1499% and -4199% against a $0.01 list and a $12-42 unit cost -
+// and a buyer reading a purchasing grid has to mentally discard them. A discount outside +/-100% is
+// not a discount, so it shows as a dash and keeps the raw figure in the title for anyone chasing it.
+const DISCOUNT_PLAUSIBLE_PCT = 100;
+
+function formatVendorDiscount(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return Math.abs(value) > DISCOUNT_PLAUSIBLE_PCT ? '—' : `${value}%`;
+}
+
 function formatGroupKey(field: GroupByField, value: unknown): string {
   if (value == null || value === '') return '(None)';
   if (field === 'unitCost' || field === 'listPrice') return `$${Number(value).toFixed(2)}`;
-  if (field === 'vendorDiscount') return `${Number(value)}%`;
+  if (field === 'vendorDiscount') return formatVendorDiscount(Number(value));
   return String(value);
 }
 
@@ -185,7 +197,13 @@ const ALL_COLUMNS: GridColDef[] = [
     headerName: 'Discount',
     flex: 0.5,
     type: 'number',
-    valueFormatter: (value: number | null) => value != null ? `${value}%` : '—',
+    valueFormatter: (value: number | null) => formatVendorDiscount(value),
+    renderCell: (params) => {
+      const raw = params.value as number | null;
+      const shown = formatVendorDiscount(raw);
+      const suppressed = raw != null && shown === '—';
+      return <span title={suppressed ? `TITAN reported ${raw}% against a placeholder list price` : undefined}>{shown}</span>;
+    },
   },
   {
     field: 'unitCost',

--- a/frontend/src/modules/import/ClassificationStep.tsx
+++ b/frontend/src/modules/import/ClassificationStep.tsx
@@ -57,8 +57,11 @@ export default function ClassificationStep({
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ ...tabularSx, mb: 1 }}>
         {isReimport
-          ? `${itemCount} items need ordering (not available or partial in inventory).`
-          : `${itemCount} hardware items across ${openingCount} openings.`}
+          ? `${itemCount} lines need ordering (not available or partial in inventory).`
+          : // "Lines", not "hardware items": these rows are aggregated by classification key, so 52
+            // of them can carry 70 pieces. Finalize counts the pieces, and calling both "hardware
+            // items" made two true numbers look like one of them was wrong.
+            `${itemCount} hardware lines across ${openingCount} openings.`}
       </Typography>
 
       {isReadOnly ? (

--- a/frontend/src/modules/import/ImportWizard.tsx
+++ b/frontend/src/modules/import/ImportWizard.tsx
@@ -270,8 +270,17 @@ export default function ImportWizard({
       { id: 'upload', label: 'Upload File' },
       { id: 'purpose', label: 'Purpose' },
       { id: 'openings', label: 'Select Openings' },
-      { id: 'reconciliation', label: 'Reconciliation' },
     ];
+    // Reconciliation compares the incoming schedule against what the project has already committed,
+    // so on a project with no persisted openings it has nothing to compare and rendered a single
+    // "New project - all items will be ordered fresh" banner over an otherwise empty full-screen
+    // step. That is a mandatory click carrying no decision, on the most-walked flow in the app.
+    // `isReimport` is `openingCount > 0`, which is exactly the condition for having something to
+    // reconcile against - and a first import can only be the PO purpose anyway, since the other two
+    // require a project with received inventory.
+    if (isReimport) {
+      base.push({ id: 'reconciliation', label: 'Reconciliation' });
+    }
     // #492: only the PO purpose asks. A shop-assembly request runs against a project whose schedule
     // is already classified, so re-asking forced the user to re-answer a question the system knows -
     // and answering it differently than the original import is exactly the drift. The assembly
@@ -290,8 +299,11 @@ export default function ImportWizard({
   // Derived via useMemo instead of a useEffect+setState to avoid cascading renders.
   const effectiveStepId = useMemo<StepId>(
     () =>
+      // Falls back to 'openings' rather than 'reconciliation': reconciliation is now conditional, so
+      // naming it here could orphan the orphan-guard itself on a first import. 'openings' is in every
+      // variant of the stepper.
       activeStepId !== 'upload' && !steps.find((s) => s.id === activeStepId)
-        ? 'reconciliation'
+        ? 'openings'
         : activeStepId,
     [steps, activeStepId],
   );
@@ -1811,7 +1823,10 @@ export default function ImportWizard({
                 <Typography sx={{ ...microLabelSx, mb: 1.5 }}>Import Summary</Typography>
 
                 <Typography sx={microLabelSx}>Project</Typography>
-                <Typography variant="body1" sx={{ mb: 1, ...monoSx, fontSize: '1rem' }}>
+                {/* `title` step off the DESIGN.md ramp, not MUI's body1 default of 1rem - the ramp
+                    has no 1rem step. component="p" because this is the card's headline value, not a
+                    heading in the document outline. */}
+                <Typography variant="h6" component="p" sx={{ mb: 1, ...monoSx }}>
                   {existingProjectName}
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ ...tabularSx, mb: 2 }}>

--- a/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
+++ b/frontend/src/modules/import/__tests__/ImportWizard.test.tsx
@@ -473,7 +473,10 @@ async function flushApollo() {
   });
 }
 
-const BASE_STEPS = ['Upload File', 'Purpose', 'Select Openings', 'Reconciliation'];
+// Reconciliation only exists when there is something to reconcile against - a project with persisted
+// openings. On a first import it has nothing to compare and is left out of the stepper entirely.
+const FIRST_IMPORT_STEPS = ['Upload File', 'Purpose', 'Select Openings'];
+const REIMPORT_STEPS = [...FIRST_IMPORT_STEPS, 'Reconciliation'];
 
 beforeEach(() => {
   mockedUseParser.mockReset();
@@ -491,7 +494,7 @@ describe('ImportWizard step transitions', () => {
 
     expect(screen.getByRole('heading', { name: 'Hardware Schedule' })).toBeInTheDocument();
     expect(screen.getByText('Drag and drop an XML file here')).toBeInTheDocument();
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Finalize']);
+    expect(stepLabels()).toEqual([...FIRST_IMPORT_STEPS, 'Finalize']);
     expect(nextButton()).toBeDisabled();
   });
 
@@ -517,10 +520,10 @@ describe('ImportWizard step transitions', () => {
     renderWizard();
     clickNext();
 
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Finalize']);
+    expect(stepLabels()).toEqual([...FIRST_IMPORT_STEPS, 'Finalize']);
     fireEvent.click(screen.getByRole('radio', { name: /Create Purchase Orders/i }));
 
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Classification', 'Purchase Orders', 'Finalize']);
+    expect(stepLabels()).toEqual([...FIRST_IMPORT_STEPS, 'Classification', 'Purchase Orders', 'Finalize']);
   });
 
   // #492: the assembly flow used to carry a Classification step. It asked the user to re-answer a
@@ -533,7 +536,7 @@ describe('ImportWizard step transitions', () => {
 
     fireEvent.click(screen.getByRole('radio', { name: /Pull Request for Shop Assembly/i }));
 
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Shop Assembly', 'Finalize']);
+    expect(stepLabels()).toEqual([...REIMPORT_STEPS, 'Shop Assembly', 'Finalize']);
   });
 
   it('shipping purpose (re-import) inserts only the Shipping PRs step', async () => {
@@ -543,7 +546,7 @@ describe('ImportWizard step transitions', () => {
 
     fireEvent.click(screen.getByRole('radio', { name: /Pull Request for Shipping Out/i }));
 
-    expect(stepLabels()).toEqual([...BASE_STEPS, 'Shipping PRs', 'Finalize']);
+    expect(stepLabels()).toEqual([...REIMPORT_STEPS, 'Shipping PRs', 'Finalize']);
   });
 
   it('blocks Next on Select Openings until at least one opening is selected', () => {
@@ -682,7 +685,10 @@ describe('ImportWizard step transitions', () => {
     expect(screen.getByText('Opening O-1 - Leaf 2')).toBeInTheDocument();
   });
 
-  it('walks the po path through Reconciliation to Classification and gates on unclassified items', () => {
+  // A first import has no persisted openings, so Reconciliation has nothing to compare against and
+  // is skipped outright: Select Openings goes straight to Classification. It used to render a lone
+  // "New project" banner over an empty full-screen step and demand a click for it.
+  it('skips Reconciliation on a first import and lands on Classification', () => {
     renderWizard();
     clickNext();
     fireEvent.click(screen.getByRole('radio', { name: /Create Purchase Orders/i }));
@@ -690,15 +696,23 @@ describe('ImportWizard step transitions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
     clickNext();
 
-    // first import: reconciliation is informational and never blocks
-    expect(screen.getByRole('heading', { name: 'Reconciliation' })).toBeInTheDocument();
-    expect(screen.getByText(/New project/)).toBeInTheDocument();
-    expect(nextButton()).toBeEnabled();
-    clickNext();
-
+    expect(screen.queryByRole('heading', { name: 'Reconciliation' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Classification' })).toBeInTheDocument();
     expect(screen.getByText('0 of 2 items classified')).toBeInTheDocument();
     expect(nextButton()).toBeDisabled();
+  });
+
+  it('walks the po path through Reconciliation to Classification on a re-import', async () => {
+    renderWizard({ project: reimportProject, mocks: reimportMocks });
+    await flushApollo();
+    clickNext();
+    fireEvent.click(screen.getByRole('radio', { name: /Create Purchase Orders/i }));
+    clickNext();
+    fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
+    clickNext();
+    await flushApollo();
+
+    expect(screen.getByRole('heading', { name: 'Reconciliation' })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/modules/po/PODetailModal.tsx
+++ b/frontend/src/modules/po/PODetailModal.tsx
@@ -487,7 +487,9 @@ export default function PODetailModal({
   const canRegisterInGp = po.status === 'DRAFT';
   const relayConnected = relayConnectedProp === true;
 
-  const canCancel = po.status === 'DRAFT' || po.status === 'GP_REGISTERED' || po.status === 'VENDOR_CONFIRMED';
+  // Draft only. Cancelling never told GP anything, so cancelling a registered PO left GP holding a
+  // live PO against the job that Nexus had dropped. Once GP has it, GP is where it gets unwound.
+  const canCancel = po.status === 'DRAFT';
 
   // The supplier PO document reads the buyer list + GP totals live, so it's only for a PO that
   // exists in GP (has a GP company + number) and needs the relay connected.
@@ -931,7 +933,7 @@ export default function PODetailModal({
       <ConfirmDialog
         open={confirmCancelOpen}
         title="Cancel PO"
-        message="Are you sure you want to cancel this PO? This action cannot be undone."
+        message="Cancelling removes this draft from the PO list for good, and returns its hardware to the schedule as still needing to be ordered. This cannot be undone."
         confirmLabel="Cancel PO"
         cancelLabel="Go Back"
         onConfirm={handleCancelPO}

--- a/frontend/src/modules/po/__tests__/PODetailModal.test.tsx
+++ b/frontend/src/modules/po/__tests__/PODetailModal.test.tsx
@@ -362,7 +362,7 @@ describe('PODetailModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel PO' }));
     const message = await screen.findByText(
-      'Are you sure you want to cancel this PO? This action cannot be undone.',
+      'Cancelling removes this draft from the PO list for good, and returns its hardware to the schedule as still needing to be ordered. This cannot be undone.',
     );
     expect(cancelCalls).toHaveLength(0); // nothing fired before confirmation
 
@@ -372,5 +372,13 @@ describe('PODetailModal', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(onRefetch).toHaveBeenCalled();
     expect(cancelCalls).toEqual([{ id: 'po-1' }]);
+  });
+
+  // Cancelling makes no relay call, so cancelling a registered PO left GP holding a live PO against
+  // the job while Nexus dropped it from every list. Once GP has the PO, GP is where it gets unwound.
+  it('offers no Cancel PO button once the PO is registered in GP', () => {
+    renderModal(registeredPo, []);
+
+    expect(screen.queryByRole('button', { name: 'Cancel PO' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -160,7 +160,8 @@ interface POStatistics {
   vendorConfirmed: number;
   partiallyReceived: number;
   closed: number;
-  cancelled: number;
+  // No `cancelled`. The resolver still returns it, but every read on this page filters
+  // deleted_at IS NULL and cancel_po sets it, so the figure is always 0 - not worth fetching.
 }
 
 

--- a/frontend/src/modules/po/index.tsx
+++ b/frontend/src/modules/po/index.tsx
@@ -180,8 +180,11 @@ const STAT_CARDS: { label: string; key: keyof POStatistics; status: string | nul
   { label: 'Vendor Confirmed', key: 'vendorConfirmed', status: 'VENDOR_CONFIRMED' },
   { label: 'Partially Received', key: 'partiallyReceived', status: 'PARTIALLY_RECEIVED' },
   { label: 'Closed', key: 'closed', status: 'CLOSED' },
-  { label: 'Cancelled', key: 'cancelled', status: 'CANCELLED' },
 ];
+// No Cancelled segment. `cancel_po` writes status=CANCELLED and deleted_at in the same statement, and
+// every read here filters deleted_at IS NULL - so the count was structurally always 0 and the segment
+// filtered to an always-empty table. A cancelled draft is gone from this list by design; a readout
+// that can only ever say "0" is worse than no readout.
 
 // --- Sort + filter state ---
 
@@ -978,7 +981,9 @@ function POListPage() {
                       component="span"
                       sx={{
                         ...tabularSx,
-                        fontSize: '1.125rem',
+                        // `title` step off the DESIGN.md ramp; the strip stays compact through its
+                        // padding and 1.0 line-height, not through an off-ramp font size.
+                        fontSize: '1.25rem',
                         fontWeight: 700,
                         lineHeight: 1,
                         color: zero ? 'text.secondary' : 'text.primary',

--- a/frontend/src/modules/shipping/StagingWorkspace.tsx
+++ b/frontend/src/modules/shipping/StagingWorkspace.tsx
@@ -881,13 +881,10 @@ function PlaceMenu({
   disabledFor?: (c: Container) => boolean;
 }) {
   const [value, setValue] = useState('');
-  if (containers.length === 0) {
-    return (
-      <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-        No containers yet
-      </Typography>
-    );
-  }
+  // With no containers there is nothing to place into, and the panel on the right already says so
+  // once. Rendering the same sentence per row repeated it 34 times on a 34-leaf pool and read as
+  // noise on screen and as 34 identical announcements to a screen reader. Render nothing instead.
+  if (containers.length === 0) return null;
   return (
     <TextField
       select


### PR DESCRIPTION
cancel_po makes no relay call. cancelling a GP_REGISTERED or VENDOR_CONFIRMED PO therefore left GP holding a live PO against the job while Nexus dropped it from every list - a phantom commitment on the job cost that the warehouse could still receive against on the GP side. narrowed to DRAFT; once GP has the PO, GP is where it gets unwound.

the Cancelled segment could never be non-zero either. cancel_po writes status=CANCELLED and deleted_at in the same statement and every read on that page filters deleted_at IS NULL, so the count was structurally 0 and the segment filtered to an always-empty table. removed rather than left reading 0 forever.

the rest came out of the same exploratory pass over a preview environment loaded with the 1998-opening TITAN fixture:

- Reconciliation is skipped on a first import. with no persisted openings it has nothing to compare against, and rendered one "New project" banner over an otherwise empty full-screen step
- the Admin tile that counts distinct (category, product code) pairs now says Distinct Products. labelled Hardware Items beside a raw Openings count it read 1,122 against 29,126 actual rows, like the schedule had imported short
- Classification counts hardware LINES, Finalize counts items. both said "hardware items", so 52 and 70 two steps apart looked like one of them was wrong
- a vendor discount outside +/-100% renders as a dash, raw figure in the title. TITAN derives it against a 0.01 placeholder list price and emits -1199%, -1499%, -4199% on real rows
- the staging pool's per-row "No containers yet" ran once per leaf, 34 times on a 34-leaf pool, and the panel beside it already says it once
- two literal font sizes off the DESIGN.md ramp moved onto the title step