### PR TITLE
relay: discover Railway preview environments instead of being told about them

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,6 +23,13 @@ CLERK_SECRET_KEY=sk_test_replace_me
 # needs the variable set on its own backend service as well. Blank disables seeding.
 RELAY_SEED_SECRET_HASH=
 
+# Read-only Railway API token, scoped to this project. PRODUCTION ONLY. It lets GET /relay-channels
+# tell the workstation relay which preview environments exist right now, so a PR environment gets a GP
+# channel without anyone editing config.toml on that machine. A backend without it answers an empty
+# list, which is what every non-production environment should answer - a preview must not be able to
+# advertise other previews. Unlike the two digests above this IS a credential; keep it read-only.
+RAILWAY_API_TOKEN=
+
 # Railway S3-compatible bucket (optional locally). Leave blank to skip; document-upload
 # flows won't work without it.
 BUCKET_ENDPOINT=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,3 +34,18 @@ RAILWAY_ENVIRONMENT_NAME = os.getenv("RAILWAY_ENVIRONMENT_NAME", "")
 # manual provision + enroll per PR (#414). A hash is a verifier, not a credential: it cannot be replayed
 # to authenticate. relay_seed refuses to act on it in production regardless.
 RELAY_SEED_SECRET_HASH = os.getenv("RELAY_SEED_SECRET_HASH", "")
+
+# Railway injects the project this service belongs to. Empty off Railway.
+RAILWAY_PROJECT_ID = os.getenv("RAILWAY_PROJECT_ID", "")
+
+# Read-only Railway API token, set ONLY on production. It lets /relay-channels tell the workstation
+# relay which preview environments exist right now, so adding a PR environment stops being a hand edit
+# on that machine (app/services/relay_channels.py). Blank disables discovery and the route answers an
+# empty list, which is the correct answer everywhere except production - a preview environment must not
+# be able to advertise other preview environments. Unlike the two digests above this IS a credential,
+# so scope it to read-only on this project.
+RAILWAY_API_TOKEN = os.getenv("RAILWAY_API_TOKEN", "")
+
+# Overridable because Railway has served its public API from more than one host; a change there should
+# be a variable edit, not a redeploy of pinned code.
+RAILWAY_API_URL = os.getenv("RAILWAY_API_URL", "https://backboard.railway.com/graphql/v2")

--- a/backend/app/services/relay_channels.py
+++ b/backend/app/services/relay_channels.py
@@ -1,0 +1,179 @@
+"""Which preview backends the workstation relay should also be dialling.
+
+The relay holds a list of backend URLs and reconciles it every ten seconds (#456), so the set of
+channels it serves is already dynamic at runtime. What was never dynamic is where that list comes
+from: a TOML file on one GP-credentialed workstation, edited by hand. Railway creates a preview
+environment per pull request, automatically, at an address nobody has seen before - so the two halves
+ran on different clocks, and every PR that needed a real GP channel waited on somebody walking to that
+machine. Environments created after the last edit were simply invisible.
+
+This closes that loop from the backend side. Production asks Railway which preview environments exist
+right now and hands the relay the derived channel URLs; the relay unions them with its own file. A
+preview environment that appears is dialled within a tick, and one that is torn down stops being
+listed, so teardown is as automatic as setup.
+
+Three properties make this safe to do without a human vetting each address:
+
+- Only PRODUCTION discovers. `RAILWAY_API_TOKEN` is set on production alone, and a backend without one
+  answers an empty list. A preview environment therefore cannot advertise other preview environments.
+- The derived URL shape is fixed and validated on BOTH sides. Nothing here can name an arbitrary host,
+  and the relay re-checks the pattern before dialling rather than trusting this answer.
+- A discovered channel can never be the primary one. `is_primary_backend_url` in the relay decides
+  that by identity against its own baked-in production URL, so every discovered channel inherits the
+  sandbox company pin (`NON_PRIMARY_ALLOWED_COMPANIES`). The worst a rogue entry could do is offer a
+  channel that may only touch TUBC.
+
+Discovery failing is not an error state. The relay keeps whatever it last knew and its config file
+still works, which is exactly where things stood before this existed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+
+import httpx
+
+from app.config import RAILWAY_API_TOKEN, RAILWAY_API_URL, RAILWAY_PROJECT_ID
+
+logger = logging.getLogger(__name__)
+
+# Railway names a pull request's environment `uc-nexus-pr-<N>`, not `pr-<N>`. Anchored: this is the
+# only thing standing between "an environment exists" and "the relay will dial it", so a name that
+# merely contains the prefix must not match.
+PREVIEW_ENVIRONMENT_RE = re.compile(r"^uc-nexus-pr-(\d+)$")
+
+# Public hostnames are `<service>-<environment>.up.railway.app`, and the backend service is `backend`
+# in every environment. Derived rather than looked up because the derivation is total: any environment
+# matching the name pattern above has exactly this address, and asking Railway for domains as well
+# would be a second round trip that can fail on its own.
+_CHANNEL_URL = "wss://backend-{environment}.up.railway.app/relay-link"
+
+# Long enough that a relay reconciling every ten seconds does not turn into ten Railway calls a minute,
+# short enough that a newly opened PR is dialled while somebody is still looking at it.
+_CACHE_SECONDS = 60.0
+
+_QUERY = """
+query PreviewEnvironments($projectId: String!) {
+  environments(projectId: $projectId) {
+    edges { node { id name } }
+  }
+}
+"""
+
+# Railway has served the environment list under both shapes. Trying the second only after the first
+# errors costs nothing on the happy path and keeps a schema change from silently emptying the list.
+_QUERY_FALLBACK = """
+query PreviewEnvironments($projectId: String!) {
+  project(id: $projectId) {
+    environments { edges { node { id name } } }
+  }
+}
+"""
+
+_lock = threading.Lock()
+_cache: tuple[float, list[str]] | None = None
+
+
+def channel_url_for(environment_name: str) -> str:
+    """The relay channel URL for a preview environment name."""
+    return _CHANNEL_URL.format(environment=environment_name)
+
+
+def _environment_names(payload: dict) -> list[str]:
+    """Environment names out of either response shape, tolerating a missing branch rather than raising.
+
+    Written defensively on purpose: this walks a third party's response, and the cost of a shape we did
+    not expect should be an empty list plus a log line, never a 500 on the route that serves it.
+    """
+    data = payload.get("data") or {}
+    container = data.get("environments") or (data.get("project") or {}).get("environments") or {}
+    edges = container.get("edges") or []
+    names = []
+    for edge in edges:
+        name = ((edge or {}).get("node") or {}).get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def _fetch_environment_names() -> list[str] | None:
+    """Every environment name in this Railway project, or None if the API could not be read."""
+    headers = {"Authorization": f"Bearer {RAILWAY_API_TOKEN}", "Content-Type": "application/json"}
+    variables = {"projectId": RAILWAY_PROJECT_ID}
+    last_errors: object = None
+    for query in (_QUERY, _QUERY_FALLBACK):
+        try:
+            response = httpx.post(
+                RAILWAY_API_URL,
+                json={"query": query, "variables": variables},
+                headers=headers,
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as e:
+            logger.warning(
+                "could not reach the Railway API for preview channel discovery",
+                extra={"error": str(e), "url": RAILWAY_API_URL},
+            )
+            return None
+        if payload.get("errors"):
+            last_errors = payload["errors"]
+            continue
+        return _environment_names(payload)
+    logger.warning(
+        "the Railway API refused both environment queries; preview channel discovery is off until "
+        "this is fixed, and the relay keeps whatever it already had",
+        extra={"errors": str(last_errors)[:500]},
+    )
+    return None
+
+
+def discover_preview_channels(*, force: bool = False) -> list[str]:
+    """Channel URLs for every live preview environment, newest PR first.
+
+    Empty - never an exception - when discovery is off or unavailable. `force` skips the cache and is
+    for tests; callers on the request path should take the cached answer.
+    """
+    global _cache
+
+    if not RAILWAY_API_TOKEN or not RAILWAY_PROJECT_ID:
+        return []
+
+    with _lock:
+        now = time.monotonic()
+        if not force and _cache is not None and now - _cache[0] < _CACHE_SECONDS:
+            return list(_cache[1])
+
+        names = _fetch_environment_names()
+        if names is None:
+            # Serve the last good answer rather than an empty one: a blip in Railway's API should not
+            # tear down working channels on the relay, and the relay's own merge treats an empty list
+            # as "discovered nothing", which is indistinguishable from "every PR closed".
+            if _cache is not None:
+                return list(_cache[1])
+            return []
+
+        matched = sorted(
+            (name for name in names if PREVIEW_ENVIRONMENT_RE.match(name)),
+            key=lambda name: int(PREVIEW_ENVIRONMENT_RE.match(name).group(1)),
+            reverse=True,
+        )
+        urls = [channel_url_for(name) for name in matched]
+        if _cache is None or _cache[1] != urls:
+            logger.info(
+                "preview relay channels discovered",
+                extra={"count": len(urls), "environments": matched},
+            )
+        _cache = (now, urls)
+        return list(urls)
+
+
+def reset_cache() -> None:
+    """Drop the memoized answer. Tests only."""
+    global _cache
+    with _lock:
+        _cache = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import strawberry
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from graphql import GraphQLError, GraphQLResolveInfo
@@ -22,6 +22,7 @@ from app.repositories import relay_repository
 from app.schemas.mutations import Mutation
 from app.schemas.queries import Query
 from app.services import gp_job_sync, gp_outbox_worker, relay_adopt, relay_seed
+from app.services import relay_channels as relay_channels_service
 from app.services.relay_gateway import HEARTBEAT_INTERVAL_SECONDS
 from app.services.relay_gateway import gateway as relay_gateway
 
@@ -254,6 +255,34 @@ async def _serve_relay_link(websocket: WebSocket, require_hello: bool = False) -
             continue
         if exc is not None:
             raise exc
+
+
+@app.get("/relay-channels")
+def relay_channels(request: Request):
+    """Which preview backends the calling relay should ALSO be dialling.
+
+    Authenticated by the same enrolled Bearer secret the relay presents on /relay-link, so this adds
+    no credential and no new trust relationship: a caller that could read this could already open the
+    channel. Answers `{"urls": [...]}`, empty wherever discovery is off - which is everywhere except
+    production, and production only when RAILWAY_API_TOKEN is set.
+
+    The relay unions this with its own config file rather than replacing it, and re-validates every URL
+    against the preview hostname pattern before dialling. So the worst a wrong answer here can do is
+    offer a channel the relay declines, and a discovered channel can never become the primary one.
+    """
+    auth_header = request.headers.get("authorization") or ""
+    scheme, _, secret = auth_header.partition(" ")
+    if scheme.lower() != "bearer" or not secret.strip():
+        raise HTTPException(status_code=401, detail="relay credential required")
+
+    with SessionLocal() as session:
+        install = relay_repository.authenticate_secret(session, secret.strip())
+        authenticated = install is not None
+        session.commit()
+    if not authenticated:
+        raise HTTPException(status_code=401, detail="relay credential required")
+
+    return {"urls": relay_channels_service.discover_preview_channels()}
 
 
 @app.websocket("/relay-link")

--- a/backend/tests/test_relay_channels.py
+++ b/backend/tests/test_relay_channels.py
@@ -1,0 +1,152 @@
+"""Preview channel discovery: what production tells the workstation relay to dial.
+
+The point of this service is to remove a manual edit on a machine nobody testing is sitting at, so the
+failure that matters most is not "wrong list" but "list that quietly stops being served" - a relay that
+discovers nothing behaves exactly like the old manual world and nobody notices for a week. These pin
+the shape, the filtering, and the fallback behaviour that keeps a Railway blip from tearing down live
+channels.
+
+No database and no network: everything here drives the module's own httpx call site.
+"""
+
+import pytest
+
+from app.services import relay_channels
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    relay_channels.reset_cache()
+    yield
+    relay_channels.reset_cache()
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    """Discovery switched on, as it is on production alone."""
+    monkeypatch.setattr(relay_channels, "RAILWAY_API_TOKEN", "token")
+    monkeypatch.setattr(relay_channels, "RAILWAY_PROJECT_ID", "project")
+
+
+def _envs(*names):
+    return {"data": {"environments": {"edges": [{"node": {"id": n, "name": n}} for n in names]}}}
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _serve(monkeypatch, payload, calls=None):
+    def _post(url, **kwargs):
+        if calls is not None:
+            calls.append(kwargs.get("json", {}).get("query", ""))
+        return _Response(payload)
+
+    monkeypatch.setattr(relay_channels.httpx, "post", _post)
+
+
+def test_only_pr_environments_become_channels(monkeypatch, configured):
+    # production and any hand-named environment share the project; neither is a preview backend, and
+    # dialling production twice would have the relay fight itself for its single connection slot.
+    _serve(monkeypatch, _envs("production", "uc-nexus-pr-554", "staging", "uc-nexus-pr-510"))
+    assert relay_channels.discover_preview_channels() == [
+        "wss://backend-uc-nexus-pr-554.up.railway.app/relay-link",
+        "wss://backend-uc-nexus-pr-510.up.railway.app/relay-link",
+    ]
+
+
+def test_the_newest_pr_is_offered_first(monkeypatch, configured):
+    # Ordered by PR number rather than by whatever order Railway returns: the environment somebody is
+    # waiting on is almost always the newest one, and the relay logs the list it was handed.
+    _serve(monkeypatch, _envs("uc-nexus-pr-9", "uc-nexus-pr-554", "uc-nexus-pr-77"))
+    assert relay_channels.discover_preview_channels() == [
+        "wss://backend-uc-nexus-pr-554.up.railway.app/relay-link",
+        "wss://backend-uc-nexus-pr-77.up.railway.app/relay-link",
+        "wss://backend-uc-nexus-pr-9.up.railway.app/relay-link",
+    ]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "pr-554",  # the shape the runbook warns about; Railway does not name environments this way
+        "uc-nexus-pr-554-old",
+        "not-uc-nexus-pr-554",
+        "uc-nexus-pr-",
+        "uc-nexus-pr-abc",
+    ],
+)
+def test_a_name_that_is_not_exactly_a_pr_environment_is_ignored(monkeypatch, configured, name):
+    # The name is the ONLY thing standing between "an environment exists" and "the relay dials it".
+    _serve(monkeypatch, _envs(name))
+    assert relay_channels.discover_preview_channels() == []
+
+
+def test_discovery_is_off_without_a_token(monkeypatch):
+    monkeypatch.setattr(relay_channels, "RAILWAY_API_TOKEN", "")
+    monkeypatch.setattr(relay_channels, "RAILWAY_PROJECT_ID", "project")
+
+    def _explode(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("a backend without a token must not call Railway")
+
+    monkeypatch.setattr(relay_channels.httpx, "post", _explode)
+    assert relay_channels.discover_preview_channels() == []
+
+
+def test_a_railway_outage_keeps_the_last_good_answer(monkeypatch, configured):
+    # The relay retires a channel that stops being listed, so answering [] on a blip would tear down
+    # working preview channels and re-create them a minute later.
+    _serve(monkeypatch, _envs("uc-nexus-pr-554"))
+    good = relay_channels.discover_preview_channels()
+    assert good == ["wss://backend-uc-nexus-pr-554.up.railway.app/relay-link"]
+
+    def _fail(*a, **k):
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(relay_channels.httpx, "post", _fail)
+    assert relay_channels.discover_preview_channels(force=True) == good
+
+
+def test_no_live_previews_really_does_answer_empty(monkeypatch, configured):
+    # The other half of the rule above: "asked and there are none" must be distinguishable from
+    # "could not ask", or a closed PR's environment is dialled forever.
+    _serve(monkeypatch, _envs("production"))
+    assert relay_channels.discover_preview_channels() == []
+
+
+def test_the_fallback_query_runs_only_when_the_first_is_refused(monkeypatch, configured):
+    calls: list[str] = []
+
+    def _post(url, **kwargs):
+        query = kwargs.get("json", {}).get("query", "")
+        calls.append(query)
+        if "project(id:" not in query:
+            return _Response({"errors": [{"message": "Cannot query field 'environments'"}]})
+        return _Response({"data": {"project": {"environments": {"edges": [{"node": {"name": "uc-nexus-pr-1"}}]}}}})
+
+    monkeypatch.setattr(relay_channels.httpx, "post", _post)
+    assert relay_channels.discover_preview_channels() == [
+        "wss://backend-uc-nexus-pr-1.up.railway.app/relay-link",
+    ]
+    assert len(calls) == 2
+
+
+def test_a_shape_nobody_expected_is_an_empty_list_not_a_crash(monkeypatch, configured):
+    # This walks a third party's response on a request path; a surprise there must not 500 the route.
+    _serve(monkeypatch, {"data": {"environments": None}})
+    assert relay_channels.discover_preview_channels() == []
+
+
+def test_the_answer_is_cached_between_relay_ticks(monkeypatch, configured):
+    calls: list[str] = []
+    _serve(monkeypatch, _envs("uc-nexus-pr-554"), calls=calls)
+    for _ in range(5):
+        relay_channels.discover_preview_channels()
+    assert len(calls) == 1

--- a/backend/tests/test_resolver_gate_completeness.py
+++ b/backend/tests/test_resolver_gate_completeness.py
@@ -146,6 +146,7 @@ _ROUTE_GATES = frozenset({"require_admin_request"})
 _ROUTE_EXEMPT: dict[str, str] = {
     "health": "public liveness probe returning a constant; deploy healthchecks call it anonymously",
     "relay_link": "authenticated by the enrolled relay's Bearer secret on the websocket handshake, not Clerk",
+    "relay_channels": "same enrolled relay Bearer secret as relay_link, checked inline; a workstation has no session",
 }
 
 

--- a/relay/config.example.toml
+++ b/relay/config.example.toml
@@ -60,12 +60,18 @@ file = "relay.log"
 # relay just runs its existing inbound HTTP server, as today). auths on connect with [auth].shared_secret.
 backend_url = "wss://backend-production-xxxx.up.railway.app/relay-link"
 
-# ADD a test backend here, naming ONLY the new one - one channel per URL, so a Railway PR environment
-# can be tested without dropping production (#414). the same enrolled secret authenticates on all of
-# them. the production channel is unrestricted; every other URL is pinned to TUBC and refuses any other
+# Railway PR environments are found automatically: the relay asks production which ones exist and dials
+# them, so testing a PR needs nothing here and a closed one is dropped on its own. Requires
+# RAILWAY_API_TOKEN on the production backend. Set false to dial only what this file names.
+#discover_preview_backends = true
+
+# ADD a test backend here, naming ONLY the new one - one channel per URL, so a backend can be tested
+# without dropping production (#414). Now mostly for what discovery cannot know about: a local dev
+# backend, or anything outside the Railway project. The same enrolled secret authenticates on all of
+# them. The production channel is unrestricted; every other URL is pinned to TUBC and refuses any other
 # company, reads and writes alike - so TUBC must also be in [gp] allowed_companies above, or this
-# workstation refuses those jobs itself. read once at serve start: restart the relay after editing, and
-# remove the URL when its PR closes.
+# workstation refuses those jobs itself. Re-read on a timer since #456, so no restart after editing;
+# remove the URL when you are done with it.
 #
 # prefer this over overriding backend_url: whether a channel is production is decided by matching the
 # baked production URL, so retyping it with one character wrong silently pins PRODUCTION to TUBC and

--- a/relay/src/ucnexus_relay/channel.py
+++ b/relay/src/ucnexus_relay/channel.py
@@ -36,7 +36,10 @@ within ~a minute (issue #277) - the websockets client auto-answers protocol ping
 import asyncio
 import json
 import logging
+import re
 import time
+import urllib.error
+import urllib.request
 
 import pyodbc
 import websockets
@@ -727,6 +730,117 @@ def _configured_urls() -> list[str] | None:
         return None
 
 
+# How often to ask the production backend which preview environments exist. Deliberately slower than
+# the reconcile tick: the answer changes when somebody opens or closes a PR, not every ten seconds, and
+# a channel list that is one minute stale costs nothing while a request per tick is just noise.
+DISCOVERY_INTERVAL_SECONDS = 60.0
+DISCOVERY_TIMEOUT_SECONDS = 10.0
+
+# The ONLY shape a discovered channel may take. This is the load-bearing check on this side: the relay
+# holds GP credentials, so "the backend told me to" is not sufficient reason to dial a host. Anchored
+# and fully literal apart from the PR number, so no answer from the network can name an arbitrary
+# destination - the worst a compromised or buggy response can produce is a Railway preview address that
+# does not exist, which fails to connect and retries harmlessly.
+_DISCOVERABLE_URL_RE = re.compile(r"^wss://backend-uc-nexus-pr-\d+\.up\.railway\.app/relay-link$")
+
+# Last good answer, so a backend blip does not tear down working preview channels. None means "never
+# successfully asked", which is different from "asked and there are none" - the latter is an empty list
+# and legitimately retires every discovered channel.
+_discovered: list[str] | None = None
+_discovered_at: float = 0.0
+
+
+def _discovery_endpoint(primary: str) -> str:
+    """The https URL of the primary backend's channel list, derived from its wss channel URL."""
+    return primary.replace("wss://", "https://", 1).replace("/relay-link", "/relay-channels", 1)
+
+
+def _fetch_discovered_urls(primary: str, secret: str) -> list[str] | None:
+    """Ask the production backend which preview channels to add. None on any failure.
+
+    Blocking on purpose - it runs in a thread. urllib rather than a real HTTP client because this is one
+    small GET and the relay ships as a PyInstaller exe, where every added dependency is weight in the
+    bundle for the operator to install.
+    """
+    request = urllib.request.Request(  # noqa: S310 - scheme is fixed by _discovery_endpoint
+        _discovery_endpoint(primary),
+        headers={"Authorization": f"Bearer {secret}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=DISCOVERY_TIMEOUT_SECONDS) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as e:
+        logger.debug(
+            "could not read discovered channels from the backend; keeping the ones already known",
+            extra={"category": "discovery_unavailable", "error": str(e)},
+        )
+        return None
+
+    urls = payload.get("urls") if isinstance(payload, dict) else None
+    if not isinstance(urls, list):
+        return None
+
+    accepted, rejected = [], []
+    for candidate in urls:
+        url = candidate.strip() if isinstance(candidate, str) else ""
+        # is_primary_backend_url as well as the pattern: belt and braces, so a discovered URL can never
+        # take production's identity and shed the sandbox company pin that makes this safe at all.
+        if _DISCOVERABLE_URL_RE.match(url) and not is_primary_backend_url(url):
+            accepted.append(url)
+        elif url:
+            rejected.append(url)
+    if rejected:
+        logger.warning(
+            "ignored discovered channel URLs that do not match the preview backend pattern",
+            extra={"category": "discovery_rejected", "rejected": rejected},
+        )
+    return accepted
+
+
+def _discovered_urls() -> list[str]:
+    """Whatever discovery last learned. Empty until the first success, so this can only ever ADD to
+    what config.toml names - a relay that never reaches the backend behaves exactly as it did before
+    discovery existed."""
+    return list(_discovered or [])
+
+
+async def _refresh_discovery(primary: str, secret: str) -> None:
+    global _discovered, _discovered_at
+    fetched = await asyncio.to_thread(_fetch_discovered_urls, primary, secret)
+    if fetched is not None:
+        # Only a successful read moves the clock. A failed one leaves the interval expired so the next
+        # tick tries again, rather than backing off for a minute over a single dropped request.
+        _discovered, _discovered_at = fetched, time.monotonic()
+
+
+def _maybe_refresh_discovery(configured: list[str]) -> asyncio.Task | None:
+    """Kick a background refresh if one is due, and return the task so the supervisor can cancel it.
+
+    Deliberately NOT awaited on the reconcile path. Discovery is an HTTP call with a ten second
+    timeout, and blocking the tick on it would hold up the thing that matters most: on a fresh start
+    the first tick is what brings PRODUCTION's channel up, and no test backend is worth delaying that.
+    So the loop reconciles what it already knows and picks the new list up on a later tick.
+    """
+    try:
+        settings = get_settings()
+        if not settings.channel.discover_preview_backends:
+            return None
+        secret = settings.auth.shared_secret
+    except Exception:
+        return None
+
+    primary = next((url for url in configured if is_primary_backend_url(url)), "")
+    if not primary or not secret:
+        # Nobody to ask, or nothing to authenticate with. A dev checkout pointed only at localhost
+        # lands here and should simply not discover.
+        return None
+
+    if _discovered is not None and time.monotonic() - _discovered_at < DISCOVERY_INTERVAL_SECONDS:
+        return None
+
+    return asyncio.create_task(_refresh_discovery(primary, secret), name="channel-discovery")
+
+
 def _warn_if_no_primary(urls: list[str]) -> None:
     """Loud, because the likeliest cause is a typo in a hand-added backend_url list rather than a
     deliberate choice: production is then just another restricted channel and every real UBC/UCSH job
@@ -763,6 +877,10 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
     set, not against liveness. `_run_channel` catches per attempt and is not supposed to exit, so one
     that does is a bug worth seeing in the log rather than papering over with a respawn loop."""
     tasks: dict[str, asyncio.Task] = {}
+    # In-flight discovery reads. Held so shutdown can cancel one mid-request rather than leaving it
+    # attached to a loop that is closing, and so a slow read cannot outlive the supervisor that
+    # started it.
+    discovery_tasks: set[asyncio.Task] = set()
     known: set[str] | None = None
 
     async def _supervised(url: str) -> None:
@@ -797,7 +915,19 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
 
     try:
         while True:
-            urls = _configured_urls()
+            configured = _configured_urls()
+            urls = None
+            if configured is not None:
+                discovery = _maybe_refresh_discovery(configured)
+                if discovery is not None:
+                    discovery_tasks.add(discovery)
+                    discovery.add_done_callback(discovery_tasks.discard)
+                # Union, config first, so a hand-added URL keeps its position and a discovered one can
+                # only ever be additive. Dedup is backend_urls' job for the config half; this repeats it
+                # across the join because the same PR environment may legitimately be in both while an
+                # operator is mid-migration off the manual step.
+                seen = {url.strip().rstrip("/").lower() for url in configured}
+                urls = configured + [u for u in _discovered_urls() if u.strip().rstrip("/").lower() not in seen]
             if urls is not None:
                 if known != set(urls):
                     # Only on a change, so a steady relay logs this once at startup rather than every
@@ -833,6 +963,9 @@ async def run_forever(stop_event: asyncio.Event | None = None) -> None:
         # Reap them rather than just cancelling: cli.py cancels THIS task on shutdown, and a bare
         # cancel() would leave the children pending as the loop closes ("Task was destroyed but it is
         # pending"). CancelledError is a BaseException, so a cancelled child is not logged above.
-        for task in tasks.values():
+        # Discovery reads are reaped the same way and for the same reason - one can be sitting in a
+        # ten second HTTP timeout when shutdown arrives.
+        children = list(tasks.values()) + list(discovery_tasks)
+        for task in children:
             task.cancel()
-        await asyncio.gather(*tasks.values(), return_exceptions=True)
+        await asyncio.gather(*children, return_exceptions=True)

--- a/relay/src/ucnexus_relay/config.py
+++ b/relay/src/ucnexus_relay/config.py
@@ -139,6 +139,12 @@ class ChannelCfg(BaseModel):
     # inherits the sandbox pin and every real UBC/UCSH job is refused. Listing only the extra URL here
     # cannot express that mistake, because production's URL comes from the baked default untouched.
     extra_backend_urls: list[str] = []
+    # Ask the production backend which Railway preview environments exist and dial those too, so a PR
+    # environment stops needing a hand edit on this machine. Only ADDS to the two keys above, only
+    # accepts the fixed preview hostname shape, and a discovered channel can never be the primary one -
+    # so it inherits the sandbox company pin like any other non-primary channel. Off means this relay
+    # dials exactly what is written here, which is what it did before #456's successor.
+    discover_preview_backends: bool = True
     # the `websockets` client's own ping_interval/ping_timeout default to 20s/20s, which already
     # satisfies the ~20s keepalive the channel needs to hold a corporate-proxy idle timeout open -
     # these just make that tunable without a code change.

--- a/relay/tests/test_channel_discovery.py
+++ b/relay/tests/test_channel_discovery.py
@@ -1,0 +1,229 @@
+"""Preview channel discovery: the relay learning which PR environments exist instead of being told.
+
+#414 let the relay hold more than one backend URL and #456 let that list change without a restart, but
+the list itself still came from a TOML file on this one workstation - edited by hand, on a machine
+nobody testing is sitting at. Railway creates a preview environment per PR automatically, so anything
+created after the last edit was invisible, and every PR needing a real GP channel waited on somebody
+walking over here.
+
+The relay now asks the production backend which previews exist and unions the answer with its file.
+That means an answer from the network decides what a GP-credentialed process dials, so the checks that
+matter here are the ones that keep that answer from meaning too much:
+
+- it can only ADD to what config.toml names, never replace or reorder it
+- only the exact preview hostname shape is accepted, so no answer can name an arbitrary host
+- a discovered URL can never become the primary channel, so it always inherits the sandbox company pin
+- an unreachable backend keeps the last good list rather than retiring live channels
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from ucnexus_relay import channel
+from ucnexus_relay.config import PRODUCTION_BACKEND_URL
+
+PR_URL = "wss://backend-uc-nexus-pr-554.up.railway.app/relay-link"
+OTHER_PR_URL = "wss://backend-uc-nexus-pr-510.up.railway.app/relay-link"
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery_state():
+    channel._discovered = None
+    channel._discovered_at = 0.0
+    yield
+    channel._discovered = None
+    channel._discovered_at = 0.0
+
+
+class _Settings:
+    def __init__(self, secret="enrolled-secret", enabled=True):
+        self.channel = type("C", (), {"discover_preview_backends": enabled})()
+        self.auth = type("A", (), {"shared_secret": secret})()
+
+
+def _serve(monkeypatch, urls, *, settings=None, record=None):
+    """Point discovery at a canned /relay-channels answer."""
+    resolved = settings or _Settings()
+    monkeypatch.setattr(channel, "get_settings", lambda: resolved)
+
+    def _fetch(primary, secret):
+        if record is not None:
+            record.append((primary, secret))
+        return list(urls)
+
+    monkeypatch.setattr(channel, "_fetch_discovered_urls", _fetch)
+
+
+def _discover(configured):
+    """Kick a refresh, let it finish, then read what the reconcile loop would see.
+
+    Two steps because discovery is deliberately never awaited on the reconcile path - the loop reads
+    the last known list and picks a new one up on a later tick.
+    """
+
+    async def _run():
+        task = channel._maybe_refresh_discovery(configured)
+        if task is not None:
+            await task
+        return channel._discovered_urls()
+
+    return asyncio.run(_run())
+
+
+# --- the endpoint the relay derives ---------------------------------------------------------------
+
+
+def test_the_channel_list_is_read_off_the_production_backend():
+    # Derived rather than configured: another URL to keep in step is another thing to get wrong, and
+    # the relay already knows production's address as a baked-in constant.
+    assert (
+        channel._discovery_endpoint(PRODUCTION_BACKEND_URL)
+        == "https://backend-production-7866.up.railway.app/relay-channels"
+    )
+
+
+# --- what a discovered answer may contain ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "wss://attacker.example.com/relay-link",
+        "wss://backend-uc-nexus-pr-554.attacker.example.com/relay-link",
+        "ws://backend-uc-nexus-pr-554.up.railway.app/relay-link",  # downgraded to plaintext
+        "wss://backend-uc-nexus-pr-554.up.railway.app/something-else",
+        "wss://backend-production-7866.up.railway.app/relay-link",  # production, which must stay primary-by-config
+        "https://backend-uc-nexus-pr-554.up.railway.app/relay-link",
+    ],
+)
+def test_only_the_preview_hostname_shape_is_accepted(monkeypatch, hostile):
+    # This is the load-bearing check on the relay side: the process holds GP credentials, so "the
+    # backend said so" is not on its own a reason to dial a host.
+    monkeypatch.setattr(
+        channel.urllib.request,
+        "urlopen",
+        _canned_response({"urls": [hostile, PR_URL]}),
+    )
+    assert channel._fetch_discovered_urls(PRODUCTION_BACKEND_URL, "secret") == [PR_URL]
+
+
+def test_a_malformed_body_discovers_nothing_rather_than_raising(monkeypatch):
+    monkeypatch.setattr(channel.urllib.request, "urlopen", _canned_response({"unexpected": True}))
+    assert channel._fetch_discovered_urls(PRODUCTION_BACKEND_URL, "secret") is None
+
+
+def test_the_enrolled_secret_authenticates_the_read(monkeypatch):
+    seen = {}
+
+    def _urlopen(request, timeout=None):
+        seen["auth"] = request.get_header("Authorization")
+        seen["url"] = request.full_url
+        return _Body({"urls": []})
+
+    monkeypatch.setattr(channel.urllib.request, "urlopen", _urlopen)
+    channel._fetch_discovered_urls(PRODUCTION_BACKEND_URL, "enrolled-secret")
+    # The same credential as the channel handshake: discovery adds no new secret to distribute, and a
+    # caller that could read this could already open the socket.
+    assert seen["auth"] == "Bearer enrolled-secret"
+    assert seen["url"].endswith("/relay-channels")
+
+
+# --- how a discovered answer joins the configured one ---------------------------------------------
+
+
+def test_discovered_channels_are_added_to_the_configured_ones(monkeypatch):
+    _serve(monkeypatch, [PR_URL])
+    assert _discover([PRODUCTION_BACKEND_URL]) == [PR_URL]
+
+
+def test_discovery_needs_a_production_channel_to_ask(monkeypatch):
+    # A dev checkout pointed only at localhost has nobody to ask and must not invent one.
+    called = []
+    _serve(monkeypatch, [PR_URL], record=called)
+    assert _discover(["wss://localhost:8000/relay-link"]) == []
+    assert called == []
+
+
+def test_discovery_can_be_switched_off(monkeypatch):
+    _serve(monkeypatch, [PR_URL], settings=_Settings(enabled=False))
+    assert _discover([PRODUCTION_BACKEND_URL]) == []
+
+
+def test_an_unreachable_backend_keeps_the_channels_already_known(monkeypatch):
+    # Retiring a channel on a blip would drop a live preview connection and re-make it a minute later.
+    _serve(monkeypatch, [PR_URL])
+    assert _discover([PRODUCTION_BACKEND_URL]) == [PR_URL]
+
+    channel._discovered_at = 0.0  # force a refresh
+    monkeypatch.setattr(channel, "_fetch_discovered_urls", lambda primary, secret: None)
+    assert _discover([PRODUCTION_BACKEND_URL]) == [PR_URL]
+
+
+def test_discovery_never_blocks_the_reconcile_tick(monkeypatch):
+    # The first tick of a fresh relay is what brings PRODUCTION's channel up. Awaiting a ten second
+    # HTTP timeout there would hold that up for a test backend, which is the wrong trade every time.
+    monkeypatch.setattr(channel, "get_settings", lambda: _Settings())
+    started = asyncio.Event()
+
+    def _slow(primary, secret):
+        started.set()
+        raise AssertionError("must not run inline on the reconcile path")
+
+    monkeypatch.setattr(channel, "_fetch_discovered_urls", _slow)
+
+    async def _run():
+        task = channel._maybe_refresh_discovery([PRODUCTION_BACKEND_URL])
+        # A task was scheduled, and nothing has run yet: the loop reads the (empty) known list and
+        # carries straight on to reconciling production.
+        assert task is not None
+        assert not started.is_set()
+        assert channel._discovered_urls() == []
+        task.cancel()
+
+    asyncio.run(_run())
+
+
+def test_an_empty_answer_really_does_retire_discovered_channels(monkeypatch):
+    # The other half: "asked, and every PR is closed" has to be distinguishable from "could not ask",
+    # or a torn-down environment is dialled forever.
+    _serve(monkeypatch, [PR_URL, OTHER_PR_URL])
+    assert _discover([PRODUCTION_BACKEND_URL]) == [PR_URL, OTHER_PR_URL]
+
+    channel._discovered_at = 0.0
+    _serve(monkeypatch, [])
+    assert _discover([PRODUCTION_BACKEND_URL]) == []
+
+
+def test_the_backend_is_not_asked_on_every_reconcile_tick(monkeypatch):
+    # The reconcile loop runs every ten seconds; the answer changes when a PR opens or closes.
+    calls = []
+    _serve(monkeypatch, [PR_URL], record=calls)
+    for _ in range(5):
+        _discover([PRODUCTION_BACKEND_URL])
+    assert len(calls) == 1
+
+
+# --- helpers --------------------------------------------------------------------------------------
+
+
+class _Body:
+    def __init__(self, payload):
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _canned_response(payload):
+    def _urlopen(request, timeout=None):
+        return _Body(payload)
+
+    return _urlopen

--- a/testing/CLAUDE.md
+++ b/testing/CLAUDE.md
@@ -112,8 +112,12 @@ with `relayInstalls { label enrolled enrolledAt lastSeenAt }` and the Railway ba
   A 403 cadence with the same null `lastSeenAt` would instead mean it is dialling and presenting the
   wrong secret. Observed on pr-554, 2026-08-09: row `seed:uc-nexus-pr-554` (TUBC, enrolled,
   `lastSeenAt: null`), zero `/relay-link` lines across the deployment, `relayStatus.connected: false`,
-  `projects: []`. That is the not-dialling signature, and it is a request to whoever runs the relay
-  workstation - not something to fix from here.
+  `projects: []`. That was the not-dialling signature, and at the time it meant a human had not added
+  the URL on the workstation. **Since channel discovery it should not happen at all**: production
+  serves the live preview list at `/relay-channels` and the relay picks a new environment up within a
+  minute or two. So the same signature now means discovery is off or failing, and the first thing to
+  check is whether `RAILWAY_API_TOKEN` is set on the PRODUCTION backend - without it the route
+  correctly answers an empty list and every preview environment stays dark.
 - **Prove the log records a refusal before you trust its silence.** "No `/relay-link` lines" only
   means "nobody dialled" if a dial would have left a line, and an empty log is equally consistent
   with logging being broken or the edge never routing the upgrade. Settle it in one shot by dialling

--- a/testing/PR-ENVIRONMENT.md
+++ b/testing/PR-ENVIRONMENT.md
@@ -21,8 +21,8 @@ them rather than restating them.
 
 **The relay does not run on the machine your session runs on, and you must never install, start, or
 configure one there.** It is a packaged Windows service on a separate GP-credentialed workstation, it
-is already enrolled, and it is already pointed at the PR environments used for testing. Connecting it
-is not part of an agent's test loop.
+is already enrolled, and it finds new PR environments by itself (see the discovery section below).
+Connecting it is not part of an agent's test loop.
 
 Your entire relay responsibility is to **confirm the channel is up and then test through it**:
 
@@ -50,18 +50,44 @@ What that rules out, because each of these has burned a session:
 machine, so running it anywhere else fails at its channel step by design. The rest of this file is
 what it does and how to diagnose it when it does not.
 
+## The relay discovers PR environments on its own
+
+Production answers `GET /relay-channels` with the preview environments that exist right now, read from
+the Railway API; the relay asks about once a minute and unions the answer with its config file. So a
+new PR environment gets a GP channel without anybody touching the workstation, and a closed one is
+retired the same way.
+
+Setup, once, ever: `RAILWAY_API_TOKEN` on the **production** backend service, scoped read-only to this
+project. Nowhere else - a preview environment must not be able to advertise other preview
+environments, so a backend without the token answers an empty list, which is the correct answer
+everywhere but production.
+
+What keeps this safe, given a network answer now decides what a GP-credentialed process dials:
+
+- The relay accepts only `wss://backend-uc-nexus-pr-<N>.up.railway.app/relay-link`, anchored and
+  literal apart from the number. No answer can name an arbitrary host.
+- A discovered channel is never the primary one. `is_primary_backend_url` decides that by identity
+  against the relay's own baked-in production URL, so everything discovered inherits the TUBC sandbox
+  pin. The worst a bad entry can do is offer a channel that may only touch the sandbox company.
+- Discovery only ADDS. It cannot remove or reorder what `config.toml` names, and it cannot switch
+  itself on where the token is absent.
+- A backend that cannot be reached leaves the last known list in place, so a blip does not tear down
+  live channels. `discover_preview_backends = false` under `[channel]` turns it off entirely.
+
+`extra_backend_urls` is still there and still the right tool for a backend discovery cannot know about
+- a local dev backend, or anything outside this Railway project.
+
 ## A PR environment is relay-disconnected by default, and that is useful
 
 By default a PR environment always reports `relayStatus.connected: false`, and no amount of waiting
 changes it. Two independent reasons, both addressed by #414 but neither automatic:
 
-1. The relay dials whatever `[channel] backend_url` in its `config.toml` names. Since #414 that takes
-   a LIST, so a PR backend can be added *alongside* production rather than replacing it - but somebody
-   at the relay workstation has to add it, and that somebody is not an agent session. **No restart**
-   since #456: `channel.run_forever` re-reads `config.toml` every `CHANNEL_RECONCILE_SECONDS` (see
-   `relay/src/ucnexus_relay/channel.py` for the live value), adding a channel for a URL that appears
-   and cancelling one for a URL that disappears. Editing that file on that machine is the whole
-   procedure - see the runbook below.
+1. The relay has to be dialling this backend. Since #414 it can hold a LIST, so a PR backend is added
+   *alongside* production rather than replacing it; since #456 the list is re-read every
+   `CHANNEL_RECONCILE_SECONDS` (see `relay/src/ucnexus_relay/channel.py`) so a change needs no
+   restart; and since discovery it does not need a human either - see the section above. This reason
+   is therefore mostly historical now, and a preview environment that stays disconnected for more than
+   a couple of minutes means discovery is off or failing rather than "nobody has added it yet".
 2. Relay installs live in Postgres and a PR environment boots a fresh empty one, so the handshake is
    refused (4403) even if the relay does dial. Since #414 the backend seeds a trusted install on
    startup from `RELAY_SEED_SECRET_HASH` - the SHA-256 already in production's row, copyable from
@@ -114,11 +140,22 @@ step here has failed silently at least once.
    refused 4403. Usually inherited at environment creation; set it by hand if the environment predates
    the variable.
    - Signal: same `railway variables` read shows it set.
-4. **Add the PR backend to the relay's channel list - performed ON THE RELAY WORKSTATION, not on the
-   machine you are reading this from.** Usually already done for the environment under test, so check
-   step 5's signal before assuming otherwise; if it genuinely is missing, that is a request to
-   whoever owns that workstation. In that machine's `%LOCALAPPDATA%\UCNexusRelay\config.toml`, under
-   `[channel]`:
+4. **Nothing. The relay finds the environment by itself.** It asks production which preview
+   environments exist and dials them, re-checking about once a minute, so an environment created after
+   the last time anybody touched that workstation is picked up without a visit. This step used to be
+   the whole reason a PR environment needed a human, and it is the step that kept getting forgotten.
+   - Signal: `relay.log` on the workstation logs `backend channels changed` with your URL under
+     `added`, then `channel connected`, within a minute or two of the environment existing. From this
+     side, just read `relayStatus`.
+   - Requires `RAILWAY_API_TOKEN` on the PRODUCTION backend. That is the one piece of setup, done
+     once, ever - see the discovery section below. Without it discovery answers an empty list and
+     everything falls back to the manual path below.
+   - Discovery only ever ADDS. `extra_backend_urls` still works and still wins nothing away from you,
+     so the manual route stays available for a backend discovery cannot know about (a local dev
+     backend, an environment outside this Railway project).
+
+   The manual route, performed ON THE RELAY WORKSTATION and not on the machine you are reading this
+   from. In that machine's `%LOCALAPPDATA%\UCNexusRelay\config.toml`, under `[channel]`:
    ```toml
    extra_backend_urls = ["wss://backend-uc-nexus-pr-<N>.up.railway.app/relay-link"]
    ```


### PR DESCRIPTION
#414 let the relay hold more than one backend URL, #456 let that list change without a restart, and the list itself still came from a TOML file on the one GP-credentialed workstation, edited by hand. Railway creates a preview environment per PR automatically at an address nobody has seen before, so anything created after the last edit was invisible, and every PR needing a real GP channel waited on somebody walking to that machine.

production now answers `GET /relay-channels` with the preview environments that exist right now, read from the Railway API. the relay asks about once a minute and unions the answer with its file, so a new environment is dialled without a visit and a closed one is retired the same way.

a network answer now decides what a GP-credentialed process dials, so it is constrained on both sides:
- only production discovers. the token lives there alone and a backend without one answers an empty list, so a preview cannot advertise previews
- the relay accepts only `wss://backend-uc-nexus-pr-<N>.up.railway.app/relay-link`, anchored and literal apart from the number, re-checked on the relay side rather than trusted from the answer
- a discovered channel can never be primary. `is_primary_backend_url` decides that by identity against the relay's baked-in production URL, so everything discovered inherits the TUBC sandbox pin - the worst a bad entry offers is a channel that may only touch the sandbox
- discovery only ADDS; it cannot reorder or remove what config.toml names
- an unreachable backend keeps the last known list rather than retiring live channels. `discover_preview_backends = false` turns it off

discovery is never awaited on the reconcile path. the first tick of a fresh relay is what brings PRODUCTION's channel up, and holding that behind a ten second HTTP timeout for a test backend is the wrong trade - so the loop reads what it already knows and picks a new list up on a later tick. caught by a test that fails if the fetch runs inline.

`extra_backend_urls` stays, for what discovery cannot know about: a local dev backend, anything outside this Railway project.

deployment
- set `RAILWAY_API_TOKEN` on the PRODUCTION backend service, read-only, scoped to this project, nowhere else
- build and install the relay on the workstation. a packaged build is a manual install by design, so this needs one deliberate visit to remove the recurring one

the runbook's step 4 becomes "nothing, the relay finds it". the relay-disconnected-by-default section is now mostly historical: a preview that stays dark for more than a couple of minutes means discovery is off or failing, not that nobody has added it yet.
